### PR TITLE
Fix: Metric format on serialized metric mode

### DIFF
--- a/packages/core/addon/mirage/fixtures/reports.js
+++ b/packages/core/addon/mirage/fixtures/reports.js
@@ -362,7 +362,7 @@ export default [
             displayName: 'Revenue (USD)'
           },
           {
-            field: 'revenue(currency-EUR)',
+            field: 'revenue(currency=EUR)',
             type: 'metric',
             displayName: 'Revenue (EUR)'
           }

--- a/packages/data/tests/unit/helpers/metric-format-test.js
+++ b/packages/data/tests/unit/helpers/metric-format-test.js
@@ -4,26 +4,26 @@ import { metricFormat } from 'navi-data/helpers/metric-format';
 
 module('Unit | Helper | metric formatter', function(hooks) {
   setupTest(hooks);
+});
 
-  test('It formats metrics appropriately', function(assert) {
-    assert.expect(6);
-    assert.equal(metricFormat({metric: 'revenue'}, 'Revenue'),
-      'Revenue',
-      'Formats metrics given longname');
-    assert.equal(metricFormat(null, 'bar'),
-      'bar',
-      'Returns long name in case metric is not available');
-    assert.equal(metricFormat({metric: 'foo'}),
-      '--',
-      'Renders -- if longname is not given');
-    assert.equal(metricFormat({metric: {name: 'foo', longName: 'Foo'}, parameters: {p: 1}}, 'Bar'),
-      'Bar (1)',
-      'Formats metric with parameters');
-    assert.equal(metricFormat({metric: {name: 'foo', longName: 'Foo'}, parameters: {p: 1, m: 3, as: 'ham'}}, 'Bar'),
-      'Bar (1,3)',
-      'Formats multiple params and ignores the `as` parameter');
-    assert.equal(metricFormat({metric: {name: 'foo', longName: 'Foo'}, parameters: {p: 1, m: 3, as: 'ham'}}),
-      '-- (1,3)',
-      'Formats multiple params and ignores the `as` parameter when default longname is allowed');
-  });
+test('It formats metrics appropriately', function(assert) {
+  assert.expect(6);
+  assert.equal(metricFormat({metric: 'revenue'}, 'Revenue'),
+    'Revenue',
+    'Formats metrics given longname');
+  assert.equal(metricFormat(null, 'bar'),
+    'bar',
+    'Returns long name in case metric is not available');
+  assert.equal(metricFormat({metric: 'foo'}),
+    '--',
+    'Renders -- if longname is not given');
+  assert.equal(metricFormat({metric: {name: 'foo', longName: 'Foo'}, parameters: {p: 1}}, 'Bar'),
+    'Bar (1)',
+    'Formats metric with parameters');
+  assert.equal(metricFormat({metric: {name: 'foo', longName: 'Foo'}, parameters: {p: 1, m: 3, as: 'ham'}}, 'Bar'),
+    'Bar (1,3)',
+    'Formats multiple params and ignores the `as` parameter');
+  assert.equal(metricFormat({metric: {name: 'foo', longName: 'Foo'}, parameters: {p: 1, m: 3, as: 'ham'}}),
+    '-- (1,3)',
+    'Formats multiple params and ignores the `as` parameter when default longname is allowed');
 });

--- a/packages/reports/tests/acceptance/navi-report-test.js
+++ b/packages/reports/tests/acceptance/navi-report-test.js
@@ -1711,7 +1711,7 @@ test("adding metrics to reordered table keeps order", function(assert) {
   });
 });
 
-test('Paramaterized metrics with default displayname are not considered custom', function(assert) {
+test('Parameterized metrics with default displayname are not considered custom', function(assert) {
   assert.expect(2);
   visit('/reports/8');
 

--- a/packages/reports/tests/acceptance/navi-report-test.js
+++ b/packages/reports/tests/acceptance/navi-report-test.js
@@ -1710,3 +1710,15 @@ test("adding metrics to reordered table keeps order", function(assert) {
     ], 'The headers are reordered as specified by the reorder');
   });
 });
+
+test('Paramaterized metrics with default displayname are not considered custom', function(assert) {
+  assert.expect(2);
+  visit('/reports/8');
+
+  andThen(() => {
+    assert.ok(find('.table-header-cell.metric > .table-header-cell__title').length,
+      'renders metric columns');
+    assert.notOk(find('.table-header-cell.metric > .table-header-cell__title').is('.table-header-cell__title--custom-name'),
+      'Parameterized metrics with default display name should not be considered custom');
+  });
+});

--- a/packages/reports/tests/unit/serializers/report-test.js
+++ b/packages/reports/tests/unit/serializers/report-test.js
@@ -227,7 +227,7 @@ test('Serializing multi param request', function(assert) {
                 displayName: 'Revenue (USD)'
               },
               {
-                field: 'revenue(currency-EUR)',
+                field: 'revenue(currency=EUR)',
                 type: 'metric',
                 displayName: 'Revenue (EUR)'
               }

--- a/packages/visualizations/addon/helpers/default-column-name.js
+++ b/packages/visualizations/addon/helpers/default-column-name.js
@@ -28,7 +28,7 @@ export function getColumnDefaultName({ type, field }, bardMetadata) {
   let model = bardMetadata.getById(type, field[type]);
 
   if (type === 'metric') {
-    return metricFormat(model, model.longName);
+    return metricFormat(field, model.longName);
   }
 
   return model.longName;

--- a/packages/visualizations/tests/integration/helpers/default-column-name-test.js
+++ b/packages/visualizations/tests/integration/helpers/default-column-name-test.js
@@ -47,3 +47,14 @@ test('metric column', function (assert) {
     'Total Page Views',
     'The default column name for totalPageViews metric is Total Page Views');
 });
+
+test('metric column with parameters', function (assert) {
+  const column = { type: 'metric', field: { metric: 'revenue', parameters: {currency: 'USD'} } };
+  this.set('column', column);
+
+  this.render(hbs`{{default-column-name column}}`);
+
+  assert.equal(this.$().text().trim(),
+    'Revenue (USD)',
+    'The default column name for revenue metric with currency param of USD is Revenue (USD)');
+});


### PR DESCRIPTION
The default name of metric column is not displayed correctly for metric with parameters