### PR TITLE
Fix: Metric param selector fails on empty parameters

### DIFF
--- a/packages/core/addon/mirage/fixtures/reports.js
+++ b/packages/core/addon/mirage/fixtures/reports.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2019, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Reports Mock Data
@@ -469,6 +469,63 @@ export default [
         {
           end: '2018-11-18 00:00:00.000',
           start: '2018-11-11 00:00:00.000'
+        }
+      ],
+      bardVersion: 'v1',
+      requestVersion: 'v1'
+    }
+  },
+  {
+    id: 11,
+    title: 'old report without params',
+    createdOn: '2015-01-01 00:00:00',
+    updatedOn: '2015-01-01 00:00:00',
+    author: 'navi_user',
+    deliveryRules: [],
+    visualization: {
+      type: 'table',
+      version: 1,
+      metadata: {
+        columns: [
+          {
+            field: 'dateTime',
+            type: 'dateTime',
+            displayName: 'Date'
+          },
+          {
+            field: 'property',
+            type: 'dimension',
+            displayName: 'Property'
+          },
+          {
+            field: { metric: 'revenue', parameters: {} },
+            type: 'metric',
+            displayName: 'Revenue'
+          }
+        ]
+      }
+    },
+    request: {
+      logicalTable: {
+        table: 'tableA',
+        timeGrain: 'day'
+      },
+      metrics: [
+        {
+          metric: 'revenue',
+          parameters: {}
+        }
+      ],
+      dimensions: [
+        {
+          dimension: 'property'
+        }
+      ],
+      filters: [],
+      intervals: [
+        {
+          end: '2018-02-16 00:00:00.000',
+          start: '2018-02-09 00:00:00.000'
         }
       ],
       bardVersion: 'v1',

--- a/packages/reports/addon/components/metric-config.js
+++ b/packages/reports/addon/components/metric-config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018, Yahoo Holdings Inc.
+ * Copyright 2019, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Usage:
@@ -106,15 +106,23 @@ export default Component.extend({
       selectedMetricParams = arr(selectedMetrics).mapBy('parameters'),
       allParametersMap = get(this, 'allParametersMap') || {};
 
-    return selectedMetricParams.map(param => {
-      //delete alias key in copy
-      let paramCopy = Object.assign({}, param);
-      delete paramCopy.as;
+    return selectedMetricParams
+      .map(param => {
+        //delete alias key in copy
+        let paramCopy = Object.assign({}, param);
+        delete paramCopy.as;
+        const paramEntries = Object.entries(paramCopy);
 
-      //fetch from map
-      let [key, value] = Object.entries(paramCopy)[0];
-      return allParametersMap[`${key}|${value}`];
-    });
+        //see if they have parameters at all
+        if (paramEntries.length === 0) {
+          return false;
+        }
+
+        //fetch from map
+        let [key, value] = paramEntries[0];
+        return allParametersMap[`${key}|${value}`];
+      })
+      .filter(e => !!e); //filter out bad or outdated parameters
   }),
 
   /**

--- a/packages/reports/tests/acceptance/metric-parameters-test.js
+++ b/packages/reports/tests/acceptance/metric-parameters-test.js
@@ -250,3 +250,14 @@ test('metric selector filter action for parameterized metrics', function(assert)
     );
   });
 });
+
+test('old reports still allow you to choose parameters', async function(assert) {
+  assert.expect(1);
+  await visit('/reports/11/view');
+
+  await click('.report-builder__metric-selector .navi-list-selector__show-link');
+  await click('.report-builder__metric-selector .grouped-list__item:contains(Revenue) .metric-config > div');
+
+  const options = find('.metric-config__dropdown-container .grouped-list__item').toArray();
+  assert.ok(options.length > 0, 'Metric options should render');
+});


### PR DESCRIPTION
Fixes bug in which, loading a report with empty parameters. (such as an old report, or a report with bad parameter values). the metric config component will fail to render entirely instead of letting users pick valid parameters.

gif of current behavior:
![metricparambad](https://user-images.githubusercontent.com/99422/50659740-0dd8c600-0f63-11e9-8754-a60092c5708c.gif)
