### PR TITLE
remove predefined ranges for All timegrain

### DIFF
--- a/packages/reports/config/environment.js
+++ b/packages/reports/config/environment.js
@@ -18,7 +18,6 @@ module.exports = function(/* environment, appConfig */) {
         timeout: 90000
       },
       predefinedIntervalRanges: {
-        all:     ['P1D', 'P7D', 'P14D', 'P30D', 'P60D', 'P90D', 'P180D', 'P400D'],
         day:     ['P1D', 'P7D', 'P14D', 'P30D', 'P60D', 'P90D', 'P180D', 'P400D'],
         week:    ['current/next', 'P1W', 'P4W', 'P8W', 'P13W', 'P26W', 'P52W', 'P78W', 'P104W'],
         month:   ['current/next','P1M', 'P3M', 'P6M', 'P12M', 'P18M', 'P24M'],

--- a/packages/reports/tests/integration/components/navi-date-range-picker-test.js
+++ b/packages/reports/tests/integration/components/navi-date-range-picker-test.js
@@ -593,7 +593,7 @@ test('Default interval for timegrains', function(assert) {
 });
 
 test('Default interval for `All` timegrain', function(assert) {
-  assert.expect(4);
+  assert.expect(3);
 
   this.dateTimePeriod = 'all';
 
@@ -605,25 +605,8 @@ test('Default interval for `All` timegrain', function(assert) {
     `);
 
   assert.equal(this.$('li').length,
-    9,
+    1,
     'Only one option is available to select for All time grain');
-
-  let ranges = this.$('.predefined-range').map(function() {
-    return $(this).text().trim();
-  }).get();
-
-  assert.deepEqual(ranges,
-    [
-      'Last Day',
-      'Last 7 Days',
-      'Last 14 Days',
-      'Last 30 Days',
-      'Last 60 Days',
-      'Last 90 Days',
-      'Last 180 Days',
-      'Last 400 Days'
-    ],
-    'All time grain ');
 
   assert.equal(this.$('li:last-of-type > div:eq(0)').text().trim(),
     'Custom range',


### PR DESCRIPTION
remove predefined ranges for All timegrain since CURRENT macro is not supported for all timegrain in fili