### PR TITLE
Add dimension date range filter value

### DIFF
--- a/packages/reports/addon/components/filter-builders/date-dimension.js
+++ b/packages/reports/addon/components/filter-builders/date-dimension.js
@@ -36,7 +36,7 @@ export default Base.extend({
     {
       id: 'bet',
       longName: 'Between (<=>)',
-      valuesComponent: 'filter-values/date-range'
+      valuesComponent: 'filter-values/dimension-date-range'
     }
   ],
 
@@ -52,7 +52,7 @@ export default Base.extend({
     return {
       subject: get(requestFragment, 'dimension'),
       operator,
-      values: arr([get(requestFragment, 'values')[0]])
+      values: arr(get(requestFragment, 'values'))
     };
   })
 });

--- a/packages/reports/addon/components/filter-values/dimension-date-range.js
+++ b/packages/reports/addon/components/filter-values/dimension-date-range.js
@@ -1,3 +1,13 @@
+/**
+ * Copyright 2019, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ *
+ * Usage:
+ *   {{filter-values/dimension-date-range
+ *       filter=filter
+ *       onUpdateFilter=(action 'update')
+ *   }}
+ */
 import Component from '@ember/component';
 import { computed, get } from '@ember/object';
 import layout from '../../templates/components/filter-values/dimension-date-range';
@@ -10,8 +20,14 @@ export default Component.extend({
    */
   classNames: ['filter-values--dimension-date-range-input'],
 
+  /**
+   * @property {Object} startDate - moment of beginning of interval
+   */
   startDate: computed.oneWay('filter.values.firstObject'),
 
+  /**
+   * @property {Object} endDate - moment of end of interval
+   */
   endDate: computed.oneWay('filter.values.lastObject'),
 
   /**

--- a/packages/reports/addon/components/filter-values/dimension-date-range.js
+++ b/packages/reports/addon/components/filter-values/dimension-date-range.js
@@ -11,6 +11,7 @@
 import Component from '@ember/component';
 import { computed, get } from '@ember/object';
 import layout from '../../templates/components/filter-values/dimension-date-range';
+import Moment from 'moment';
 
 export default Component.extend({
   layout,
@@ -21,12 +22,12 @@ export default Component.extend({
   classNames: ['filter-values--dimension-date-range-input'],
 
   /**
-   * @property {Object} startDate - moment of beginning of interval
+   * @property {String} startDate - date (YYYY-MM-DD) of beginning of interval
    */
   startDate: computed.oneWay('filter.values.firstObject'),
 
   /**
-   * @property {Object} endDate - moment of end of interval
+   * @property {String} endDate - date (YYYY-MM-DD) of end of interval
    */
   endDate: computed.oneWay('filter.values.lastObject'),
 
@@ -47,7 +48,7 @@ export default Component.extend({
      */
     setLowValue(value) {
       this.attrs.onUpdateFilter({
-        values: [value, get(this, 'filter.values.lastObject')]
+        values: [Moment(value).format('YYYY-MM-DD'), get(this, 'filter.values.lastObject')]
       });
     },
 
@@ -57,7 +58,7 @@ export default Component.extend({
      */
     setHighValue(value) {
       this.attrs.onUpdateFilter({
-        values: [get(this, 'filter.values.firstObject'), value]
+        values: [get(this, 'filter.values.firstObject'), Moment(value).format('YYYY-MM-DD')]
       });
     }
   }

--- a/packages/reports/addon/components/filter-values/dimension-date-range.js
+++ b/packages/reports/addon/components/filter-values/dimension-date-range.js
@@ -1,0 +1,48 @@
+import Component from '@ember/component';
+import { computed, get } from '@ember/object';
+import layout from '../../templates/components/filter-values/dimension-date-range';
+
+export default Component.extend({
+  layout,
+
+  /**
+   * @property {Array} classNames
+   */
+  classNames: ['filter-values--dimension-date-range-input'],
+
+  startDate: computed.oneWay('filter.values.firstObject'),
+
+  endDate: computed.oneWay('filter.values.lastObject'),
+
+  /**
+   * @property {String} lowPlaceholder
+   */
+  lowPlaceholder: 'Since',
+
+  /**
+   * @property {String} highPlaceholder
+   */
+  highPlaceholder: 'Before',
+
+  actions: {
+    /**
+     * @action setLowValue
+     * @param {String} value - first value to be set in filter
+     */
+    setLowValue(value) {
+      this.attrs.onUpdateFilter({
+        values: [value, get(this, 'filter.values.lastObject')]
+      });
+    },
+
+    /**
+     * @action setHighValue
+     * @param {String} value - last value to be set in filter
+     */
+    setHighValue(value) {
+      this.attrs.onUpdateFilter({
+        values: [get(this, 'filter.values.firstObject'), value]
+      });
+    }
+  }
+});

--- a/packages/reports/addon/templates/components/filter-values/dimension-date-range.hbs
+++ b/packages/reports/addon/templates/components/filter-values/dimension-date-range.hbs
@@ -1,0 +1,28 @@
+{{!-- Copyright 2018, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{#dropdown-date-picker
+  date=(moment startDate)
+  onUpdate=(action 'setLowValue')
+}}
+  <div class='filter-values--dimension-date-range-input__trigger filter-values--dimension-date-range-input__low-value'>  
+    {{#if startDate}}
+      {{moment-format startDate 'MMM DD, YYYY'}}
+    {{else}}
+      <span class='date__placeholder'>{{lowPlaceholder}}</span>
+    {{/if}}
+  </div>
+{{/dropdown-date-picker}}
+
+<span class='filter-values--dimension-date-range-input__separator'>and</span>
+
+{{#dropdown-date-picker
+  date=(moment endDate)
+  onUpdate=(action 'setHighValue')
+}}
+  <div class='filter-values--dimension-date-range-input__trigger filter-values--dimension-date-range-input__high-value'>  
+    {{#if endDate}}
+      {{moment-format endDate 'MMM DD, YYYY'}}
+    {{else}}
+      <span class='date__placeholder'>{{highPlaceholder}}</span>
+    {{/if}}
+  </div>
+{{/dropdown-date-picker}}

--- a/packages/reports/addon/templates/components/filter-values/dimension-date-range.hbs
+++ b/packages/reports/addon/templates/components/filter-values/dimension-date-range.hbs
@@ -1,15 +1,14 @@
-{{!-- Copyright 2018, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{!-- Copyright 2019, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 {{#dropdown-date-picker
   date=(moment startDate)
   onUpdate=(action 'setLowValue')
+  classNames='filter-values--dimension-date-range-input__trigger filter-values--dimension-date-range-input__low-value'
 }}
-  <div class='filter-values--dimension-date-range-input__trigger filter-values--dimension-date-range-input__low-value'>  
-    {{#if startDate}}
-      {{moment-format startDate 'MMM DD, YYYY'}}
-    {{else}}
-      <span class='date__placeholder'>{{lowPlaceholder}}</span>
-    {{/if}}
-  </div>
+  {{#if startDate}}
+    {{moment-format startDate 'MMM DD, YYYY'}}
+  {{else}}
+    <span class='date__placeholder'>{{lowPlaceholder}}</span>
+  {{/if}}
 {{/dropdown-date-picker}}
 
 <span class='filter-values--dimension-date-range-input__separator'>and</span>
@@ -17,12 +16,11 @@
 {{#dropdown-date-picker
   date=(moment endDate)
   onUpdate=(action 'setHighValue')
+  classNames='filter-values--dimension-date-range-input__trigger filter-values--dimension-date-range-input__high-value'
 }}
-  <div class='filter-values--dimension-date-range-input__trigger filter-values--dimension-date-range-input__high-value'>  
-    {{#if endDate}}
-      {{moment-format endDate 'MMM DD, YYYY'}}
-    {{else}}
-      <span class='date__placeholder'>{{highPlaceholder}}</span>
-    {{/if}}
-  </div>
+  {{#if endDate}}
+    {{moment-format endDate 'MMM DD, YYYY'}}
+  {{else}}
+    <span class='date__placeholder'>{{highPlaceholder}}</span>
+  {{/if}}
 {{/dropdown-date-picker}}

--- a/packages/reports/app/components/filter-values/dimension-date-range.js
+++ b/packages/reports/app/components/filter-values/dimension-date-range.js
@@ -1,0 +1,1 @@
+export { default } from 'navi-reports/components/filter-values/dimension-date-range';

--- a/packages/reports/app/styles/navi-reports/components/filter-collection.less
+++ b/packages/reports/app/styles/navi-reports/components/filter-collection.less
@@ -75,7 +75,8 @@
     line-height: @navi-ideal-line-height;
   }
 
-  .filter-values--date-dimension-select {
+  .filter-values--date-dimension-select,
+  .filter-values--dimension-date-range-input {
     &__trigger {
       border: 1px solid @navi-gray-400;
       cursor: pointer;

--- a/packages/reports/app/styles/navi-reports/components/filter-values.less
+++ b/packages/reports/app/styles/navi-reports/components/filter-values.less
@@ -28,6 +28,19 @@
     }
   }
 
+  &--dimension-date-range-input {
+    display: flex;
+    flex-direction: row;
+
+    & > div {
+      flex: 2;
+    }
+
+    &__separator {
+      padding: 5px;
+    }
+  }
+
   &--range-input__input,
   &--multi-value-input,
   &--value-input {

--- a/packages/reports/app/styles/navi-reports/components/filter-values.less
+++ b/packages/reports/app/styles/navi-reports/components/filter-values.less
@@ -39,6 +39,10 @@
     &__separator {
       padding: 5px;
     }
+
+    .dropdown-date-picker__trigger {
+      line-height: @filter-collection-row-height;
+    }
   }
 
   &--range-input__input,

--- a/packages/reports/tests/integration/components/filter-values/dimension-date-range-test.js
+++ b/packages/reports/tests/integration/components/filter-values/dimension-date-range-test.js
@@ -1,5 +1,9 @@
 import { moduleForComponent, test } from 'ember-qunit';
+import { clickTrigger } from 'ember-basic-dropdown/test-support/helpers';
+import { A as arr } from '@ember/array';
+import { get } from '@ember/object';
 import hbs from 'htmlbars-inline-precompile';
+import Moment from 'moment';
 
 moduleForComponent(
   'filter-values/dimension-date-range',
@@ -9,30 +13,61 @@ moduleForComponent(
   }
 );
 
-test('it renders', function(assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
+test('displayed dates and update actions', function(assert) {
+  assert.expect(4);
+  const filterValueMapper = value => (Moment.isMoment(value) ? value.format('YYYY-MM-DD') : null);
 
-  this.render(hbs`{{filter-values/dimension-date-range}}`);
+  this.set('filter', { values: arr([]) });
+  this.set('onUpdateFilter', () => null);
+
+  this.render(hbs`{{filter-values/dimension-date-range
+    filter=filter
+    onUpdateFilter=(action onUpdateFilter)
+  }}`);
 
   assert.equal(
     this.$()
       .text()
+      .replace(/\s\s+/g, ' ')
       .trim(),
-    ''
+    'Since and Before',
+    'Appropriate placeholders are displayed when the filter has no dates'
   );
 
-  // Template block usage:
-  this.render(hbs`
-    {{#filter-values/dimension-date-range}}
-      template block text
-    {{/filter-values/dimension-date-range}}
-  `);
+  this.set('filter', { values: arr([Moment('2019-01-05'), null]) });
 
+  //Check that setting low value sends the new date value to the action
+  this.set('onUpdateFilter', filter => {
+    assert.deepEqual(
+      get(filter, 'values').map(filterValueMapper),
+      ['2019-01-12', null],
+      'Selecting the low date updates the filter'
+    );
+  });
+  clickTrigger('.filter-values--dimension-date-range-input__low-value>.dropdown-date-picker__trigger');
+  $('td.day:contains(12)').click();
+  $('.dropdown-date-picker__apply').click();
+
+  //Check that setting high value sends the new date value to the action
+  this.set('onUpdateFilter', filter => {
+    assert.deepEqual(
+      get(filter, 'values').map(filterValueMapper),
+      ['2019-01-05', '2019-01-15'],
+      'Selecting the low date updates the filter'
+    );
+  });
+  clickTrigger('.filter-values--dimension-date-range-input__high-value>.dropdown-date-picker__trigger');
+  $('td.day:contains(15)').click();
+  $('.dropdown-date-picker__apply').click();
+
+  //Check that dates are displayed correctly
+  this.set('filter', { values: arr([Moment('2019-01-12'), Moment('2019-01-15')]) });
   assert.equal(
     this.$()
       .text()
+      .replace(/\s\s+/g, ' ')
       .trim(),
-    'template block text'
+    'Jan 12, 2019 and Jan 15, 2019',
+    'Appropriate dates are displayed when the filter has dates'
   );
 });

--- a/packages/reports/tests/integration/components/filter-values/dimension-date-range-test.js
+++ b/packages/reports/tests/integration/components/filter-values/dimension-date-range-test.js
@@ -1,0 +1,38 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent(
+  'filter-values/dimension-date-range',
+  'Integration | Component | filter values/dimension date range',
+  {
+    integration: true
+  }
+);
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{filter-values/dimension-date-range}}`);
+
+  assert.equal(
+    this.$()
+      .text()
+      .trim(),
+    ''
+  );
+
+  // Template block usage:
+  this.render(hbs`
+    {{#filter-values/dimension-date-range}}
+      template block text
+    {{/filter-values/dimension-date-range}}
+  `);
+
+  assert.equal(
+    this.$()
+      .text()
+      .trim(),
+    'template block text'
+  );
+});

--- a/packages/reports/tests/integration/components/filter-values/dimension-date-range-test.js
+++ b/packages/reports/tests/integration/components/filter-values/dimension-date-range-test.js
@@ -3,7 +3,6 @@ import { clickTrigger } from 'ember-basic-dropdown/test-support/helpers';
 import { A as arr } from '@ember/array';
 import { get } from '@ember/object';
 import hbs from 'htmlbars-inline-precompile';
-import Moment from 'moment';
 
 moduleForComponent(
   'filter-values/dimension-date-range',
@@ -15,7 +14,6 @@ moduleForComponent(
 
 test('displayed dates and update actions', function(assert) {
   assert.expect(4);
-  const filterValueMapper = value => (Moment.isMoment(value) ? value.format('YYYY-MM-DD') : null);
 
   this.set('filter', { values: arr([]) });
   this.set('onUpdateFilter', () => null);
@@ -34,15 +32,11 @@ test('displayed dates and update actions', function(assert) {
     'Appropriate placeholders are displayed when the filter has no dates'
   );
 
-  this.set('filter', { values: arr([Moment('2019-01-05'), null]) });
+  this.set('filter', { values: arr(['2019-01-05', null]) });
 
   //Check that setting low value sends the new date value to the action
   this.set('onUpdateFilter', filter => {
-    assert.deepEqual(
-      get(filter, 'values').map(filterValueMapper),
-      ['2019-01-12', null],
-      'Selecting the low date updates the filter'
-    );
+    assert.deepEqual(get(filter, 'values'), ['2019-01-12', null], 'Selecting the low date updates the filter');
   });
   clickTrigger('.filter-values--dimension-date-range-input__low-value>.dropdown-date-picker__trigger');
   $('td.day:contains(12)').click();
@@ -50,18 +44,14 @@ test('displayed dates and update actions', function(assert) {
 
   //Check that setting high value sends the new date value to the action
   this.set('onUpdateFilter', filter => {
-    assert.deepEqual(
-      get(filter, 'values').map(filterValueMapper),
-      ['2019-01-05', '2019-01-15'],
-      'Selecting the low date updates the filter'
-    );
+    assert.deepEqual(get(filter, 'values'), ['2019-01-05', '2019-01-15'], 'Selecting the low date updates the filter');
   });
   clickTrigger('.filter-values--dimension-date-range-input__high-value>.dropdown-date-picker__trigger');
   $('td.day:contains(15)').click();
   $('.dropdown-date-picker__apply').click();
 
   //Check that dates are displayed correctly
-  this.set('filter', { values: arr([Moment('2019-01-12'), Moment('2019-01-15')]) });
+  this.set('filter', { values: arr(['2019-01-12', '2019-01-15']) });
   assert.equal(
     this.$()
       .text()


### PR DESCRIPTION
<img width="1036" alt="screen shot 2019-01-11 at 1 02 21 pm" src="https://user-images.githubusercontent.com/23023478/51054065-29665100-15a1-11e9-8255-e88a8b056430.png">

Uses two dropdown date pickers to select two dates that make up an interval for dimensions with date values to filter by.