### PR TITLE
Fix: Unsaved report links in directory

### DIFF
--- a/packages/directory/addon/components/dir-item-name-cell.js
+++ b/packages/directory/addon/components/dir-item-name-cell.js
@@ -34,6 +34,11 @@ export default Component.extend({
   }),
 
   /**
+   * @property {String} itemId - the id of the model or the tempId of an unsaved model
+   */
+  itemId: computed.oneWay('value.modelId'),
+
+  /**
    * @property {String} type - the type of the item
    */
   type: computed('value', function() {

--- a/packages/directory/addon/templates/components/dir-item-name-cell.hbs
+++ b/packages/directory/addon/templates/components/dir-item-name-cell.hbs
@@ -1,8 +1,12 @@
 {{!-- Copyright 2018, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
-{{#link-to itemLink (get value 'id') classNames='dir-item-name-cell'}}
+{{#link-to itemLink itemId classNames='dir-item-name-cell'}}
   {{navi-icon iconClass classNames=(concat 'dir-item-name-cell__icon dir-icon__' type)}}
   {{get value 'title'}}
-  {{#if (get value 'isFavorite')}}
-    {{navi-icon 'star' classNames='dir-item-name-cell__fav-icon dir-icon__favorites'}}
-  {{/if}}
 {{/link-to}}
+
+{{#if (get value 'tempId')}}
+  <span class='dir-item-name-cell__unsaved-label'>Unsaved</span>
+{{/if}}
+{{#if (get value 'isFavorite')}}
+  {{navi-icon 'star' classNames='dir-item-name-cell__fav-icon dir-icon__favorites'}}
+{{/if}}

--- a/packages/directory/app/styles/navi-directory/components/dir-item-name-cell.less
+++ b/packages/directory/app/styles/navi-directory/components/dir-item-name-cell.less
@@ -10,4 +10,10 @@
   &__fav-icon {
     margin-left: 5px;
   }
+
+  &__unsaved-label {
+    color: @disabled-gray;
+    font-size: @font-size-mid;
+    margin-left: 8px;
+  }
 }

--- a/packages/directory/tests/integration/components/dir-item-name-cell-test.js
+++ b/packages/directory/tests/integration/components/dir-item-name-cell-test.js
@@ -53,4 +53,40 @@ module('Integration | Component | dir-item-name-cell', function(hooks) {
       'The favorite icon is not shown for a item that is not a favorite'
     );
   });
+
+  test('unsaved report label', async function(assert) {
+    assert.expect(2);
+
+    let report = {
+      title: 'Untitled Report',
+      id: null,
+      tempId: 'd8828a30-c2ab-11e8-9028-e546f1b5f84f',
+      isFavorite: false,
+      serialize() {
+        return {
+          data: {
+            type: 'reports'
+          }
+        };
+      }
+    };
+
+    set(this, 'item', report);
+    await render(hbs`{{dir-item-name-cell value=item}}`);
+
+    assert.ok(
+      this.element.querySelector('.dir-item-name-cell__unsaved-label'),
+      'The unsaved label is shown for an unsaved item'
+    );
+
+    set(report, 'id', 2);
+    set(report, 'tempId', undefined);
+
+    await render(hbs`{{dir-item-name-cell value=item}}`);
+
+    assert.notOk(
+      this.element.querySelector('.dir-item-name-cell__unsaved-label'),
+      'The unsaved label is not shown for a saved item'
+    );
+  });
 });

--- a/packages/directory/tests/unit/components/dir-item-name-cell-test.js
+++ b/packages/directory/tests/unit/components/dir-item-name-cell-test.js
@@ -1,0 +1,29 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Component | dir-item-name-cell', function(hooks) {
+  setupTest(hooks);
+
+  test('links are constructed correctly', function(assert) {
+    assert.expect(2);
+
+    const subject = this.owner.factoryFor('component:dir-item-name-cell');
+
+    let unsavedReportComponent = subject.create({
+      value: {
+        serialize() {
+          return { data: { type: 'reports' } };
+        },
+        modelId: '12345'
+      }
+    });
+
+    assert.equal(
+      unsavedReportComponent.get('itemLink'),
+      'reports.report',
+      'Component builds the link based on the type of the model correctly'
+    );
+
+    assert.equal(unsavedReportComponent.get('itemId'), '12345', 'Component uses the modelId to construct the link');
+  });
+});

--- a/packages/reports/addon/routes/reports/report/index.js
+++ b/packages/reports/addon/routes/reports/report/index.js
@@ -1,16 +1,17 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2018, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
-import Ember from 'ember';
+import Route from '@ember/routing/route';
+import { get } from '@ember/object';
 
-export default Ember.Route.extend({
+export default Route.extend({
   /**
    * @overide
    * @method redirect
    * @param {DS.Model} model - report model record
    */
   redirect(model) {
-    this.replaceWith('reports.report.view', Ember.get(model, 'id'));
+    this.replaceWith('reports.report.view', get(model, 'modelId'));
   }
 });


### PR DESCRIPTION
An issue was found where trying to open an unsaved report from the directory view wouldn't do anything. This should restore that functionality and I added a couple tests.

![image](https://user-images.githubusercontent.com/23023478/46219259-797c1900-c30c-11e8-820d-e45e5224c805.png)
Unsaved report at the bottom