### PR TITLE
Breaking: Make navi more compatible with Ember 3.x apps

### DIFF
--- a/packages/app/app/router.js
+++ b/packages/app/app/router.js
@@ -17,20 +17,20 @@ Router.map(function() {
     this.route('my-data');
   });
 
-  this.route('dashboardCollections', function() {
-    this.route('collection', { path: '/:collectionId' });
+  this.route('dashboard-collections', function() {
+    this.route('collection', { path: '/:collection_id' });
   });
 
   this.route('dashboards', function() {
     this.route('new');
-    this.route('dashboard', { path: '/:dashboardId' }, function() {
+    this.route('dashboard', { path: '/:dashboard_id' }, function() {
       this.route('clone');
       this.route('view');
 
       this.route('widgets', function() {
         this.route('add');
         this.route('new');
-        this.route('widget', { path: '/:widgetId' }, function() {
+        this.route('widget', { path: '/:widget_id' }, function() {
           this.route('edit');
           this.route('invalid');
           this.route('view');
@@ -42,7 +42,7 @@ Router.map(function() {
 
   this.route('reports', function() {
     this.route('new');
-    this.route('report', { path: '/:reportId' }, function() {
+    this.route('report', { path: '/:report_id' }, function() {
       this.route('edit');
       this.route('invalid');
       this.route('view');
@@ -53,7 +53,7 @@ Router.map(function() {
 
   this.route('beta', function() {
     this.route('reports', function() {
-      this.route('report', { path: '/:reportId' }, function() {
+      this.route('report', { path: '/:report_id' }, function() {
         this.route('view');
       });
     });

--- a/packages/core/addon/mirage/serializers/base-json-serializer.js
+++ b/packages/core/addon/mirage/serializers/base-json-serializer.js
@@ -4,7 +4,7 @@ import { camelize } from '@ember/string';
 export default JSONAPISerializer.extend({
   alwaysIncludeLinkageData: true,
 
-  keyForAttribute: attr => camelize(attr),
+  keyForAttribute: attr => attr,
 
   keyForModel: attr => camelize(attr),
 

--- a/packages/dashboards/addon/routes/dashboard-collections/collection.js
+++ b/packages/dashboards/addon/routes/dashboard-collections/collection.js
@@ -1,18 +1,18 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2019, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   /**
    * @method model
    * @override
    *
    * Makes an ajax request to retrieve relevant dashbords in the collection
    */
-  model({ collectionId }) {
-    return this.store.find('dashboard-collection', collectionId);
+  model({ collection_id }) {
+    return this.store.find('dashboard-collection', collection_id);
   }
 });

--- a/packages/dashboards/addon/routes/dashboards/dashboard.js
+++ b/packages/dashboards/addon/routes/dashboards/dashboard.js
@@ -1,17 +1,19 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2019, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
+import { computed, get, set, setProperties } from '@ember/object';
+import { A as arr, makeArray } from '@ember/array';
+import { isEmpty } from '@ember/utils';
+import { run } from '@ember/runloop';
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
-import Ember from 'ember';
-
-const { computed, get, makeArray, run, set, setProperties } = Ember;
-
-export default Ember.Route.extend({
+export default Route.extend({
   /**
    * @property {Service} user
    */
-  user: Ember.inject.service(),
+  user: service(),
 
   /**
    * @property {DS.Model} currentDashboard - current dashboard model
@@ -23,7 +25,7 @@ export default Ember.Route.extend({
   /**
    * @property {Service} naviNotifications
    */
-  naviNotifications: Ember.inject.service(),
+  naviNotifications: service(),
 
   /**
    * Makes an ajax request to retrieve relevant widgets in the dashboard
@@ -35,8 +37,8 @@ export default Ember.Route.extend({
    * @returns {Promise} Promise that resolves to a dashboard model
    *
    */
-  model({ dashboardId }) {
-    return get(this, 'store').find('dashboard', dashboardId);
+  model({ dashboard_id }) {
+    return get(this, 'store').find('dashboard', dashboard_id);
   },
 
   /**
@@ -50,7 +52,7 @@ export default Ember.Route.extend({
    */
   _updateLayout(updatedWidgets) {
     let dashboard = get(this, 'currentDashboard'),
-      layout = Ember.A(get(dashboard, 'presentation.layout'));
+      layout = arr(get(dashboard, 'presentation.layout'));
 
     makeArray(updatedWidgets).forEach(updatedWidget => {
       let modelWidget = layout.findBy('widgetId', Number(updatedWidget.id));
@@ -138,7 +140,7 @@ export default Ember.Route.extend({
 
           // Remove layout reference
           let presentation = get(this, 'currentDashboard.presentation'),
-            newLayout = Ember.A(get(presentation, 'layout')).rejectBy('widgetId', Number(id));
+            newLayout = arr(get(presentation, 'layout')).rejectBy('widgetId', Number(id));
           set(presentation, 'layout', newLayout);
           this.send('saveDashboard');
 
@@ -182,7 +184,7 @@ export default Ember.Route.extend({
      * @param {String} title
      */
     updateTitle(title) {
-      if (!Ember.isEmpty(title)) {
+      if (!isEmpty(title)) {
         let dashboard = get(this, 'currentDashboard');
         set(dashboard, 'title', title);
         this.send('saveDashboard');

--- a/packages/dashboards/addon/routes/dashboards/dashboard/widgets/widget.js
+++ b/packages/dashboards/addon/routes/dashboards/dashboard/widgets/widget.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018, Yahoo Holdings Inc.
+ * Copyright 2019, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import Ember from 'ember';
@@ -14,15 +14,15 @@ export default ReportRoute.extend({
    * @param {String} params.widgetId - persisted id or temp id of widget to fetch
    * @returns {DS.Model} model for requested widget
    */
-  model({ widgetId }) {
+  model({ widget_id }) {
     let widgets = this.modelFor('dashboards.dashboard.widgets'),
-      widgetModel = widgets.findBy('id', widgetId) || this._findTempWidget(widgetId);
+      widgetModel = widgets.findBy('id', widget_id) || this._findTempWidget(widget_id);
 
     if (widgetModel) {
       return widgetModel;
     }
 
-    throw new Error(`Widget ${widgetId} could not be found`);
+    throw new Error(`Widget ${widget_id} could not be found`);
   },
 
   /**

--- a/packages/dashboards/blueprints/navi-dashboards/index.js
+++ b/packages/dashboards/blueprints/navi-dashboards/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2019, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 
@@ -18,7 +18,7 @@ module.exports = {
       "\tthis.route('dashboardCollections', function() { " +
       EOL +
       "\
-  this.route('collection', {path:'/:collectionId'}); " +
+  this.route('collection', {path:'/:collection_id'}); " +
       EOL +
       '\
 });' +
@@ -30,7 +30,7 @@ this.route('print', function() { " +
   this.route('dashboards', function() { " +
       EOL +
       "\
-    this.route('dashboard', { path: '/:dashboardId' }, function() {" +
+    this.route('dashboard', { path: '/:dashboard_id' }, function() {" +
       EOL +
       "\
       this.route('view'); " +
@@ -51,7 +51,7 @@ this.route('dashboards', function() { " +
   this.route('new'); " +
       EOL +
       "\
-  this.route('dashboard', { path: '/:dashboardId' }, function() {" +
+  this.route('dashboard', { path: '/:dashboard_id' }, function() {" +
       EOL +
       "\
     this.route('clone'); " +
@@ -69,7 +69,7 @@ this.route('dashboards', function() { " +
       this.route('new'); " +
       EOL +
       "\
-      this.route('widget', { path: '/:widgetId'}, function() { " +
+      this.route('widget', { path: '/:widget_id'}, function() { " +
       EOL +
       "\
         this.route('edit'); " +

--- a/packages/dashboards/tests/dummy/app/router.js
+++ b/packages/dashboards/tests/dummy/app/router.js
@@ -12,19 +12,19 @@ Router.map(function() {
   });
 
   this.route('dashboardCollections', function() {
-    this.route('collection', { path: '/:collectionId' });
+    this.route('collection', { path: '/:collection_id' });
   });
   this.route('dashboards', function() {
     this.route('new');
 
-    this.route('dashboard', { path: '/:dashboardId' }, function() {
+    this.route('dashboard', { path: '/:dashboard_id' }, function() {
       this.route('clone');
       this.route('view');
 
       this.route('widgets', function() {
         this.route('add');
         this.route('new');
-        this.route('widget', { path: '/:widgetId' }, function() {
+        this.route('widget', { path: '/:widget_id' }, function() {
           this.route('clone-to-report');
           this.route('edit');
           this.route('view');
@@ -36,14 +36,14 @@ Router.map(function() {
 
   this.route('print', function() {
     this.route('dashboards', function() {
-      this.route('dashboard', { path: '/:dashboardId' }, function() {
+      this.route('dashboard', { path: '/:dashboard_id' }, function() {
         this.route('view');
       });
     });
   });
 
   this.route('reports', function() {
-    this.route('report', { path: '/:reportId' }, function() {
+    this.route('report', { path: '/:report_id' }, function() {
       this.route('view');
       this.route('clone');
       this.route('edit');

--- a/packages/dashboards/tests/unit/routes/dashboard-collections/dashboard-collections-test.js
+++ b/packages/dashboards/tests/unit/routes/dashboard-collections/dashboard-collections-test.js
@@ -35,16 +35,16 @@ test('model', function(assert) {
   assert.expect(4);
 
   return Ember.run(() => {
-    let params = { collectionId: 1 },
+    let params = { collection_id: 1 },
       route = this.subject(),
       modelPromise = route.model(params);
 
     assert.ok(modelPromise.then, 'Route returns a promise in the model hook');
 
     return modelPromise.then(model => {
-      assert.equal(model.id, params.collectionId, 'The requested collection is retrieved');
+      assert.equal(model.id, params.collection_id, 'The requested collection is retrieved');
 
-      assert.equal(model.get('title'), `Collection ${params.collectionId}`, 'The requested collection is retrieved');
+      assert.equal(model.get('title'), `Collection ${params.collection_id}`, 'The requested collection is retrieved');
 
       return model.get('dashboards').then(dashboards => {
         assert.equal(dashboards.length, 2, 'The requested collection is retrieved with the two dashboards');

--- a/packages/dashboards/tests/unit/routes/dashboards/dashboard/widgets/widget-test.js
+++ b/packages/dashboards/tests/unit/routes/dashboards/dashboard/widgets/widget-test.js
@@ -27,16 +27,16 @@ test('model hook', function(assert) {
   });
 
   /* == Persisted id == */
-  let model = route.model({ widgetId: 1 });
+  let model = route.model({ widget_id: 1 });
   assert.equal(model.id, 1, 'Route model looks up widget based on id');
 
   /* == Temp id == */
-  model = route.model({ widgetId: '123-456' });
+  model = route.model({ widget_id: '123-456' });
   assert.equal(model.tempId, '123-456', 'Route can find widgets based on temp id');
 
   /* == Error widget not found == */
   try {
-    route.model({ widgetId: 10 });
+    route.model({ widget_id: 10 });
   } catch (error) {
     assert.equal(
       error.message,

--- a/packages/dashboards/tests/unit/routes/dashboards/dashboards-test.js
+++ b/packages/dashboards/tests/unit/routes/dashboards/dashboards-test.js
@@ -50,6 +50,7 @@ moduleFor('route:dashboards/dashboard', 'Unit | Route | dashboards/dashboard', {
     'model:bard-request/fragments/logicalTable',
     'model:bard-request/fragments/metric',
     'model:bard-request/fragments/sort',
+    'model:delivery-rule',
     'model:metadata/table',
     'model:metadata/dimension',
     'model:metadata/metric',
@@ -63,6 +64,9 @@ moduleFor('route:dashboards/dashboard', 'Unit | Route | dashboards/dashboard', {
     'validator:chart-type',
     'validator:request-metrics',
     'validator:request-dimension-order',
+    'validator:number',
+    'validator:request-time-grain',
+    'validator:request-filters',
     'service:bard-metadata',
     'serializer:bard-request/fragments/logical-table',
     'serializer:bard-request/fragments/interval',
@@ -99,13 +103,13 @@ test('model', function(assert) {
   assert.expect(4);
 
   return Ember.run(() => {
-    let params = { dashboardId: '1' },
+    let params = { dashboard_id: '1' },
       modelPromise = Route.model(params);
 
     assert.ok(modelPromise.then, 'Route returns a promise in the model hook');
 
     return modelPromise.then(dashboard => {
-      assert.equal(dashboard.id, params.dashboardId, 'The requested dashboard is retrieved');
+      assert.equal(dashboard.id, params.dashboard_id, 'The requested dashboard is retrieved');
 
       assert.equal(dashboard.get('title'), 'Tumblr Goals Dashboard', 'The requested dashboard is retrieved');
 
@@ -272,7 +276,7 @@ test('delete widget - failure', function(assert) {
   assert.expect(3);
 
   //Mock Server Endpoint
-  server.delete('/dashboards/:id/widgets/:widgetId', () => {
+  server.delete('/dashboards/:id/widgets/:widget_id', () => {
     return new Mirage.Response(500);
   });
 

--- a/packages/reports/addon/routes/report-collections/collection.js
+++ b/packages/reports/addon/routes/report-collections/collection.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2019, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import Ember from 'ember';
@@ -12,9 +12,9 @@ export default Ember.Route.extend({
    * @param collectionId
    * @returns {*|Promise|Promise.<TResult>}
    */
-  model({ collectionId }) {
+  model({ collection_id }) {
     return Ember.get(this, 'user')
       .findOrRegister()
-      .then(() => this.get('store').findRecord('reportCollection', collectionId));
+      .then(() => this.get('store').findRecord('reportCollection', collection_id));
   }
 });

--- a/packages/reports/addon/routes/reports/report.js
+++ b/packages/reports/addon/routes/reports/report.js
@@ -45,10 +45,10 @@ export default Route.extend({
    * @param {String} params.reportId - persisted id or temp id of report to fetch
    * @returns {DS.Model|Promise} model for requested report
    */
-  model({ reportId }) {
+  model({ report_id }) {
     return get(this, 'user')
       .findOrRegister()
-      .then(() => this._findByTempId(reportId) || this.store.findRecord('report', reportId))
+      .then(() => this._findByTempId(report_id) || this.store.findRecord('report', report_id))
       .then(this._defaultVisualization.bind(this));
   },
 

--- a/packages/reports/addon/routes/reports/report/view.js
+++ b/packages/reports/addon/routes/reports/report/view.js
@@ -1,24 +1,25 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2019, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
-import Ember from 'ember';
 import isEqual from 'lodash/isEqual';
+import { get, set, computed } from '@ember/object';
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 import merge from 'lodash/merge';
 import { isForbiddenError } from 'ember-ajax/errors';
+import { reject } from 'rsvp';
 
-const { get, set } = Ember;
-
-export default Ember.Route.extend({
+export default Route.extend({
   /**
    * @property {Service} facts - instance of bard facts service
    */
-  facts: Ember.inject.service('bard-facts'),
+  facts: service('bard-facts'),
 
   /**
    * @property {Service} naviVisualizations - instance of navi visualizations service
    */
-  naviVisualizations: Ember.inject.service(),
+  naviVisualizations: service(),
 
   /**
    * @property {Object} requestOptions - options for bard request
@@ -32,7 +33,7 @@ export default Ember.Route.extend({
   /**
    * @property {Object} parentModel - object containing request to view
    */
-  parentModel: Ember.computed(function() {
+  parentModel: computed(function() {
     return this.modelFor('reports.report');
   }).volatile(),
 
@@ -64,7 +65,7 @@ export default Ember.Route.extend({
         if (isForbiddenError(response)) {
           this.transitionTo('reports.report.unauthorized', get(report, 'id'));
         } else {
-          return Ember.RSVP.reject(response);
+          return reject(response);
         }
       });
   },
@@ -136,7 +137,12 @@ export default Ember.Route.extend({
      * @action loading
      */
     loading(transition) {
-      transition.send('setReportState', 'running');
+      /**
+       * false is sent as the first argument due to a change in router_js
+       * TODO: Remove false if this is ever removed
+       * https://github.com/emberjs/ember.js/issues/17545
+       */
+      transition.send(false, 'setReportState', 'running');
       return true; // allows the loading template to be shown
     },
 
@@ -144,7 +150,12 @@ export default Ember.Route.extend({
      * @action error
      */
     error(error, transition) {
-      transition.send('setReportState', 'failed');
+      /**
+       * false is sent as the first argument due to a change in router_js
+       * TODO: Remove false if this is ever removed
+       * https://github.com/emberjs/ember.js/issues/17545
+       */
+      transition.send(false, 'setReportState', 'failed');
       return true; // allows the error template to be shown
     },
 

--- a/packages/reports/blueprints/navi/index.js
+++ b/packages/reports/blueprints/navi/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2019, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Blueprint utility to auto-insert the custom reports routes after installing the addon
@@ -21,7 +21,7 @@ module.exports = {
         this.route('new');" +
       EOL +
       "\
-        this.route('report', { path: '/:reportId'}, function() {" +
+        this.route('report', { path: '/:report_id'}, function() {" +
       EOL +
       "\
             this.route('view');" +
@@ -49,7 +49,7 @@ module.exports = {
       "\tthis.route('reportCollections', function() {" +
       EOL +
       "\
-        this.route('collection', {path: '/:collectionId'})" +
+        this.route('collection', {path: '/:collection_id'})" +
       EOL +
       '\
     });' +
@@ -65,7 +65,7 @@ module.exports = {
             this.route('new');" +
       EOL +
       "\
-            this.route('report', { path: '/:reportId'}, function() {" +
+            this.route('report', { path: '/:report_id'}, function() {" +
       EOL +
       "\
                 this.route('view');" +

--- a/packages/reports/tests/dummy/app/router.js
+++ b/packages/reports/tests/dummy/app/router.js
@@ -9,7 +9,7 @@ const Router = EmberRouter.extend({
 Router.map(function() {
   this.route('reports', function() {
     this.route('new');
-    this.route('report', { path: '/:reportId' }, function() {
+    this.route('report', { path: '/:report_id' }, function() {
       this.route('clone');
       this.route('save-as');
       this.route('invalid');
@@ -24,13 +24,13 @@ Router.map(function() {
   });
 
   this.route('reportCollections', function() {
-    this.route('collection', { path: '/:collectionId' });
+    this.route('collection', { path: '/:collection_id' });
   });
 
   this.route('print', function() {
     this.route('reports', function() {
       this.route('new');
-      this.route('report', { path: '/:reportId' }, function() {
+      this.route('report', { path: '/:report_id' }, function() {
         this.route('view');
         this.route('invalid');
       });

--- a/packages/reports/tests/unit/routes/report-collections/collection-test.js
+++ b/packages/reports/tests/unit/routes/report-collections/collection-test.js
@@ -12,6 +12,7 @@ moduleFor('route:report-collections/collection', 'Unit | Route | report collecti
     'adapter:report',
     'adapter:user',
     'model:report',
+    'model:deliverable-item',
     'model:user',
     'transform:array',
     'transform:fragment-array',
@@ -24,6 +25,8 @@ moduleFor('route:report-collections/collection', 'Unit | Route | report collecti
     'validator:request-metrics',
     'validator:request-metric-exist',
     'validator:request-dimension-order',
+    'validator:request-time-grain',
+    'validator:request-filters',
     'model:bard-request/request',
     'model:bard-request/fragments/dimension',
     'model:bard-request/fragments/filter',
@@ -74,18 +77,18 @@ test('model', function(assert) {
   assert.expect(4);
 
   return Ember.run(() => {
-    let params = { collectionId: 1 },
+    let params = { collection_id: 1 },
       route = this.subject(),
       modelPromise = route.model(params);
 
     assert.ok(modelPromise.then, 'Route returns a promise in the model hook');
 
     return modelPromise.then(model => {
-      assert.equal(model.id, params.collectionId, 'The requested collection is retrieved');
+      assert.equal(model.id, params.collection_id, 'The requested collection is retrieved');
 
       assert.equal(
         model.get('title'),
-        `Report Collection ${params.collectionId}`,
+        `Report Collection ${params.collection_id}`,
         'The requested collection is retrieved'
       );
 

--- a/packages/reports/tests/unit/routes/reports/report-test.js
+++ b/packages/reports/tests/unit/routes/reports/report-test.js
@@ -38,10 +38,10 @@ test('model hook', function(assert) {
     _defaultVisualization: report => report
   });
 
-  return route.model({ reportId: 1 }).then(model => {
+  return route.model({ report_id: 1 }).then(model => {
     assert.equal(model.id, 1, 'Route model looks up report based on id');
 
-    return route.model({ reportId: '123-456' }).then(model => {
+    return route.model({ report_id: '123-456' }).then(model => {
       assert.equal(model.tempId, '123-456', 'Route can find reports based on temp id');
     });
   });


### PR DESCRIPTION
The dynamic segments of the routes should be in snake case for Ember 3. 

Also there was an issue with setting the report state. The [issue](https://github.com/emberjs/ember.js/issues/17545) is that the contract for the `transition.send` function changed. The first argument in the function definition is `ignoreFailure` which used to be defined as a boolean. So I think since we were calling `transition.send` and passing a string as the first argument, the compiler would know that the string wasn't meant to be assigned to `ignoreFailure`. There was a change recently that no longer defines `ignoreFailure` as a boolean, but gives it a default value of `false`. Now that means that when we pass a string as the first argument, that string gets passed as `ignoreFailure` to `transition.send` and everything blows up. The issue I mentioned says that they solved the issue by bumping up the version of `router_js`, but the [line](https://github.com/tildeio/router.js/blob/2d611a583b74b8f8d8290146cf2816f175e251e3/lib/router/transition.ts#L323) still has the default value and not a boolean specified like it did before. So for now, we will pass `false` as the first parameter to `transition.send`.