### PR TITLE
Update: Dimension filter uses primaryKey tag

### DIFF
--- a/packages/data/addon/mirage/fixtures/bard-meta-dimensions.js
+++ b/packages/data/addon/mirage/fixtures/bard-meta-dimensions.js
@@ -171,6 +171,18 @@ export default {
       cardinality: 0,
       category: 'test',
       storageStrategy: 'none'
+    },
+    {
+      name: 'multiSystemId',
+      longName: 'Multi System Id',
+      cardinality: 9999999,
+      category: 'test',
+      storageStrategy: 'loaded',
+      fields: [
+        {name: 'id', tags: []},
+        {name: 'desc', tags: ['description']},
+        {name: 'key', tags: ['primaryKey']}
+      ]
     }
   ],
 

--- a/packages/data/addon/mirage/routes/bard-lite.js
+++ b/packages/data/addon/mirage/routes/bard-lite.js
@@ -72,10 +72,15 @@ function _fakeDimensionValues(name, count) {
   let fakeValues = [];
 
   for (let i = 0; i < count; i++) {
-    fakeValues.push({
+    let key = null;
+    // used to generate alternative primary keys for dimensions that don't use `id` as their primaryKey (in this case uses `key` instead)
+    if(name === 'multiSystemId') {
+      key = `k${i + 1}`;
+    }
+    fakeValues.push(Object.assign({
       id: `${i + 1}`,
-      description: faker.commerce.productName()
-    });
+      description: faker.commerce.productName(),
+    }, key ? {key} : null));
   }
 
   return fakeValues;
@@ -183,10 +188,10 @@ export default function(
     if ('filters' in request.queryParams) {
       let [/* full match */, queryString] = request.queryParams.filters.match(/\[(.*)\]/),
           values = queryString.split(','),
-          isIdSearch = /\|id/.test(request.queryParams.filters);
+          fieldMatch = request.queryParams.filters.match(/\|(id|key)/);
 
-      rows = isIdSearch ? 
-        rows.filter(row => values.includes(row.id)) :
+      rows = fieldMatch && fieldMatch.length > 0 ? 
+        rows.filter(row => values.includes(row[fieldMatch[1]])) :
         rows.filter(row => values.some(value => row.description.toLowerCase().includes(value.toLowerCase())));
     }
 

--- a/packages/reports/addon/components/filter-values/dimension-select.js
+++ b/packages/reports/addon/components/filter-values/dimension-select.js
@@ -32,6 +32,11 @@ export default Ember.Component.extend({
   dimensionName: computed.readOnly('filter.subject.name'),
 
   /**
+   * @property {String} primaryKey - primary key for this dimension
+   */
+  primaryKey: computed.readOnly('filter.subject.primaryKeyFieldName'),
+
+  /**
    * @property {BardDimensionArray} dimensionOptions - list of all dimension values
    */
   dimensionOptions: computed('filter.subject', function() {
@@ -47,11 +52,12 @@ export default Ember.Component.extend({
   selectedDimensions: computed('filter.values', function() {
     let dimensionIds = get(this, 'filter.values'),
         dimensionName = get(this, 'dimensionName'),
+        primaryKey = get(this, 'primaryKey'),
         dimensionService = get(this, '_dimensionService');
 
     // Only fetch dimensions if filter has values
     if (get(dimensionIds, 'length')) {
-      return dimensionService.find(dimensionName, {field: 'id', values: dimensionIds.join(',')});
+      return dimensionService.find(dimensionName, {field: primaryKey, values: dimensionIds.join(',')});
     } else {
       return Ember.RSVP.resolve(Ember.A());
     }
@@ -79,8 +85,9 @@ export default Ember.Component.extend({
      * @param {Array} values
      */
     setValues(values) {
+      let primaryKey = get(this, 'primaryKey');
       this.attrs.onUpdateFilter({
-        rawValues: Ember.A(values).mapBy('id')
+        rawValues: Ember.A(values).mapBy(primaryKey)
       });
     },
 

--- a/packages/reports/addon/consumers/request/filter.js
+++ b/packages/reports/addon/consumers/request/filter.js
@@ -10,13 +10,7 @@ import { canonicalizeMetric } from 'navi-data/utils/metric';
 import { getSelectedMetricsOfBase, getUnfilteredMetricsOfBase } from 'navi-reports/utils/request-metric';
 import { isEmpty } from '@ember/utils';
 
-const { assign, inject, get, set, setProperties } = Ember;
-
-const DEFAULT_DIM_FILTER = {
-  operator: 'in',
-  field: 'id',
-  values: []
-};
+const { assign, inject, get, set, setProperties, assert } = Ember;
 
 const DEFAULT_METRIC_FILTER = {
   operator: 'gt',
@@ -74,8 +68,9 @@ export default ActionConsumer.extend({
      * @param {Object} dimension - dimension to filter
      */
     [RequestActions.ADD_DIM_FILTER]: ({ currentModel }, dimension) => {
+      assert("Dimension model has correct primaryKeyFieldName", typeof get(dimension, 'primaryKeyFieldName') === 'string');
       get(currentModel, 'request').addFilter(
-        assign({ dimension }, DEFAULT_DIM_FILTER)
+        { dimension, operator: 'in', field: get(dimension, 'primaryKeyFieldName'), values: [] }
       );
     },
 

--- a/packages/reports/tests/integration/components/dimension-selector-test.js
+++ b/packages/reports/tests/integration/components/dimension-selector-test.js
@@ -83,7 +83,7 @@ test('groups', function(assert) {
 
   assert.deepEqual(groups, [
     'Time Grain (5)',
-    'test (23)',
+    'test (24)',
     'Asset (4)'
   ], 'The groups rendered by the component include dimension groups and Time Grain');
 });

--- a/packages/reports/tests/integration/components/filter-values/dimension-select-test.js
+++ b/packages/reports/tests/integration/components/filter-values/dimension-select-test.js
@@ -10,7 +10,8 @@ import config from 'ember-get-config';
 const MockFilter = {
   subject: {
     name: 'age',
-    storageStrategy: 'loaded'
+    storageStrategy: 'loaded',
+    primaryKeyFieldName: 'id'
   },
   values: ['1', '2', '3'],
   validations: {}
@@ -120,4 +121,31 @@ test('error state', function(assert) {
   this.set('filter.validations', { attrs: { rawValues: { isInvalid: true } } });
   assert.ok(this.$('.filter-values--dimension-select--error').is(':visible'),
     'The input should have error state');
+});
+
+test('alternative primary key', function(assert) {
+  assert.expect(1);
+  this.filter = {
+    subject: {
+      name: 'multiSystemId',
+      storageStrategy: 'loaded',
+      primaryKeyFieldName: 'key'
+    },
+    values: ['k1', 'k3'],
+    validations: {}
+  };
+
+  this.render(hbs`{{filter-values/dimension-select filter=filter}}`);
+
+  return wait().then(() => {
+
+    let selectedValueText = this.$('.ember-power-select-multiple-option span:nth-of-type(2)').toArray().map(el => {
+      let text = $(el).text().trim();
+      return text.substr(text.lastIndexOf('('));
+    });
+
+    assert.deepEqual(selectedValueText, 
+      ['(1)', '(3)'],
+      'Select values by key instead of id');
+  });
 });

--- a/packages/reports/tests/unit/consumers/request/filter-test.js
+++ b/packages/reports/tests/unit/consumers/request/filter-test.js
@@ -116,7 +116,7 @@ test('ADD_DIM_FILTER', function(assert) {
 
   let addFilter = (filterObj) => {
         assert.deepEqual(filterObj,{
-          dimension: 'mockDim',
+          dimension:  {dimension: 'mockDim', primaryKeyFieldName: 'id'},
           field: 'id',
           operator: 'in',
           values: []
@@ -124,7 +124,23 @@ test('ADD_DIM_FILTER', function(assert) {
       },
       currentModel = { request: { filters: Ember.A(), addFilter } };
 
-  this.subject().send(RequestActions.ADD_DIM_FILTER, { currentModel }, 'mockDim');
+  this.subject().send(RequestActions.ADD_DIM_FILTER, { currentModel }, {dimension: 'mockDim', primaryKeyFieldName: 'id'});
+});
+
+test('ADD_DIM_FILTER - alternative primary key', function(assert) {
+  assert.expect(1);
+
+  let addFilter = (filterObj) => {
+        assert.deepEqual(filterObj,{
+          dimension: {dimension: 'mockDim', primaryKeyFieldName: 'key'},
+          field: 'key',
+          operator: 'in',
+          values: []
+        }, 'the filterObj passed to the request has the right field');
+      },
+      currentModel = { request: { filters: Ember.A(), addFilter } };
+
+  this.subject().send(RequestActions.ADD_DIM_FILTER, { currentModel }, {dimension: 'mockDim', primaryKeyFieldName: 'key'});
 });
 
 test('TOGGLE_METRIC_FILTER', function(assert) {

--- a/packages/visualizations/addon/components/cell-renderers/dimension.js
+++ b/packages/visualizations/addon/components/cell-renderers/dimension.js
@@ -10,14 +10,65 @@
  * }}
  */
 
-import Ember from 'ember';
+import Component from '@ember/component';
+import { computed, get } from '@ember/object'
 import layout from '../../templates/components/cell-renderers/dimension';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
 
   /**
    * @property {Array} classNames - list of component class names
    */
-  classNames: ['table-cell-content', 'dimension']
+  classNames: ['table-cell-content', 'dimension'],
+
+  /**
+   * @property {String} descField - field to find the description
+   */
+  descField: computed('column.field.dimension', function() {
+    return get(this, 'column.field.dimension') + '|desc';
+  }),
+
+  /**
+   * @property {String} idField - field to find id
+   */
+  idField: computed('column.field.dimension', function() {
+    return get(this, 'column.field.dimension') + '|id';
+  }),
+
+  /**
+   * @property {String} title - value that should be used in hoverover title
+   */
+  title: computed('descField', 'idField', 'data', function() {
+    let descField = get(this, 'descField'),
+        idField = get(this, 'idField'),
+        data = get(this, 'data');
+
+    if(data[idField] && data[descField]) {
+      return `${data[descField]} (${data[idField]})`
+    } else if(data[idField]) {
+      return data[idField];
+    } else if(data[descField]) {
+      return data[descField];
+    }
+
+    return '';
+  }),
+
+  /**
+   * @property {String} value - value that should be displayed in table cell
+   */
+  value: computed('descField', 'idField', 'data', function() {
+    let descField = get(this, 'descField'),
+        idField = get(this, 'idField'),
+        data = get(this, 'data');
+
+    if(data[descField]) {
+      return data[descField];
+    } else if(data[idField]) {
+      return data[idField];
+    }
+    
+    return '--';
+  })
 });

--- a/packages/visualizations/addon/templates/components/cell-renderers/dimension.hbs
+++ b/packages/visualizations/addon/templates/components/cell-renderers/dimension.hbs
@@ -1,10 +1,2 @@
 {{!-- Copyright 2017, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
-{{#with (get data (concat column.field.dimension '|desc' )) as |description|}}
-    <span title={{description}}>{{description}}</span>
-{{else}}
-    {{#with (get data (concat column.field.dimension '|id' )) as |id|}}
-        <span title={{id}}>{{id}}</span>
-    {{else}}
-        --
-    {{/with}}
-{{/with}}
+<span title={{title}}>{{value}}</span>

--- a/packages/visualizations/tests/integration/components/cell-renderers/dimension-test.js
+++ b/packages/visualizations/tests/integration/components/cell-renderers/dimension-test.js
@@ -44,7 +44,7 @@ moduleForComponent('cell-renderers/dimension', 'Integration | Component | cell r
 });
 
 test('dimension renders description value correctly', function(assert) {
-  assert.expect(2);
+  assert.expect(3);
   this.render(TEMPLATE);
 
   assert.ok($('.table-cell-content').is(':visible'),
@@ -53,10 +53,14 @@ test('dimension renders description value correctly', function(assert) {
   assert.equal($('.table-cell-content').text().trim(),
     'BlackBerry OS',
     'The dimension cell renders correctly when present description field is present');
+
+  assert.equal($('.table-cell-content span').attr('title'),
+    'BlackBerry OS (BlackBerry)',
+    'The dimension cell title renders correctly when present description and id field is present');
 });
 
 test('dimension renders id value when description is empty', function(assert) {
-  assert.expect(1);
+  assert.expect(2);
   let data2 = {
     'dateTime': '2016-05-30 00:00:00.000',
     'os|id': 'BlackBerry',
@@ -71,10 +75,35 @@ test('dimension renders id value when description is empty', function(assert) {
   assert.equal($('.table-cell-content').text().trim(),
     'BlackBerry',
     'The dimension cell renders id correctly when description empty');
+
+  assert.equal($('.table-cell-content span').attr('title'),
+    'BlackBerry',
+    'The dimension cell renders id correctly in title when description empty');
+});
+
+test('dimension renders desc value when id is empty', function(assert) {
+  assert.expect(2);
+  let data2 = {
+    'dateTime': '2016-05-30 00:00:00.000',
+    'os|desc': 'BlackBerry OS',
+    'uniqueIdentifier': 172933788,
+    'totalPageViews': 3669828357
+  };
+
+  this.set('data', data2);
+  this.render(TEMPLATE);
+
+  assert.equal($('.table-cell-content').text().trim(),
+    'BlackBerry OS',
+    'The dimension cell renders desc correctly when id empty');
+
+  assert.equal($('.table-cell-content span').attr('title'),
+    'BlackBerry OS',
+    'The dimension cell renders desc correctly in title when id empty');
 });
 
 test('dimension renders no value with dashes correctly', function(assert) {
-  assert.expect(1);
+  assert.expect(2);
 
   this.set('data', {});
 
@@ -89,4 +118,8 @@ test('dimension renders no value with dashes correctly', function(assert) {
   assert.equal($('.table-cell-content').text().trim(),
     '--',
     'The dimension cell renders correctly when present description field is not present');
+
+  assert.equal($('.table-cell-content span').attr('title'),
+    '',
+    'The dimension cell renders title correctly when present description field is not present');
 });


### PR DESCRIPTION
Dimensions don't always use `id` as their primary key.  We have tags set up to specify which dimension field is the primary key, and therefore we can build the correct dimension filter that gives the intended results.