### PR TITLE
Fix: Adding a new widget creates unsaved reports

### DIFF
--- a/packages/dashboards/addon/helpers/reportify.js
+++ b/packages/dashboards/addon/helpers/reportify.js
@@ -30,7 +30,6 @@ export default Helper.extend({
 
     return store.createRecord('report', {
       title: clonedModel.title,
-      author: get(model, 'author'),
       request: get(model, 'request').clone(),
       visualization: store.createFragment(clonedModel.visualization.type, clonedModel.visualization)
     });


### PR DESCRIPTION
The `reportify` helper creates a `report` from a `dashboard-widget`, which is then passed to `export` or `multiple-format-export` component.
It is not persisted at any point.
My first thinking was to make `reportify` return an Ember object instead of a `report` model.
csv link would work fine with an object, however `pdfHref` in `multiple-format-export` uses the `model-compression` service which expects a `report` model. 
This could be refactored as well to accept an object, but a more simple solution would be to just remove the `author` property when reportifying a widget, and then it wouldn't show up in the user's directory.
We actually do the same in `multiple-format-export` when we export a new unsaved report (with no `id`) - we call `report.clone()` which does not copy the `author` property that is not needed to render a pdf.