### PR TITLE
Add column edit msg

### DIFF
--- a/packages/app/config/environment.js
+++ b/packages/app/config/environment.js
@@ -33,7 +33,8 @@ module.exports = function(environment) {
 
     navi: {
       FEATURES: {
-        enableMultipleExport: false
+        enableMultipleExport: false,
+        enableTableEditing: true
       }
     }
   };

--- a/packages/visualizations/addon/components/navi-visualizations/table.js
+++ b/packages/visualizations/addon/components/navi-visualizations/table.js
@@ -18,6 +18,7 @@ import { inject as service } from '@ember/service';
 import { assign } from '@ember/polyfills';
 import { A as arr } from '@ember/array';
 import Component from '@ember/component';
+import { isBlank } from '@ember/utils';
 import cloneDeep from 'lodash/cloneDeep';
 import groupBy from 'lodash/groupBy';
 import { canonicalizeMetric } from 'navi-data/utils/metric';
@@ -146,6 +147,22 @@ export default Component.extend({
   },
 
   /**
+   * @method _hasCustomDisplayName
+   * Determines if column has a custom display name
+   *
+   * @private
+   * @returns {Boolean}
+   */
+  _hasCustomDisplayName(column) {
+    if(isBlank(column.displayName)) {
+      return false;
+    }
+
+    let defaultName = getColumnDefaultName(column, get(this, 'bardMetadata'));
+    return column.displayName !== defaultName;
+  },
+
+  /**
    * @property {Object} groupedData - data grouped by grouping column specified in selectedSubtotal
    */
   groupedData: computed('selectedSubtotal', 'rawData', function () {
@@ -214,7 +231,7 @@ export default Component.extend({
       let { field, type } = column,
           fieldName = type === 'dateTime' ? type : canonicalizeMetric(field),
           sort = arr(sorts).findBy('metric', fieldName) || {},
-          hasCustomDisplayName = column.displayName !== getColumnDefaultName(column, get(this, 'bardMetadata')),
+          hasCustomDisplayName = this._hasCustomDisplayName(column),
           sortDirection;
 
       if (column.type === 'dateTime') {

--- a/packages/visualizations/addon/templates/components/navi-visualizations/table.hbs
+++ b/packages/visualizations/addon/templates/components/navi-visualizations/table.hbs
@@ -1,7 +1,14 @@
 {{!-- Copyright 2018, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
-<div class='table-widget__row-info'>
-  <span class='table-widget__row-info--number'>{{format-number rowsInResponse fallback='0'}}</span> out of
-  <span class='table-widget__row-info--number'>{{format-number totalRows fallback='0'}}</span> rows
+<div class="table-widget__info-header">
+  <div class='table-widget__row-info'>
+    <span class='table-widget__row-info-number'>{{format-number rowsInResponse fallback='0'}}</span> out of
+    <span class='table-widget__row-info-number'>{{format-number totalRows fallback='0'}}</span> rows
+  </div>
+  {{#if (and (feature-flag 'enableTableEditing') isEditing)}}
+    <div class='table-widget__edit-col-msg'>
+      {{navi-icon 'pencil'}} <span>Enter custom column names</span>
+    </div>
+  {{/if}}
 </div>
 <div class="table-widget__horizontal-scroll-container">
   <div class= 'table-widget-container'>

--- a/packages/visualizations/addon/templates/components/navi-visualizations/table.hbs
+++ b/packages/visualizations/addon/templates/components/navi-visualizations/table.hbs
@@ -6,7 +6,7 @@
 <div class="table-widget__horizontal-scroll-container">
   <div class= 'table-widget-container'>
       {{#if (and (feature-flag 'enableTableEditing') isEditing)}}
-        <div class='table-header-row'>
+        <div class='table-header-row table-header-row--edit'>
           {{#each columns as |column|}}
             <div class='table-header-cell {{column.type}}'>
               {{input
@@ -25,13 +25,17 @@
         {{#sortable-group class='table-header-row' direction='x' onChange='updateColumnOrder' as | group |}}
           {{#each columns as |column|}}
             {{#sortable-item
-              class=(concat 'table-header-cell ' column.type) 
-              classNameBindings='column.hasCustomDisplayName:custom-name'
+              class=(concat 'table-header-cell ' column.type)
               model=(readonly column)
               group=group
               click=(action 'headerClicked' column)
             }}
-                <span class='table-header-cell__title' title='Drag column header to reorder'>{{or column.displayName (default-column-name column)}}</span>
+                <span 
+                  class='table-header-cell__title {{if column.hasCustomDisplayName 'table-header-cell__title--custom-name'}}' 
+                  title='Drag column header to reorder'
+                >
+                    {{or column.displayName (default-column-name column)}}
+                </span>
                 {{#if column.sortDirection}}
                   {{navi-table-sort-icon
                     class='table-header-cell__icon'

--- a/packages/visualizations/app/styles/navi-visualizations/visualizations/table.less
+++ b/packages/visualizations/app/styles/navi-visualizations/visualizations/table.less
@@ -18,17 +18,19 @@
   overflow-y: auto;
   overflow-x: hidden;
 
-  &__row-info {
+  &__info-header {
+    align-items: center;
     display: flex;
     font-size: @font-size-mid;
-    justify-content: flex-end;
-    padding: 3px 0;
-    margin-right: 12px;
+    flex-flow: row-reverse;
+    justify-content: space-between;
+    margin: @row-margin;
+    padding: 6px 0 0;
+  }
 
-    &--number {
-      font-weight: bold;
-      padding: 0 5px;
-    }
+  &__row-info-number {
+    font-weight: bold;
+    padding: 0 5px;
   }
 
   .table-widget-container {
@@ -57,6 +59,15 @@
     /** Update word-break to break-all, this will cause very long name
         to be broken when used as titled to column. **/
     word-break: break-all;
+
+    &--edit {
+      & > div:first-of-type {
+        padding-left: 0;
+      }
+      & > div:last-of-type {
+        padding-right: 0;
+      }
+    }
   }
 
   .table-header-cell {

--- a/packages/visualizations/app/styles/navi-visualizations/visualizations/table.less
+++ b/packages/visualizations/app/styles/navi-visualizations/visualizations/table.less
@@ -94,7 +94,6 @@
       &--custom-name {
         text-decoration: underline;
         text-decoration-style: dotted;
-        text-decoration-color: #aaaaaa;
       }
     }
 

--- a/packages/visualizations/app/styles/navi-visualizations/visualizations/table.less
+++ b/packages/visualizations/app/styles/navi-visualizations/visualizations/table.less
@@ -74,18 +74,17 @@
       cursor: grabbing;
     }
 
-    &.custom-name {
-      text-decoration: underline;
-      text-decoration-style: dotted;
-      text-decoration-color: #aaaaaa;
-    }
-
     &__icon {
       padding: 3px 5px;
     }
 
     &__title {
       flex: 1;
+      &--custom-name {
+        text-decoration: underline;
+        text-decoration-style: dotted;
+        text-decoration-color: #aaaaaa;
+      }
     }
 
     &__input {

--- a/packages/visualizations/tests/acceptance/table-test.js
+++ b/packages/visualizations/tests/acceptance/table-test.js
@@ -81,3 +81,24 @@ test('edit table field', function(assert) {
       'DateTime field should have custom name class after editing');
   });
 });
+
+test('edit table field - empty title', function(assert) {
+  assert.expect(2);
+
+  visit('/table');
+
+  click('.table-config__total-toggle-button .x-toggle-btn');
+  fillIn('.dateTime > .table-header-cell__input', null);
+  click('.table-config__total-toggle-button .x-toggle-btn');
+
+  andThen(function() {
+    assert.equal(find('.dateTime > .table-header-cell__title').text().trim(),
+      'Date',
+      'DateTime field should have the default name "Date"');
+  });
+
+  andThen(function() {
+    assert.notOk(find('.dateTime').hasClass('custom-name'),
+      'DateTime field should not have custom name class after removing title');
+  });
+});

--- a/packages/visualizations/tests/acceptance/table-test.js
+++ b/packages/visualizations/tests/acceptance/table-test.js
@@ -68,7 +68,7 @@ test('toggle table editing', function(assert) {
 });
 
 test('edit table field', function(assert) {
-  assert.expect(1);
+  assert.expect(2);
 
   visit('/table');
 
@@ -77,7 +77,13 @@ test('edit table field', function(assert) {
   click('.table-config__total-toggle-button .x-toggle-btn');
 
   andThen(function() {
-    assert.ok(find('.dateTime').hasClass('custom-name'),
+    assert.equal(find('.dateTime > .table-header-cell__title').text().trim(),
+      'test',
+      'DateTime field should have custom name "test"');
+  });
+
+  andThen(function() {
+    assert.ok(find('.dateTime > .table-header-cell__title').hasClass('table-header-cell__title--custom-name'),
       'DateTime field should have custom name class after editing');
   });
 });


### PR DESCRIPTION

- Fix: Don't mark blank column titles as edited
- Fix: Only style column title when edited
- Update: Add table column title edit message 
  - Added table column title edit message
  - Refactored table header styles and selectors

<img width="835" alt="capture" src="https://user-images.githubusercontent.com/2983409/41637491-c847e5d8-7419-11e8-8fc2-c2694105015d.PNG">
