### PR TITLE
[Fixes Build] Dimension date range selector not saving

### DIFF
--- a/packages/reports/addon/components/dropdown-date-picker.js
+++ b/packages/reports/addon/components/dropdown-date-picker.js
@@ -10,39 +10,23 @@
  */
 import Component from '@ember/component';
 import layout from '../templates/components/dropdown-date-picker';
+import { computed } from '@ember/object';
 
 export default Component.extend({
   layout,
 
   /**
    * @private
-   * @property {Object} _selectedDate - local moment set by date picker
+   * @property {Object} _selectedDate - local moment set by date picker (initally set to passed in date)
    */
-  _selectedDate: null,
-
-  /**
-   * @method init
-   * @override
-   */
-  init() {
-    this._super(...arguments);
-
-    this.loadSavedDate();
-  },
-
-  /**
-   * @method loadSavedDate
-   */
-  loadSavedDate() {
-    this.set('_selectedDate', this.get('date'));
-  },
+  _selectedDate: computed.oneWay('date'),
 
   actions: {
     /**
      * @action resetDate - set selected date to the saved date
      */
     resetDate() {
-      this.loadSavedDate();
+      this.set('_selectedDate', this.get('date'));
     }
   }
 });

--- a/packages/reports/addon/components/filter-builders/date-dimension.js
+++ b/packages/reports/addon/components/filter-builders/date-dimension.js
@@ -46,13 +46,15 @@ export default Base.extend({
    */
   filter: computed('requestFragment.{operator,dimension,values.[]}', function() {
     const requestFragment = get(this, 'requestFragment'),
+      serializedFilter =
+        typeof requestFragment.serialize === 'function' ? requestFragment.serialize() : requestFragment,
       operatorId = get(requestFragment, 'operator'),
       operator = arr(get(this, 'supportedOperators')).findBy('id', operatorId);
 
     return {
       subject: get(requestFragment, 'dimension'),
       operator,
-      values: arr(get(requestFragment, 'values'))
+      values: arr(get(serializedFilter, 'values'))
     };
   })
 });

--- a/packages/reports/tests/acceptance/date-filter-test.js
+++ b/packages/reports/tests/acceptance/date-filter-test.js
@@ -27,3 +27,39 @@ test('date filter builder', function(assert) {
     });
   });
 });
+
+test('dimension date range filter keeps values after save', async function(assert) {
+  assert.expect(5);
+
+  await visit('/reports/1/view');
+  await click('.grouped-list__group-header:contains(test)');
+  await click('.grouped-list__item:contains(User Signup Date)>.checkbox-selector__filter');
+  await click('.filter-builder__operator:contains(Since)>.filter-builder__select-trigger');
+  await click('li.ember-power-select-option:contains(Between)');
+
+  assert.ok(find('.filter-builder__operator:contains(Between)'), 'Between is the selected operator');
+
+  //Set low value
+  await clickDropdown('.filter-values--dimension-date-range-input__low-value>.dropdown-date-picker__trigger');
+  await click('td.day:contains(4):first-of-type');
+  await click('.dropdown-date-picker__apply');
+
+  //Set high value
+  await clickDropdown('.filter-values--dimension-date-range-input__high-value>.dropdown-date-picker__trigger');
+  await click('td.day:contains(5):first-of-type');
+  await click('.dropdown-date-picker__apply');
+
+  assert.ok(find('.filter-values--dimension-date-range-input__low-value:contains(4)'), 'The low value is set');
+  assert.ok(find('.filter-values--dimension-date-range-input__high-value:contains(9)'), 'The high value is set');
+
+  await click('.navi-report__save-btn');
+
+  assert.ok(
+    find('.filter-values--dimension-date-range-input__low-value:contains(4)'),
+    'The low value is still set after the report is saved'
+  );
+  assert.ok(
+    find('.filter-values--dimension-date-range-input__high-value:contains(9)'),
+    'The high value is still set after the report is saved'
+  );
+});

--- a/packages/reports/tests/integration/components/filter-values/dimension-date-range-test.js
+++ b/packages/reports/tests/integration/components/filter-values/dimension-date-range-test.js
@@ -42,6 +42,9 @@ test('displayed dates and update actions', function(assert) {
   $('td.day:contains(12)').click();
   $('.dropdown-date-picker__apply').click();
 
+  //Set a high value so that the calendar opens to January 2019 instead of the month that this test is run
+  this.set('filter', { values: arr(['2019-01-05', '2019-01-12']) });
+
   //Check that setting high value sends the new date value to the action
   this.set('onUpdateFilter', filter => {
     assert.deepEqual(get(filter, 'values'), ['2019-01-05', '2019-01-15'], 'Selecting the low date updates the filter');

--- a/packages/reports/tests/integration/components/filter-values/dimension-date-range-test.js
+++ b/packages/reports/tests/integration/components/filter-values/dimension-date-range-test.js
@@ -47,7 +47,7 @@ test('displayed dates and update actions', function(assert) {
 
   //Check that setting high value sends the new date value to the action
   this.set('onUpdateFilter', filter => {
-    assert.deepEqual(get(filter, 'values'), ['2019-01-05', '2019-01-15'], 'Selecting the low date updates the filter');
+    assert.deepEqual(get(filter, 'values'), ['2019-01-05', '2019-01-15'], 'Selecting the high date updates the filter');
   });
   clickTrigger('.filter-values--dimension-date-range-input__high-value>.dropdown-date-picker__trigger');
   $('td.day:contains(15)').click();


### PR DESCRIPTION
The test for the dimension date range filter was dependent on the time that the test was run. These changes should make it behave the same way no matter when it's run. When I was fixing this, I also noticed an issue where a report that has a dimension date range filter would not keep the filter values after being saved. I fixed that and added a test for that behavior.