### PR TITLE
Fix: Build failing due to new ember-cli-flash version

### DIFF
--- a/packages/app/tests/unit/services/navi-notifications-test.js
+++ b/packages/app/tests/unit/services/navi-notifications-test.js
@@ -1,7 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('service:navi-notifications', 'Unit | Service | navi notifications', {
-  needs: ['service:flash-messages']
+  needs: ['service:flash-messages', 'config:environment']
 });
 
 test('clearMessages', function(assert) {


### PR DESCRIPTION
Build fails in navi-app without this