### PR TITLE
Breaking: Table visualization model change (fixes #300)

### DIFF
--- a/packages/core/addon/components/cell-renderers/dimension.js
+++ b/packages/core/addon/components/cell-renderers/dimension.js
@@ -12,6 +12,7 @@
 
 import Component from '@ember/component';
 import { computed, get } from '@ember/object';
+import { readOnly } from '@ember/object/computed';
 import layout from '../../templates/components/cell-renderers/dimension';
 import { isEmpty } from '@ember/utils';
 
@@ -24,28 +25,30 @@ export default Component.extend({
   classNames: ['table-cell-content', 'dimension'],
 
   /**
+   * @property {String} name - dimension name
+   */
+  name: readOnly('column.attributes.name'),
+
+  /**
    * @property {String} descField - field to find the description
    */
-  descField: computed('column.field.dimension', function() {
-    return get(this, 'column.field.dimension') + '|desc';
+  descField: computed('name', function() {
+    return get(this, 'name') + '|desc';
   }),
 
   /**
    * @property {String} idField - field to find id
    */
-  idField: computed('column.field.dimension', function() {
-    return get(this, 'column.field.dimension') + '|id';
+  idField: computed('name', function() {
+    return get(this, 'name') + '|id';
   }),
 
   /**
    * @property {Object} dimensionField - field to find dimension field
    */
-  dimensionField: computed('column.field.dimension', 'column.field.field', function() {
-    if (!get(this, 'column.field.field')) {
-      return null;
-    }
-
-    return `${get(this, 'column.field.dimension')}|${get(this, 'column.field.field')}`;
+  dimensionField: computed('name', 'column.attributes.field', function() {
+    let field = get(this, 'column.attributes.field');
+    return field ? `${get(this, 'name')}|${field}` : null;
   }),
 
   /**

--- a/packages/core/addon/components/cell-renderers/metric.js
+++ b/packages/core/addon/components/cell-renderers/metric.js
@@ -15,7 +15,7 @@ import layout from '../../templates/components/cell-renderers/metric';
 import { computed, get } from '@ember/object';
 import { oneWay } from '@ember/object/computed';
 import { isEmpty } from '@ember/utils';
-import { canonicalizeMetric } from 'navi-data/utils/metric';
+import { canonicalizeColumnAttributes } from 'navi-data/utils/metric';
 import { smartFormatNumber } from 'navi-core/helpers/smart-format-number';
 import numeral from 'numeral';
 
@@ -28,22 +28,17 @@ export default Ember.Component.extend({
   classNames: ['table-cell-content', 'metric'],
 
   /**
-   * @property {String} metric - metric name used to fetch the value for
+   * @property {Object} attributes - metric name and optional parameters used to fetch the value for
    */
-  metric: oneWay('column.field'),
-
-  /**
-   * @property {String} format - format the number should be rendered
-   */
-  format: oneWay('column.format'),
+  attributes: oneWay('column.attributes'),
 
   /**
    * @property {Number} - value to be rendered on the cell
    */
-  metricValue: computed('data', 'metric', 'format', function() {
-    let format = get(this, 'format'),
+  metricValue: computed('data', 'attributes', function() {
+    let format = get(this, 'attributes.format'),
       type = get(this, 'column.type'),
-      canonicalName = canonicalizeMetric(get(this, 'metric')),
+      canonicalName = canonicalizeColumnAttributes(get(this, 'attributes')),
       metricValue = get(this, `data.${canonicalName}`);
 
     if (isEmpty(metricValue)) {

--- a/packages/core/addon/components/number-format-dropdown.js
+++ b/packages/core/addon/components/number-format-dropdown.js
@@ -11,9 +11,9 @@
 
 import Component from '@ember/component';
 import layout from '../templates/components/number-format-dropdown';
-import { assign } from '@ember/polyfills';
 import { oneWay } from '@ember/object/computed';
-import { getWithDefault } from '@ember/object';
+import { get, getWithDefault } from '@ember/object';
+import merge from 'lodash/merge';
 
 export default Component.extend({
   layout,
@@ -26,7 +26,7 @@ export default Component.extend({
   /**
    * @property {String} format
    */
-  format: oneWay('column.format'),
+  format: oneWay('column.attributes.format'),
 
   actions: {
     /**
@@ -34,9 +34,10 @@ export default Component.extend({
      */
     updateColumnNumberFormat() {
       let { onUpdateReport, column } = this,
-        format = getWithDefault(this, 'format', column.format);
+        format = getWithDefault(this, 'format', get(column, 'attributes.format')),
+        updatedColumn = merge({}, column, { attributes: { format } });
 
-      onUpdateReport('updateColumn', assign({}, column, { format }));
+      onUpdateReport('updateColumn', updatedColumn);
     }
   }
 });

--- a/packages/core/addon/helpers/default-column-name.js
+++ b/packages/core/addon/helpers/default-column-name.js
@@ -7,6 +7,7 @@ import Helper from '@ember/component/helper';
 import { get } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { metricFormat } from 'navi-data/helpers/metric-format';
+import { mapColumnAttributes } from 'navi-data/utils/metric';
 import { formatDimensionName } from 'navi-data/utils/dimension';
 
 /**
@@ -17,7 +18,7 @@ import { formatDimensionName } from 'navi-data/utils/dimension';
  * @param {Object} bardMetadata - bard metadata service
  * @return {String} - default display name
  */
-export function getColumnDefaultName({ type, field }, bardMetadata) {
+export function getColumnDefaultName({ type, attributes }, bardMetadata) {
   if (type === 'dateTime') {
     return 'Date';
   }
@@ -26,16 +27,17 @@ export function getColumnDefaultName({ type, field }, bardMetadata) {
     type = 'metric';
   }
 
-  let model = bardMetadata.getById(type, field[type]);
+  let { name, field } = attributes,
+    model = bardMetadata.getById(type, name);
 
   if (type === 'metric') {
-    return metricFormat(field, model.longName);
+    return metricFormat(mapColumnAttributes(attributes), model.longName);
   }
 
-  if (type === 'dimension' && field.field) {
+  if (type === 'dimension' && field) {
     return formatDimensionName({
-      dimension: model.longName,
-      field: field.field
+      name: model.longName,
+      field
     });
   }
 

--- a/packages/core/tests/dummy/app/controllers/table.js
+++ b/packages/core/tests/dummy/app/controllers/table.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import isEqual from 'lodash/isEqual';
 import merge from 'lodash/merge';
+import omit from 'lodash/omit';
 
 const { A: arr, computed, get, set, setProperties } = Ember;
 
@@ -21,27 +22,27 @@ export default Ember.Controller.extend({
   options: {
     columns: [
       {
-        field: { dateTime: 'dateTime' },
+        attributes: { name: 'dateTime' },
         type: 'dateTime',
         displayName: 'Date'
       },
       {
-        field: { dimension: 'os' },
+        attributes: { name: 'os' },
         type: 'dimension',
         displayName: 'Operating System'
       },
       {
-        field: { metric: 'uniqueIdentifier', parameters: {} },
+        attributes: { name: 'uniqueIdentifier', parameters: {} },
         type: 'metric',
         displayName: 'Unique Identifiers'
       },
       {
-        field: { metric: 'totalPageViews', parameters: {} },
+        attributes: { name: 'totalPageViews', parameters: {} },
         type: 'metric',
         displayName: 'Total Page Views'
       },
       {
-        field: { metric: 'totalPageViewsWoW', parameters: {} },
+        attributes: { name: 'totalPageViewsWoW', parameters: {} },
         type: 'threshold',
         displayName: 'Total Page Views WoW'
       }
@@ -71,7 +72,9 @@ export default Ember.Controller.extend({
 
   updateColumn(column) {
     const newColumns = get(this, 'options.columns').map(col => {
-      if (isEqual(col.field, column.field)) {
+      let propsToOmit = ['format'];
+
+      if (isEqual(omit(col.attributes, propsToOmit), omit(column.attributes, propsToOmit))) {
         return column;
       }
 

--- a/packages/core/tests/integration/components/cell-renderers/dimension-test.js
+++ b/packages/core/tests/integration/components/cell-renderers/dimension-test.js
@@ -17,7 +17,7 @@ const data = {
 };
 
 const column = {
-  field: { dimension: 'os' },
+  attributes: { name: 'os' },
   type: 'dimension',
   displayName: 'Operating System'
 };

--- a/packages/core/tests/integration/components/cell-renderers/metric-test.js
+++ b/packages/core/tests/integration/components/cell-renderers/metric-test.js
@@ -1,5 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import merge from 'lodash/merge';
 
 const TEMPLATE = hbs`
   {{cell-renderers/metric
@@ -17,7 +18,7 @@ let data = {
 };
 
 let column = {
-  field: { metric: 'uniqueIdentifier', parameters: {} },
+  attributes: { name: 'uniqueIdentifier', parameters: {} },
   type: 'metric',
   displayName: 'Unique Identifiers'
 };
@@ -150,7 +151,7 @@ test('metric renders null value correctly', function(assert) {
 test('render value based on column format', function(assert) {
   assert.expect(1);
 
-  this.set('column', Object.assign({}, column, { format: '$0,0[.]00' }));
+  this.set('column', merge({}, column, { attributes: { format: '$0,0[.]00' } }));
   this.render(TEMPLATE);
 
   assert.equal(

--- a/packages/core/tests/integration/components/cell-renderers/threshold-test.js
+++ b/packages/core/tests/integration/components/cell-renderers/threshold-test.js
@@ -1,5 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import merge from 'lodash/merge';
 
 const TEMPLATE = hbs`
   {{cell-renderers/threshold
@@ -17,7 +18,7 @@ const data = {
 };
 
 const column = {
-  field: { metric: 'totalPageViewsWoW', parameters: {} },
+  attributes: { name: 'totalPageViewsWoW', parameters: {} },
   type: 'threshold',
   displayName: 'Total Page Views WoW'
 };
@@ -114,7 +115,7 @@ test('threshold renders null value correctly', function(assert) {
 test('render value based on column format', function(assert) {
   assert.expect(1);
 
-  this.set('column', Object.assign({}, column, { format: '$0,0[.]00' }));
+  this.set('column', merge({}, column, { attributes: { format: '$0,0[.]00' } }));
   this.render(TEMPLATE);
 
   assert.equal(

--- a/packages/core/tests/integration/components/navi-visualizations/table-print-test.js
+++ b/packages/core/tests/integration/components/navi-visualizations/table-print-test.js
@@ -56,22 +56,22 @@ const Model = Ember.A([
 const Options = {
   columns: [
     {
-      field: { dateTime: 'dateTime' },
+      attributes: { name: 'dateTime' },
       type: 'dateTime',
       displayName: 'Date'
     },
     {
-      field: { dimension: 'os' },
+      attributes: { name: 'os' },
       type: 'dimension',
       displayName: 'Operating System'
     },
     {
-      field: { metric: 'uniqueIdentifier', parameters: {} },
+      attributes: { name: 'uniqueIdentifier', parameters: {} },
       type: 'metric',
       displayName: 'Unique Identifiers'
     },
     {
-      field: { metric: 'totalPageViews', parameters: {} },
+      attributes: { name: 'totalPageViews', parameters: {} },
       type: 'metric',
       displayName: 'Total Page Views'
     }

--- a/packages/core/tests/integration/components/navi-visualizations/table-test.js
+++ b/packages/core/tests/integration/components/navi-visualizations/table-test.js
@@ -103,27 +103,27 @@ const Model = arr([
 const Options = {
   columns: [
     {
-      field: { dateTime: 'dateTime' },
+      attributes: { name: 'dateTime' },
       type: 'dateTime',
       displayName: 'Date'
     },
     {
-      field: { dimension: 'os' },
+      attributes: { name: 'os' },
       type: 'dimension',
       displayName: 'Operating System'
     },
     {
-      field: { metric: 'uniqueIdentifier', parameters: {} },
+      attributes: { name: 'uniqueIdentifier', parameters: {} },
       type: 'metric',
       displayName: 'Unique Identifiers'
     },
     {
-      field: { metric: 'totalPageViews', parameters: {} },
+      attributes: { name: 'totalPageViews', parameters: {} },
       type: 'metric',
       displayName: 'Total Page Views'
     },
     {
-      field: { metric: 'platformRevenue', parameters: { currency: 'USD' } },
+      attributes: { name: 'platformRevenue', parameters: { currency: 'USD' } },
       type: 'metric',
       displayName: 'Platform Revenue (USD)'
     }
@@ -209,32 +209,32 @@ test('onUpdateReport', function(assert) {
     merge({}, Options, {
       columns: [
         {
-          field: 'dateTime',
+          attributes: { name: 'dateTime' },
           type: 'dateTime',
           displayName: 'Date'
         },
         {
-          field: { dimension: 'os' },
+          attributes: { name: 'os' },
           type: 'dimension',
           displayName: 'Operating System'
         },
         {
-          field: { metric: 'uniqueIdentifier', parameters: {} },
+          attributes: { name: 'uniqueIdentifier', parameters: {} },
           type: 'metric',
           displayName: 'Unique Identifiers'
         },
         {
-          field: { metric: 'totalPageViews', parameters: {} },
+          attributes: { name: 'totalPageViews', parameters: {} },
           type: 'metric',
           displayName: 'Total Page Views'
         },
         {
-          field: { metric: 'platformRevenue', parameters: { currency: 'USD' } },
+          attributes: { name: 'platformRevenue', parameters: { currency: 'USD' } },
           type: 'metric',
           displayName: 'Platform Revenue (USD)'
         },
         {
-          field: { metric: 'totalPageViewsWoW', parameters: {} },
+          attributes: { name: 'totalPageViewsWoW', parameters: {} },
           type: 'threshold',
           displayName: 'Total Page Views WoW'
         }

--- a/packages/core/tests/integration/components/table-cell-renderer-test.js
+++ b/packages/core/tests/integration/components/table-cell-renderer-test.js
@@ -7,7 +7,7 @@ moduleForComponent('table-cell-renderer', 'Integration | Component | table cell 
 
 test('it renders the correct cell renderer', function(assert) {
   this.set('column', {
-    field: { metric: 'foo', parameters: {} },
+    attributes: { name: 'foo', parameters: {} },
     type: 'metric'
   });
 
@@ -33,7 +33,7 @@ test('it renders the correct cell renderer', function(assert) {
   assert.ok(this.$('.table-cell-content').hasClass('metric'), 'renders metric cell-formatter');
 
   this.set('column', {
-    field: { dimension: 'foo' },
+    attributes: { name: 'foo' },
     type: 'dimension'
   });
 
@@ -51,7 +51,7 @@ test('it renders the correct cell renderer', function(assert) {
   assert.ok(this.$('.table-cell-content').hasClass('dimension'), 'renders using dimension cell-formatter');
 
   this.set('column', {
-    type: 'date-time'
+    type: 'dateTime'
   });
 
   this.set('data', {
@@ -74,7 +74,7 @@ test('it renders the correct cell renderer', function(assert) {
   assert.ok(this.$('.table-cell-content').hasClass('date-time'), 'renders using date-time cell-formatter');
 
   this.set('column', {
-    field: { metric: 'foo', parameters: {} },
+    attributes: { name: 'foo', parameters: {} },
     type: 'threshold'
   });
 

--- a/packages/core/tests/integration/helpers/default-column-name-test.js
+++ b/packages/core/tests/integration/helpers/default-column-name-test.js
@@ -33,7 +33,7 @@ test('dateTime column', function(assert) {
 });
 
 test('dimension column', function(assert) {
-  const column = { type: 'dimension', field: { dimension: 'os' } };
+  const column = { type: 'dimension', attributes: { name: 'os' } };
   this.set('column', column);
 
   this.render(hbs`{{default-column-name column}}`);
@@ -48,7 +48,7 @@ test('dimension column', function(assert) {
 });
 
 test('metric column', function(assert) {
-  const column = { type: 'metric', field: { metric: 'totalPageViews' } };
+  const column = { type: 'metric', attributes: { name: 'totalPageViews' } };
   this.set('column', column);
 
   this.render(hbs`{{default-column-name column}}`);
@@ -65,7 +65,7 @@ test('metric column', function(assert) {
 test('metric column with parameters', function(assert) {
   const column = {
     type: 'metric',
-    field: { metric: 'revenue', parameters: { currency: 'USD' } }
+    attributes: { name: 'revenue', parameters: { currency: 'USD' } }
   };
   this.set('column', column);
 

--- a/packages/core/tests/unit/components/navi-visualizations/table-test.js
+++ b/packages/core/tests/unit/components/navi-visualizations/table-test.js
@@ -111,14 +111,14 @@ const MODEL = Ember.A([
 
 const OPTIONS = {
   columns: [
-    { field: { dateTime: 'dateTime' }, type: 'dateTime', displayName: 'Date' },
+    { attributes: { name: 'dateTime' }, type: 'dateTime', displayName: 'Date' },
     {
-      field: { metric: 'uniqueIdentifier', parameters: {} },
+      attributes: { name: 'uniqueIdentifier', parameters: {} },
       type: 'metric',
       displayName: 'Unique Identifiers'
     },
     {
-      field: { metric: 'totalPageViewsWoW', parameters: {} },
+      attributes: { name: 'totalPageViewsWoW', parameters: {} },
       type: 'threshold',
       displayName: 'Total Page Views WoW'
     }

--- a/packages/core/tests/unit/models/table-test.js
+++ b/packages/core/tests/unit/models/table-test.js
@@ -208,23 +208,21 @@ test('rebuildConfig', function(assert) {
         columns: [
           {
             displayName: 'Date',
-            field: { dateTime: 'dateTime' },
+            attributes: { name: 'dateTime' },
             type: 'dateTime'
           },
-          { displayName: 'D1', field: { dimension: 'd1' }, type: 'dimension' },
-          { displayName: 'D2 (id)', field: { dimension: 'd2', field: 'id' }, type: 'dimension' },
-          { displayName: 'D2 (desc)', field: { dimension: 'd2', field: 'desc' }, type: 'dimension' },
+          { displayName: 'D1', attributes: { name: 'd1' }, type: 'dimension' },
+          { displayName: 'D2 (id)', attributes: { name: 'd2', field: 'id' }, type: 'dimension' },
+          { displayName: 'D2 (desc)', attributes: { name: 'd2', field: 'desc' }, type: 'dimension' },
           {
             displayName: 'M1',
-            field: { metric: 'm1', parameters: {} },
-            type: 'metric',
-            format: ''
+            attributes: { name: 'm1', parameters: {}, format: '' },
+            type: 'metric'
           },
           {
             displayName: 'M2',
-            field: { metric: 'm2', parameters: {} },
-            type: 'metric',
-            format: ''
+            attributes: { name: 'm2', parameters: {}, format: '' },
+            type: 'metric'
           }
         ]
       }
@@ -244,20 +242,18 @@ test('rebuildConfig', function(assert) {
         columns: [
           {
             displayName: 'Date',
-            field: { dateTime: 'dateTime' },
+            attributes: { name: 'dateTime' },
             type: 'dateTime'
           },
           {
             displayName: 'M1',
-            field: { metric: 'm1', parameters: {} },
-            type: 'metric',
-            format: ''
+            attributes: { name: 'm1', parameters: {}, format: '' },
+            type: 'metric'
           },
           {
             displayName: 'M2',
-            field: { metric: 'm2', parameters: {} },
-            type: 'metric',
-            format: ''
+            attributes: { name: 'm2', parameters: {}, format: '' },
+            type: 'metric'
           }
         ]
       }
@@ -279,20 +275,18 @@ test('rebuildConfig', function(assert) {
         columns: [
           {
             displayName: 'Date',
-            field: { dateTime: 'dateTime' },
+            attributes: { name: 'dateTime' },
             type: 'dateTime'
           },
           {
             displayName: 'M1',
-            field: { metric: 'm1', parameters: {} },
-            type: 'threshold',
-            format: ''
+            attributes: { name: 'm1', parameters: {}, format: '' },
+            type: 'threshold'
           },
           {
             displayName: 'M2',
-            field: { metric: 'm2', parameters: {} },
-            type: 'metric',
-            format: ''
+            attributes: { name: 'm2', parameters: {}, format: '' },
+            type: 'metric'
           }
         ]
       }
@@ -313,20 +307,18 @@ test('rebuildConfig', function(assert) {
         columns: [
           {
             displayName: 'Date',
-            field: { dateTime: 'dateTime' },
+            attributes: { name: 'dateTime' },
             type: 'dateTime'
           },
           {
             displayName: 'M4',
-            field: { metric: 'm1', parameters: {} },
-            type: 'threshold',
-            format: ''
+            attributes: { name: 'm1', parameters: {}, format: '' },
+            type: 'threshold'
           },
           {
             displayName: 'M2',
-            field: { metric: 'm2', parameters: {} },
-            type: 'metric',
-            format: 'number'
+            attributes: { name: 'm2', parameters: {}, format: '' },
+            type: 'metric'
           }
         ]
       }
@@ -367,26 +359,23 @@ test('rebuildConfig with parameterized metrics', function(assert) {
         columns: [
           {
             displayName: 'Date',
-            field: { dateTime: 'dateTime' },
+            attributes: { name: 'dateTime' },
             type: 'dateTime'
           },
           {
             displayName: 'M1 (paramVal1)',
-            field: { metric: 'm1', parameters: { param1: 'paramVal1' } },
-            type: 'metric',
-            format: ''
+            attributes: { name: 'm1', parameters: { param1: 'paramVal1' }, format: '' },
+            type: 'metric'
           },
           {
             displayName: 'M1 (paramVal2)',
-            field: { metric: 'm1', parameters: { param1: 'paramVal2' } },
-            type: 'metric',
-            format: ''
+            attributes: { name: 'm1', parameters: { param1: 'paramVal2' }, format: '' },
+            type: 'metric'
           },
           {
             displayName: 'M2',
-            field: { metric: 'm2', parameters: {} },
-            type: 'metric',
-            format: ''
+            attributes: { name: 'm2', parameters: {}, format: '' },
+            type: 'metric'
           }
         ]
       }
@@ -404,26 +393,23 @@ test('rebuildConfig with parameterized metrics', function(assert) {
         columns: [
           {
             displayName: 'Date',
-            field: { dateTime: 'dateTime' },
+            attributes: { name: 'dateTime' },
             type: 'dateTime'
           },
           {
             displayName: 'M1 (paramVal1)',
-            field: { metric: 'm1', parameters: { param1: 'paramVal1' } },
-            type: 'metric',
-            format: ''
+            attributes: { name: 'm1', parameters: { param1: 'paramVal1' }, format: '' },
+            type: 'metric'
           },
           {
             displayName: 'M1 (paramVal2)',
-            field: { metric: 'm1', parameters: { param1: 'paramVal2' } },
-            type: 'metric',
-            format: ''
+            attributes: { name: 'm1', parameters: { param1: 'paramVal2' }, format: '' },
+            type: 'metric'
           },
           {
             displayName: 'M2',
-            field: { metric: 'm2', parameters: {} },
-            type: 'metric',
-            format: ''
+            attributes: { name: 'm2', parameters: {}, format: '' },
+            type: 'metric'
           }
         ]
       }
@@ -437,27 +423,27 @@ test('index column by id', function(assert) {
 
   let dimensionColumn = {
       type: 'dimension',
-      field: {
-        dimension: 'D1'
+      attributes: {
+        name: 'D1'
       }
     },
     dimensionColumnWithField = {
       type: 'dimension',
-      field: {
-        dimension: 'D2',
+      attributes: {
+        name: 'D2',
         field: 'desc'
       }
     },
     metricColumn = {
       type: 'metric',
-      field: {
-        metric: 'M'
+      attributes: {
+        name: 'M'
       }
     },
     thresholdColumn = {
       type: 'threshold',
-      field: {
-        metric: 'T'
+      attributes: {
+        name: 'T'
       }
     },
     rows = [dimensionColumn, dimensionColumnWithField, metricColumn, thresholdColumn];
@@ -483,24 +469,24 @@ test('index column by id', function(assert) {
  */
 function buildTestConfig(dimensions = [], metrics = [], thresholds = []) {
   let columns = [
-    { field: { dateTime: 'dateTime' }, type: 'dateTime' },
+    { attributes: { name: 'dateTime' }, type: 'dateTime' },
     ...metrics.map(m => {
-      let metricName = get(m, 'metric'),
+      let name = get(m, 'metric'),
         parameters = get(m, 'parameters') || {},
         valueType = isPresent(parameters) && get(parameters, 'currency') ? 'money' : 'number';
       return {
-        field: { metric: metricName, parameters },
+        attributes: { name, parameters },
         type: 'metric',
         valueType
       };
     }),
     ...thresholds.map(t => {
-      let metricName = get(t, 'metric'),
+      let name = get(t, 'metric'),
         parameters = get(t, 'parameters') || {};
-      return { field: { metric: metricName, parameters }, type: 'threshold' };
+      return { attributes: { name, parameters }, type: 'threshold' };
     }),
     ...dimensions.map(({ dimension, field }) => ({
-      field: { dimension, field },
+      attributes: { name: dimension, field },
       type: 'dimension'
     }))
   ];

--- a/packages/core/tests/unit/serializers/table-test.js
+++ b/packages/core/tests/unit/serializers/table-test.js
@@ -33,12 +33,20 @@ test('normalize', function(assert) {
           {
             field: { metric: 'pageViews', parameters: {} },
             type: 'metric',
-            displayName: 'Page Views'
+            displayName: 'Page Views',
+            format: '',
+            foo: 'bar'
+          },
+          {
+            attributes: { name: 'revenue', parameters: { currency: 'EUR' } },
+            type: 'threshold',
+            displayName: 'Revenue (EUR)'
           },
           {
             field: 'revenue(currency=USD)',
             type: 'threshold',
-            displayName: 'Revenue (USD)'
+            displayName: 'Revenue (USD)',
+            format: ''
           },
           {
             field: 'gender',
@@ -49,6 +57,12 @@ test('normalize', function(assert) {
             field: { dimension: 'age' },
             type: 'dimension',
             displayName: 'Age'
+          },
+          {
+            attributes: { name: 'platform' },
+            type: 'dimension',
+            displayName: 'Platform',
+            foo: 'bar'
           },
           {
             field: 'dateTime',
@@ -69,32 +83,44 @@ test('normalize', function(assert) {
           metadata: {
             columns: [
               {
-                field: { metric: 'clicks', parameters: {} },
+                attributes: { name: 'clicks', parameters: {} },
                 type: 'metric',
                 displayName: 'Clicks'
               },
               {
-                field: { metric: 'pageViews', parameters: {} },
+                attributes: { name: 'pageViews', parameters: {}, format: '' },
                 type: 'metric',
-                displayName: 'Page Views'
+                displayName: 'Page Views',
+                foo: 'bar'
               },
               {
-                field: { metric: 'revenue', parameters: { currency: 'USD' } },
+                attributes: { name: 'revenue', parameters: { currency: 'EUR' } },
+                type: 'threshold',
+                displayName: 'Revenue (EUR)'
+              },
+              {
+                attributes: { name: 'revenue', parameters: { currency: 'USD' }, format: '' },
                 type: 'threshold',
                 displayName: 'Revenue (USD)'
               },
               {
-                field: { dimension: 'gender' },
+                attributes: { name: 'gender' },
                 type: 'dimension',
                 displayName: 'Gender'
               },
               {
-                field: { dimension: 'age' },
+                attributes: { name: 'age' },
                 type: 'dimension',
                 displayName: 'Age'
               },
               {
-                field: { dateTime: 'dateTime' },
+                attributes: { name: 'platform' },
+                type: 'dimension',
+                displayName: 'Platform',
+                foo: 'bar'
+              },
+              {
+                attributes: { name: 'dateTime' },
                 type: 'dateTime',
                 displayName: 'Date'
               }
@@ -109,6 +135,6 @@ test('normalize', function(assert) {
   assert.deepEqual(
     Serializer.normalize(Model, initialMetadata),
     expectedPayload,
-    'Field strings are converted to objects and other fields are left alone'
+    'Columns with a `field` property are mapped to ones with `attributes` and other columns are left alone'
   );
 });

--- a/packages/data/addon/utils/dimension.js
+++ b/packages/data/addon/utils/dimension.js
@@ -7,29 +7,31 @@ import upperFirst from 'lodash/upperFirst';
 /**
  * Returns canonicalized name of a dimension
  * @function canonicalizeDimension
- * @param {String} dimension.dimension - dimension name
+ * @param {Object} dimension - dimension
+ * @param {String} dimension.name - dimension name
  * @param {String} dimension.field - field name
  */
-export function canonicalizeDimension({ dimension, field }) {
+export function canonicalizeDimension({ name, field }) {
   if (field) {
-    return `${dimension}(${field})`;
+    return `${name}(${field})`;
   }
 
-  return dimension;
+  return name;
 }
 
 /**
  * Formats a dimension given name and field
  * @function formatDimensionName
- * @param {String} dimension.dimension - dimension name
+ * @param {Object} dimension - dimension
+ * @param {String} dimension.name - dimension name
  * @param {String} dimension.field - field name
  */
-export function formatDimensionName({ dimension, field }) {
-  let name = upperFirst(dimension);
+export function formatDimensionName({ name, field }) {
+  let upperName = upperFirst(name);
 
   if (field) {
-    return `${name} (${field})`;
+    return `${upperName} (${field})`;
   }
 
-  return name;
+  return upperName;
 }

--- a/packages/data/addon/utils/metric.js
+++ b/packages/data/addon/utils/metric.js
@@ -17,6 +17,17 @@ export function canonicalizeMetric(metric) {
 }
 
 /**
+ * Returns canonicalized name given metric column attributes
+ * @function canonicalizeColumnAttributes
+ * @param {Object} attributes
+ * @param {String} attributes.name - metric name
+ * @param {Object} attributes.parameters - a key: value object of parameters
+ */
+export function canonicalizeColumnAttributes(attributes) {
+  return canonicalizeMetric(mapColumnAttributes(attributes));
+}
+
+/**
  * @function hasParameters
  *
  * Returns if metric has parameters
@@ -121,4 +132,23 @@ export function parseMetricName(canonicalName) {
     metric,
     parameters
   };
+}
+
+/**
+ * Returns a metric object given column attributes
+ * @function mapColumnAttributes
+ * @param {Object} attributes - column attributes
+ * @param {String} attributes.name - metric name
+ * @param {Object} attributes.parameters - metric parameters
+ * @returns {Object} - object with metric name and parameters
+ */
+export function mapColumnAttributes(attributes) {
+  let metric = get(attributes, 'name'),
+    parameters = get(attributes, 'parameters') || {};
+
+  if (isEmpty(metric)) {
+    throw new Error('Metric Column Attributes Mapper: Error, empty metric name');
+  }
+
+  return { metric, parameters };
 }

--- a/packages/reports/tests/integration/components/print-report-view-test.js
+++ b/packages/reports/tests/integration/components/print-report-view-test.js
@@ -127,12 +127,12 @@ test('visualization is chosen based on report', function(assert) {
       metadata: {
         columns: [
           {
-            field: 'dateTime',
+            attributes: { name: 'dateTime' },
             type: 'dateTime',
             displayName: 'Date'
           },
           {
-            field: { metric: 'adClicks' },
+            attributes: { name: 'adClicks' },
             type: 'metric',
             displayName: 'Ad Clicks'
           }

--- a/packages/reports/tests/integration/components/report-view-test.js
+++ b/packages/reports/tests/integration/components/report-view-test.js
@@ -175,12 +175,12 @@ test('visualization is chosen based on report', function(assert) {
       metadata: {
         columns: [
           {
-            field: 'dateTime',
+            attributes: { name: 'dateTime' },
             type: 'dateTime',
             displayName: 'Date'
           },
           {
-            field: { metric: 'adClicks' },
+            attributes: { name: 'adClicks' },
             type: 'metric',
             displayName: 'Ad Clicks'
           }

--- a/packages/reports/tests/unit/consumers/report/table-visualization-test.js
+++ b/packages/reports/tests/unit/consumers/report/table-visualization-test.js
@@ -67,11 +67,11 @@ test('reorder metrics', function(assert) {
   let newColumns = [
     {
       type: 'metric',
-      field: { metric: 'b' }
+      attributes: { name: 'b' }
     },
     {
       type: 'threshold',
-      field: { metric: 'a' }
+      attributes: { name: 'a' }
     }
   ];
 
@@ -93,7 +93,7 @@ test('UPDATE_TABLE_COLUMN', function(assert) {
     visualization: {
       type: 'table',
       metadata: {
-        columns: [{ field: { metric: 'a' }, value: 1 }, { field: { metric: 'b' }, value: 2 }]
+        columns: [{ attributes: { name: 'a' }, value: 1 }, { attributes: { name: 'b', format: 'foo' }, value: 2 }]
       }
     }
   };
@@ -102,13 +102,13 @@ test('UPDATE_TABLE_COLUMN', function(assert) {
     this.subject().send(
       UpdateReportActions.UPDATE_TABLE_COLUMN,
       { currentModel },
-      { field: { metric: 'b' }, value: 3 }
+      { attributes: { name: 'b', format: 'bar' }, value: 3 }
     );
   });
 
   assert.deepEqual(
     get(currentModel, 'visualization.metadata.columns'),
-    [{ field: { metric: 'a' }, value: 1 }, { field: { metric: 'b' }, value: 3 }],
+    [{ attributes: { name: 'a' }, value: 1 }, { attributes: { name: 'b', format: 'bar' }, value: 3 }],
     'updateColumn updates the column in the visualization metadata'
   );
 });


### PR DESCRIPTION
This changes the columns representations to:
```
{
  type: 'dimension',
  attributes: {
    name: 'advanceTrafficCurrency',
    field: 'id'
  },
  displayName: 'Traffic Currency'
}
```

```
{
  type: 'metric',
  attributes: {
    name: 'pageViews',
    format: '0.0a',
    parameters: {...}
  },
  displayName: 'Page Views'
}
```

```
{
  type: 'dateTime',
  attributes: {
    name: 'dateTime'
  },
  displayName: 'Date'
}
```