### PR TITLE
Fix: Vertical Collection header scroll gesture

### DIFF
--- a/packages/core/addon/components/table-renderer-vertical-collection.js
+++ b/packages/core/addon/components/table-renderer-vertical-collection.js
@@ -34,6 +34,11 @@ const SCROLL_EVENT = 'scroll';
  */
 const RESIZE_EVENT = 'didResize';
 
+/**
+ * @constant {String} WHEEL_EVENT - event for mouse and trackpad gestures
+ */
+const WHEEL_EVENT = 'wheel';
+
 export default Component.extend({
   layout,
 
@@ -93,6 +98,8 @@ export default Component.extend({
     [get(this, 'tableWrapperDomElement'), get(this, 'tableHeadersDomElement')].forEach(elm =>
       elm.addEventListener(SCROLL_EVENT, () => this._syncScroll())
     );
+
+    get(this, 'tableHeadersDomElement').addEventListener(WHEEL_EVENT, e => this._headerWheelSync(e));
   },
 
   /**
@@ -179,6 +186,21 @@ export default Component.extend({
   },
 
   /**
+   * Event handler for wheel events in header to scroll the table body vertically.
+   * Works for mouse wheels and vertical scrolling via mousepad gestures.
+   * @param {Event} event - wheel event
+   * @private
+   * @returns {Boolean} false
+   */
+  _headerWheelSync(event) {
+    let table = get(this, 'tableWrapperDomElement');
+
+    table.scrollTo(table.scrollLeft + event.deltaX, table.scrollTop);
+    event.preventDefault(); // Prevents the page navigation gesture in Mac OSX
+    return false;
+  },
+
+  /**
    * attach scroll and view resize event listeners when first rendered
    *
    * @method didInsertElement
@@ -221,6 +243,8 @@ export default Component.extend({
     [get(this, 'tableWrapperDomElement'), get(this, 'tableHeadersDomElement')].forEach(elm =>
       elm.removeEventListener(SCROLL_EVENT, () => this._syncScroll())
     );
+
+    get(this, 'tableHeadersDomElement').removeEventListener(WHEEL_EVENT, e => this._headerWheelSync(e));
 
     //turn off view resize listener
     get(this, 'resize').off(RESIZE_EVENT);

--- a/packages/core/addon/components/table-renderer-vertical-collection.js
+++ b/packages/core/addon/components/table-renderer-vertical-collection.js
@@ -195,7 +195,7 @@ export default Component.extend({
   _headerWheelSync(event) {
     let table = get(this, 'tableWrapperDomElement');
 
-    table.scrollTo(table.scrollLeft + event.deltaX, table.scrollTop);
+    table.scrollLeft += event.deltaX;
     event.preventDefault(); // Prevents the page navigation gesture in Mac OSX
     return false;
   },

--- a/packages/core/addon/components/table-renderer-vertical-collection.js
+++ b/packages/core/addon/components/table-renderer-vertical-collection.js
@@ -190,7 +190,7 @@ export default Component.extend({
    * Works for mouse wheels and vertical scrolling via mousepad gestures.
    * @param {Event} event - wheel event
    * @private
-   * @returns {Boolean} false
+   * @returns {void}
    */
   _headerWheelSync(event) {
     let table = get(this, 'tableWrapperDomElement');

--- a/packages/core/addon/components/table-renderer-vertical-collection.js
+++ b/packages/core/addon/components/table-renderer-vertical-collection.js
@@ -197,7 +197,6 @@ export default Component.extend({
 
     table.scrollLeft += event.deltaX;
     event.preventDefault(); // Prevents the page navigation gesture in Mac OSX
-    return false;
   },
 
   /**


### PR DESCRIPTION
Scrolling via the header via trackpad gesture or vertical scroll wheel didn't work.

This fixes that as both seem to be capturable with the 'wheel' event.  best of all this event is fired even when the container isn't scrollable! So we take the data from the wheel event and fire a scroll event to the table body.

![2018-12-10 16-31-05](https://user-images.githubusercontent.com/99422/49767011-8c13b680-fc9c-11e8-9914-f97d3ece0632.gif)
