### PR TITLE
Fix: Build timing out in reports and core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
 install:
   - travis_wait npm install
 script:
-  - travis_wait lerna run test --scope $PACKAGE
+  - travis_wait lerna run test --scope $PACKAGE --stream
 jobs:
   include:
     - stage: Publish

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
 install:
   - travis_wait npm install
 script:
-  - travis_wait lerna run test --scope $PACKAGE --stream
+  - travis_wait lerna run test --scope $PACKAGE
 jobs:
   include:
     - stage: Publish

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -71,7 +71,7 @@
     "ember-resize": "0.0.17",
     "ember-resolver": "^4.0.0",
     "ember-route-action-helper": "^2.0.6",
-    "ember-sortable": "^1.12.1",
+    "ember-sortable": "1.12.3",
     "ember-source": "~2.16.0",
     "ember-tether": "^1.0.0",
     "ember-toggle": "^5.2.1",

--- a/packages/core/addon/chart-builders/date-time.js
+++ b/packages/core/addon/chart-builders/date-time.js
@@ -21,6 +21,7 @@ import { get, set, getWithDefault } from '@ember/object';
 import { canonicalizeMetric } from 'navi-data/utils/metric';
 
 const API_DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss.SSS';
+const YEAR_WITH_53_ISOWEEKS = '2015-01-01';
 
 /**
  * @constant {Object} logic for grouping one time grain by another
@@ -93,7 +94,7 @@ export const GROUP = {
         xValueCount: 53,
         getXValue: dateTime => dateTime.isoWeek(),
         getXDisplay: x =>
-          moment()
+          moment(YEAR_WITH_53_ISOWEEKS)
             .isoWeek(x)
             .format('MMM'),
         getSeries: dateTime => dateTime.format('GGGG')

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,7 +35,7 @@
     "ember-power-select": "^1.10.4",
     "ember-radio-button": "^1.2.1",
     "ember-resize": "^0.2.4",
-    "ember-sortable": "^1.12.1",
+    "ember-sortable": "1.12.3",
     "ember-tether": "^1.0.0",
     "ember-toggle": "^5.2.1",
     "ember-tooltips": "^2.10.0",

--- a/packages/core/tests/acceptance/table-test.js
+++ b/packages/core/tests/acceptance/table-test.js
@@ -12,50 +12,44 @@ moduleForAcceptance('Acceptance | table', {
   }
 });
 
-test('visiting /table', function(assert) {
+test('visiting /table', async function(assert) {
   assert.expect(2);
 
-  visit('/table');
+  await visit('/table');
 
-  andThen(function() {
-    assert.deepEqual(
-      find('.table-header-row-vc--view .table-header-cell__title')
-        .toArray()
-        .map(el =>
-          $(el)
-            .text()
-            .trim()
-        ),
-      ['Date', 'Operating System', 'Unique Identifiers', 'Total Page Views', 'Total Page Views WoW'],
-      'The headers for the table are as specified'
-    );
-  });
+  assert.deepEqual(
+    find('.table-header-row-vc--view .table-header-cell__title')
+      .toArray()
+      .map(el =>
+        $(el)
+          .text()
+          .trim()
+      ),
+    ['Date', 'Operating System', 'Unique Identifiers', 'Total Page Views', 'Total Page Views WoW'],
+    'The headers for the table are as specified'
+  );
 
-  andThen(() => {
-    return reorder(
-      'mouse',
-      '.table-header-cell',
-      '.dimension:contains(Operating System)',
-      '.dateTime',
-      '.metric:contains(Unique Identifiers)',
-      '.metric:contains(Total Page Views)',
-      '.threshold:contains(Total Page Views WoW)'
-    );
-  });
+  await reorder(
+    'mouse',
+    '.table-header-cell',
+    '.dimension:contains(Operating System)',
+    '.dateTime',
+    '.metric:contains(Unique Identifiers)',
+    '.metric:contains(Total Page Views)',
+    '.threshold:contains(Total Page Views WoW)'
+  );
 
-  andThen(() => {
-    assert.deepEqual(
-      find('.table-header-row-vc--view .table-header-cell__title')
-        .toArray()
-        .map(el =>
-          $(el)
-            .text()
-            .trim()
-        ),
-      ['Operating System', 'Date', 'Unique Identifiers', 'Total Page Views', 'Total Page Views WoW'],
-      'The headers are reordered as specified by the reorder'
-    );
-  });
+  assert.deepEqual(
+    find('.table-header-row-vc--view .table-header-cell__title')
+      .toArray()
+      .map(el =>
+        $(el)
+          .text()
+          .trim()
+      ),
+    ['Operating System', 'Date', 'Unique Identifiers', 'Total Page Views', 'Total Page Views WoW'],
+    'The headers are reordered as specified by the reorder'
+  );
 });
 
 test('toggle table editing', function(assert) {

--- a/packages/core/tests/dummy/config/ember-intl.js
+++ b/packages/core/tests/dummy/config/ember-intl.js
@@ -1,0 +1,5 @@
+module.exports = function() {
+  return {
+    locales: ['en-us']
+  };
+};

--- a/packages/core/tests/helpers/destroy-app.js
+++ b/packages/core/tests/helpers/destroy-app.js
@@ -2,4 +2,7 @@ import { run } from '@ember/runloop';
 
 export default function destroyApp(application) {
   run(application, 'destroy');
+  if (window.server) {
+    window.server.shutdown();
+  }
 }

--- a/packages/core/tests/integration/components/navi-visualizations/goal-gauge-test.js
+++ b/packages/core/tests/integration/components/navi-visualizations/goal-gauge-test.js
@@ -4,21 +4,21 @@ import { set } from '@ember/object';
 import { moduleForComponent, test } from 'ember-qunit';
 import { initialize as injectC3Enhancements } from 'navi-core/initializers/inject-c3-enhancements';
 import hbs from 'htmlbars-inline-precompile';
-import { startMirage } from 'dummy/initializers/ember-cli-mirage';
+import { setupMock, teardownMock } from '../../../helpers/mirage-helper';
 
 moduleForComponent('goal-gauge', 'Integration | Component | goal gauge ', {
   integration: true,
 
   beforeEach() {
     injectC3Enhancements();
-    this.server = startMirage();
+    setupMock();
     return getOwner(this)
       .lookup('service:bard-metadata')
       .loadMetadata();
   },
 
   afterEach() {
-    return this.server.shutdown();
+    return teardownMock();
   }
 });
 

--- a/packages/core/tests/integration/components/navi-visualizations/table-print-test.js
+++ b/packages/core/tests/integration/components/navi-visualizations/table-print-test.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import config from 'ember-get-config';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { startMirage } from 'dummy/initializers/ember-cli-mirage';
+import { setupMock, teardownMock } from '../../../helpers/mirage-helper';
 
 const TEMPLATE = hbs`
   {{navi-visualizations/table-print
@@ -82,7 +82,7 @@ moduleForComponent('navi-visualizations/table-print', 'Integration | Component |
   integration: true,
   beforeEach() {
     config.navi.FEATURES.enableVerticalCollectionTableIterator = true;
-    this.server = startMirage();
+    setupMock();
 
     this.set('model', Model);
     this.set('options', Options);
@@ -94,7 +94,7 @@ moduleForComponent('navi-visualizations/table-print', 'Integration | Component |
   },
   afterEach() {
     config.navi.FEATURES.enableVerticalCollectionTableIterator = false;
-    this.server.shutdown();
+    teardownMock();
   }
 });
 

--- a/packages/core/tests/integration/components/navi-visualizations/table-test.js
+++ b/packages/core/tests/integration/components/navi-visualizations/table-test.js
@@ -6,7 +6,7 @@ import merge from 'lodash/merge';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
-import { startMirage } from 'dummy/initializers/ember-cli-mirage';
+import { setupMock, teardownMock } from '../../../helpers/mirage-helper';
 
 const TEMPLATE = hbs`
   <div style="width: 800px; height: 800px; display: flex;">
@@ -134,7 +134,7 @@ moduleForComponent('navi-visualizations/table', 'Integration | Component | table
   integration: true,
   beforeEach() {
     config.navi.FEATURES.enableVerticalCollectionTableIterator = true;
-    this.server = startMirage();
+    setupMock();
 
     this.set('model', Model);
     this.set('options', Options);
@@ -146,7 +146,7 @@ moduleForComponent('navi-visualizations/table', 'Integration | Component | table
   },
   afterEach() {
     config.navi.FEATURES.enableVerticalCollectionTableIterator = false;
-    this.server.shutdown();
+    teardownMock();
   }
 });
 

--- a/packages/core/tests/integration/components/visualization-config/table-test.js
+++ b/packages/core/tests/integration/components/visualization-config/table-test.js
@@ -2,19 +2,19 @@ import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import config from 'ember-get-config';
-import { startMirage } from 'dummy/initializers/ember-cli-mirage';
+import { setupMock, teardownMock } from '../../../helpers/mirage-helper';
 import { clickTrigger as toggleSelector, nativeMouseUp as toggleOption } from 'ember-power-select/test-support/helpers';
 
 moduleForComponent('visualization-config/table', 'Integration | Component | visualization config/table', {
   integration: true,
   beforeEach() {
-    this.server = startMirage();
+    setupMock();
     return Ember.getOwner(this)
       .lookup('service:bard-metadata')
       .loadMetadata();
   },
   afterEach() {
-    this.server.shutdown();
+    teardownMock();
   }
 });
 

--- a/packages/core/tests/integration/helpers/default-column-name-test.js
+++ b/packages/core/tests/integration/helpers/default-column-name-test.js
@@ -1,19 +1,19 @@
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { startMirage } from 'dummy/initializers/ember-cli-mirage';
+import { setupMock, teardownMock } from '../../helpers/mirage-helper';
 
 moduleForComponent('default-column-name', 'helper:default-column-name', {
   integration: true,
   beforeEach() {
-    this.server = startMirage();
+    setupMock();
 
     return Ember.getOwner(this)
       .lookup('service:bard-metadata')
       .loadMetadata();
   },
   afterEach() {
-    this.server.shutdown();
+    teardownMock();
   }
 });
 

--- a/packages/core/tests/unit/chart-builders/date-test.js
+++ b/packages/core/tests/unit/chart-builders/date-test.js
@@ -1,12 +1,12 @@
 import { test, module } from 'ember-qunit';
-import Ember from 'ember';
+import { get } from '@ember/object';
+import Object from '@ember/object';
 import BuilderClass from 'navi-core/chart-builders/date-time';
 import TooltipTemplate from '../../../../navi-core/templates/chart-tooltips/date';
 
 const DateChartBuilder = BuilderClass.create();
-const { get } = Ember;
 
-module('Unit | Chart Builders | Chart Builder Date Time');
+module('Unit | Chart Builders | Date Time');
 
 test('weeks by year uses isoWeekYear', function(assert) {
   assert.expect(2);
@@ -435,7 +435,7 @@ test('buildTooltip', function(assert) {
     ],
     data = DateChartBuilder.buildData(response, config, request),
     mixin = DateChartBuilder.buildTooltip(data, config, request),
-    tooltipClass = Ember.Object.extend(mixin, {}),
+    tooltipClass = Object.extend(mixin, {}),
     tooltip = tooltipClass.create({ config, request, tooltipData, x });
 
   assert.equal(get(tooltip, 'layout'), TooltipTemplate, 'Tooltip uses date template');

--- a/packages/core/tests/unit/chart-builders/date-test.js
+++ b/packages/core/tests/unit/chart-builders/date-test.js
@@ -6,7 +6,7 @@ import TooltipTemplate from '../../../../navi-core/templates/chart-tooltips/date
 const DateChartBuilder = BuilderClass.create();
 const { get } = Ember;
 
-module('Unit | Utils | Chart Builder Date Time');
+module('Unit | Chart Builders | Chart Builder Date Time');
 
 test('weeks by year uses isoWeekYear', function(assert) {
   assert.expect(2);
@@ -30,7 +30,7 @@ test('weeks by year uses isoWeekYear', function(assert) {
         pageViews: 2
       },
       {
-        dateTime: '2016-01-01 00:00:00.000', // Week 52, 2015
+        dateTime: '2016-01-01 00:00:00.000', // Week 53, 2015
         pageViews: 1
       }
     ],

--- a/packages/core/tests/unit/chart-builders/dimension-test.js
+++ b/packages/core/tests/unit/chart-builders/dimension-test.js
@@ -166,7 +166,7 @@ const DATA2 = [
     ]
   };
 
-module('Unit | Utils | Chart Builder Dimension');
+module('Unit | Chart Builders | Dimension');
 
 test('buildData - no dimensions', function(assert) {
   assert.expect(1);

--- a/packages/core/tests/unit/chart-builders/metric-test.js
+++ b/packages/core/tests/unit/chart-builders/metric-test.js
@@ -48,7 +48,7 @@ const DATA = [
     ]
   };
 
-moduleFor('chart-builder:metric', 'Unit | Utils | Chart Builder Metric', {
+moduleFor('chart-builder:metric', 'Unit | Chart Builders | Metric', {
   needs: [
     'helper:metric-format',
     'model:metadata/table',

--- a/packages/core/tests/unit/components/visualization-config/table-test.js
+++ b/packages/core/tests/unit/components/visualization-config/table-test.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
-import { startMirage } from 'dummy/initializers/ember-cli-mirage';
+import { setupMock, teardownMock } from '../../../helpers/mirage-helper';
 
 moduleForComponent('visualization-config/table', 'Unit | Component | table config', {
   unit: 'true',
@@ -16,13 +16,13 @@ moduleForComponent('visualization-config/table', 'Unit | Component | table confi
     'service:ajax'
   ],
   beforeEach() {
-    this.server = startMirage();
+    setupMock();
     Ember.getOwner(this)
       .lookup('service:bard-metadata')
       .loadMetadata();
   },
   afterEach() {
-    this.server.shutdown();
+    teardownMock();
   }
 });
 

--- a/packages/core/tests/unit/models/bard-request/fragments/dimension-test.js
+++ b/packages/core/tests/unit/models/bard-request/fragments/dimension-test.js
@@ -1,5 +1,5 @@
 import { moduleForModel, test } from 'ember-qunit';
-import { startMirage } from '../../../../../initializers/ember-cli-mirage';
+import { setupMock, teardownMock } from '../../../../helpers/mirage-helper';
 import wait from 'ember-test-helpers/wait';
 import { getOwner } from '@ember/application';
 import { run } from '@ember/runloop';
@@ -29,7 +29,7 @@ moduleForModel('fragments-mock', 'Unit | Model Fragment | BardRequest - Dimensio
   ],
 
   beforeEach() {
-    this.server = startMirage();
+    setupMock();
 
     Store = getOwner(this).lookup('service:store');
     MetadataService = getOwner(this).lookup('service:bard-metadata');
@@ -50,7 +50,7 @@ moduleForModel('fragments-mock', 'Unit | Model Fragment | BardRequest - Dimensio
     });
   },
   afterEach() {
-    this.server.shutdown();
+    teardownMock();
   }
 });
 

--- a/packages/core/tests/unit/models/bard-request/fragments/filter-test.js
+++ b/packages/core/tests/unit/models/bard-request/fragments/filter-test.js
@@ -1,5 +1,5 @@
 import { moduleForModel, test } from 'ember-qunit';
-import { startMirage } from '../../../../../initializers/ember-cli-mirage';
+import { setupMock, teardownMock } from '../../../../helpers/mirage-helper';
 import wait from 'ember-test-helpers/wait';
 import config from 'ember-get-config';
 import { A as arr } from '@ember/array';
@@ -7,7 +7,7 @@ import { get } from '@ember/object';
 import { getOwner } from '@ember/application';
 import { run } from '@ember/runloop';
 
-var Store, MetadataService;
+let Store, MetadataService, Server;
 
 const TextInput = arr(['mirror', 'shield', 'deku', 'tree']);
 
@@ -54,11 +54,11 @@ moduleForModel('fragments-mock', 'Unit | Model Fragment | BardRequest - Filter',
   ],
 
   beforeEach() {
-    this.server = startMirage();
+    Server = setupMock();
     Store = getOwner(this).lookup('service:store');
 
-    this.server.urlPrefix = config.navi.dataSources[0].uri;
-    this.server.get(`/v1/dimensions/age/values/`, () => {
+    Server.urlPrefix = config.navi.dataSources[0].uri;
+    Server.get(`/v1/dimensions/age/values/`, () => {
       return {
         rows: AgeResponse.slice(0, 2)
       };
@@ -88,7 +88,7 @@ moduleForModel('fragments-mock', 'Unit | Model Fragment | BardRequest - Filter',
     });
   },
   afterEach() {
-    this.server.shutdown();
+    teardownMock();
   }
 });
 

--- a/packages/core/tests/unit/models/bard-request/fragments/having-test.js
+++ b/packages/core/tests/unit/models/bard-request/fragments/having-test.js
@@ -1,5 +1,5 @@
 import { moduleForModel, test } from 'ember-qunit';
-import { startMirage } from '../../../../../initializers/ember-cli-mirage';
+import { setupMock, teardownMock } from '../../../../helpers/mirage-helper';
 import wait from 'ember-test-helpers/wait';
 import { getOwner } from '@ember/application';
 import { run } from '@ember/runloop';
@@ -32,7 +32,7 @@ moduleForModel('fragments-mock', 'Unit | Model Fragment | BardRequest - Having',
 
   beforeEach() {
     Store = getOwner(this).lookup('service:store');
-    this.server = startMirage();
+    setupMock();
 
     MetadataService = getOwner(this).lookup('service:bard-metadata');
 
@@ -63,7 +63,7 @@ moduleForModel('fragments-mock', 'Unit | Model Fragment | BardRequest - Having',
     });
   },
   afterEach() {
-    this.server.shutdown();
+    teardownMock();
   }
 });
 

--- a/packages/core/tests/unit/models/bard-request/fragments/interval-test.js
+++ b/packages/core/tests/unit/models/bard-request/fragments/interval-test.js
@@ -3,7 +3,7 @@ import moment from 'moment';
 import DateUtils from 'navi-core/utils/date';
 import Interval from 'navi-core/utils/classes/interval';
 import Duration from 'navi-core/utils/classes/duration';
-import { startMirage } from '../../../../../initializers/ember-cli-mirage';
+import { setupMock, teardownMock } from '../../../../helpers/mirage-helper';
 import { getOwner } from '@ember/application';
 import { run } from '@ember/runloop';
 
@@ -29,7 +29,7 @@ moduleForModel('fragments-mock', 'Unit | Model Fragment | BardRequest - Interval
       end: '2015-08-20 00:00:00.000'
     };
 
-    this.server = startMirage();
+    setupMock();
     Store = getOwner(this).lookup('service:store');
 
     //Add instances to the store
@@ -46,7 +46,7 @@ moduleForModel('fragments-mock', 'Unit | Model Fragment | BardRequest - Interval
     });
   },
   afterEach() {
-    this.server.shutdown();
+    teardownMock();
   }
 });
 

--- a/packages/core/tests/unit/models/bard-request/fragments/logical-table-test.js
+++ b/packages/core/tests/unit/models/bard-request/fragments/logical-table-test.js
@@ -1,5 +1,5 @@
 import { moduleForModel, test } from 'ember-qunit';
-import { startMirage } from '../../../../../initializers/ember-cli-mirage';
+import { setupMock, teardownMock } from '../../../../helpers/mirage-helper';
 import wait from 'ember-test-helpers/wait';
 import { getOwner } from '@ember/application';
 import { run } from '@ember/runloop';
@@ -26,12 +26,12 @@ moduleForModel('fragments-mock', 'Unit | Model Fragment | BardRequest - Logical 
     'adapter:dimensions/bard'
   ],
 
-  beforeEach() {
-    this.server = startMirage();
+  async beforeEach() {
+    setupMock();
     Store = getOwner(this).lookup('service:store');
     MetadataService = getOwner(this).lookup('service:bard-metadata');
 
-    MetadataService.loadMetadata().then(() => {
+    await MetadataService.loadMetadata().then(() => {
       //Add instances to the store
       return run(() => {
         Store.pushPayload({
@@ -50,43 +50,41 @@ moduleForModel('fragments-mock', 'Unit | Model Fragment | BardRequest - Logical 
     });
   },
   afterEach() {
-    this.server.shutdown();
+    teardownMock();
   }
 });
 
 test('Model using the Logical Table Fragment', function(assert) {
   assert.expect(5);
 
-  return wait().then(() => {
-    let mockModel = Store.peekRecord('fragments-mock', 1);
-    assert.ok(mockModel, 'mockModel is fetched from the store');
+  let mockModel = Store.peekRecord('fragments-mock', 1);
+  assert.ok(mockModel, 'mockModel is fetched from the store');
 
-    return run(() => {
-      /* == Getter Method == */
-      assert.equal(
-        mockModel.get('table.table.description'),
-        'Network, Product, and Property level data',
-        'The property `table` has the description `Network table`'
-      );
+  return run(() => {
+    /* == Getter Method == */
+    assert.equal(
+      mockModel.get('table.table.description'),
+      'Network, Product, and Property level data',
+      'The property `table` has the description `Network table`'
+    );
 
-      assert.equal(mockModel.get('table.timeGrainName'), 'day', 'The property `table` has the time grain `day`');
+    assert.equal(mockModel.get('table.timeGrainName'), 'day', 'The property `table` has the time grain `day`');
 
-      /* == Setter Method == */
-      mockModel.set('table.table', MetadataService.getById('table', 'tableA'));
-      mockModel.set('table.timeGrainName', 'week');
+    /* == Setter Method == */
+    mockModel.set('table.table', MetadataService.getById('table', 'tableA'));
+    mockModel.set('table.timeGrainName', 'week');
 
-      assert.equal(
-        mockModel.get('table.table.description'),
-        'Table A',
-        'The property `table` has been updated with the description `Table A`'
-      );
+    assert.equal(
+      mockModel.get('table.table.description'),
+      'Table A',
+      'The property `table` has been updated with the description `Table A`'
+    );
 
-      assert.equal(
-        mockModel.get('table.timeGrainName'),
-        'week',
-        'The property `table` has been updated with the time grain `week`'
-      );
-    });
+    assert.equal(
+      mockModel.get('table.timeGrainName'),
+      'week',
+      'The property `table` has been updated with the time grain `week`'
+    );
   });
 });
 

--- a/packages/core/tests/unit/models/bard-request/fragments/metric-test.js
+++ b/packages/core/tests/unit/models/bard-request/fragments/metric-test.js
@@ -1,5 +1,5 @@
 import { moduleForModel, test } from 'ember-qunit';
-import { startMirage } from '../../../../../initializers/ember-cli-mirage';
+import { setupMock, teardownMock } from '../../../../helpers/mirage-helper';
 import { getOwner } from '@ember/application';
 import { run } from '@ember/runloop';
 
@@ -30,7 +30,7 @@ moduleForModel('fragments-mock', 'Unit | Model | Fragment | BardRequest - Metric
   ],
 
   beforeEach() {
-    this.server = startMirage();
+    setupMock();
 
     Store = getOwner(this).lookup('service:store');
     MetadataService = getOwner(this).lookup('service:bard-metadata');
@@ -51,7 +51,7 @@ moduleForModel('fragments-mock', 'Unit | Model | Fragment | BardRequest - Metric
     });
   },
   afterEach() {
-    this.server.shutdown();
+    teardownMock();
   }
 });
 

--- a/packages/core/tests/unit/models/bard-request/fragments/sort-test.js
+++ b/packages/core/tests/unit/models/bard-request/fragments/sort-test.js
@@ -1,5 +1,5 @@
 import { moduleForModel, test } from 'ember-qunit';
-import { startMirage } from '../../../../../initializers/ember-cli-mirage';
+import { setupMock, teardownMock } from '../../../../helpers/mirage-helper';
 import wait from 'ember-test-helpers/wait';
 import { getOwner } from '@ember/application';
 import { run } from '@ember/runloop';
@@ -31,7 +31,7 @@ moduleForModel('fragments-mock', 'Unit | Model | Fragment | BardRequest - Sort',
   ],
 
   beforeEach() {
-    this.server = startMirage();
+    setupMock();
 
     Store = getOwner(this).lookup('service:store');
     MetadataService = getOwner(this).lookup('service:bard-metadata');
@@ -58,7 +58,7 @@ moduleForModel('fragments-mock', 'Unit | Model | Fragment | BardRequest - Sort',
     });
   },
   afterEach() {
-    this.server.shutdown();
+    teardownMock();
   }
 });
 

--- a/packages/core/tests/unit/models/bard-request/request-test.js
+++ b/packages/core/tests/unit/models/bard-request/request-test.js
@@ -1,5 +1,5 @@
 import { moduleForModel, test } from 'ember-qunit';
-import { startMirage } from '../../../../initializers/ember-cli-mirage';
+import { setupMock, teardownMock } from '../../../helpers/mirage-helper';
 import wait from 'ember-test-helpers/wait';
 import { getOwner } from '@ember/application';
 import { get, set } from '@ember/object';
@@ -56,7 +56,7 @@ moduleForModel('fragments-mock', 'Unit | Model Fragment | BardRequest - Request'
   ],
 
   beforeEach() {
-    this.server = startMirage();
+    setupMock();
     Store = getOwner(this).lookup('service:store');
 
     MetadataService = getOwner(this).lookup('service:bard-metadata');
@@ -224,7 +224,7 @@ moduleForModel('fragments-mock', 'Unit | Model Fragment | BardRequest - Request'
     });
   },
   afterEach() {
-    this.server.shutdown();
+    teardownMock();
   }
 });
 

--- a/packages/dashboards/package.json
+++ b/packages/dashboards/package.json
@@ -37,7 +37,7 @@
     "ember-power-select": "^1.10.4",
     "ember-promise-helpers": "^1.0.3",
     "ember-route-action-helper": "^2.0.6",
-    "ember-sortable": "^1.12.1",
+    "ember-sortable": "1.12.3",
     "ember-tag-input": "^1.2.1",
     "ember-tether": "^1.0.0",
     "ember-toggle": "5.2.1",

--- a/packages/dashboards/tests/helpers/destroy-app.js
+++ b/packages/dashboards/tests/helpers/destroy-app.js
@@ -2,4 +2,7 @@ import { run } from '@ember/runloop';
 
 export default function destroyApp(application) {
   run(application, 'destroy');
+  if (window.server) {
+    window.server.shutdown();
+  }
 }

--- a/packages/directory/package.json
+++ b/packages/directory/package.json
@@ -66,7 +66,7 @@
     "ember-promise-helpers": "^1.0.6",
     "ember-resolver": "^4.0.0",
     "ember-route-action-helper": "^2.0.6",
-    "ember-sortable": "^1.12.1",
+    "ember-sortable": "1.12.3",
     "ember-source": "^3.1.3",
     "ember-source-channel-url": "^1.1.0",
     "ember-tag-input": "1.2.1",

--- a/packages/reports/package.json
+++ b/packages/reports/package.json
@@ -82,7 +82,7 @@
     "ember-qunit-assert-helpers": "^0.2.0",
     "ember-resize": "0.0.17",
     "ember-resolver": "^4.0.0",
-    "ember-sortable": "^1.12.1",
+    "ember-sortable": "1.12.3",
     "ember-source": "~2.16.0",
     "eslint-config-prettier": "^3.0.1",
     "loader.js": "^4.2.3",

--- a/packages/reports/tests/helpers/destroy-app.js
+++ b/packages/reports/tests/helpers/destroy-app.js
@@ -2,4 +2,7 @@ import { run } from '@ember/runloop';
 
 export default function destroyApp(application) {
   run(application, 'destroy');
+  if (window.server) {
+    window.server.shutdown();
+  }
 }


### PR DESCRIPTION
We should statically determine what the display month is for a week rather than depend on the date of runtime. 

It seems that ember-sortable 1.12.4 released about a week ago and it was causing some of our tests to time out.