### PR TITLE
Fix: Remove z-index property from missing intervals warning

### DIFF
--- a/packages/reports/app/styles/navi-reports/components/missing-intervals-warning.less
+++ b/packages/reports/app/styles/navi-reports/components/missing-intervals-warning.less
@@ -7,7 +7,6 @@
   background-color: @navi-white;
   bottom: 0;
   width: 100%;
-  z-index: 1000;
 
   &__arrow-icon {
     margin-right: 10px;


### PR DESCRIPTION
Issue shown here:
![image](https://user-images.githubusercontent.com/23023478/40085067-e9e8f1ae-585e-11e8-970f-7d9130acc414.png)

![image](https://user-images.githubusercontent.com/23023478/40085177-3efd4618-585f-11e8-8ee7-23126286f88d.png)

Fixed: 
![image](https://user-images.githubusercontent.com/23023478/40085196-4dabf038-585f-11e8-9584-25c3c2a1d853.png)
