### PR TITLE
Fix: Cleanup tooltip registry when chart is destroyed

### DIFF
--- a/packages/core/addon/components/navi-visualizations/line-chart.js
+++ b/packages/core/addon/components/navi-visualizations/line-chart.js
@@ -11,15 +11,17 @@
 
 /* global requirejs */
 
-import Ember from 'ember';
+import Component from '@ember/component';
+import { camelize } from '@ember/string';
+import { computed, get } from '@ember/object';
+import config from 'ember-get-config';
+import { getOwner } from '@ember/application';
+import { guidFor } from '@ember/object/internals';
+import { inject as service } from '@ember/service';
 import layout from '../../templates/components/navi-visualizations/line-chart';
 import numeral from 'numeral';
-import config from 'ember-get-config';
-import { inject as service } from '@ember/service';
-import { guidFor } from '@ember/object/internals';
 import merge from 'lodash/merge';
-
-const { computed, get, getOwner } = Ember;
+import { run } from '@ember/runloop';
 
 const DEFAULT_OPTIONS = {
   axis: {
@@ -58,7 +60,7 @@ const DEFAULT_OPTIONS = {
   }
 };
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
 
   /**
@@ -91,7 +93,7 @@ export default Ember.Component.extend({
         chartBuilderEntries = Object.keys(requirejs.entries).filter((key) => builderRegExp.test(key)),
         owner = getOwner(this),
         builderMap = chartBuilderEntries.reduce((map, builderName) => {
-          let builderKey = Ember.String.camelize(builderRegExp.exec(builderName)[1]);
+          let builderKey = camelize(builderRegExp.exec(builderName)[1]);
 
           map[builderKey] = owner.lookup(`chart-builder:${builderKey}`);
           return map;
@@ -211,17 +213,26 @@ export default Ember.Component.extend({
   }),
 
   /**
+   * @property {String} tooltipComponentName - name of the tooltip component
+   */
+  tooltipComponentName: computed(function() {
+    const guid       = guidFor(this);
+    const seriesType = get(this, 'seriesConfig.type');
+    const chartType  = get(this, 'chartType');
+    return `${chartType}-chart-${seriesType}-tooltip-${guid}`;
+  }),
+
+  /**
    * @property {Ember.Component} tooltipComponent - component used for rendering HTMLBars templates
    */
   tooltipComponent: computed('dataConfig', function() {
     let request = get(this, 'model.firstObject.request'),
         seriesConfig = get(this, 'seriesConfig.config'),
-        seriesType = get(this, 'seriesConfig.type'),
-        elementId = guidFor(this),
-        registryEntry = `component:line-chart-${seriesType}-tooltip-${elementId}`,
+        tooltipComponentName = get(this, 'tooltipComponentName'),
+        registryEntry = `component:${tooltipComponentName}`,
         builder = get(this, 'builder'),
         owner = getOwner(this),
-        tooltipComponent = Ember.Component.extend(
+        tooltipComponent = Component.extend(
           owner.ownerInjection(),
           builder.buildTooltip(seriesConfig, request),
           { renderer: owner.lookup('renderer:-dom') }
@@ -229,7 +240,7 @@ export default Ember.Component.extend({
     if(!owner.lookup(registryEntry)) {
       owner.register(registryEntry, tooltipComponent);
     }
-    
+
     /*
      * Ember 3.x requires components to be registered with the container before they are instantiated.
      * Use the factory that has been registered instead of an anonymous component.
@@ -260,7 +271,7 @@ export default Ember.Component.extend({
               seriesConfig
             });
 
-        Ember.run(() => {
+        run(() => {
           let element = document.createElement('div');
           tooltip.appendTo(element);
         });
@@ -294,5 +305,25 @@ export default Ember.Component.extend({
         }
       }
     };
-  })
+  }),
+
+  /**
+   * Fires before the element is destroyed
+   * @method willDestroy
+   * @override
+   */
+  willDestroy() {
+    this._super(...arguments)
+    this._removeTooltipFromRegistry();
+  },
+
+  /**
+   * Removes tooltip component from registry
+   * @method _removeTooltipFromRegistry
+   * @private
+   */
+  _removeTooltipFromRegistry() {
+    const tooltipComponentName = get(this, 'tooltipComponentName');
+    getOwner(this).unregister(`component:${tooltipComponentName}`);
+  }
 });

--- a/packages/core/addon/components/navi-visualizations/pie-chart.js
+++ b/packages/core/addon/components/navi-visualizations/pie-chart.js
@@ -119,12 +119,20 @@ export default Component.extend({
   }),
 
   /**
+   * @property {String} tooltipComponentName - name of the tooltip component
+   */
+  tooltipComponentName: computed(function() {
+    const guid = guidFor(this);
+    return `pie-chart-tooltip-${guid}`;
+  }),
+
+  /**
    * @property {Component} tooltipComponent - component used for rendering HTMLBars templates
    */
   tooltipComponent: computed(function() {
-    const elementId = guidFor(this);
-    const registryEntry = `component:pie-chart-tooltip-${elementId}`;
     let owner = getOwner(this),
+        tooltipComponentName = get(this, 'tooltipComponentName'),
+        registryEntry = `component:${tooltipComponentName}`,
         byXSeries = get(this, 'builder.byXSeries'),
         tooltipComponent = Component.extend(
           owner.ownerInjection(),
@@ -145,7 +153,7 @@ export default Component.extend({
     if(!owner.lookup(registryEntry)) {
       owner.register(registryEntry, tooltipComponent);
     }
-    
+
     /*
      * Ember 3.x requires components to be registered with the container before they are instantiated.
      * Use the factory that has been registered instead of an anonymous component.
@@ -188,7 +196,19 @@ export default Component.extend({
    * @override
    */
   willDestroy() {
+    this._super(...arguments)
     this._removeMetricLabel();
+    this._removeTooltipFromRegistry();
+  },
+
+  /**
+   * Removes tooltip component from registry
+   * @method _removeTooltipFromRegistry
+   * @private
+   */
+  _removeTooltipFromRegistry() {
+    const tooltipComponentName = get(this, 'tooltipComponentName');
+    getOwner(this).unregister(`component:${tooltipComponentName}`);
   },
 
   /**

--- a/packages/core/tests/unit/components/navi-visualizations/line-chart-test.js
+++ b/packages/core/tests/unit/components/navi-visualizations/line-chart-test.js
@@ -4,8 +4,8 @@ import { run } from '@ember/runloop';
 import moment from 'moment';
 import { setupMock, teardownMock } from '../../../helpers/mirage-helper';
 import merge from 'lodash/merge';
+import { getOwner } from '@ember/application';
 
-const { getOwner } = Ember;
 
 let MetadataService;
 
@@ -271,7 +271,7 @@ test('config', function(assert){
   assert.deepEqual(component.get('config'),
     merge({}, defaultConfig, dimensionChartType, yAxislabelOptions, { tooltip: component.get('chartTooltip') }),
     'Component displays y-axis label for a non-metric chart');
-  
+
   //set the chart type to be metric
   component.set('options', {
     axis: {
@@ -460,7 +460,7 @@ test('tooltips', function(assert){
     let element = document.createElement('div');
     tooltip.appendTo(element);
   });
-  assert.ok(tooltip.get('rowData.firstObject').hasOwnProperty('uniqueIdentifier'), 
+  assert.ok(tooltip.get('rowData.firstObject').hasOwnProperty('uniqueIdentifier'),
     'Initial tooltip render has the right rowData');
 
   //new data
@@ -510,7 +510,7 @@ test('tooltips', function(assert){
     let element = document.createElement('div');
     tooltip.appendTo(element);
   });
-  assert.ok(tooltip.get('rowData.firstObject').hasOwnProperty('navClicks'), 
+  assert.ok(tooltip.get('rowData.firstObject').hasOwnProperty('navClicks'),
     'New response has tooltip render has the right rowData');
 
 });


### PR DESCRIPTION
- Cleanup tooltip registry when chart is destroyed
- Include `chartType` in tooltip name to distinguish between `bar` & `line` chart