### PR TITLE
Dropdown date picker component

### DIFF
--- a/packages/reports/addon/components/dropdown-date-picker.js
+++ b/packages/reports/addon/components/dropdown-date-picker.js
@@ -15,11 +15,14 @@ export default Component.extend({
   layout,
 
   /**
-   * @property {Moment} _selectedDate - local moment set by date picker
-   * @private
+   * @property {Moment} selectedDate - local moment set by date picker
    */
-  _selectedDate: null,
+  selectedDate: null,
 
+  /**
+   * @method init
+   * @override
+   */
   init() {
     this._super(...arguments);
 
@@ -30,7 +33,7 @@ export default Component.extend({
    * @method loadSavedDate
    */
   loadSavedDate() {
-    this.set('_selectedDate', this.get('savedDate'));
+    this.set('selectedDate', this.get('savedDate'));
   },
 
   actions: {

--- a/packages/reports/addon/components/dropdown-date-picker.js
+++ b/packages/reports/addon/components/dropdown-date-picker.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2018, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ *
+ * Usage:
+ *   {{dropdown-date-picker
+ *       onApply=(action 'onApply')
+ *       savedDate=(moment savedDate)
+ *   }}
+ */
+import Component from '@ember/component';
+import layout from '../templates/components/dropdown-date-picker';
+
+export default Component.extend({
+  layout,
+
+  /**
+   * @property {Moment} _selectedDate - local moment set by date picker
+   * @private
+   */
+  _selectedDate: null,
+
+  init() {
+    this._super(...arguments);
+
+    this.loadSavedDate();
+  },
+
+  /**
+   * @method loadSavedDate
+   */
+  loadSavedDate() {
+    this.set('_selectedDate', this.get('savedDate'));
+  },
+
+  actions: {
+    /**
+     * @action resetDate - set selected date to the saved date
+     */
+    resetDate() {
+      this.loadSavedDate();
+    }
+  }
+});

--- a/packages/reports/addon/components/dropdown-date-picker.js
+++ b/packages/reports/addon/components/dropdown-date-picker.js
@@ -4,8 +4,8 @@
  *
  * Usage:
  *   {{dropdown-date-picker
- *       onApply=(action 'onApply')
- *       savedDate=(moment savedDate)
+ *       onUpdate=(action 'onUpdate')
+ *       date=(moment savedDate)
  *   }}
  */
 import Component from '@ember/component';
@@ -15,9 +15,10 @@ export default Component.extend({
   layout,
 
   /**
-   * @property {Moment} selectedDate - local moment set by date picker
+   * @private
+   * @property {Object} selectedDate - local moment set by date picker
    */
-  selectedDate: null,
+  _selectedDate: null,
 
   /**
    * @method init
@@ -33,7 +34,7 @@ export default Component.extend({
    * @method loadSavedDate
    */
   loadSavedDate() {
-    this.set('selectedDate', this.get('savedDate'));
+    this.set('_selectedDate', this.get('date'));
   },
 
   actions: {

--- a/packages/reports/addon/components/dropdown-date-picker.js
+++ b/packages/reports/addon/components/dropdown-date-picker.js
@@ -16,7 +16,7 @@ export default Component.extend({
 
   /**
    * @private
-   * @property {Object} selectedDate - local moment set by date picker
+   * @property {Object} _selectedDate - local moment set by date picker
    */
   _selectedDate: null,
 

--- a/packages/reports/addon/components/filter-values/date.js
+++ b/packages/reports/addon/components/filter-values/date.js
@@ -12,7 +12,7 @@
 import Component from '@ember/component';
 import Moment from 'moment';
 import layout from '../../templates/components/filter-values/date';
-import { computed, get } from '@ember/object';
+import { computed } from '@ember/object';
 
 export default Component.extend({
   layout,
@@ -23,36 +23,9 @@ export default Component.extend({
   classNames: ['filter-values--date'],
 
   /**
-   * @property {Moment} _selectedDate - local moment set by date picker
-   * @private
-   */
-  _selectedDate: null,
-
-  /**
    * @property {String} savedDate - the date that's saved in the filter
-   * @private
    */
-  _savedDate: computed.oneWay('filter.values.firstObject'),
-
-  /**
-   * @method init
-   * @override
-   */
-  init() {
-    this._super(...arguments);
-
-    this.loadSavedDate();
-  },
-
-  /**
-   * @method loadSavedDate
-   */
-  loadSavedDate() {
-    let filterVal = get(this, '_savedDate'),
-      savedDate = filterVal ? Moment(filterVal) : filterVal;
-
-    this.set('_selectedDate', savedDate);
-  },
+  savedDate: computed.oneWay('filter.values.firstObject'),
 
   actions: {
     /**
@@ -63,13 +36,6 @@ export default Component.extend({
       this.attrs.onUpdateFilter({
         values: [Moment(date).format('YYYY-MM-DD')]
       });
-    },
-
-    /**
-     * @action resetDate - reset selectedDate to the saved value
-     */
-    resetDate() {
-      this.loadSavedDate();
     }
   }
 });

--- a/packages/reports/addon/components/filter-values/date.js
+++ b/packages/reports/addon/components/filter-values/date.js
@@ -23,9 +23,9 @@ export default Component.extend({
   classNames: ['filter-values--date'],
 
   /**
-   * @property {String} savedDate - the date that's saved in the filter
+   * @property {String} date - the date that's saved in the filter
    */
-  savedDate: computed.oneWay('filter.values.firstObject'),
+  date: computed.oneWay('filter.values.firstObject'),
 
   actions: {
     /**

--- a/packages/reports/addon/components/navi-date-picker.js
+++ b/packages/reports/addon/components/navi-date-picker.js
@@ -42,7 +42,7 @@ export default Ember.Component.extend({
   classNameBindings: ['dateTimePeriod'],
 
   /**
-   * @property {Moment} date - date should be after `minDate`
+   * @property {Object} date - date should be after `minDate`
    */
   date: undefined,
 

--- a/packages/reports/addon/components/navi-date-picker.js
+++ b/packages/reports/addon/components/navi-date-picker.js
@@ -4,9 +4,9 @@
  *
  * Usage:
  *   {{navi-date-picker
- *      selectedDate=initialDate
+ *      date=initialDate
  *      dateTimePeriod='month'
- *      dateSelected='actionWhenDateChanges'
+ *      onUpdate='actionWhenDateChanges'
  *   }}
  */
 import Ember from 'ember';
@@ -42,9 +42,9 @@ export default Ember.Component.extend({
   classNameBindings: ['dateTimePeriod'],
 
   /**
-   * @property {Moment} selectedDate - selectedDate should be after `minDate`
+   * @property {Moment} date - date should be after `minDate`
    */
-  selectedDate: undefined,
+  date: undefined,
 
   /**
    * @property {String} dateTimePeriod - unit of time being selected ('day', 'week', or 'month')
@@ -88,17 +88,18 @@ export default Ember.Component.extend({
   didReceiveAttrs() {
     this._super(...arguments);
 
-    let selectedDate = get(this, 'selectedDate'),
+    let selectedDate = get(this, 'date'),
       previousDate = get(this, 'previousDate');
 
     if (selectedDate !== previousDate) {
-      let selectedDate = get(this, 'selectedDate'),
-        date = selectedDate ? selectedDate.toDate() : undefined;
+      let date = selectedDate ? selectedDate.toDate() : undefined;
+
       set(this, 'selectedDateObj', date);
     }
 
     //Store old date for rerender logic above
     set(this, 'previousDate', selectedDate);
+    set(this, '_lastTimeDate', selectedDate);
 
     // Make sure selection is highlighted
     Ember.run.scheduleOnce('afterRender', this, this._highlightSelection);
@@ -174,9 +175,9 @@ export default Ember.Component.extend({
    * @returns {boolean} true if date is the same
    */
   _isNewDateValue(newDate) {
-    let lastTime = get(this, 'lastTimeDate');
+    let lastTime = get(this, '_lastTimeDate');
 
-    set(this, 'lastTimeDate', newDate);
+    set(this, '_lastTimeDate', newDate);
 
     if (!lastTime) {
       return false;
@@ -204,7 +205,7 @@ export default Ember.Component.extend({
 
       // Convert date to start of time period
       let dateTimePeriod = getIsoDateTimePeriod(get(this, 'dateTimePeriod'));
-      this.sendAction('dateSelected', moment(newDate).startOf(dateTimePeriod));
+      this.sendAction('onUpdate', moment(newDate).startOf(dateTimePeriod));
     }
   }
 });

--- a/packages/reports/addon/components/navi-date-picker.js
+++ b/packages/reports/addon/components/navi-date-picker.js
@@ -174,9 +174,9 @@ export default Ember.Component.extend({
    * @returns {boolean} true if date is the same
    */
   _isNewDateValue(newDate) {
-    let lastTime = get(this, '_lastTimeDate');
+    let lastTime = get(this, 'lastTimeDate');
 
-    set(this, '_lastTimeDate', newDate);
+    set(this, 'lastTimeDate', newDate);
 
     if (!lastTime) {
       return false;

--- a/packages/reports/addon/templates/components/dropdown-date-picker.hbs
+++ b/packages/reports/addon/templates/components/dropdown-date-picker.hbs
@@ -1,0 +1,24 @@
+{{!-- Copyright 2018, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{#basic-dropdown as |dd| }}
+  {{#dd.trigger class='dropdown-date-picker__trigger'}}
+    {{yield}}
+  {{/dd.trigger}}
+
+  {{#dd.content class='dropdown-date-picker__dropdown'}}
+    {{navi-date-picker
+      selectedDate=_selectedDate
+      dateTimePeriod='day'
+      dateSelected=(action (mut _selectedDate))
+      _lastTimeDate=(readonly savedDate)
+    }}
+
+    <div class='dropdown-date-picker__controls'>
+      <button class='dropdown-date-picker__reset btn btn-secondary' onclick={{action 'resetDate'}}>
+        Reset
+      </button>
+      <button class='dropdown-date-picker__apply btn btn-primary' onclick={{pipe (action this.attrs.onApply _selectedDate) (action dd.actions.close)}}>
+        Apply
+      </button>
+    </div>
+  {{/dd.content}}
+{{/basic-dropdown}}

--- a/packages/reports/addon/templates/components/dropdown-date-picker.hbs
+++ b/packages/reports/addon/templates/components/dropdown-date-picker.hbs
@@ -6,17 +6,17 @@
 
   {{#dd.content class='dropdown-date-picker__dropdown'}}
     {{navi-date-picker
-      selectedDate=_selectedDate
+      selectedDate=selectedDate
       dateTimePeriod='day'
-      dateSelected=(action (mut _selectedDate))
-      _lastTimeDate=(readonly savedDate)
+      dateSelected=(action (mut selectedDate))
+      lastTimeDate=(readonly savedDate)
     }}
 
     <div class='dropdown-date-picker__controls'>
       <button class='dropdown-date-picker__reset btn btn-secondary' onclick={{action 'resetDate'}}>
         Reset
       </button>
-      <button class='dropdown-date-picker__apply btn btn-primary' onclick={{pipe (action this.attrs.onApply _selectedDate) (action dd.actions.close)}}>
+      <button class='dropdown-date-picker__apply btn btn-primary' onclick={{pipe (action this.attrs.onApply selectedDate) (action dd.actions.close)}}>
         Apply
       </button>
     </div>

--- a/packages/reports/addon/templates/components/dropdown-date-picker.hbs
+++ b/packages/reports/addon/templates/components/dropdown-date-picker.hbs
@@ -6,17 +6,16 @@
 
   {{#dd.content class='dropdown-date-picker__dropdown'}}
     {{navi-date-picker
-      selectedDate=selectedDate
+      date=_selectedDate
       dateTimePeriod='day'
-      dateSelected=(action (mut selectedDate))
-      lastTimeDate=(readonly savedDate)
+      onUpdate=(action (mut _selectedDate))
     }}
 
     <div class='dropdown-date-picker__controls'>
       <button class='dropdown-date-picker__reset btn btn-secondary' onclick={{action 'resetDate'}}>
         Reset
       </button>
-      <button class='dropdown-date-picker__apply btn btn-primary' onclick={{pipe (action this.attrs.onApply selectedDate) (action dd.actions.close)}}>
+      <button class='dropdown-date-picker__apply btn btn-primary' onclick={{pipe (action this.attrs.onUpdate _selectedDate) (action dd.actions.close)}}>
         Apply
       </button>
     </div>

--- a/packages/reports/addon/templates/components/filter-values/date.hbs
+++ b/packages/reports/addon/templates/components/filter-values/date.hbs
@@ -1,11 +1,11 @@
 {{!-- Copyright 2018, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 {{#dropdown-date-picker
-  date=(moment savedDate)
+  date=(moment date)
   onUpdate=(action 'setDate')
 }}
   <div class='filter-values--date-dimension-select__trigger'>  
-    {{#if savedDate}}
-      {{moment-format savedDate 'MMM DD, YYYY'}}
+    {{#if date}}
+      {{moment-format date 'MMM DD, YYYY'}}
     {{else}}
       <span class='date__placeholder'>Select date</span>
     {{/if}}

--- a/packages/reports/addon/templates/components/filter-values/date.hbs
+++ b/packages/reports/addon/templates/components/filter-values/date.hbs
@@ -1,27 +1,14 @@
 {{!-- Copyright 2018, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
-{{#basic-dropdown as |dd| }}
-  {{#dd.trigger class='filter-values--date-dimension-select__trigger'}}
-    {{#if _savedDate}}
-      {{moment-format _savedDate 'MMM DD, YYYY'}}
+{{#dropdown-date-picker
+  savedDate=(moment savedDate)
+  onApply=(action 'setDate')
+}}
+{{log (moment savedDate)}}
+  <div class='filter-values--date-dimension-select__trigger'>  
+    {{#if savedDate}}
+      {{moment-format savedDate 'MMM DD, YYYY'}}
     {{else}}
       <span class='date__placeholder'>Select date</span>
     {{/if}}
-  {{/dd.trigger}}
-
-  {{#dd.content class='filter-values--date-dimension-select__dropdown'}}
-    {{navi-date-picker
-      selectedDate=_selectedDate
-      dateTimePeriod='day'
-      dateSelected=(action (mut _selectedDate))
-    }}
-
-    <div class='date-dimension-select__controls'>
-      <button class='date-dimension-select__reset btn btn-secondary' onclick={{action 'resetDate'}}>
-        Reset
-      </button>
-      <button class='date-dimension-select__apply btn btn-primary' onclick={{pipe (action 'setDate' _selectedDate) (action dd.actions.close)}}>
-        Apply
-      </button>
-    </div>
-  {{/dd.content}}
-{{/basic-dropdown}}
+  </div>
+{{/dropdown-date-picker}}

--- a/packages/reports/addon/templates/components/filter-values/date.hbs
+++ b/packages/reports/addon/templates/components/filter-values/date.hbs
@@ -1,9 +1,8 @@
 {{!-- Copyright 2018, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 {{#dropdown-date-picker
-  savedDate=(moment savedDate)
-  onApply=(action 'setDate')
+  date=(moment savedDate)
+  onUpdate=(action 'setDate')
 }}
-{{log (moment savedDate)}}
   <div class='filter-values--date-dimension-select__trigger'>  
     {{#if savedDate}}
       {{moment-format savedDate 'MMM DD, YYYY'}}

--- a/packages/reports/addon/templates/components/navi-date-range-picker.hbs
+++ b/packages/reports/addon/templates/components/navi-date-range-picker.hbs
@@ -45,15 +45,15 @@
                         <div class='date-picker-label'>Start Date</div>
                         <div class='date-picker-label'>End Date</div>
                         {{navi-date-picker
-                            selectedDate=dateMoments.start
+                            date=dateMoments.start
                             dateTimePeriod=dateTimePeriod
-                            dateSelected='setStart'
+                            onUpdate='setStart'
                             targetObject=container
                         }}
                         {{navi-date-picker
-                            selectedDate=dateMoments.end
+                            date=dateMoments.end
                             dateTimePeriod=dateTimePeriod
-                            dateSelected='setEnd'
+                            onUpdate='setEnd'
                             targetObject=container
                         }}
                         {{#unless showAdvancedCalendar}}

--- a/packages/reports/app/components/dropdown-date-picker.js
+++ b/packages/reports/app/components/dropdown-date-picker.js
@@ -1,0 +1,1 @@
+export { default } from 'navi-reports/components/dropdown-date-picker';

--- a/packages/reports/app/styles/navi-reports/components/dropdown-date-picker.less
+++ b/packages/reports/app/styles/navi-reports/components/dropdown-date-picker.less
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2018, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+
+.dropdown-date-picker {
+  &__dropdown {
+    border: 1px solid @navi-lightest-gray;
+  }
+
+  &__apply {
+    border-radius: 5px;
+    border-width: 0 0 3px 0;
+    font-size: @font-size-mid;
+    padding: 2px 13px;
+  }
+
+  &__reset {
+    background: none;
+    border: none;
+    font-size: @font-size-mid;
+    vertical-align: inherit;
+  }
+
+  &__controls {
+    background-color: @navi-lightest-gray;
+    border: 1px solid @gray-date-picker;
+    display: flex;
+    justify-content: flex-end;
+    padding: 5px 10px;
+    width: 100%;
+  }
+}

--- a/packages/reports/app/styles/navi-reports/components/filter-values.less
+++ b/packages/reports/app/styles/navi-reports/components/filter-values.less
@@ -20,39 +20,6 @@
     }
   }
 
-  &--date-dimension-select__dropdown {
-    border: 1px solid @navi-lightest-gray;
-
-    .date-dimension-select {
-      &__apply {
-        border-radius: 5px;
-        border-width: 0 0 3px 0;
-        font-size: @font-size-mid;
-        padding: 2px 13px;
-      }
-
-      &__reset {
-        background: none;
-        border: none;
-        font-size: @font-size-mid;
-        vertical-align: inherit;
-      }
-
-      &__controls {
-        background-color: @navi-lightest-gray;
-        border: 1px solid @gray-date-picker;
-        display: flex;
-        justify-content: flex-end;
-        padding: 5px 10px;
-        width: 100%;
-      }
-
-      &__reset {
-        margin-right: 10px;
-      }
-    }
-  }
-
   &--range-input {
     display: flex;
 

--- a/packages/reports/app/styles/navi-reports/components/index.less
+++ b/packages/reports/app/styles/navi-reports/components/index.less
@@ -18,6 +18,7 @@
 @import 'report-collection';
 @import 'show-all';
 @import 'dimension-bulk-import';
+@import 'dropdown-date-picker';
 @import 'filter-collection';
 @import 'report-builder';
 @import 'report-view';

--- a/packages/reports/tests/integration/components/dropdown-date-picker-test.js
+++ b/packages/reports/tests/integration/components/dropdown-date-picker-test.js
@@ -12,19 +12,19 @@ test('dropdown-date-picker', function(assert) {
 
   this.set('savedDate', '2018-12-25');
   this.set('actions', {
-    onApply(date) {
+    onUpdate(date) {
       assert.equal(
         Moment(date).format('YYYY-MM-DD'),
         '2018-12-24',
-        'The current selected date is sent to the onApply action'
+        'The current selected date is sent to the onUpdate action'
       );
     }
   });
 
   this.render(hbs`
     {{#dropdown-date-picker
-      savedDate=(moment savedDate)
-      onApply=(action 'onApply')
+      date=(moment savedDate)
+      onUpdate=(action 'onUpdate')
     }}
       Dropdown Trigger
     {{/dropdown-date-picker}}

--- a/packages/reports/tests/integration/components/dropdown-date-picker-test.js
+++ b/packages/reports/tests/integration/components/dropdown-date-picker-test.js
@@ -1,0 +1,70 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import { clickTrigger } from 'ember-basic-dropdown/test-support/helpers';
+import Moment from 'moment';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('dropdown-date-picker', 'Integration | Component | dropdown date picker', {
+  integration: true
+});
+
+test('dropdown-date-picker', function(assert) {
+  assert.expect(8);
+
+  this.set('savedDate', '2018-12-25');
+  this.set('actions', {
+    onApply(date) {
+      assert.equal(
+        Moment(date).format('YYYY-MM-DD'),
+        '2018-12-24',
+        'The current selected date is sent to the onApply action'
+      );
+    }
+  });
+
+  this.render(hbs`
+    {{#dropdown-date-picker
+      savedDate=(moment savedDate)
+      onApply=(action 'onApply')
+    }}
+      Dropdown Trigger
+    {{/dropdown-date-picker}}
+  `);
+
+  assert.equal(
+    $('.dropdown-date-picker__trigger')
+      .text()
+      .trim(),
+    'Dropdown Trigger',
+    'Trigger is displayed'
+  );
+
+  clickTrigger('.dropdown-date-picker__trigger');
+
+  assert.ok(
+    $('.navi-date-picker.day').is(':visible'),
+    'The day time grain date picker is shown when the dropdown is open'
+  );
+
+  assert.ok($('.dropdown-date-picker__controls').is(':visible'), 'The controls for the date picker are shown');
+
+  assert.equal(
+    $('.active.day')[0].innerText.trim(),
+    '25',
+    'The saved date is passed to the date picker as the selected date'
+  );
+
+  $('.day:contains(24)').click();
+  assert.equal($('.active.day')[0].innerText.trim(), '24', 'The selected date changed');
+
+  $('.dropdown-date-picker__reset').click();
+  assert.equal(
+    $('.active.day')[0].innerText.trim(),
+    '25',
+    'The selected date is reset to the saved date after clicking reset'
+  );
+
+  $('.day:contains(24)').click();
+  assert.equal($('.active.day')[0].innerText.trim(), '24', 'The selected date changed');
+
+  $('.dropdown-date-picker__apply').click();
+});

--- a/packages/reports/tests/integration/components/filter-values/date-test.js
+++ b/packages/reports/tests/integration/components/filter-values/date-test.js
@@ -1,9 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import Moment from 'moment';
 import { A as arr } from '@ember/array';
 import { run } from '@ember/runloop';
-import { clickTrigger } from 'ember-basic-dropdown/test-support/helpers';
 
 moduleForComponent('filter-values/date', 'Integration | Component | filter values/date', {
   integration: true,
@@ -45,45 +43,5 @@ test('Displayed text', function(assert) {
       .trim(),
     'Oct 31, 2018',
     'The selected date is displayed'
-  );
-});
-
-test('Apply changes', function(assert) {
-  assert.expect(2);
-
-  this.set('onUpdateFilter', changeSet => {
-    assert.deepEqual(changeSet, { values: arr(['2018-10-31']) }, 'Date is sent to onUpdateFilter correctly');
-  });
-  this.set('selectedDate', new Moment('2018-10-31'));
-
-  clickTrigger('.filter-values--date-dimension-select__trigger');
-  $('.date-dimension-select__apply.btn.btn-primary').click();
-
-  assert.notOk(
-    $('.filter-values--date-dimension-select__dropdown').is(':visible'),
-    'The dropdown closes after applying the selected date to the filter'
-  );
-});
-
-test('Reset changes', function(assert) {
-  assert.expect(3);
-
-  this.set('selectedDate', new Moment('2018-10-31'));
-  this.set('filter.values', arr(['2018-10-31']));
-
-  clickTrigger('.filter-values--date-dimension-select__trigger');
-
-  assert.equal($('.active.day')[0].innerText.trim(), '31', 'The selected date is active');
-
-  $('.day:contains(20)').click();
-
-  assert.equal($('.active.day')[0].innerText.trim(), '20', 'The selected day has been changed, but not saved yet.');
-
-  $('.date-dimension-select__reset.btn.btn-secondary').click();
-
-  assert.equal(
-    $('.active.day')[0].innerText.trim(),
-    '31',
-    'The selected day is reset to the value stored in the filter'
   );
 });

--- a/packages/reports/tests/integration/components/navi-date-picker-test.js
+++ b/packages/reports/tests/integration/components/navi-date-picker-test.js
@@ -13,11 +13,11 @@ moduleForComponent('navi-date-picker', 'Integration | Component | Navi Date Pick
 test('Select date', function(assert) {
   assert.expect(5);
 
-  this.set('selectedDate', moment('2015-07-14', TEST_FORMAT));
+  this.set('date', moment('2015-07-14', TEST_FORMAT));
 
   this.render(hbs`
         {{navi-date-picker
-            selectedDate=selectedDate
+            date=date
         }}
     `);
 
@@ -29,9 +29,9 @@ test('Select date', function(assert) {
     'The active month is based on the given date'
   );
 
-  /* == Update selectedDate after creation == */
+  /* == Update date after creation == */
   Ember.run(() => {
-    this.set('selectedDate', moment('2015-06-17', TEST_FORMAT));
+    this.set('date', moment('2015-06-17', TEST_FORMAT));
   });
 
   assert.equal(this.$('.day.active').text(), '17', 'The active day is based on the new given date');
@@ -44,7 +44,7 @@ test('Select date', function(assert) {
 
   /* == Date outside of range == */
   Ember.run(() => {
-    this.set('selectedDate', moment('2050-06-17', TEST_FORMAT));
+    this.set('date', moment('2050-06-17', TEST_FORMAT));
   });
 
   assert.equal(this.$('.day.active').length, 1, 'No date, even a future date is out of range');
@@ -57,11 +57,11 @@ test('Change date through calendar, then through attr', function(assert) {
     clickDate = moment('2015-07-18', TEST_FORMAT),
     boundDate = moment('2015-07-12', TEST_FORMAT);
 
-  this.set('selectedDate', originalDate);
+  this.set('date', originalDate);
 
   this.render(hbs`
         {{navi-date-picker
-            selectedDate=selectedDate
+            date=date
         }}
     `);
 
@@ -71,7 +71,7 @@ test('Change date through calendar, then through attr', function(assert) {
   assert.ok(isDayActive(this, clickDate), 'Clicked date is visibly selected');
 
   // Change date back through binding
-  this.set('selectedDate', boundDate);
+  this.set('date', boundDate);
 
   assert.ok(isDayActive(this, boundDate), 'Bound date is visibly selected');
   assert.ok(!isDayActive(this, clickDate), 'Clicked date is no longer selected');
@@ -84,26 +84,26 @@ test('Change date action', function(assert) {
     newDate = moment('2015-07-18', TEST_FORMAT);
 
   this.set('date', originalDate);
-  this.on('dateSelected', date => assert.ok(date.isSame(newDate), 'dateSelected action was called with new date'));
+  this.on('onUpdate', date => assert.ok(date.isSame(newDate), 'onUpdate action was called with new date'));
   this.render(hbs`
         {{navi-date-picker
-            selectedDate=date
-            dateSelected="dateSelected"
+            date=date
+            onUpdate="onUpdate"
         }}
     `);
 
   // Test clicking on a different date
   findDayElement(this, newDate).click();
 
-  assert.ok(originalDate.isSame(moment('2015-07-14', TEST_FORMAT)), 'selectedDate is a one way binding');
+  assert.ok(originalDate.isSame(moment('2015-07-14', TEST_FORMAT)), 'date is a one way binding');
   assert.ok(isDayActive(this, newDate), 'New date is visibly selected regardless of action being handled');
   assert.ok(!isDayActive(this, originalDate), 'Original date is no longer selected');
 
   /*
-   * Check that changing `selectedDate` to the date suggested by the action does not
+   * Check that changing `date` to the date suggested by the action does not
    * trigger the action again, causing a cycle
    */
-  this.on('dateSelected', () => {
+  this.on('onUpdate', () => {
     throw new Error('Action was incorrectly called');
   });
   this.set('date', newDate);
@@ -112,25 +112,24 @@ test('Change date action', function(assert) {
   findDayElement(this, newDate).click();
 });
 
-test('Change date action always gives start of time period', function(assert) {
+test('Change date action always gives start of time period', async function(assert) {
   assert.expect(1);
 
   let originalDate = moment('2015-07-14', TEST_FORMAT);
 
   this.set('date', originalDate);
-  this.on('dateSelected', date =>
-    assert.ok(date.isSame(originalDate.startOf('isoweek')), 'dateSelected action was called with start of week')
+  this.on('onUpdate', date =>
+    assert.ok(date.isSame(originalDate.startOf('isoweek')), 'onUpdate action was called with start of week')
   );
   this.render(hbs`
         {{navi-date-picker
-            selectedDate=date
+            date=date
             dateTimePeriod="week"
-            dateSelected="dateSelected"
+            onUpdate="onUpdate"
         }}
     `);
-
   // Click in the middle of the week
-  findDayElement(this, originalDate.subtract(1, 'day')).click();
+  await findDayElement(this, originalDate.clone().subtract(1, 'day')).click();
 });
 
 test('Selection view changes with time period', function(assert) {
@@ -140,7 +139,7 @@ test('Selection view changes with time period', function(assert) {
   this.set('dateTimePeriod', 'month');
   this.render(hbs`
         {{navi-date-picker
-            selectedDate=date
+            date=date
             dateTimePeriod=dateTimePeriod
         }}
     `);
@@ -169,7 +168,7 @@ test('Selection changes with time period', function(assert) {
   this.set('dateTimePeriod', 'day');
   this.render(hbs`
         {{navi-date-picker
-            selectedDate=date
+            date=date
             dateTimePeriod=dateTimePeriod
         }}
     `);
@@ -237,7 +236,7 @@ test('Click same date twice', function(assert) {
   this.set('dateTimePeriod', 'week');
   this.render(hbs`
         {{navi-date-picker
-            selectedDate=date
+            date=date
             dateTimePeriod=dateTimePeriod
         }}
     `);
@@ -261,7 +260,7 @@ test('Start date', function(assert) {
   this.set('dateTimePeriod', 'day');
   this.render(hbs`
         {{navi-date-picker
-            selectedDate=date
+            date=date
             dateTimePeriod=dateTimePeriod
         }}
     `);


### PR DESCRIPTION
Moved the dropdown date picker with reset and apply buttons to its own component. Before, we only had this for filter values so this is a little more generic. Next PR will use two instances of this component to make a dimension date range selector filter value component. 