### PR TITLE
Fix table select styling for long table names

### DIFF
--- a/packages/reports/app/styles/navi-reports/components/navi-table-select.less
+++ b/packages/reports/app/styles/navi-reports/components/navi-table-select.less
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2018, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 .navi-table-select {
@@ -20,6 +20,7 @@
     .ember-power-select-trigger:focus {
       border: 0;
       font-size: 14px;
+      height: 24px;
     }
 
     .ember-power-select-selected-item,


### PR DESCRIPTION
Before:
table wraps to second line
<img width="1440" alt="screen shot 2018-12-20 at 3 21 36 pm" src="https://user-images.githubusercontent.com/3818860/50311489-03023980-046b-11e9-837d-5df4f53e66d5.png">


After:
table name stays on the current line
<img width="1440" alt="screen shot 2018-12-20 at 3 20 30 pm" src="https://user-images.githubusercontent.com/3818860/50311500-0ac1de00-046b-11e9-948a-3e09ee35afcf.png">

Fixes #233 