### PR TITLE
Fix: Shows error when report has invalid logical table

### DIFF
--- a/packages/reports/addon/components/dimension-selector.js
+++ b/packages/reports/addon/components/dimension-selector.js
@@ -18,7 +18,7 @@ import Ember from 'ember';
 import { A as arr } from '@ember/array';
 import layout from '../templates/components/dimension-selector';
 
-const { $, computed, get, set } = Ember;
+const { $, computed, get, set, getWithDefault } = Ember;
 
 export default Ember.Component.extend({
   layout,
@@ -60,8 +60,8 @@ export default Ember.Component.extend({
    */
   listItems: computed('allTimeGrains', 'allDimensions', function() {
     return [
-      ...get(this, 'allTimeGrains'),
-      ...get(this, 'allDimensions')
+      ...getWithDefault(this, 'allTimeGrains', []),
+      ...getWithDefault(this, 'allDimensions', [])
     ];
   }),
 

--- a/packages/reports/addon/components/filter-builders/date-time.js
+++ b/packages/reports/addon/components/filter-builders/date-time.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2018, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Usage:
@@ -33,8 +33,8 @@ export default Base.extend({
    */
   filter: computed('requestFragment.interval', 'request.logicalTable.timeGrain', function() {
     let interval = get(this, 'requestFragment.interval'),
-        timeGrain = get(this, 'request.logicalTable.timeGrain'),
-        longName = `Date Time (${timeGrain.longName})`,
+        timeGrainName = get(this, 'request.logicalTable.timeGrain.longName'),
+        longName = `Date Time (${timeGrainName})`,
         operator = get(this, 'supportedOperators')[0]; // Only 1 operator allowed
 
     return {

--- a/packages/reports/addon/components/report-builder.js
+++ b/packages/reports/addon/components/report-builder.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2018, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import Ember from 'ember';
@@ -21,6 +21,15 @@ export default Ember.Component.extend({
    * @property {Object} request
    */
   request: computed.readOnly('report.request'),
+
+  /**
+   * @property {boolean} -- whether report has valid table
+   */
+  hasValidLogicalTable: computed('report.request.logicalTable.table', function() {
+    const allTables = get(this, 'allTables');
+    const tableName = get(this, 'report.request.logicalTable.table.name');
+    return allTables.filterBy('name', tableName).length > 0;
+  }),
 
   /**
    * @property {Array} allTables - All metadata table records

--- a/packages/reports/addon/consumers/request/logical-table.js
+++ b/packages/reports/addon/consumers/request/logical-table.js
@@ -22,7 +22,7 @@ export default ActionConsumer.extend({
      */
     [RequestActions.UPDATE_TABLE](route, table) {
       let currentModel = get(route, 'currentModel'),
-          oldTimeGrain = get(currentModel, 'request.logicalTable.timeGrain') || {name: ''}; // allow findBy to work when switching from an invalid table so switching to valid a table works
+          oldTimeGrain = get(currentModel, 'request.logicalTable.timeGrain') || {name: ''}; // allow findBy to work when switching from an invalid table so switching to a valid table works
 
       set(currentModel, 'request.logicalTable.table', table);
 

--- a/packages/reports/addon/consumers/request/logical-table.js
+++ b/packages/reports/addon/consumers/request/logical-table.js
@@ -22,7 +22,7 @@ export default ActionConsumer.extend({
      */
     [RequestActions.UPDATE_TABLE](route, table) {
       let currentModel = get(route, 'currentModel'),
-          oldTimeGrain = get(currentModel, 'request.logicalTable.timeGrain');
+          oldTimeGrain = get(currentModel, 'request.logicalTable.timeGrain') || {name: ''}; // allow findBy to work when switching from an invalid table so switching to valid a table works
 
       set(currentModel, 'request.logicalTable.table', table);
 

--- a/packages/reports/addon/mirage/fixtures/reports.js
+++ b/packages/reports/addon/mirage/fixtures/reports.js
@@ -403,5 +403,55 @@ export default [
       bardVersion: 'v1',
       requestVersion: 'v1'
     }
+  },
+  {
+    id: 9,
+    title: 'Report with unknown table',
+    createdOn: '2015-01-01 00:00:00',
+    updatedOn: '2015-01-01 00:00:00',
+    author: 'navi_user',
+    deliveryRules: [],
+    visualization:  {
+      type: 'table',
+      version: 1,
+      metadata: {
+        columns: [
+          {
+            field: 'dateTime',
+            type: 'dateTime',
+            displayName: 'Date'
+          },
+          {
+            field: 'revenue(currency=USD)',
+            type: 'metric',
+            displayName: 'Revenue (USD)'
+          }
+        ]
+      }
+    },
+    request: {
+      logicalTable: {
+        table: 'oak',
+        timeGrain: 'day'
+      },
+      metrics: [
+        {
+          metric: 'revenue',
+          parameters: {
+            currency: 'USD'
+          }
+        }
+      ],
+      dimensions: [],
+      filters: [],
+      intervals: [
+        {
+          end: '2018-02-16 00:00:00.000',
+          start: '2018-02-09 00:00:00.000'
+        }
+      ],
+      bardVersion: 'v1',
+      requestVersion: 'v1'
+    }
   }
 ];

--- a/packages/reports/addon/models/bard-request/fragments/logical-table.js
+++ b/packages/reports/addon/models/bard-request/fragments/logical-table.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2018, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 
@@ -13,7 +13,7 @@ const { Fragment } = MF;
 const Validations = buildValidations({
   table: validator('presence', {
     presence: true,
-    message: 'Please select a table'
+    message: 'Table is invalid or unavailable'
   }),
   timeGrainName: validator('presence', {
     presence: true,

--- a/packages/reports/addon/templates/components/report-builder.hbs
+++ b/packages/reports/addon/templates/components/report-builder.hbs
@@ -1,6 +1,6 @@
 {{!-- Copyright 2018, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 <div class='report-builder__side'>
-    {{#if (gt allTables.length 1) }}
+    {{#if (or (gt allTables.length 1) (not hasValidLogicalTable))}}
       {{navi-table-select
           classNames='report-builder__container report-builder__container--table'
           options=allTables
@@ -9,6 +9,7 @@
       }}
     {{/if}}
     <div class='report-builder__container--builder'>
+        {{#if hasValidLogicalTable}}
         {{dimension-selector
             class='report-builder__container report-builder__dimension-selector'
             request=request
@@ -25,22 +26,26 @@
             removeMetric=(report-action 'REMOVE_METRIC')
             toggleMetricFilter=(report-action 'TOGGLE_METRIC_FILTER')
         }}
+        {{/if}}
     </div>
 </div>
 <div class='report-builder__main'>
-    <div class='report-builder__container report-builder__container--filters'>
-        <span class='report-builder__container-header'>
-            FILTERS
-        </span>
-        {{#filter-collection
-            class='report-builder__filter-collection'
-            request=request
-            onUpdateFilter=(report-action 'UPDATE_FILTER')
-            onRemoveFilter=(report-action 'REMOVE_FILTER')
-        }}
-            Click the icon {{navi-icon 'filter' class='filter-collection__message--icon'}} next to a dimension/metric to add a filter.
-        {{/filter-collection}}
-    </div>
+    {{#if hasValidLogicalTable}}
+      <div class='report-builder__container report-builder__container--filters'>
+          <span class='report-builder__container-header'>
+              FILTERS
+          </span>
+
+            {{#filter-collection
+                class='report-builder__filter-collection'
+                request=request
+                onUpdateFilter=(report-action 'UPDATE_FILTER')
+                onRemoveFilter=(report-action 'REMOVE_FILTER')
+            }}
+                Click the icon {{navi-icon 'filter' class='filter-collection__message--icon'}} next to a dimension/metric to add a filter.
+            {{/filter-collection}}
+      </div>
+    {{/if}}
     <div class='report-builder__container report-builder__container--result'>
         {{yield}}
     </div>

--- a/packages/reports/addon/templates/components/report-builder.hbs
+++ b/packages/reports/addon/templates/components/report-builder.hbs
@@ -8,7 +8,7 @@
           onChange=(report-action 'UPDATE_TABLE')
       }}
     {{/if}}
-    <div class='report-builder__container--builder'>
+    <div class='report-builder__container--builder {{if (not hasValidLogicalTable) 'report-builder__container--builder-skel'}}'>
         {{#if hasValidLogicalTable}}
         {{dimension-selector
             class='report-builder__container report-builder__dimension-selector'

--- a/packages/reports/app/styles/navi-reports/components/report-builder.less
+++ b/packages/reports/app/styles/navi-reports/components/report-builder.less
@@ -29,6 +29,11 @@
          flex-flow: column;
          margin-bottom: 5px;
          min-height: 0;
+         &-skel {
+             border: 1px solid @nv-color-border;
+             background-color: @nv-color-background-primary;
+             margin: 5px;
+         }
      }
 
      &__container--result {

--- a/packages/reports/tests/acceptance/navi-report-test.js
+++ b/packages/reports/tests/acceptance/navi-report-test.js
@@ -1626,3 +1626,14 @@ test('Date Picker doesn`t change date when moving to time grain where dates are 
     });
   });
 });
+
+test('Report with an unknown table doesn\'t crash', function(assert) {
+  assert.expect(1);
+  visit('/reports/9');
+
+  andThen(() => {
+    assert.equal(find('.navi-info-message__error-list-item').text().trim(),
+      'Table is invalid or unavailable',
+      'Should show aan error message when table cannot be found in metadata');
+  });
+});

--- a/packages/reports/tests/acceptance/navi-report-test.js
+++ b/packages/reports/tests/acceptance/navi-report-test.js
@@ -1634,6 +1634,6 @@ test('Report with an unknown table doesn\'t crash', function(assert) {
   andThen(() => {
     assert.equal(find('.navi-info-message__error-list-item').text().trim(),
       'Table is invalid or unavailable',
-      'Should show aan error message when table cannot be found in metadata');
+      'Should show an error message when table cannot be found in metadata');
   });
 });

--- a/packages/reports/tests/unit/models/bard-request/fragments/logical-table-test.js
+++ b/packages/reports/tests/unit/models/bard-request/fragments/logical-table-test.js
@@ -160,7 +160,7 @@ test('Validations', function(assert) {
         'There is one validation error');
 
       assert.equal(validations.get('messages').objectAt(0),
-        'Please select a table',
+        'Table is invalid or unavailable',
         'Table cannot be empty is a part of the error messages');
     });
 

--- a/packages/reports/tests/unit/models/bard-request/fragments/logical-table-test.js
+++ b/packages/reports/tests/unit/models/bard-request/fragments/logical-table-test.js
@@ -161,7 +161,7 @@ test('Validations', function(assert) {
 
       assert.equal(validations.get('messages').objectAt(0),
         'Table is invalid or unavailable',
-        'Table cannot be empty is a part of the error messages');
+        'Table is invalid or unavailable is a part of the error messages');
     });
 
     logicalTable.set('timeGrainName', '');

--- a/packages/reports/tests/unit/models/bard-request/request-test.js
+++ b/packages/reports/tests/unit/models/bard-request/request-test.js
@@ -1469,8 +1469,8 @@ test('logicalTable belongs-to validation', function(assert) {
         2,
         'Two Fields are invalid in the request model');
       assert.equal(validations.get('messages').objectAt(0),
-        'Please select a table',
-        'Please select a table is a part of the messages');
+        'Table is invalid or unavailable',
+        'Table is invalid or unavailable is a part of the messages');
       assert.equal(validations.get('messages').objectAt(1),
         'The timeGrainName field cannot be empty',
         'Time Grain Name cannot be empty is a part of the messages');


### PR DESCRIPTION
* Would crash UI otherwise
* Likely to happen when users share reports to a table that
one user doesn't have access
* Also hides components that would crash without metadata
that user wouldn't be able to use anyway
* Allows users to select a valid table.
* Changes error message to reflect the actual problem

![apr-13-2018 11-25-16](https://user-images.githubusercontent.com/99422/38746532-66aae5dc-3f0d-11e8-8fb9-98fb5c2ad3d3.gif)


