### PR TITLE
Update: Ember-tooltips version to support Ember 3.x

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -75,7 +75,7 @@
     "ember-source": "~2.16.0",
     "ember-tether": "^0.4.1",
     "ember-toggle": "^5.2.1",
-    "ember-tooltips": "^2.9.2",
+    "ember-tooltips": "^2.10.0",
     "ember-truth-helpers": "^2.0.0",
     "ember-uuid": "1.0.0",
     "liquid-fire": "^0.29.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -65,7 +65,7 @@
     "ember-source": "~2.16.0",
     "ember-tether": "^0.4.1",
     "ember-toggle": "^5.2.1",
-    "ember-tooltips": "^2.9.2",
+    "ember-tooltips": "^2.10.0",
     "ember-truth-helpers": "^2.0.0",
     "ember-uuid": "^1.0.0",
     "loader.js": "^4.2.3",

--- a/packages/dashboards/package.json
+++ b/packages/dashboards/package.json
@@ -71,7 +71,7 @@
     "ember-tag-input": "^1.2.1",
     "ember-tether": "^0.4.1",
     "ember-toggle": "5.2.1",
-    "ember-tooltips": "^2.9.2",
+    "ember-tooltips": "^2.10.0",
     "ember-truth-helpers": "^2.0.0",
     "ember-uuid": "^1.0.0",
     "liquid-fire": "^0.29.2",

--- a/packages/directory/package.json
+++ b/packages/directory/package.json
@@ -73,7 +73,7 @@
     "ember-source-channel-url": "^1.1.0",
     "ember-tether": "^0.4.1",
     "ember-toggle": "^5.2.1",
-    "ember-tooltips": "^2.9.2",
+    "ember-tooltips": "^2.10.0",
     "ember-truth-helpers": "^2.0.0",
     "ember-try": "^0.2.23",
     "ember-uuid": "^1.0.1",

--- a/packages/reports/package.json
+++ b/packages/reports/package.json
@@ -78,7 +78,7 @@
     "ember-tag-input": "1.2.1",
     "ember-tether": "^0.4.1",
     "ember-toggle": "5.2.1",
-    "ember-tooltips": "^2.9.2",
+    "ember-tooltips": "^2.10.0",
     "ember-truth-helpers": "^2.0.0",
     "ember-uuid": "^1.0.0",
     "ember-validators": "^1.1.1",


### PR DESCRIPTION
The fix for Ember 3.0 that I submitted to ember-tooltips got merged and they came out with a release today.