### PR TITLE
Breaking: Refactor tooltips to use new metric object shape in visualizations (refs #71)

### DIFF
--- a/packages/visualizations/addon/components/navi-visualizations/line-chart.js
+++ b/packages/visualizations/addon/components/navi-visualizations/line-chart.js
@@ -231,9 +231,7 @@ export default Ember.Component.extend({
     let rawData = get(this, 'dataConfig.data.json'),
         tooltipComponent = get(this, 'tooltipComponent'),
         request = get(this, 'model.firstObject.request'),
-        seriesConfig = get(this, 'seriesConfig.config'),
-        metricName = get(this, 'metricName'),
-        metricDisplayName = get(this, 'metricDisplayName');
+        seriesConfig = get(this, 'seriesConfig.config');
 
     return {
       contents(tooltipData) {
@@ -242,17 +240,11 @@ export default Ember.Component.extend({
          * to the raw x value for better formatting
          */
         let x = rawData[tooltipData[0].x].x.rawValue,
-            metricDisplayMap = seriesConfig.metrics ? seriesConfig.metrics.reduce((acc,metric) => {
-              acc[metricName.getDisplayName(metric)] = metric;
-              return acc;
-            } , {}) : undefined,
             tooltip = tooltipComponent.create({
               tooltipData,
               x,
               request,
-              seriesConfig,
-              metricDisplayName,
-              metricDisplayMap
+              seriesConfig
             });
 
         Ember.run(() => {

--- a/packages/visualizations/addon/components/navi-visualizations/pie-chart.js
+++ b/packages/visualizations/addon/components/navi-visualizations/pie-chart.js
@@ -150,7 +150,7 @@ export default Component.extend({
   chartTooltip: computed('seriesConfig.metric', function() {
     let tooltipComponent = get(this, 'tooltipComponent'),
         rawData = get(this, 'dataConfig.data.json'),
-        metricName = get(this, 'seriesConfig.metric');
+        metric = get(this, 'seriesConfig.metric');
 
     return {
       contents(tooltipData) {
@@ -158,7 +158,7 @@ export default Component.extend({
             tooltip = tooltipComponent.create({
               x,
               requiredToolTipData: tooltipData[0],
-              metricName
+              metric
             });
 
         run(() => {

--- a/packages/visualizations/addon/helpers/tooltip-value-formatter.js
+++ b/packages/visualizations/addon/helpers/tooltip-value-formatter.js
@@ -11,11 +11,11 @@ import { smartFormatNumber } from 'navi-core/helpers/smart-format-number';
  *
  * @method tooltipValueFormatter
  * @param {Number|String} value
- * @param {String} metricName
+ * @param {Object} metric - Metric JSON Object
  * @param {Object} row - response row for the current value and metric
  * @return {String} Formatted string for the provided number
  */
-export function tooltipValueFormatter([ value /*, metricName, rowData*/ ]) {
+export function tooltipValueFormatter([ value /*, metric, rowData*/ ]) {
   return smartFormatNumber([value]);
 }
 

--- a/packages/visualizations/addon/templates/chart-tooltips/date.hbs
+++ b/packages/visualizations/addon/templates/chart-tooltips/date.hbs
@@ -1,6 +1,6 @@
 {{!-- Copyright 2018, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 <div class='title'>{{request.logicalTable.timeGrain}} {{x}}</div>
-<div class='sub-title'>{{metricDisplayName}}</div>
+<div class='sub-title'>{{metric-format (get seriesConfig 'metric')}}</div>
 <ol class='hover-metrics'>
   {{#each tooltipData as |series|}}
     <li class='metric-val'>

--- a/packages/visualizations/addon/templates/chart-tooltips/dimension.hbs
+++ b/packages/visualizations/addon/templates/chart-tooltips/dimension.hbs
@@ -1,6 +1,6 @@
 {{!-- Copyright 2018, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 <div class='title'>{{format-chart-tooltip-date request x}}</div>
-<div class='sub-title'>{{metricDisplayName}}</div>
+<div class='sub-title'>{{metric-format (get seriesConfig 'metric')}}</div>
 <ol class='hover-dimensions'>
   {{#each tooltipData as |series|}}
     <li class='metric-val'>

--- a/packages/visualizations/addon/templates/chart-tooltips/metric.hbs
+++ b/packages/visualizations/addon/templates/chart-tooltips/metric.hbs
@@ -1,12 +1,12 @@
 {{!-- Copyright 2017, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 <div class='title'>{{format-chart-tooltip-date request x}}</div>
 <ol class='hover-metrics'>
-  {{#each tooltipData as |series|}}
+  {{#each tooltipData as |series index|}}
     <li class='metric-val'>
       <svg class='series-indicator'>
           <circle cx='50%' cy='50%' r='40%' class='chart-series-{{series.seriesIndex}}'/>
       </svg>
-      <span>{{tooltip-value-formatter series.value (get metricDisplayMap series.id) (object-at series.seriesIndex rowData)}}</span>
+      <span>{{tooltip-value-formatter series.value (object-at index seriesConfig.metrics) (object-at series.seriesIndex rowData)}}</span>
     </li>
   {{/each}}
 </ol>

--- a/packages/visualizations/addon/templates/chart-tooltips/pie-chart.hbs
+++ b/packages/visualizations/addon/templates/chart-tooltips/pie-chart.hbs
@@ -5,6 +5,6 @@
         <svg class='pie-chart-tooltip__series-indicator'>
             <circle cx='50%' cy='50%' r='40%' class='chart-series-{{requiredToolTipData.seriesIndex}}'/>
         </svg>
-        <span>{{tooltip-value-formatter requiredToolTipData.value metricName rowData}}</span>
+        <span>{{tooltip-value-formatter requiredToolTipData.value metric rowData}}</span>
     </li>
 </ol>

--- a/packages/visualizations/tests/dummy/app/controllers/pie-chart.js
+++ b/packages/visualizations/tests/dummy/app/controllers/pie-chart.js
@@ -21,19 +21,22 @@ export default Ember.Controller.extend({
         metric: {
           name: 'totalPageViews',
           longName: 'Total Page Views'
-        }
+        },
+        toJSON() { return {metric: this.metric.name, parameters: {}}; }
       },
       {
         metric: {
           name: 'uniqueIdentifier',
           longName: 'Unique Identifier'
-        }
+        },
+        toJSON() { return {metric: this.metric.name, parameters: {}}; }
       },
       {
         metric: {
           name: 'revenue',
           longName: 'Revenue'
-        }
+        },
+        toJSON() { return {metric: this.metric.name, parameters: {}}; }
       }
     ]
   },
@@ -182,19 +185,22 @@ export default Ember.Controller.extend({
         metric: {
           name: 'totalPageViews',
           longName: 'Total Page Views'
-        }
+        },
+        toJSON() { return {metric: this.metric.name, parameters: {}}; }
       },
       {
         metric: {
           name: 'uniqueIdentifier',
           longName: 'Unique Identifier'
-        }
+        },
+        toJSON() { return {metric: this.metric.name, parameters: {}}; }
       },
       {
         metric: {
           name: 'revenue',
           longName: 'Revenue'
-        }
+        },
+        toJSON() { return {metric: this.metric.name, parameters: {}}; }
       }
     ],
     logicalTable: {


### PR DESCRIPTION
With the metric reshaping in the visualizations, we can get rid of some of the things that we pass to the tooltips. This does mean that apps that use navi-visualizations and override the 
tooltip-value-formatter helper will need an update to handle the metric object. 