### PR TITLE
Fix: Better default request for validator

### DIFF
--- a/packages/visualizations/addon/validators/request-metric-exist.js
+++ b/packages/visualizations/addon/validators/request-metric-exist.js
@@ -12,7 +12,7 @@ import { A as arr } from '@ember/array';
 export default BaseValidator.extend({
   validate(value, options/*, model, attribute*/) {
     if(value) {
-      let requestMetrics = getRequestMetrics(getWithDefault(options, 'request', {})).map(metric => get(metric, 'canonicalName') || canonicalizeMetric(metric)),
+      let requestMetrics = getRequestMetrics(getWithDefault(options, 'request', {metrics: []})).map(metric => get(metric, 'canonicalName') || canonicalizeMetric(metric)),
           valueCanonicalName = get(value, 'canonicalName') || canonicalizeMetric(value);
 
       return arr(requestMetrics).includes(valueCanonicalName);


### PR DESCRIPTION
having just {} as default request was causing chart-data util to fail.

This broke when you refreshed goal gauge reports for example