### PR TITLE
Fix: Smartkey dimension bulk-import fix

### DIFF
--- a/packages/data/addon/mirage/fixtures/bard-meta-dimensions.js
+++ b/packages/data/addon/mirage/fixtures/bard-meta-dimensions.js
@@ -181,7 +181,11 @@ export default {
       cardinality: 9999999,
       category: 'test',
       storageStrategy: 'loaded',
-      fields: [{ name: 'id', tags: [] }, { name: 'desc', tags: ['description'] }, { name: 'key', tags: ['primaryKey'] }]
+      fields: [
+        { name: 'id', tags: ['id'] },
+        { name: 'desc', tags: ['description'] },
+        { name: 'key', tags: ['primaryKey'] }
+      ]
     }
   ],
 

--- a/packages/data/addon/models/metadata/dimension.js
+++ b/packages/data/addon/models/metadata/dimension.js
@@ -49,6 +49,11 @@ let Model = EmberObject.extend(ExtendedMetadataMixin, {
   descriptionTag: 'description',
 
   /**
+   * @property {String} idTag - name of the searchable id tag
+   */
+  idTag: 'id',
+
+  /**
    * Fetches tags for a given field name
    *
    * @method getTagsForField
@@ -94,6 +99,15 @@ let Model = EmberObject.extend(ExtendedMetadataMixin, {
     let tag = get(this, 'descriptionTag'),
       field = this.getFieldsForTag(tag)[0] || {};
     return get(field, 'name') || 'desc';
+  }),
+
+  /**
+   * @property {String} idFieldName
+   */
+  idFieldName: computed(function() {
+    let tag = get(this, 'idTag'),
+      field = this.getFieldsForTag(tag)[0] || {};
+    return get(field, 'name') || get(this, 'primaryKeyFieldName');
   })
 });
 

--- a/packages/data/addon/services/bard-dimensions.js
+++ b/packages/data/addon/services/bard-dimensions.js
@@ -274,7 +274,13 @@ export default Service.extend({
     return get(this, '_bardAdapter').find(dimension, {
       field,
       operator,
-      values: operator === 'contains' ? query.split(/\s+/) : [query]
+      values:
+        operator === 'contains'
+          ? query
+              .split(/,\s+|\s+/)
+              .map(s => s.trim())
+              .filter(_ => _)
+          : [query]
     });
   },
 

--- a/packages/reports/addon/components/power-select-bulk-import-trigger.js
+++ b/packages/reports/addon/components/power-select-bulk-import-trigger.js
@@ -58,7 +58,7 @@ export default Trigger.extend({
       // Get pasted data via clipboard API
       let clipboardData = pasteEvent.clipboardData || window.clipboardData,
         pastedData = clipboardData.getData('Text'),
-        queryIds = pastedData.split(BULK_IMPORT_DELIMETER),
+        queryIds = pastedData.split(BULK_IMPORT_DELIMETER).map(s => s.trim()),
         isBulkImportRequest = queryIds.length > 1;
 
       if (isBulkImportRequest) {

--- a/packages/reports/tests/integration/components/dimension-bulk-import-test.js
+++ b/packages/reports/tests/integration/components/dimension-bulk-import-test.js
@@ -50,6 +50,29 @@ moduleForComponent('dimension-bulk-import', 'Integration | Component | Dimension
           return [200, { 'Content-Type': 'application/json' }, JSON.stringify(PROPERTY_MOCK_DATA)];
         }
       });
+
+      this.get(`${HOST}/v1/dimensions/multiSystemId/values/`, request => {
+        if (request.queryParams.filters === 'multiSystemId|id-in[6,7]') {
+          return [
+            200,
+            { 'Content-Type': 'application/json' },
+            JSON.stringify({
+              rows: [
+                {
+                  id: '6',
+                  key: 'k6',
+                  description: 'System ID 1'
+                },
+                {
+                  id: '7',
+                  key: 'k7',
+                  description: 'System ID 2'
+                }
+              ]
+            })
+          ];
+        }
+      });
     });
 
     let dimension = {
@@ -290,6 +313,31 @@ test('behaviour of headers', function(assert) {
         .trim(),
       'Search Results.',
       'Secondary header has expected result text after searching'
+    );
+  });
+});
+
+test('Search dimension with smart key', function(assert) {
+  assert.expect(1);
+  this.setProperties({
+    dimension: { name: 'multiSystemId', longName: 'Multi System Id' },
+    onSelectValues: () => {},
+    onCancel: () => {},
+    queryIds: ['6', '7']
+  });
+
+  this.render(COMMON_TEMPLATE);
+
+  return wait().then(() => {
+    let validPills = this.$('.id-container:first .item');
+    assert.deepEqual(
+      validPills
+        .map(function() {
+          return this.childNodes[0].wholeText.trim();
+        })
+        .get(),
+      ['System ID 1 (6)', 'System ID 2 (7)'],
+      'Search returns valid IDs as expected'
     );
   });
 });


### PR DESCRIPTION
When we have a dimension with a smartkey, we need people to do bulk import of searchable ids.  The bulk importer needs to search against the right field.  This change makes sure that bulk-import works for smart key dimensions by looking to see if they have an 'id' tagged field and searching against that.  Otherwise, we search against primaryKey (searching against primaryKey was previous behavior).

Also found an issue which putting ids that were comma separated with spaces was sending bad requests to fili.  The splitting has been improved.