### PR TITLE
Breaking: Update goal gauge model metric to be an object (refs #71)

### DIFF
--- a/packages/dashboards/app/mirage/fixtures/dashboard-widget.js
+++ b/packages/dashboards/app/mirage/fixtures/dashboard-widget.js
@@ -10,7 +10,7 @@ export default [
       metadata: {
         baselineValue: 200,
         goalValue: 1000,
-        metric: 'adClicks'
+        metric: {metric: 'adClicks', parameters: {}}
       }
     },
     requests: [

--- a/packages/dashboards/tests/unit/models/dashboard-widget-test.js
+++ b/packages/dashboards/tests/unit/models/dashboard-widget-test.js
@@ -124,7 +124,7 @@ test('Retrieving Records', function(assert) {
             metadata: {
               baselineValue: 200,
               goalValue: 1000,
-              metric: 'adClicks'
+              metric: {metric: 'adClicks', parameters: {}}
             }
           },
           requests: [

--- a/packages/visualizations/addon/components/navi-visualizations/goal-gauge.js
+++ b/packages/visualizations/addon/components/navi-visualizations/goal-gauge.js
@@ -18,12 +18,13 @@ import { inject as service } from '@ember/service';
 import numeral from 'numeral';
 import layout from '../../templates/components/navi-visualizations/goal-gauge';
 import { metricFormat } from 'navi-data/helpers/metric-format';
+import { canonicalizeMetric } from 'navi-data/utils/metric';
 
 const DEFAULT_OPTIONS = {
   baselineValue: 0,
   goalValue: 0,
   metricTitle: '',
-  metric: '',
+  metric: {metric: '', parameters: {}},
   prefix: '',
   unit: '',
   thresholdColors: [ '#f05050', '#ffc831', '#44b876' ],
@@ -48,7 +49,7 @@ export default Component.extend({
    * @property {Number} - value to be rendered on gauge
    */
   actualValue: computed(function() {
-    let metric = get(this, 'config.metric');
+    let metric = canonicalizeMetric(get(this, 'config.metric'));
     return get(this, `model.firstObject.response.rows.0.${metric}`);
   }),
 

--- a/packages/visualizations/addon/models/goal-gauge.js
+++ b/packages/visualizations/addon/models/goal-gauge.js
@@ -8,6 +8,7 @@ import { A as arr } from '@ember/array';
 import DS from 'ember-data';
 import VisualizationBase from './visualization';
 import { buildValidations, validator } from 'ember-cp-validations';
+import { canonicalizeMetric } from 'navi-data/utils/metric';
 
 /**
  * @constant {Object} Validations - Validation object
@@ -48,8 +49,9 @@ export default VisualizationBase.extend(Validations, {
 
     if (request && response) {
       let metrics = arr( get(request, 'metrics') ),
-          metric =  get(metrics, 'firstObject.canonicalName'),
-          actualValue =  get(arr(response.rows), `firstObject.${metric}`),
+          metric =  get(metrics, 'firstObject').toJSON(),
+          canonicalName = canonicalizeMetric(metric),
+          actualValue =  get(arr(response.rows), `firstObject.${canonicalName}`),
           above = actualValue * 1.1,
           below = actualValue * 0.9,
           baselineValue =  actualValue > 0 ? below : above,

--- a/packages/visualizations/addon/serializers/goal-gauge.js
+++ b/packages/visualizations/addon/serializers/goal-gauge.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2018, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+import VisualizationSerializer from 'navi-visualizations/serializers/visualization';
+import { parseMetricName } from 'navi-data/utils/metric';
+import { get } from '@ember/object';
+
+export default VisualizationSerializer.extend({
+  /**
+   * Normalizes payload so that it can be applied to models correctly
+   * @override
+   * @method normalize
+   * @param type - class type as a DS model
+   * @param visualization - json parsed object
+   * @return {Object} normalized payload
+   */
+  normalize(type, visualization) {
+    if(visualization) {
+      let metric = get(visualization, 'metadata.metric');
+      visualization.metadata.metric = parseMetricName(metric);
+    }
+
+    return this._super(type, visualization);
+  }
+});

--- a/packages/visualizations/app/serializers/goal-gauge.js
+++ b/packages/visualizations/app/serializers/goal-gauge.js
@@ -1,1 +1,1 @@
-export { default } from 'navi-visualizations/serializers/visualization';
+export { default } from 'navi-visualizations/serializers/goal-gauge';

--- a/packages/visualizations/tests/dummy/app/controllers/goal-gauge.js
+++ b/packages/visualizations/tests/dummy/app/controllers/goal-gauge.js
@@ -9,7 +9,7 @@ export default Ember.Controller.extend({
   }),
 
   goalGaugeOptions: {
-    metric: 'DAU',
+    metric: {metric: 'DAU', parameters: {}},
     baselineValue: '2900000000',
     goalValue: '3100000000'
   },

--- a/packages/visualizations/tests/dummy/app/routes/goal-gauge.js
+++ b/packages/visualizations/tests/dummy/app/routes/goal-gauge.js
@@ -3,7 +3,10 @@ import Ember from 'ember';
 export default Ember.Route.extend({
   model() {
     return Ember.A([
-      { response: { rows: [ { DAU: 3060000000 } ] } }
+      {
+        response: { rows: [ { DAU: 3060000000 } ] },
+        request: { metrics: [{metric: 'DAU', parameters: {}}]}
+      }
     ]);
   }
 });

--- a/packages/visualizations/tests/integration/components/navi-visualizations/goal-gauge-test.js
+++ b/packages/visualizations/tests/integration/components/navi-visualizations/goal-gauge-test.js
@@ -1,5 +1,6 @@
 import { A as arr } from '@ember/array';
 import { getOwner } from '@ember/application';
+import { set } from '@ember/object';
 import { moduleForComponent, test } from 'ember-qunit';
 import { initialize as injectC3Enhancements} from 'navi-visualizations/initializers/inject-c3-enhancements';
 import hbs from 'htmlbars-inline-precompile';
@@ -23,13 +24,14 @@ test('goal-gauge renders correctly', function(assert) {
   assert.expect(6);
 
   _setModel(this, 'pageViews', 3030000000);
+  set(this, 'metric', {metric: 'pageViews', paramters: {}});
   this.render(hbs`
   {{navi-visualizations/goal-gauge
       model=model
       options=(hash
         baselineValue=290000000
         goalValue=310000000
-        metric='pageViews'
+        metric=metric
       )
     }}
   `);
@@ -62,6 +64,7 @@ test('goal-gauge renders correctly with unit', function(assert) {
   assert.expect(6);
 
   _setModel(this, 'pageViews', 75);
+  set(this, 'metric', {metric: 'pageViews', paramters: {}});
   this.render(hbs`
     {{navi-visualizations/goal-gauge
       model=model
@@ -69,7 +72,7 @@ test('goal-gauge renders correctly with unit', function(assert) {
         baselineValue=50
         goalValue=100
         unit='%'
-        metric='pageViews'
+        metric=metric
       )
     }}
   `);
@@ -102,6 +105,7 @@ test('goal-gauge renders correctly with prefix', function(assert) {
   assert.expect(6);
 
   _setModel(this, 'pageViews', 75);
+  set(this, 'metric', {metric: 'pageViews', paramters: {}});
   this.render(hbs`
     {{navi-visualizations/goal-gauge
       model=model
@@ -109,7 +113,7 @@ test('goal-gauge renders correctly with prefix', function(assert) {
         baselineValue=50
         goalValue=100
         prefix='$'
-        metric='pageViews'
+        metric=metric
       )
     }}
   `);
@@ -142,13 +146,14 @@ test('goal-gauge title class is based on actualValue vs baselineValue', function
   assert.expect(3);
 
   _setModel(this, 'm1', 150);
+  set(this, 'metric', {metric: 'm1', paramters: {}});
   this.render(hbs`
     {{navi-visualizations/goal-gauge
       model=model
       options=(hash
         baselineValue=100
         goalValue=200
-        metric='m1'
+        metric=metric
       )
     }}
   `);
@@ -162,7 +167,7 @@ test('goal-gauge title class is based on actualValue vs baselineValue', function
       options=(hash
         baselineValue=100
         goalValue=200
-        metric='m1'
+        metric=metric
       )
     }}
   `);
@@ -176,7 +181,7 @@ test('goal-gauge title class is based on actualValue vs baselineValue', function
       options=(hash
         baselineValue=100
         goalValue=200
-        metric='m1'
+        metric=metric
       )
     }}
   `);
@@ -190,7 +195,7 @@ test('goal-guage with parameterized metric', function(assert) {
       response: {
         rows: [
           {
-            'revenue(currency=USD)': "300"
+            'revenue(currency=USD)': '300'
           }
         ]
       },
@@ -209,7 +214,7 @@ test('goal-guage with parameterized metric', function(assert) {
   this.set('options', {
     baselineValue: 200,
     goalValue: 500,
-    metric: 'revenue(currency=USD)'
+    metric: {metric: 'revenue', parameters: {currency: 'USD'}}
   });
 
   this.render(hbs`
@@ -246,7 +251,7 @@ test('goal-gauge value & min/max precision', function(assert) {
   this.set('options', {
     baselineValue: 1234567,
     goalValue:    1234567,
-    metric:       'm1'
+    metric:       {metric: 'm1', parameters: {}}
   });
 
   this.render(hbs`
@@ -272,7 +277,7 @@ test('goal-gauge value & min/max precision', function(assert) {
   this.set('options', {
     baselineValue: 9123456789,
     goalValue:    9123456789,
-    metric:       'm1'
+    metric:       {metric: 'm1', parameters: {}}
   });
 
   this.render(hbs`
@@ -299,8 +304,8 @@ test('goal-gauge renders custom metric title', function(assert) {
   assert.expect(1);
 
   _setModel(this, 'm1', 75);
-
-  this.set('metricTitle', 'A real good metric');
+  set(this, 'metric', {metric: 'm1', paramters: {}});
+  set(this, 'metricTitle', 'A real good metric');
 
   this.render(hbs`
     {{navi-visualizations/goal-gauge
@@ -308,7 +313,7 @@ test('goal-gauge renders custom metric title', function(assert) {
       options=(hash
         baselineValue=50
         goalValue=100
-        metric='m1'
+        metric=metric
         metricTitle=metricTitle
       )
     }}
@@ -323,6 +328,7 @@ test('cleanup', function(assert) {
   assert.expect(2);
 
   _setModel(this, 'm1', 75);
+  set(this, 'metric', {metric: 'm1', paramters: {}});
 
   this.set('metricTitle', 'A real good metric');
 
@@ -332,7 +338,7 @@ test('cleanup', function(assert) {
       options=(hash
         baselineValue=50
         goalValue=100
-        metric='m1'
+        metric=metric
         metricTitle=metricTitle
       )
     }}

--- a/packages/visualizations/tests/unit/models/goal-gauge-test.js
+++ b/packages/visualizations/tests/unit/models/goal-gauge-test.js
@@ -103,7 +103,7 @@ test('rebuildConfig', function(assert) {
         metadata: {
           baselineValue: 9,
           goalValue: 11,
-          metric: 'rupees'
+          metric: {metric: 'rupees', parameters: {}}
         },
         type: 'goal-gauge',
         version: 1
@@ -112,7 +112,7 @@ test('rebuildConfig', function(assert) {
         metadata: {
           baselineValue: 0.9,
           goalValue: 1.1,
-          metric: 'rupees'
+          metric: {metric: 'rupees', parameters: {}}
         },
         type: 'goal-gauge',
         version: 1
@@ -121,7 +121,7 @@ test('rebuildConfig', function(assert) {
         metadata: {
           baselineValue: -11,
           goalValue: -9,
-          metric: 'rupees'
+          metric: {metric: 'rupees', parameters: {}}
         },
         type: 'goal-gauge',
         version: 1
@@ -130,7 +130,7 @@ test('rebuildConfig', function(assert) {
         metadata: {
           baselineValue: 0,
           goalValue: 1,
-          metric: 'rupees'
+          metric: {metric: 'rupees', parameters: {}}
         },
         type: 'goal-gauge',
         version: 1
@@ -139,7 +139,7 @@ test('rebuildConfig', function(assert) {
         metadata: {
           baselineValue: 9,
           goalValue: 11,
-          metric: 'revenue(currency=HYR)'
+          metric: {metric: 'revenue', parameters: {currency: 'HYR'}}
         },
         type: 'goal-gauge',
         version: 1

--- a/packages/visualizations/tests/unit/serializers/goal-gauge-test.js
+++ b/packages/visualizations/tests/unit/serializers/goal-gauge-test.js
@@ -1,0 +1,81 @@
+import { moduleFor, test } from 'ember-qunit';
+import { setupMock, teardownMock } from '../../helpers/mirage-helper';
+import { getOwner } from '@ember/application';
+
+let Serializer, Model;
+
+moduleFor('serializer:goal-gauge', 'Unit | Serializer | goal gauge', {
+  needs: [
+    'model:goal-gauge',
+    'validator:request-metric-exist',
+  ],
+  beforeEach() {
+    setupMock();
+    Serializer = this.subject();
+    Model = getOwner(this).factoryFor('model:goal-gauge').class;
+  },
+  afterEach() {
+    teardownMock();
+  }
+});
+
+test('normalize', function(assert) {
+  assert.expect(3);
+
+  let initialMetaData = {
+        version: 1,
+        type: 'goal-gauge',
+        metadata: {
+          metric: 'rupees',
+          baselineValue: 1000,
+          goalValue: 1500,
+          metricTitle: null,
+          unit: null,
+          prefix: null
+        }
+      },
+      metricObjectMetaData = {
+        version: 1,
+        type: 'goal-gauge',
+        metadata: {
+          metric: {metric: 'rupees', parameters: {}},
+          baselineValue: 1000,
+          goalValue: 1500,
+          metricTitle: null,
+          unit: null,
+          prefix: null
+        }
+      },
+      expectedPayload = {
+        data: {
+          id: null,
+          relationships: {},
+          type: 'goal-gauge',
+          attributes: {
+            version: 1,
+            type: 'goal-gauge',
+            metadata: {
+              metric: {metric: 'rupees', parameters: {}},
+              baselineValue: 1000,
+              goalValue: 1500,
+              metricTitle: null,
+              unit: null,
+              prefix: null
+            }
+          }
+        }
+      };
+
+  assert.deepEqual(Serializer.normalize(),
+    {data: null},
+    'null is returned for an undefined response');
+
+  assert.deepEqual(Serializer.normalize(Model, initialMetaData),
+    expectedPayload,
+    'Config with a metric name stored is successfully converted to an object for a non-parameterized metric');
+
+  assert.deepEqual(Serializer.normalize(Model, metricObjectMetaData),
+    expectedPayload,
+    'Config with a metric object stored is unchanged');
+
+});


### PR DESCRIPTION
Updates goal gauge visualization to use a metric object instead of a string

Part of #71 