### PR TITLE
Tooltip data binding fix

### DIFF
--- a/packages/core/addon/chart-builders/date-time.js
+++ b/packages/core/addon/chart-builders/date-time.js
@@ -242,7 +242,7 @@ export default Ember.Object.extend({
    * @returns {Object} object with tooltip template and rendering context
    */
   buildTooltip() {
-    let byXSeries = get(this, 'byXSeries');
+    let builder = this;
 
     return Ember.Mixin.create({
       layout: tooltipLayout,
@@ -253,7 +253,7 @@ export default Ember.Object.extend({
       rowData: Ember.computed('x', 'tooltipData', function() {
         return get(this, 'tooltipData').map(series => {
           // Get the full data for this combination of x + series
-          let dataForSeries = byXSeries.getDataForKey(get(this, 'x') + series.name) || [];
+          let dataForSeries = get(builder, 'byXSeries').getDataForKey(get(this, 'x') + series.name) || [];
 
           return dataForSeries[0];
         });

--- a/packages/core/addon/chart-builders/dimension.js
+++ b/packages/core/addon/chart-builders/dimension.js
@@ -137,7 +137,7 @@ export default Ember.Object.extend({
    * @returns {Object} layout for tooltip
    */
   buildTooltip() {
-    let byXSeries = get(this, 'byXSeries');
+    let builder = this;
 
     return Ember.Mixin.create({
       layout: tooltipLayout,
@@ -148,7 +148,7 @@ export default Ember.Object.extend({
       rowData: Ember.computed('x', 'tooltipData', function() {
         return get(this, 'tooltipData').map(series => {
           // Get the full data for this combination of x + series
-          let dataForSeries = byXSeries.getDataForKey(get(this, 'x') + series.id) || [];
+          let dataForSeries = get(builder, 'byXSeries').getDataForKey(get(this, 'x') + series.id) || [];
 
           return dataForSeries[0];
         });

--- a/packages/core/addon/chart-builders/metric.js
+++ b/packages/core/addon/chart-builders/metric.js
@@ -91,7 +91,7 @@ export default Ember.Object.extend({
    * @returns {Object} layout for tooltip
    */
   buildTooltip() {
-    let byXSeries = get(this, 'byXSeries');
+    let builder = this;
 
     return Ember.Mixin.create({
       layout: tooltipLayout,
@@ -102,7 +102,7 @@ export default Ember.Object.extend({
       rowData: Ember.computed('x', 'tooltipData', function() {
         return get(this, 'tooltipData').map(() => {
           // Get the full data for this combination of x + series
-          let dataForSeries = byXSeries.getDataForKey(get(this, 'x')) || [];
+          let dataForSeries = get(builder, 'byXSeries').getDataForKey(get(this, 'x')) || [];
           return dataForSeries[0];
         });
       })

--- a/packages/core/addon/components/navi-visualizations/line-chart.js
+++ b/packages/core/addon/components/navi-visualizations/line-chart.js
@@ -224,9 +224,10 @@ export default Ember.Component.extend({
           builder.buildTooltip(seriesConfig, request),
           { renderer: owner.lookup('renderer:-dom') }
         );
-    if(!owner.lookup(registryEntry)) {
-      owner.register(registryEntry, tooltipComponent);
+    if(owner.lookup(registryEntry)) {
+      owner.unregister(registryEntry);
     }
+    owner.register(registryEntry, tooltipComponent);
 
     /*
      * Ember 3.x requires components to be registered with the container before they are instantiated.

--- a/packages/core/addon/components/navi-visualizations/line-chart.js
+++ b/packages/core/addon/components/navi-visualizations/line-chart.js
@@ -16,6 +16,7 @@ import layout from '../../templates/components/navi-visualizations/line-chart';
 import numeral from 'numeral';
 import config from 'ember-get-config';
 import { inject as service } from '@ember/service';
+import { guidFor } from '@ember/object/internals';
 import merge from 'lodash/merge';
 
 const { computed, get, getOwner } = Ember;
@@ -212,11 +213,12 @@ export default Ember.Component.extend({
   /**
    * @property {Ember.Component} tooltipComponent - component used for rendering HTMLBars templates
    */
-  tooltipComponent: computed(function() {
+  tooltipComponent: computed('dataConfig', function() {
     let request = get(this, 'model.firstObject.request'),
         seriesConfig = get(this, 'seriesConfig.config'),
         seriesType = get(this, 'seriesConfig.type'),
-        registryEntry = `component:line-chart-${seriesType}-tooltip`,
+        elementId = guidFor(this),
+        registryEntry = `component:line-chart-${seriesType}-tooltip-${elementId}`,
         builder = get(this, 'builder'),
         owner = getOwner(this),
         tooltipComponent = Ember.Component.extend(
@@ -224,11 +226,10 @@ export default Ember.Component.extend({
           builder.buildTooltip(seriesConfig, request),
           { renderer: owner.lookup('renderer:-dom') }
         );
-    if(owner.lookup(registryEntry)) {
-      owner.unregister(registryEntry);
+    if(!owner.lookup(registryEntry)) {
+      owner.register(registryEntry, tooltipComponent);
     }
-    owner.register(registryEntry, tooltipComponent);
-
+    
     /*
      * Ember 3.x requires components to be registered with the container before they are instantiated.
      * Use the factory that has been registered instead of an anonymous component.

--- a/packages/core/addon/components/navi-visualizations/pie-chart.js
+++ b/packages/core/addon/components/navi-visualizations/pie-chart.js
@@ -122,7 +122,8 @@ export default Component.extend({
    * @property {Component} tooltipComponent - component used for rendering HTMLBars templates
    */
   tooltipComponent: computed(function() {
-    const registryEntry = 'component:pie-chart-tooltip';
+    const elementId = guidFor(this);
+    const registryEntry = `component:pie-chart-tooltip-${elementId}`;
     let owner = getOwner(this),
         byXSeries = get(this, 'builder.byXSeries'),
         tooltipComponent = Component.extend(
@@ -141,13 +142,10 @@ export default Component.extend({
           },
           { renderer: owner.lookup('renderer:-dom') }
         );
-    if(owner.lookup(registryEntry)) {
-      owner.unregister(registryEntry);
-
+    if(!owner.lookup(registryEntry)) {
+      owner.register(registryEntry, tooltipComponent);
     }
-    owner.register(registryEntry, tooltipComponent);
-
-
+    
     /*
      * Ember 3.x requires components to be registered with the container before they are instantiated.
      * Use the factory that has been registered instead of an anonymous component.

--- a/packages/core/addon/components/navi-visualizations/pie-chart.js
+++ b/packages/core/addon/components/navi-visualizations/pie-chart.js
@@ -141,9 +141,12 @@ export default Component.extend({
           },
           { renderer: owner.lookup('renderer:-dom') }
         );
-    if(!owner.lookup(registryEntry)) {
-      owner.register(registryEntry, tooltipComponent);
+    if(owner.lookup(registryEntry)) {
+      owner.unregister(registryEntry);
+
     }
+    owner.register(registryEntry, tooltipComponent);
+
 
     /*
      * Ember 3.x requires components to be registered with the container before they are instantiated.


### PR DESCRIPTION
Found issue with the data that was being closed over by the tooltip component could become out of date.  To fix this we bind the object instead.  Also, we use a unique registry entry for the component so tooltips have the right data bound when there are multiple charts.