### PR TITLE
Revert "Fix: Metric selector fails on empty parameters (#279)"

### DIFF
--- a/packages/core/addon/mirage/fixtures/reports.js
+++ b/packages/core/addon/mirage/fixtures/reports.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, Yahoo Holdings Inc.
+ * Copyright 2017, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Reports Mock Data
@@ -469,63 +469,6 @@ export default [
         {
           end: '2018-11-18 00:00:00.000',
           start: '2018-11-11 00:00:00.000'
-        }
-      ],
-      bardVersion: 'v1',
-      requestVersion: 'v1'
-    }
-  },
-  {
-    id: 11,
-    title: 'old report without params',
-    createdOn: '2015-01-01 00:00:00',
-    updatedOn: '2015-01-01 00:00:00',
-    author: 'navi_user',
-    deliveryRules: [],
-    visualization: {
-      type: 'table',
-      version: 1,
-      metadata: {
-        columns: [
-          {
-            field: 'dateTime',
-            type: 'dateTime',
-            displayName: 'Date'
-          },
-          {
-            field: 'property',
-            type: 'dimension',
-            displayName: 'Property'
-          },
-          {
-            field: { metric: 'revenue', parameters: {} },
-            type: 'metric',
-            displayName: 'Revenue'
-          }
-        ]
-      }
-    },
-    request: {
-      logicalTable: {
-        table: 'tableA',
-        timeGrain: 'day'
-      },
-      metrics: [
-        {
-          metric: 'revenue',
-          parameters: {}
-        }
-      ],
-      dimensions: [
-        {
-          dimension: 'property'
-        }
-      ],
-      filters: [],
-      intervals: [
-        {
-          end: '2018-02-16 00:00:00.000',
-          start: '2018-02-09 00:00:00.000'
         }
       ],
       bardVersion: 'v1',

--- a/packages/core/testem.js
+++ b/packages/core/testem.js
@@ -7,7 +7,7 @@ module.exports = {
   browser_args: {
     Chrome: {
       mode: 'ci',
-      args: ['--disable-gpu', '--headless', '--remote-debugging-port=9222', '--window-size=1440,900']
+      args: ['--disable-gpu', '--no-sandbox', '--headless', '--remote-debugging-port=9222', '--window-size=1440,900']
     }
   }
 };

--- a/packages/reports/addon/components/metric-config.js
+++ b/packages/reports/addon/components/metric-config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, Yahoo Holdings Inc.
+ * Copyright 2018, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Usage:
@@ -106,23 +106,15 @@ export default Component.extend({
       selectedMetricParams = arr(selectedMetrics).mapBy('parameters'),
       allParametersMap = get(this, 'allParametersMap') || {};
 
-    return selectedMetricParams
-      .map(param => {
-        //delete alias key in copy
-        let paramCopy = Object.assign({}, param);
-        delete paramCopy.as;
-        const paramEntries = Object.entries(paramCopy);
+    return selectedMetricParams.map(param => {
+      //delete alias key in copy
+      let paramCopy = Object.assign({}, param);
+      delete paramCopy.as;
 
-        //see if they have parameters at all
-        if (paramEntries.length === 0) {
-          return false;
-        }
-
-        //fetch from map
-        let [key, value] = paramEntries[0];
-        return allParametersMap[`${key}|${value}`];
-      })
-      .filter(e => !!e); //filter out bad or outdated parameters
+      //fetch from map
+      let [key, value] = Object.entries(paramCopy)[0];
+      return allParametersMap[`${key}|${value}`];
+    });
   }),
 
   /**

--- a/packages/reports/tests/acceptance/metric-parameters-test.js
+++ b/packages/reports/tests/acceptance/metric-parameters-test.js
@@ -250,14 +250,3 @@ test('metric selector filter action for parameterized metrics', function(assert)
     );
   });
 });
-
-test('old reports still allow you to choose parameters', async function(assert) {
-  assert.expect(1);
-  await visit('/reports/11/view');
-
-  await click('.report-builder__metric-selector .navi-list-selector__show-link');
-  await click('.report-builder__metric-selector .grouped-list__item:contains(Revenue) .metric-config > div');
-
-  const options = find('.metric-config__dropdown-container .grouped-list__item').toArray();
-  assert.ok(options.length > 0, 'Metric options should render');
-});


### PR DESCRIPTION
This reverts commit 31fefbb6d74db8f63176a8472429d75927a44d0c.

This is the last commit in master where the build is working. 