### PR TITLE
Update: Add margin to bottom of dashboard

### DIFF
--- a/packages/dashboards/app/styles/navi-dashboards/components/navi-dashboard.less
+++ b/packages/dashboards/app/styles/navi-dashboards/components/navi-dashboard.less
@@ -20,6 +20,10 @@
     margin: 3px 10px;
   }
 
+  &__widgets {
+    margin-bottom: 20px;
+  }
+
   .page-header {
     align-items: center;
     .display-flex;

--- a/packages/dashboards/package.json
+++ b/packages/dashboards/package.json
@@ -34,7 +34,7 @@
     "ember-cli-bootstrap-datepicker": "^0.5.3",
     "ember-cli-clipboard": "^0.8.1",
     "ember-cli-code-coverage": "^0.4.1",
-    "ember-cli-dependency-checker": "^2.0.0",
+    "ember-cli-dependency-checker": "^2.1.1",
     "ember-cli-eslint": "^4.0.0",
     "ember-cli-format-number": "^2.0.0",
     "ember-cli-htmlbars-inline-precompile": "^1.0.0",


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/23023478/41730353-4216e2b0-7541-11e8-8cc7-82a34ab3b028.png)

After: 
![image](https://user-images.githubusercontent.com/23023478/41730374-4ad3b982-7541-11e8-82b7-6ea062b3245e.png)

Adds some space between the bottom widget and the bottom of the dashboard body. 
Also updated ember-cli-dependency-checker because the app would not run locally for me otherwise.
