### PR TITLE
Update: Add occlusion rendering to directory table

### DIFF
--- a/packages/directory/addon/components/dir-icon.js
+++ b/packages/directory/addon/components/dir-icon.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2018, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ *
+ * Usage:
+ * {{dir-icon iconClass}}
+ */
+
+import Component from '@ember/component';
+import layout from '../templates/components/dir-icon';
+
+export default Component.extend({
+  layout,
+
+  classNames: ['dir-icon'],
+
+  tagName: 'span'
+}).reopenClass({
+  positionalParams: ['iconClass']
+});

--- a/packages/directory/addon/templates/components/dir-icon.hbs
+++ b/packages/directory/addon/templates/components/dir-icon.hbs
@@ -1,0 +1,2 @@
+{{!-- Copyright 2018, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{navi-icon iconClass}}

--- a/packages/directory/addon/templates/components/dir-item-name-cell.hbs
+++ b/packages/directory/addon/templates/components/dir-item-name-cell.hbs
@@ -1,7 +1,10 @@
 {{!-- Copyright 2018, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 {{#link-to itemLink itemId classNames='dir-item-name-cell'}}
-  {{navi-icon iconClass classNames=(concat 'dir-item-name-cell__icon dir-icon__' type)}}
+  {{dir-icon iconClass}}
   {{get value 'title'}}
+  {{#if (get value 'isFavorite')}}
+    {{dir-icon 'star'}}
+  {{/if}}
 {{/link-to}}
 
 {{#if (get value 'tempId')}}

--- a/packages/directory/addon/templates/components/dir-new-button.hbs
+++ b/packages/directory/addon/templates/components/dir-new-button.hbs
@@ -5,7 +5,7 @@
     {{#each fileTypeNames as |typeName|}}
       {{#with (get fileTypes typeName) as |typeObject|}}
         {{#link-to (get typeObject 'linkRoute') classNames='dir-new-button__dropdown-option'}}
-          {{navi-icon (get typeObject 'iconClass') classNames=(concat 'dir-icon__' typeName)}}
+          {{dir-icon (get typeObject 'iconClass')}}
           <span class='dir-new-button__option-text'>{{capitalize (singularize typeName) }}</span>
         {{/link-to}}
       {{/with}}

--- a/packages/directory/addon/templates/components/dir-table.hbs
+++ b/packages/directory/addon/templates/components/dir-table.hbs
@@ -2,6 +2,8 @@
 {{#light-table table
   classNames='dir-table'
   responsive=true
+  occlusion=true
+  estimatedRowHeight=40
   as |t|
 }}
   {{t.head

--- a/packages/directory/app/styles/navi-directory/components/dir-icon.less
+++ b/packages/directory/app/styles/navi-directory/components/dir-icon.less
@@ -3,21 +3,21 @@
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 .dir-icon {
-  &__reports {
-    .reports-icon;
-    bottom: 2px;
-    font-size: @font-size-base-large;
-    position: relative;
+  .fa-star {
+    color: @navi-yellow;
+    font-size: @font-size-base;
   }
 
-  &__dashboards {
+  .fa-th-large {
     .dashboards-icon;
     font-size: @font-size-base-large;
     position: relative;
   }
 
-  &__favorites {
-    color: @navi-yellow;
-    font-size: @font-size-base;
+  .fa-file-text {
+    .reports-icon;
+    bottom: 2px;
+    font-size: @font-size-base-large;
+    position: relative;
   }
 }

--- a/packages/directory/tests/acceptance/dir-table-test.js
+++ b/packages/directory/tests/acceptance/dir-table-test.js
@@ -10,12 +10,12 @@ module('Acceptance | dir table', function(hooks) {
 
     await visit('/directory/my-data');
 
-    assert.equal(findAll('tbody>tr').length, 5, 'All items for a user are listed by default in my-data');
+    assert.equal(findAll('tbody tr').length, 5, 'All items for a user are listed by default in my-data');
 
     await visit('/directory/my-data?filter=favorites');
 
     assert.equal(
-      findAll('tbody>tr').length,
+      findAll('tbody tr').length,
       2,
       'Only the favorite items are shown in the table when the favorites filter is applied'
     );

--- a/packages/directory/tests/integration/components/dir-icon-test.js
+++ b/packages/directory/tests/integration/components/dir-icon-test.js
@@ -1,0 +1,20 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | dir-icon', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('Renders icon', async function(assert) {
+    assert.expect(1);
+    this.set('iconClass', 'star');
+
+    await render(hbs`{{dir-icon iconClass}}`);
+
+    assert.ok(
+      this.element.querySelector('.dir-icon>.fa-star'),
+      'An fa icon element with parent class dir-icon is rendered with the `fa-star` class'
+    );
+  });
+});

--- a/packages/directory/tests/integration/components/dir-item-name-cell-test.js
+++ b/packages/directory/tests/integration/components/dir-item-name-cell-test.js
@@ -37,19 +37,19 @@ module('Integration | Component | dir-item-name-cell', function(hooks) {
     set(this, 'item', report);
     await render(hbs`{{dir-item-name-cell value=item}}`);
 
-    assert.ok(this.element.querySelector('.dir-icon__reports'), 'The correct icon is used for a report');
+    assert.ok(this.element.querySelector('.fa-file-text'), 'The correct icon is used for a report');
 
     assert.equal(this.element.textContent.trim(), 'Report 1', "The item's title is displayed in the component");
 
-    assert.ok(this.element.querySelector('.dir-icon__favorites'), 'The favorite icon is shown for a favorited item');
+    assert.ok(this.element.querySelector('.fa-star'), 'The favorite icon is shown for a favorited item');
 
     set(this, 'item', dashboard);
     await render(hbs`{{dir-item-name-cell value=item}}`);
 
-    assert.ok(this.element.querySelector('.dir-icon__dashboards'), 'The correct icon is used for a dashboard');
+    assert.ok(this.element.querySelector('.fa-th-large'), 'The correct icon is used for a dashboard');
 
     assert.notOk(
-      this.element.querySelector('.dir-icon__favorites'),
+      this.element.querySelector('.fa-star'),
       'The favorite icon is not shown for a item that is not a favorite'
     );
   });


### PR DESCRIPTION
Sets the occlusion flag to true on the dir-table. There were some issues with the classNames being applied incorrectly to the icons with occlusion on, so I've added a wrapper component `dir-icon` to the `navi-icon` component in order to apply the correct styles.