### PR TITLE
Fix: Reorder table column error

### DIFF
--- a/packages/reports/addon/consumers/report/table-visualization.js
+++ b/packages/reports/addon/consumers/report/table-visualization.js
@@ -24,7 +24,7 @@ export default ActionConsumer.extend({
           metrics = get(report, 'request.metrics'),
           metricIndex = keyBy(metrics.toArray(), metric => get(metric, 'canonicalName')),
           reorderedMetrics = newColumnOrder
-            .filter(column => column.type === 'metric')
+            .filter(column => column.type === 'metric' || column.type === 'threshold')
             .map(column => metricIndex[column.field]);
 
       set(report, 'visualization.metadata',

--- a/packages/reports/tests/unit/consumers/report/table-visualization-test.js
+++ b/packages/reports/tests/unit/consumers/report/table-visualization-test.js
@@ -64,7 +64,7 @@ test('reorder metrics', function (assert) {
     type: 'metric',
     field: 'b'
   }, {
-    type: 'metric',
+    type: 'threshold',
     field: 'a'
   }]
 


### PR DESCRIPTION
Reordering a metric whose name is changed, breaks the report

https://digits-ziggurat-zigguratcomponent-prod.gq1-1.paas.yahoo.com:4443/reports/8888/view
reordering the table columns in the above report breaks