### PR TITLE
Fix: Route names should be hyphenated

### DIFF
--- a/packages/dashboards/addon/templates/dashboard-collections/index.hbs
+++ b/packages/dashboards/addon/templates/dashboard-collections/index.hbs
@@ -5,7 +5,7 @@
 {{navi-collection
   items=model
   config=(hash
-    itemRoute='dashboardCollections.collection'
+    itemRoute='dashboard-collections.collection'
     emptyMsg='Looks like no dashboard collections have been created yet.'
   )
 }}

--- a/packages/reports/addon/templates/report-collections/index.hbs
+++ b/packages/reports/addon/templates/report-collections/index.hbs
@@ -5,7 +5,7 @@
 {{navi-collection
     items=model
     config=(hash
-        itemRoute='reportCollections.collection'
+        itemRoute='report-collections.collection'
         emptyMsg='Looks like no report collections have been created yet.'
     )
 }}


### PR DESCRIPTION
## Description
Previous PR changed routes to use snake case for dynamic route segments and hyphenated the route names

## Proposed Changes
- Hyphenate route names that were missed

## Screenshots
