### PR TITLE
Fix: Reinclude bower in the npmignore.

### DIFF
--- a/packages/core/.npmignore
+++ b/packages/core/.npmignore
@@ -6,7 +6,7 @@
 /bower_components/
 
 # misc
-/**/.gitkeep
+/.bowerrc
 /.editorconfig
 /.ember-cli
 /.env*
@@ -17,6 +17,7 @@
 /.template-lintrc.js
 /.travis.yml
 /.watchmanconfig
+/**/.gitkeep
 /config/ember-try.js
 /CONTRIBUTING.md
 /ember-cli-build.js

--- a/packages/core/.npmignore
+++ b/packages/core/.npmignore
@@ -6,8 +6,7 @@
 /bower_components/
 
 # misc
-**/.gitkeep
-/.bowerrc
+/**/.gitkeep
 /.editorconfig
 /.ember-cli
 /.env*
@@ -18,7 +17,6 @@
 /.template-lintrc.js
 /.travis.yml
 /.watchmanconfig
-/bower.json
 /config/ember-try.js
 /CONTRIBUTING.md
 /ember-cli-build.js


### PR DESCRIPTION
## Description
the `bower.json` file was not pushed to NPM because it was listed in the `.npmignore` file.  This breaks the node-core install.

## Proposed Changes
- Remove `bower.json` and `.bowerrc` from `.npmignore`.