### PR TITLE
Revert Changes before transitioning

### DIFF
--- a/packages/reports/addon/routes/reports/report.js
+++ b/packages/reports/addon/routes/reports/report.js
@@ -101,7 +101,8 @@ export default Route.extend({
    */
   deactivate() {
     let model = this.currentModel;
-    if (!get(model, 'isNew') && get(model, 'hasDirtyAttributes')) {
+    // https://github.com/emberjs/ember.js/issues/16820
+    if (!this.isDestroying && !get(model, 'isNew') && get(model, 'hasDirtyAttributes')) {
       this.send('revertChanges', model);
     }
   },

--- a/packages/reports/tests/acceptance/navi-report-test.js
+++ b/packages/reports/tests/acceptance/navi-report-test.js
@@ -154,6 +154,54 @@ test('New report - copy api', function(assert) {
   });
 });
 
+test('Revert changes when exiting report - existing report', function(assert) {
+  assert.expect(5);
+
+  // visit report 1
+  visit('/reports/1/view');
+  andThen(() => {
+    assert.ok(
+      $('.checkbox-selector--dimension .grouped-list__item:contains(Day) .grouped-list__item-label input').is(
+        ':checked'
+      ),
+      'Day timegrain is checked by default'
+    );
+  });
+
+  // uncheck the day timegrain
+  click('.checkbox-selector--dimension .grouped-list__item:contains(Day) .grouped-list__item-label');
+  andThen(() => {
+    assert.notOk(
+      $('.checkbox-selector--dimension .grouped-list__item:contains(Day) .grouped-list__item-label input').is(
+        ':checked'
+      ),
+      'Day timegrain is unchecked after clicking on it'
+    );
+    assert.ok(
+      $('.navi-report__revert-btn').is(':visible'),
+      'Revert changes button is visible once a change has been made'
+    );
+  });
+
+  // leave the route
+  visit('/reports');
+
+  // enter the route again
+  click("a[href$='/reports/1/view']");
+  andThen(() => {
+    assert.notOk(
+      $('.navi-report__revert-btn').is(':visible'),
+      'After navigating away and back to the route, the Revert button disappears'
+    );
+    assert.ok(
+      $('.checkbox-selector--dimension .grouped-list__item:contains(Day) .grouped-list__item-label input').is(
+        ':checked'
+      ),
+      'After navigating away and back to the route, changes are reverted'
+    );
+  });
+});
+
 test('Revert changes - existing report', function(assert) {
   assert.expect(4);
 
@@ -161,7 +209,7 @@ test('Revert changes - existing report', function(assert) {
   andThen(() => {
     assert.ok(
       $('.filter-builder__subject:contains(Day)').is(':visible'),
-      'After navigating out of the route, the report model is rolled back'
+      'After navigating to a route, the Timegrain "Day" option is visible'
     );
   });
 


### PR DESCRIPTION
While upgrading my project which depends on navi. I get the error: 
Assertion Failed: Attempted to call .send() with the action 'revertChanges' on the destroyed route 'reports.report'

Found that in ember 3.2 they've added an assertion to check for actions being sent on destroyed components.
https://github.com/emberjs/ember.js/issues/16820

speaks of a workaround

fixes https://github.com/yahoo/navi/issues/287