### PR TITLE
Update: Favorites filter should link to my-data route then add filter

### DIFF
--- a/packages/directory/addon/templates/components/dir-sidebar.hbs
+++ b/packages/directory/addon/templates/components/dir-sidebar.hbs
@@ -14,7 +14,7 @@
 </section>
 <section class='dir-sidebar__filters'>
   {{#each filters as | filter |}}
-    {{#link-to (query-params filter=filter.queryParams.filter sortBy=filter.queryParams.sortBy)
+    {{#link-to 'directory.my-data' (query-params filter=filter.queryParams.filter sortBy=filter.queryParams.sortBy)
       classNames='dir-sidebar__filter'
     }}
       <div>

--- a/packages/directory/tests/acceptance/dir-sidebar-test.js
+++ b/packages/directory/tests/acceptance/dir-sidebar-test.js
@@ -6,7 +6,7 @@ module('Acceptance | dir sidebar', function(hooks) {
   setupApplicationTest(hooks);
 
   test('transitions for sidebar link-tos', async function(assert) {
-    assert.expect(5);
+    assert.expect(7);
 
     await visit('/directory');
     assert.equal(currentURL(), '/directory/my-data', 'Directory route redirects to `my-data` child route');
@@ -23,17 +23,23 @@ module('Acceptance | dir sidebar', function(hooks) {
       'The active sidebar filter link corresponds to the active route and the active filter query param'
     );
 
+    await click('.dir-sidebar__group:nth-of-type(2)');
+    assert.equal(currentURL(), '/directory/other-data', 'Currently on a different directory subroute than my-data');
+
     let favoriteFilter = findAll('.dir-sidebar__filter').find(el => el.textContent.trim() === 'Favorites');
     await click(favoriteFilter);
     assert.equal(
       currentURL(),
       '/directory/my-data?filter=favorites',
-      '`favorites` is set as the query param when the favorites filter is clicked on'
+      '`favorites` is set as the query param and applied to the my-data route when the favorites filter is clicked on'
     );
     assert.equal(
       find('.dir-sidebar .active').textContent.trim(),
       'Favorites',
       'The active sidebar filter link now corresponds to `favorites` filter query param'
     );
+
+    await click('.dir-sidebar__group:nth-of-type(2)');
+    assert.equal(currentURL(), '/directory/other-data', 'Clicking another directory removes the favorites filter');
   });
 });

--- a/packages/directory/tests/dummy/app/components/dir-sidebar.js
+++ b/packages/directory/tests/dummy/app/components/dir-sidebar.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright 2019, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+import SidebarComponent from 'navi-directory/components/dir-sidebar';
+import Directories from '../utils/enums/directories';
+
+export default SidebarComponent.extend({
+  directories: Directories
+});

--- a/packages/directory/tests/dummy/app/router.js
+++ b/packages/directory/tests/dummy/app/router.js
@@ -10,6 +10,7 @@ const Router = EmberRouter.extend({
 Router.map(function() {
   this.route('directory', function() {
     this.route('my-data');
+    this.route('other-data');
   });
 
   this.route('dashboards', function() {

--- a/packages/directory/tests/dummy/app/routes/directory/other-data.js
+++ b/packages/directory/tests/dummy/app/routes/directory/other-data.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2019, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+import Route from '@ember/routing/route';
+
+export default Route.extend({
+  /**
+   * @method model
+   * @override
+   */
+  model() {
+    //returning an object so that the table can handle the promise
+    return {
+      items: []
+    };
+  }
+});

--- a/packages/directory/tests/dummy/app/templates/directory/other-data.hbs
+++ b/packages/directory/tests/dummy/app/templates/directory/other-data.hbs
@@ -1,0 +1,6 @@
+{{!-- Copyright 2019, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{dir-table
+  isLoading=(is-pending searchResults)
+  items=(await searchResults)
+  searchQuery=directory.q
+}}

--- a/packages/directory/tests/dummy/app/utils/enums/directories.js
+++ b/packages/directory/tests/dummy/app/utils/enums/directories.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2019, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+export default [
+  {
+    name: 'My Data',
+    routeLink: 'directory.my-data',
+    filters: [
+      {
+        name: 'Favorites',
+        icon: 'star-o',
+        queryParam: { filter: 'favorites', sortBy: 'title' }
+      },
+      {
+        name: 'Recently Updated',
+        icon: 'cloud-upload',
+        queryParam: { filter: null, sortBy: 'updatedOn' }
+      }
+    ]
+  },
+  {
+    name: 'Other Data',
+    routeLink: 'directory.other-data',
+    filters: []
+  }
+];

--- a/packages/directory/tests/integration/components/dir-sidebar-test.js
+++ b/packages/directory/tests/integration/components/dir-sidebar-test.js
@@ -17,7 +17,7 @@ module('Integration | Component | dir sidebar', function(hooks) {
 
     assert.deepEqual(
       findAll('.dir-sidebar__group').map(el => el.textContent.trim()),
-      ['My Data'],
+      ['My Data', 'Other Data'],
       'The sidebar component has the right groups'
     );
 


### PR DESCRIPTION
The favorites filter in the directory route should specifically be applied to `my-data`