### PR TITLE
Update: Remove Flag that shouldn't be published

### DIFF
--- a/packages/dashboards/index.js
+++ b/packages/dashboards/index.js
@@ -10,9 +10,5 @@ module.exports = {
     var target = parentAddon || app;
 
     target.import('vendor/loader.css');
-  },
-
-  isDevelopingAddon: function() {
-    return true;
   }
 };

--- a/packages/data/index.js
+++ b/packages/data/index.js
@@ -1,9 +1,5 @@
 'use strict';
 
 module.exports = {
-  name: 'navi-data',
-
-  isDevelopingAddon: function() {
-    return true;
-  }
+  name: 'navi-data'
 };

--- a/packages/reports/index.js
+++ b/packages/reports/index.js
@@ -18,9 +18,5 @@ module.exports = {
 
     var target = parentAddon || app;
     target.import('vendor/loader.css');
-  },
-
-  isDevelopingAddon: function() {
-    return true;
   }
 };


### PR DESCRIPTION
We have `isDevelopingAddon` set to true in only dashboards, reports, and data. These shouldn't be true when we publish our addons. With Ember 3, this flag will cause Navi's template files to be run through the template linter for apps that use Navi.

More info:
https://github.com/ember-template-lint/ember-template-lint/issues/119#issuecomment-258620041