### PR TITLE
Fix: size of loading view in Firefox

### DIFF
--- a/packages/core/app/styles/navi-core/components/navi-loader.less
+++ b/packages/core/app/styles/navi-core/components/navi-loader.less
@@ -12,13 +12,7 @@
   }
 
   &__spinner {
-    align-items: center;
-    background-color: @navi-container-gray;
-    display: flex;
-    flex: 1;
-    height: 300px;
-    justify-content: center;
-    width: 100%;
+    .spinner;
   }
 
   &__bounce {

--- a/packages/core/app/styles/navi-core/components/navi-loader.less
+++ b/packages/core/app/styles/navi-core/components/navi-loader.less
@@ -8,7 +8,6 @@
     display: flex;
     flex-flow: column;
     margin: 10px;
-    width: 100%;
   }
 
   &__spinner {


### PR DESCRIPTION
Firefox before/after:
<img src="https://user-images.githubusercontent.com/12093492/47675203-433ded80-db87-11e8-80c5-f0b326e68b61.gif" width="330"> <img src="https://user-images.githubusercontent.com/12093492/47675202-433ded80-db87-11e8-93bb-29f3750dd54e.gif" width="330">

Chrome:
<img src="https://user-images.githubusercontent.com/12093492/47675279-75e7e600-db87-11e8-9c75-a97bb4a734ea.gif" width="500">


---

There's still a small issue with the horizontal scroll bar in Firefox, but I'm not sure what's causing it