### PR TITLE
Fix: Add missing bowerrc

### DIFF
--- a/packages/directory/.bowerrc
+++ b/packages/directory/.bowerrc
@@ -1,0 +1,4 @@
+{
+  "directory": "bower_components",
+  "analytics": false
+}


### PR DESCRIPTION
```
> navi-directory@0.1.0-alpha.497411ed postinstall /Users/balajim1/Git/Teller/node_modules/navi-directory
> bower install
bower                           ENOENT No bower.json present
```
