### PR TITLE
Fix: Remove line leftover from rebase

### DIFF
--- a/packages/directory/addon/templates/components/dir-item-name-cell.hbs
+++ b/packages/directory/addon/templates/components/dir-item-name-cell.hbs
@@ -10,6 +10,3 @@
 {{#if (get value 'tempId')}}
   <span class='dir-item-name-cell__unsaved-label'>Unsaved</span>
 {{/if}}
-{{#if (get value 'isFavorite')}}
-  {{navi-icon 'star' classNames='dir-item-name-cell__fav-icon dir-icon__favorites'}}
-{{/if}}


### PR DESCRIPTION
These lines were accidentally included when rebasing my occlusion PR branch. We only want one favorite icon