### PR TITLE
Update: Use new dimensions search endpoint

### DIFF
--- a/packages/data/addon/mirage/routes/bard-lite.js
+++ b/packages/data/addon/mirage/routes/bard-lite.js
@@ -211,4 +211,25 @@ export default function(
 
     return { rows };
   });
+
+  this.get('/dimensions/:dimension/search', function(db, request) {
+    let dimension = request.params.dimension,
+      rows = _getDimensionValues(dimension),
+      { query } = request.queryParams;
+
+    if (query) {
+      let values = query
+        .toLowerCase()
+        .split(/\s+/)
+        .map(v => v.trim())
+        .filter(_ => _);
+
+      rows = rows.filter(row => {
+        let rowValue = `${row.id} ${row.description}`.toLowerCase();
+        return values.every(value => rowValue.includes(value));
+      });
+    }
+
+    return { rows };
+  });
 }

--- a/packages/reports/addon/components/filter-values/dimension-select.js
+++ b/packages/reports/addon/components/filter-values/dimension-select.js
@@ -10,6 +10,7 @@
  */
 import Ember from 'ember';
 import layout from '../../templates/components/filter-values/dimension-select';
+import { featureFlag } from 'navi-core/helpers/feature-flag';
 
 const { computed, get } = Ember;
 
@@ -67,6 +68,13 @@ export default Ember.Component.extend({
   }),
 
   /**
+   * @property {Boolean} useNewSearchAPI - whether to use /search endpoint instead of /values
+   */
+  useNewSearchAPI: computed(function() {
+    return featureFlag('newDimensionsSearchAPI');
+  }),
+
+  /**
    * Executes a dimension search for a given term and executes the
    * provided callbacks
    *
@@ -78,9 +86,11 @@ export default Ember.Component.extend({
    * @returns {Void}
    */
   _performSearch(term, resolve, reject) {
-    let dimension = get(this, 'dimensionName');
+    let dimension = get(this, 'dimensionName'),
+      useNewSearchAPI = get(this, 'useNewSearchAPI');
+
     get(this, '_dimensionService')
-      .search(dimension, { term })
+      .search(dimension, { term, useNewSearchAPI })
       .then(resolve, reject);
   },
 


### PR DESCRIPTION
## Description
New endpoint `/dimensions/<dimensionName>/search/?query=<query>` when searching for dimension values. 
Behind a `newDimensionsSearchAPI` feature flag.

## Screenshots
<img width="1023" alt="Screen Shot 2019-03-18 at 2 35 41 PM" src="https://user-images.githubusercontent.com/13946669/54565352-3fbacf80-498b-11e9-836c-bff1726d2a25.png">
