### PR TITLE
Update: Add date-dimension filter builder for dimensions of datatype date

### DIFF
--- a/packages/core/addon/models/bard-request/fragments/filter.js
+++ b/packages/core/addon/models/bard-request/fragments/filter.js
@@ -5,12 +5,13 @@
 
 import DS from 'ember-data';
 import MF from 'model-fragments';
-import Ember from 'ember';
 import { validator, buildValidations } from 'ember-cp-validations';
+import { computed, get, set } from '@ember/object';
+import { inject as service } from '@ember/service';
+import { A as arr } from '@ember/array';
+import RSVP from 'rsvp';
 
-const { Fragment } = MF;
-
-const { computed, get, set } = Ember,
+const { Fragment } = MF,
   Validations = buildValidations({
     dimension: validator('presence', {
       presence: true,
@@ -24,7 +25,7 @@ const { computed, get, set } = Ember,
       validator('length', {
         min: 1,
         message() {
-          let dimensionName = Ember.get(this, 'model.dimension.longName');
+          let dimensionName = get(this, 'model.dimension.longName');
           return `${dimensionName} filter needs at least one value`;
         }
       }),
@@ -37,10 +38,10 @@ const { computed, get, set } = Ember,
 export default Fragment.extend(Validations, {
   dimension: DS.attr('dimension'),
   operator: DS.attr('string', { defaultValue: 'in' }),
-  rawValues: DS.attr({ defaultValue: () => Ember.A([]) }),
+  rawValues: DS.attr({ defaultValue: () => arr([]) }),
   field: DS.attr('string', { defaultValue: 'id' }),
 
-  dimensionService: Ember.inject.service('bard-dimensions'),
+  dimensionService: service('bard-dimensions'),
 
   /**
    * @property {DS.PromiseArray} values - dimension model objects computed from rawValues
@@ -49,26 +50,26 @@ export default Fragment.extend(Validations, {
     get() {
       if (get(this, 'operator') === 'contains') {
         let rawValues = get(this, 'rawValues'),
-          promise = new Ember.RSVP.resolve(rawValues);
+          promise = new RSVP.resolve(rawValues);
 
         return DS.PromiseArray.create({ promise });
       } else {
         let dimensionName = get(this, 'dimension.name'),
-          values = Ember.A(get(this, 'rawValues')).join(','),
+          values = arr(get(this, 'rawValues')).join(','),
           dimensionService = get(this, 'dimensionService');
 
         return DS.PromiseArray.create({
-          promise: dimensionService.find(dimensionName, { values }).then(values => Ember.A(values))
+          promise: dimensionService.find(dimensionName, { values }).then(values => arr(values))
         });
       }
     },
 
     set(type, value) {
       // some operators don't need to be mapped, as values don't always have id fields and mapping by ID will cause errors
-      if (['contains', 'null', 'notnull'].includes(get(this, 'operator'))) {
+      if (['contains', 'null', 'notnull', 'gte', 'lt', 'bet'].includes(get(this, 'operator'))) {
         set(this, 'rawValues', value);
       } else {
-        set(this, 'rawValues', Ember.A(value).mapBy('id'));
+        set(this, 'rawValues', arr(value).mapBy('id'));
       }
       return value;
     }

--- a/packages/data/addon/mirage/fixtures/bard-meta-dimensions.js
+++ b/packages/data/addon/mirage/fixtures/bard-meta-dimensions.js
@@ -5,6 +5,7 @@ export default {
       longName: 'Operating System',
       cardinality: 100,
       category: 'test',
+      datatype: 'text',
       storageStrategy: 'loaded'
     },
     {
@@ -12,6 +13,7 @@ export default {
       longName: 'User Device Type',
       cardinality: 100,
       category: 'test',
+      datatype: 'text',
       storageStrategy: 'loaded'
     },
     {
@@ -19,6 +21,7 @@ export default {
       longName: 'Age',
       cardinality: 100,
       category: 'test',
+      datatype: 'text',
       storageStrategy: 'loaded'
     },
     {
@@ -26,6 +29,7 @@ export default {
       longName: 'Currency',
       cardinality: 500,
       category: 'test',
+      datatype: 'text',
       storageStrategy: 'loaded'
     },
     {
@@ -33,6 +37,7 @@ export default {
       longName: 'Display Currency',
       cardinality: 54,
       category: 'test',
+      datatype: 'text',
       storageStrategy: 'loaded'
     },
     {
@@ -40,6 +45,7 @@ export default {
       longName: 'Gender',
       cardinality: 100,
       category: 'test',
+      datatype: 'text',
       storageStrategy: 'loaded'
     },
     {
@@ -47,6 +53,7 @@ export default {
       longName: 'Property Country',
       cardinality: 100,
       category: 'test',
+      datatype: 'text',
       storageStrategy: 'loaded'
     },
     {
@@ -54,6 +61,7 @@ export default {
       longName: 'Logged-in State',
       cardinality: 100,
       category: 'test',
+      datatype: 'text',
       storageStrategy: 'loaded'
     },
     {
@@ -61,6 +69,7 @@ export default {
       longName: 'Platform',
       cardinality: 100,
       category: 'test',
+      datatype: 'text',
       storageStrategy: 'loaded'
     },
     {
@@ -68,6 +77,7 @@ export default {
       longName: 'User Device Type V3',
       cardinality: 100,
       category: 'test',
+      datatype: 'text',
       storageStrategy: 'loaded'
     },
     {
@@ -75,6 +85,7 @@ export default {
       longName: 'Product Family',
       cardinality: 100,
       category: 'Asset',
+      datatype: 'text',
       storageStrategy: 'loaded'
     },
     {
@@ -82,6 +93,7 @@ export default {
       longName: 'Property',
       cardinality: 5000,
       category: 'Asset',
+      datatype: 'text',
       storageStrategy: 'loaded'
     },
     {
@@ -89,6 +101,7 @@ export default {
       longName: 'Browser',
       cardinality: 100,
       category: 'test',
+      datatype: 'text',
       storageStrategy: 'loaded'
     },
     {
@@ -96,6 +109,7 @@ export default {
       longName: 'Browser Version',
       cardinality: 100,
       category: 'test',
+      datatype: 'text',
       storageStrategy: 'loaded'
     },
     {
@@ -103,6 +117,7 @@ export default {
       longName: 'Product Region',
       cardinality: 100,
       category: 'test',
+      datatype: 'text',
       storageStrategy: 'loaded'
     },
     {
@@ -110,6 +125,7 @@ export default {
       longName: 'Platform Version',
       cardinality: 100,
       category: 'test',
+      datatype: 'text',
       storageStrategy: 'loaded'
     },
     {
@@ -117,6 +133,7 @@ export default {
       longName: 'Screen Type',
       cardinality: 100,
       category: 'test',
+      datatype: 'text',
       storageStrategy: 'loaded'
     },
     {
@@ -124,6 +141,7 @@ export default {
       longName: 'Language',
       cardinality: 100,
       category: 'test',
+      datatype: 'text',
       storageStrategy: 'loaded'
     },
     {
@@ -131,6 +149,7 @@ export default {
       longName: 'User Country',
       cardinality: 100,
       category: 'test',
+      datatype: 'text',
       storageStrategy: 'loaded'
     },
     {
@@ -138,6 +157,7 @@ export default {
       longName: 'User Region',
       cardinality: 100,
       category: 'test',
+      datatype: 'text',
       storageStrategy: 'loaded'
     },
     {
@@ -145,6 +165,7 @@ export default {
       longName: 'User Sub Region',
       cardinality: 100,
       category: 'test',
+      datatype: 'text',
       storageStrategy: 'loaded'
     },
     {
@@ -152,6 +173,7 @@ export default {
       longName: 'Product Sub Region',
       cardinality: 100,
       category: 'test',
+      datatype: 'text',
       storageStrategy: 'loaded'
     },
     {
@@ -159,6 +181,7 @@ export default {
       longName: 'Outflow Channel',
       cardinality: 100,
       category: 'test',
+      datatype: 'text',
       storageStrategy: 'loaded'
     },
     {
@@ -166,6 +189,7 @@ export default {
       longName: 'Outflow Site',
       cardinality: 100,
       category: 'test',
+      datatype: 'text',
       storageStrategy: 'loaded'
     },
     {
@@ -173,6 +197,7 @@ export default {
       longName: 'Context Id',
       cardinality: 0,
       category: 'test',
+      datatype: 'text',
       storageStrategy: 'none'
     },
     {
@@ -180,12 +205,21 @@ export default {
       longName: 'Multi System Id',
       cardinality: 9999999,
       category: 'test',
+      datatype: 'text',
       storageStrategy: 'loaded',
       fields: [
         { name: 'id', tags: ['id'] },
         { name: 'desc', tags: ['description'] },
         { name: 'key', tags: ['primaryKey'] }
       ]
+    },
+    {
+      name: 'userSignupDate',
+      longName: 'User Signup Date',
+      cardinality: 39896,
+      category: 'test',
+      datatype: 'date',
+      storageStrategy: 'loaded'
     }
   ],
 
@@ -195,6 +229,7 @@ export default {
       longName: 'EventId',
       cardinality: 9999999,
       category: 'Asset',
+      datatype: 'text',
       storageStrategy: 'loaded'
     },
     {
@@ -202,6 +237,7 @@ export default {
       longName: 'Parent Event Id',
       cardinality: 9999999,
       category: 'Asset',
+      datatype: 'text',
       storageStrategy: 'loaded'
     }
   ]

--- a/packages/data/addon/models/metadata/dimension.js
+++ b/packages/data/addon/models/metadata/dimension.js
@@ -34,6 +34,11 @@ let Model = EmberObject.extend(ExtendedMetadataMixin, {
   cardinality: undefined,
 
   /**
+   * @property {String} datatype
+   */
+  datatype: undefined,
+
+  /**
    * @property {Array} Array of field objects
    */
   fields: undefined,

--- a/packages/reports/addon/components/filter-builders/date-dimension.js
+++ b/packages/reports/addon/components/filter-builders/date-dimension.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2018, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ *
+ * Usage:
+ *   {{filter-builders/date-dimension
+ *       requestFragment=request.filters.firstObject
+ *       request=request
+ *   }}
+ */
+import Base from './base';
+import { computed, get } from '@ember/object';
+import { A as arr } from '@ember/array';
+
+export default Base.extend({
+  /**
+   * @property {Object} requestFragment - interval fragment from request
+   */
+  requestFragment: undefined,
+
+  /**
+   * @property {Array} supportedOperators
+   * @override
+   */
+  supportedOperators: [
+    {
+      id: 'gte',
+      longName: 'Since (>=)',
+      valuesComponent: 'filter-values/date'
+    },
+    {
+      id: 'lt',
+      longName: 'Before (<)',
+      valuesComponent: 'filter-values/date'
+    },
+    {
+      id: 'bet',
+      longName: 'Between (<=>)',
+      valuesComponent: 'filter-values/dimension-date-range'
+    }
+  ],
+
+  /**
+   * @property {Object} filter
+   * @override
+   */
+  filter: computed('requestFragment.{operator,dimension,values.[]}', function() {
+    const requestFragment = get(this, 'requestFragment'),
+      operatorId = get(requestFragment, 'operator'),
+      operator = arr(get(this, 'supportedOperators')).findBy('id', operatorId);
+
+    return {
+      subject: get(requestFragment, 'dimension'),
+      operator,
+      values: arr([get(requestFragment, 'values')[0]])
+    };
+  })
+});

--- a/packages/reports/addon/components/filter-collection.js
+++ b/packages/reports/addon/components/filter-collection.js
@@ -9,12 +9,12 @@
  *       onRemoveFilter=(update-report-action 'REMOVE_FILTER')
  *   }}
  */
-import Ember from 'ember';
 import layout from '../templates/components/filter-collection';
+import { computed, get } from '@ember/object';
+import { featureFlag } from 'navi-core/helpers/feature-flag';
+import Component from '@ember/component';
 
-const { computed, get } = Ember;
-
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
 
   /**
@@ -35,8 +35,11 @@ export default Ember.Component.extend({
     });
 
     let dimFilters = get(this, 'request.filters').map(filter => {
+      let dimensionDataType = get(filter, 'dimension.datatype'),
+        type = featureFlag('dateDimensionFilter') && dimensionDataType === 'date' ? 'date-dimension' : 'dimension';
+
       return {
-        type: 'dimension',
+        type,
         requestFragment: filter
       };
     });

--- a/packages/reports/addon/components/filter-values/date.js
+++ b/packages/reports/addon/components/filter-values/date.js
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2018, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ *
+ * Usage:
+ *   {{filter-values/date
+ *       filter=filter
+ *       request=request
+ *       onUpdateFilter=(action 'update')
+ *   }}
+ */
+import Component from '@ember/component';
+import Moment from 'moment';
+import layout from '../../templates/components/filter-values/date';
+import { computed, get } from '@ember/object';
+
+export default Component.extend({
+  layout,
+
+  /**
+   * @property {Array} classNames
+   */
+  classNames: ['date'],
+
+  /**
+   * @property {Moment} selectedDate
+   */
+  selectedDate: null,
+
+  /**
+   * @property {String} displayedDate
+   */
+  displayedDate: computed('filter.values', function() {
+    let filterDate = get(this, 'filter.values.firstObject');
+
+    return filterDate ? Moment(filterDate).format('MMM DD, YYYY') : 'Select date';
+  }),
+
+  actions: {
+    /**
+     * @action setDate
+     * @param {Date} date - new date to set in filter
+     */
+    setDate(date) {
+      this.attrs.onUpdateFilter({
+        values: [Moment(date).format('YYYY-MM-DD')]
+      });
+    },
+
+    /**
+     * @action resetDate - reset selectedDate to the saved value
+     */
+    resetDate() {
+      let filterVal = get(this, 'filter.values.firstObject'),
+        savedDate = filterVal ? Moment(filterVal) : filterVal;
+
+      this.set('selectedDate', savedDate);
+    },
+
+    /**
+     * @action closeDropdown
+     * @param {Object} dropdown - the ember-basic-dropdown object
+     */
+    closeDropdown(dropdown) {
+      dropdown.actions.close();
+    }
+  }
+});

--- a/packages/reports/addon/components/filter-values/dimension-date-range.js
+++ b/packages/reports/addon/components/filter-values/dimension-date-range.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2018, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ *
+ * Usage:
+ *   {{filter-values/dimension-date-range
+ *       filter=filter
+ *       request=request
+ *       onUpdateFilter=(action 'update')
+ *   }}
+ */
+import Component from '@ember/component';
+import layout from '../../templates/components/filter-values/date-range';
+import { get } from '@ember/object';
+
+export default Component.extend({
+  layout,
+
+  classNames: ['dimension-date-range', 'date-range'],
+
+  actions: {
+    /**
+     * @action setInterval
+     * @param {Interval} interval - new interval to set in filter
+     */
+    setInterval(interval) {
+      let intervalStr = interval.asStrings('YYYY-MM-DD');
+
+      this.attrs.onUpdateFilter({
+        values: [`${get(intervalStr, 'start')}/${get(intervalStr, 'end')}`]
+      });
+    }
+  }
+});

--- a/packages/reports/addon/components/navi-date-picker.js
+++ b/packages/reports/addon/components/navi-date-picker.js
@@ -6,7 +6,7 @@
  *   {{navi-date-picker
  *      selectedDate=initialDate
  *      dateTimePeriod='month'
- *      dateSelection='actionWhenDateChanges'
+ *      dateSelected='actionWhenDateChanges'
  *   }}
  */
 import Ember from 'ember';

--- a/packages/reports/addon/components/navi-date-range-picker.js
+++ b/packages/reports/addon/components/navi-date-range-picker.js
@@ -29,7 +29,7 @@ export default Ember.Component.extend({
   /**
    * @property {Array} list of class name bindings
    */
-  classNameBindings: ['interval:interval-set'],
+  classNameBindings: ['intervalInstance:interval-set'],
 
   /**
    * @property {String} dateTimePeriod - time grain being used for calendar selection
@@ -44,7 +44,23 @@ export default Ember.Component.extend({
   /**
    * @property {Object} customRange - custom range interval, or default interval
    */
-  customRange: computed.or('interval', 'defaultInterval'),
+  customRange: computed.or('intervalInstance', 'defaultInterval'),
+
+  /**
+   * @property {Object} intervalInstance - Interval Object that is either passed in as an attribute or built from a string
+   */
+  intervalInstance: computed('interval', function() {
+    let interval = get(this, 'interval');
+
+    if (typeof interval === 'string') {
+      //Expects format of Date/Date e.g. '2018-31-10/2018-05-11' for an interval between October 31 and November 5
+      let intervalStrs = interval.split('/');
+
+      return Interval.parseFromStrings(intervalStrs[0], intervalStrs[1]);
+    }
+
+    return interval;
+  }),
 
   /**
    * @property {Object} defaultInterval - get a default interval based on the dateTime period
@@ -82,7 +98,7 @@ export default Ember.Component.extend({
   /**
    * @property (Array} ranges - list of ranges with `isActive` flag
    */
-  ranges: Ember.computed('dateTimePeriod', 'interval', 'predefinedRanges', function() {
+  ranges: Ember.computed('dateTimePeriod', 'intervalInstance', 'predefinedRanges', function() {
     let ranges = this.get('predefinedRanges');
     ranges.forEach(range => {
       Ember.set(range, 'isActive', this.isActiveInterval(range.interval));
@@ -93,9 +109,9 @@ export default Ember.Component.extend({
   /**
    * @property {Boolean} isCustomRangeActive - whether or not selected interval is a custom range
    */
-  isCustomRangeActive: computed('interval', 'ranges', function() {
+  isCustomRangeActive: computed('intervalInstance', 'ranges', function() {
     // Custom range is considered active when the selected interval does not match any existing range
-    return get(this, 'interval') && !Ember.A(get(this, 'ranges')).isAny('isActive');
+    return get(this, 'intervalInstance') && !Ember.A(get(this, 'ranges')).isAny('isActive');
   }),
 
   /**
@@ -119,6 +135,6 @@ export default Ember.Component.extend({
       return false;
     }
 
-    return this.get('interval').isEqual(interval);
+    return this.get('intervalInstance').isEqual(interval);
   }
 });

--- a/packages/reports/addon/consumers/request/filter.js
+++ b/packages/reports/addon/consumers/request/filter.js
@@ -9,6 +9,7 @@ import DefaultIntervals from 'navi-reports/utils/enums/default-intervals';
 import { canonicalizeMetric } from 'navi-data/utils/metric';
 import { getSelectedMetricsOfBase, getUnfilteredMetricsOfBase } from 'navi-reports/utils/request-metric';
 import { isEmpty } from '@ember/utils';
+import { featureFlag } from 'navi-core/helpers/feature-flag';
 
 const { assign, inject, get, set, setProperties, assert } = Ember;
 
@@ -72,9 +73,11 @@ export default ActionConsumer.extend({
         'Dimension model has correct primaryKeyFieldName',
         typeof get(dimension, 'primaryKeyFieldName') === 'string'
       );
+      let defaultOperator = featureFlag('dateDimensionFilter') && get(dimension, 'datatype') === 'date' ? 'gte' : 'in';
+
       get(currentModel, 'request').addFilter({
         dimension,
-        operator: 'in',
+        operator: defaultOperator,
         field: get(dimension, 'primaryKeyFieldName'),
         values: []
       });

--- a/packages/reports/addon/templates/components/filter-values/date.hbs
+++ b/packages/reports/addon/templates/components/filter-values/date.hbs
@@ -1,0 +1,23 @@
+{{!-- Copyright 2018, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{#basic-dropdown as |dd| }}
+  {{#dd.trigger class='filter-values--date-dimension-select__trigger'}}
+    {{displayedDate}}
+  {{/dd.trigger}}
+
+  {{#dd.content class='filter-values--date-dimension-select__dropdown'}}
+    {{navi-date-picker
+      selectedDate=selectedDate
+      dateTimePeriod='day'
+      dateSelected=(action (mut selectedDate))
+    }}
+
+    <div class='date-dimension-select__controls'>
+      <button class='date-dimension-select__reset btn btn-secondary' onclick={{action 'resetDate'}}>
+        Reset
+      </button>
+      <button class='date-dimension-select__apply btn btn-primary' onclick={{pipe (action 'setDate' selectedDate) (action 'closeDropdown' dd)}}>
+        Apply
+      </button>
+    </div>
+  {{/dd.content}}
+{{/basic-dropdown}}

--- a/packages/reports/addon/templates/components/navi-date-range-picker.hbs
+++ b/packages/reports/addon/templates/components/navi-date-range-picker.hbs
@@ -2,13 +2,13 @@
 {{#pick-container updateSelection=this.attrs.setInterval as |selection container|}}
     {{#pick-value classNames='selection-box' classNameBindings='container.isFormOpen:open'}}
         {{#if hasBlock}}
-            {{yield interval}}
+            {{yield intervalInstance}}
         {{else}}
-            {{#if interval}}
+            {{#if intervalInstance}}
                 <label>Select date range</label>
                 <div class='value'>
                     {{navi-icon 'calendar'}}
-                    {{format-interval-inclusive-inclusive interval dateTimePeriod}}
+                    {{format-interval-inclusive-inclusive intervalInstance dateTimePeriod}}
                 </div>
             {{else}}
                 <span class='placeholder'>{{navi-icon 'calendar'}}Date Range</span>

--- a/packages/reports/app/components/filter-builders/date-dimension-range.js
+++ b/packages/reports/app/components/filter-builders/date-dimension-range.js
@@ -1,0 +1,1 @@
+export { default } from 'navi-reports/components/filter-builders/date-dimension-range';

--- a/packages/reports/app/components/filter-builders/date-dimension.js
+++ b/packages/reports/app/components/filter-builders/date-dimension.js
@@ -1,0 +1,1 @@
+export { default } from 'navi-reports/components/filter-builders/date-dimension';

--- a/packages/reports/app/components/filter-values/date.js
+++ b/packages/reports/app/components/filter-values/date.js
@@ -1,0 +1,1 @@
+export { default } from 'navi-reports/components/filter-values/date';

--- a/packages/reports/app/components/filter-values/dimension-date-range.js
+++ b/packages/reports/app/components/filter-values/dimension-date-range.js
@@ -1,0 +1,1 @@
+export { default } from 'navi-reports/components/filter-values/dimension-date-range';

--- a/packages/reports/app/styles/navi-reports/components/filter-collection.less
+++ b/packages/reports/app/styles/navi-reports/components/filter-collection.less
@@ -75,6 +75,16 @@
     line-height: @navi-ideal-line-height;
   }
 
+  .filter-values--date-dimension-select {
+    &__trigger {
+      border: 1px solid @navi-gray-400;
+      cursor: pointer;
+      height: @filter-collection-row-height;
+      line-height: @filter-collection-row-height;
+      padding-left: 8px;
+    }
+  }
+
   &__remove {
     .clickable;
 

--- a/packages/reports/app/styles/navi-reports/components/filter-values.less
+++ b/packages/reports/app/styles/navi-reports/components/filter-values.less
@@ -20,6 +20,35 @@
     }
   }
 
+  &--date-dimension-select__dropdown {
+    border: 1px solid @navi-lightest-gray;
+
+    .date-dimension-select {
+      &__controls {
+        background-color: @navi-lightest-gray;
+        border: 1px solid @gray-date-picker;
+        display: flex;
+        justify-content: flex-end;
+        padding: 5px 10px;
+        width: 100%;
+      }
+
+      &__reset {
+        margin-right: 10px;
+      }
+    }
+
+    .ember-power-calendar-nav {
+      background-color: @navi-form-purple;
+      color: @navi-white;
+      padding: 10px 5px;
+
+      button {
+        color: white;
+      }
+    }
+  }
+
   &--range-input {
     display: flex;
 

--- a/packages/reports/app/styles/navi-reports/components/filter-values.less
+++ b/packages/reports/app/styles/navi-reports/components/filter-values.less
@@ -24,6 +24,20 @@
     border: 1px solid @navi-lightest-gray;
 
     .date-dimension-select {
+      &__apply {
+        border-radius: 5px;
+        border-width: 0 0 3px 0;
+        font-size: @font-size-mid;
+        padding: 2px 13px;
+      }
+
+      &__reset {
+        background: none;
+        border: none;
+        font-size: @font-size-mid;
+        vertical-align: inherit;
+      }
+
       &__controls {
         background-color: @navi-lightest-gray;
         border: 1px solid @gray-date-picker;

--- a/packages/reports/tests/dummy/config/environment.js
+++ b/packages/reports/tests/dummy/config/environment.js
@@ -44,7 +44,8 @@ module.exports = function(environment) {
         enableScheduleReports: true,
         enableMultipleExport: true,
         enableContains: true,
-        enableTableEditing: true
+        enableTableEditing: true,
+        dateDimensionFilter: true
       }
     }
   };

--- a/packages/reports/tests/integration/components/dimension-selector-test.js
+++ b/packages/reports/tests/integration/components/dimension-selector-test.js
@@ -84,7 +84,7 @@ test('groups', function(assert) {
 
   assert.deepEqual(
     groups,
-    ['Time Grain (5)', 'test (24)', 'Asset (4)'],
+    ['Time Grain (5)', 'test (25)', 'Asset (4)'],
     'The groups rendered by the component include dimension groups and Time Grain'
   );
 });

--- a/packages/reports/tests/integration/components/filter-values/date-test.js
+++ b/packages/reports/tests/integration/components/filter-values/date-test.js
@@ -1,0 +1,89 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import Moment from 'moment';
+import { A as arr } from '@ember/array';
+import { run } from '@ember/runloop';
+import { clickTrigger } from 'ember-basic-dropdown/test-support/helpers';
+
+moduleForComponent('filter-values/date', 'Integration | Component | filter values/date', {
+  integration: true,
+
+  beforeEach: function() {
+    this.filter = { values: [] };
+    this.request = { logicalTable: { timeGrain: { name: 'day' } } };
+    this.onUpdateFilter = () => null;
+    this.selectedDate = null;
+
+    this.render(hbs`
+      {{filter-values/date
+        filter=filter
+        request=request
+        onUpdateFilter=(action onUpdateFilter)
+        selectedDate=selectedDate
+      }}`);
+  }
+});
+
+test('Displayed text', function(assert) {
+  assert.expect(2);
+
+  assert.equal(
+    this.$()
+      .text()
+      .trim(),
+    'Select date',
+    'The placeholder text is displayed when no date is selected'
+  );
+
+  run(() => {
+    this.set('filter', { values: arr(['2018-10-31']) });
+  });
+
+  assert.equal(
+    this.$()
+      .text()
+      .trim(),
+    'Oct 31, 2018',
+    'The selected date is displayed'
+  );
+});
+
+test('Apply changes', function(assert) {
+  assert.expect(2);
+
+  this.set('onUpdateFilter', changeSet => {
+    assert.deepEqual(changeSet, { values: arr(['2018-10-31']) }, 'Date is sent to onUpdateFilter correctly');
+  });
+  this.set('selectedDate', new Moment('2018-10-31'));
+
+  clickTrigger('.filter-values--date-dimension-select__trigger');
+  $('.date-dimension-select__apply.btn.btn-primary').click();
+
+  assert.notOk(
+    $('.filter-values--date-dimension-select__dropdown').is(':visible'),
+    'The dropdown closes after applying the selected date to the filter'
+  );
+});
+
+test('Reset changes', function(assert) {
+  assert.expect(3);
+
+  this.set('selectedDate', new Moment('2018-10-31'));
+  this.set('filter.values', arr(['2018-10-31']));
+
+  clickTrigger('.filter-values--date-dimension-select__trigger');
+
+  assert.equal($('.active.day')[0].innerText.trim(), '31', 'The selected date is active');
+
+  $('.day:contains(20)').click();
+
+  assert.equal($('.active.day')[0].innerText.trim(), '20', 'The selected day has been changed, but not saved yet.');
+
+  $('.date-dimension-select__reset.btn.btn-secondary').click();
+
+  assert.equal(
+    $('.active.day')[0].innerText.trim(),
+    '31',
+    'The selected day is reset to the value stored in the filter'
+  );
+});

--- a/packages/reports/tests/integration/components/filter-values/dimension-date-range-test.js
+++ b/packages/reports/tests/integration/components/filter-values/dimension-date-range-test.js
@@ -1,0 +1,37 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent(
+  'filter-values/dimension-date-range',
+  'Integration | Component | filter values/dimension date range',
+  {
+    integration: true,
+
+    beforeEach: function() {
+      this.filter = { values: [] };
+      this.request = { logicalTable: { timeGrain: { name: 'day' } } };
+      this.onUpdateFilter = () => null;
+
+      this.render(hbs`{{filter-values/dimension-date-range
+            filter=filter
+            request=request
+            onUpdateFilter=(action onUpdateFilter)
+        }}`);
+    }
+  }
+);
+
+test('changing values', function(assert) {
+  assert.expect(1);
+
+  this.set('onUpdateFilter', changeSet => {
+    let expectedInterval = 'P7D/current';
+    assert.equal(
+      changeSet.values[0],
+      expectedInterval,
+      'Selected interval is given to update action through the values property'
+    );
+  });
+
+  this.$('.predefined-range:contains(Last 7 Days)').click();
+});

--- a/packages/reports/tests/integration/components/navi-date-range-picker-test.js
+++ b/packages/reports/tests/integration/components/navi-date-range-picker-test.js
@@ -656,6 +656,35 @@ test('Default interval for `All` timegrain', function(assert) {
   this.$('.btn.btn-primary').click();
 });
 
+test('interval accepts interval or string', function(assert) {
+  assert.expect(2);
+  const expectedInterval = Interval.parseFromStrings('2018-10-31', '2018-11-01');
+
+  this.set('interval', '2018-10-31/2018-11-01');
+  this.set('setInterval', interval => {
+    assert.ok(interval.isEqual(expectedInterval), 'Interval string is turned into an interval class instance');
+  });
+
+  this.render(`
+    {{navi-date-range-picker
+        dateTimePeriod='day'
+        setInterval=(action setInterval)
+        interval=interval
+    }}
+  `);
+
+  this.$('.custom-range-form').click();
+  this.$('.navi-date-range-picker__apply-btn').click();
+
+  this.set('interval', Interval.parseFromStrings('2018-10-31', '2018-11-01'));
+  this.set('setInterval', interval => {
+    assert.ok(interval.isEqual(expectedInterval), 'Interval class instance is passed through');
+  });
+
+  this.$('.custom-range-form').click();
+  this.$('.navi-date-range-picker__apply-btn').click();
+});
+
 function openRangePicker(test) {
   test.$('.navi-date-range-picker > .pick-container > .pick-value').click();
 }

--- a/packages/reports/tests/unit/components/navi-date-range-picker-test.js
+++ b/packages/reports/tests/unit/components/navi-date-range-picker-test.js
@@ -1,0 +1,28 @@
+import { run } from '@ember/runloop';
+import { test, moduleForComponent } from 'ember-qunit';
+import Interval from 'navi-core/utils/classes/interval';
+
+moduleForComponent('navi-date-range-picker', 'Unit | Component | Navi Date Range Picker', {
+  unit: true,
+  needs: ['component:bootstrap-datepicker-inline']
+});
+
+test('intervalInstance', function(assert) {
+  assert.expect(2);
+
+  let component = run(() => this.subject({ dateTimePeriod: 'day' })),
+    stringInterval = '2018-10-31/2018-11-01',
+    classInterval = Interval.parseFromStrings('2018-10-31', '2018-11-01');
+
+  component.set('interval', stringInterval);
+  assert.ok(
+    classInterval.isEqual(component.get('intervalInstance')),
+    'Interval Instance is created correctly from a string'
+  );
+
+  component.set('interval', classInterval);
+  assert.ok(
+    classInterval.isEqual(component.get('intervalInstance')),
+    'Interval Instance returns the passed in interval class'
+  );
+});


### PR DESCRIPTION
Uses the navi-date-picker to allow selection of date/interval values for dimensions with date values. 

The supported operators are Since, Before, and Between.

![screen shot 2018-11-01 at 6 40 30 pm](https://user-images.githubusercontent.com/23023478/47886010-b8b6f180-de05-11e8-9338-d7b51549c364.png)

![screen shot 2018-11-02 at 11 24 40 am](https://user-images.githubusercontent.com/23023478/47927706-0a0cc280-de92-11e8-8244-7fd046dc39a9.png)

![screen shot 2018-11-02 at 11 25 11 am](https://user-images.githubusercontent.com/23023478/47927708-0da04980-de92-11e8-833c-3ac36f4340c5.png)



