### PR TITLE
Fix: Remove targetObject use and ember internals copy (fixes #296)

### DIFF
--- a/packages/core/addon/components/pick-container.js
+++ b/packages/core/addon/components/pick-container.js
@@ -12,6 +12,7 @@
  */
 import Ember from 'ember';
 import Layout from '../templates/components/pick-container';
+import { get } from '@ember/object';
 
 export default Ember.Component.extend({
   layout: Layout,
@@ -204,7 +205,8 @@ export default Ember.Component.extend({
      */
     applyChanges(newSelection) {
       let selection = newSelection || this.get('_editableSelection');
-      this.sendAction('updateSelection', selection);
+      const updateSelection = get(this, 'updateSelection') || (() => {});
+      updateSelection(selection);
 
       if (this.get('autoClose')) {
         this.toggleForm();

--- a/packages/core/addon/models/bard-request/fragments/metric.js
+++ b/packages/core/addon/models/bard-request/fragments/metric.js
@@ -8,6 +8,7 @@ import MF from 'model-fragments';
 import { validator, buildValidations } from 'ember-cp-validations';
 import { computed, get } from '@ember/object';
 import { canonicalizeMetric } from 'navi-data/utils/metric';
+import { Copyable } from 'ember-copy';
 
 const { Fragment } = MF;
 
@@ -18,7 +19,7 @@ const Validations = buildValidations({
   })
 });
 
-export default Fragment.extend(Validations, {
+export default Fragment.extend(Copyable, Validations, {
   metric: DS.attr('metric'),
   parameters: DS.attr({ defaultValue: () => ({}) }),
 

--- a/packages/core/addon/models/bard-request/request.js
+++ b/packages/core/addon/models/bard-request/request.js
@@ -12,7 +12,7 @@ import { assert } from '@ember/debug';
 import { get } from '@ember/object';
 import { isEmpty } from '@ember/utils';
 import { inject as service } from '@ember/service';
-import { copy } from '@ember/object/internals';
+import { copy } from 'ember-copy';
 import { canonicalizeMetric } from 'navi-data/utils/metric';
 
 const { Fragment, fragment, fragmentArray } = MF;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,6 +25,7 @@
     "ember-cli-string-helpers": "^1.8.1",
     "ember-collection": "1.0.0-alpha.9",
     "ember-composable-helpers": "^2.1.0",
+    "ember-copy": "^1.0.0",
     "ember-cp-validations": "^3.5.3",
     "ember-data-model-fragments": "~2.11.5",
     "ember-debounced-properties": "0.0.5",

--- a/packages/reports/addon/templates/components/navi-date-range-picker.hbs
+++ b/packages/reports/addon/templates/components/navi-date-range-picker.hbs
@@ -33,8 +33,7 @@
                 tagName='li'
                 selection=(readonly customRange)
                 dateTimePeriod=dateTimePeriod
-                updateSelection='applyChanges'
-                targetObject=container
+                updateSelection=(action 'applyChanges' target=container)
                 as |selection container dateMoments dateStrings|}}
 
                     {{#pick-value}}

--- a/packages/reports/addon/templates/components/pick-single.hbs
+++ b/packages/reports/addon/templates/components/pick-single.hbs
@@ -1,7 +1,7 @@
 {{!-- Copyright 2017, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 {{#pick-container
     selection=selection
-    updateSelection='updateSelection'
+    updateSelection=(action 'updateSelection')
     as |selection container|
 }}
     {{#pick-value classNameBindings='container.isFormOpen:has-focus'}}


### PR DESCRIPTION
fixes #296 
fixes #297 

passing a target to a closure action
https://github.com/emberjs/ember.js/blob/v3.7.2/packages/%40ember/-internals/glimmer/lib/helpers/action.ts#L79

deprecated target Object
https://github.com/emberjs/ember.js/issues/14168

deprecation of ember internals copy
https://deprecations-app-prod.herokuapp.com/deprecations/v3.x/#toc_ember-runtime-deprecate-copy-copyable