### PR TITLE
Fix: Build failing in directory due to new Ember release

### DIFF
--- a/packages/directory/package.json
+++ b/packages/directory/package.json
@@ -67,7 +67,7 @@
     "ember-resolver": "^4.0.0",
     "ember-route-action-helper": "^2.0.6",
     "ember-sortable": "1.12.3",
-    "ember-source": "^3.1.3",
+    "ember-source": "~3.1.3",
     "ember-source-channel-url": "^1.1.0",
     "ember-tag-input": "1.2.1",
     "ember-toggle": "5.2.1",


### PR DESCRIPTION
Solves an issue where the OrderedSet class was not being found within Ember. Daniel is working on upgrading Ember in this addon anyway so we can keep it to ~3.1.3 until his upgrade is ready.