### PR TITLE
Fix: Directory Sidebar spacing issue in Firefox

### DIFF
--- a/packages/directory/app/styles/navi-directory/components/dir-sidebar.less
+++ b/packages/directory/app/styles/navi-directory/components/dir-sidebar.less
@@ -16,7 +16,7 @@
 .dir-sidebar {
   color: @navi-blue-300;
   display: grid;
-  height: fit-content;
+  grid-template-rows: fit-content(50px);
 
   &__group {
     cursor: pointer;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/23023478/47168596-e6a91b80-d2c6-11e8-997e-edaab31c4143.png)

After:
![image](https://user-images.githubusercontent.com/23023478/47168568-d98c2c80-d2c6-11e8-8d37-a0819b51b205.png)
