### PR TITLE
Fix: Parameterized metrics get renamed the same

### DIFF
--- a/packages/visualizations/addon/models/table.js
+++ b/packages/visualizations/addon/models/table.js
@@ -79,7 +79,7 @@ export default VisualizationBase.extend(Validations, {
           isTrend = ~(category.toLowerCase().indexOf('trend')),
           type = isTrend ? 'threshold' : 'metric',
           field = metric.toJSON(),
-          column = columnIndex[field.metric],
+          column = columnIndex[canonicalizeMetric(field)],
           longName = get(metric, 'metric.longName'),
           displayName = column ? column.displayName : metricFormat(metric, longName),
           format = column ? column.format : '';
@@ -130,6 +130,6 @@ export function indexColumnById(columns) {
       type = 'metric';
     }
 
-    return field[type];
+    return type === 'metric' ? canonicalizeMetric(field) : field[type];
   });
 }

--- a/packages/visualizations/tests/unit/models/table-test.js
+++ b/packages/visualizations/tests/unit/models/table-test.js
@@ -131,13 +131,19 @@ test('rebuildConfig', function(assert) {
 });
 
 test('rebuildConfig with parameterized metrics', function(assert) {
-  assert.expect(1);
+  assert.expect(2);
   let table    = run(() => this.subject().get('table')),
       request4 = buildTestRequest([], [
         {
           metric: 'm1',
           parameters: {
             param1: 'paramVal1'
+          }
+        },
+        {
+          metric: 'm1',
+          parameters: {
+            param1: 'paramVal2'
           }
         },
         { metric: 'm2' }
@@ -151,10 +157,25 @@ test('rebuildConfig with parameterized metrics', function(assert) {
       'columns': [
         { 'displayName': 'Date', 'field': { dateTime: 'dateTime' }, 'type': 'dateTime' },
         { 'displayName': 'M1 (paramVal1)', 'field': { metric: 'm1', parameters: { param1: 'paramVal1' } }, 'type': 'metric', format: '' },
+        { 'displayName': 'M1 (paramVal2)', 'field': { metric: 'm1', parameters: { param1: 'paramVal2' } }, 'type': 'metric', format: '' },
         { 'displayName': 'M2', 'field': { metric: 'm2', parameters: {} }, 'type': 'metric', format: '' }
       ]
     }
   },'Columns with parameterized metrics are formatted correctly');
+
+  let config5 = run(() => table.rebuildConfig(request4).toJSON());
+  assert.deepEqual(config5, {
+    'type': 'table',
+    'version': 1,
+    'metadata': {
+      'columns': [
+        { 'displayName': 'Date', 'field': { dateTime: 'dateTime' }, 'type': 'dateTime' },
+        { 'displayName': 'M1 (paramVal1)', 'field': { metric: 'm1', parameters: { param1: 'paramVal1' } }, 'type': 'metric', format: '' },
+        { 'displayName': 'M1 (paramVal2)', 'field': { metric: 'm1', parameters: { param1: 'paramVal2' } }, 'type': 'metric', format: '' },
+        { 'displayName': 'M2', 'field': { metric: 'm2', parameters: {} }, 'type': 'metric', format: '' }
+      ]
+    }
+  },'Rebuilding again provides consistent results');
 });
 
 test('index column by id', function(assert) {


### PR DESCRIPTION
to reproduce:
1) Choose a few paramterized metric off the same base metric, run report
2) See column names are all different as expected.
3) add another metric or dimension, run report
4) See the parameterized metric all have the same display name.
