### PR TITLE
Fix: Table rendering in widgets

### DIFF
--- a/packages/core/addon/components/navi-visualizations/table.js
+++ b/packages/core/addon/components/navi-visualizations/table.js
@@ -62,17 +62,17 @@ export default Component.extend({
   /**
    * @property {Array} rawData - data from the WS
    */
-  rawData: readOnly('model.0.response.rows'),
+  rawData: readOnly('model.firstObject.response.rows'),
 
   /**
    * @property {Number} totalRows - total rows for the request
    */
-  totalRows: readOnly('model.0.response.meta.pagination.numberOfResults'),
+  totalRows: readOnly('model.firstObject.response.meta.pagination.numberOfResults'),
 
   /**
    * @property {Number} rowsInResponse - rows in response
    */
-  rowsInResponse: alias('model.0.response.rows.length'),
+  rowsInResponse: alias('model.firstObject.response.rows.length'),
 
   /**
    * @method computeColumnTotal

--- a/packages/core/tests/integration/components/navi-visualizations/table-test.js
+++ b/packages/core/tests/integration/components/navi-visualizations/table-test.js
@@ -355,19 +355,12 @@ module('Integration | Component | table', function(hooks) {
     assert.expect(1);
 
     Model[0].response.rows = ROWS.slice(0, 4);
-    let model = merge({}, Model, [
-      {
-        response: {
-          meta: {
-            pagination: {
-              numberOfResults: 10
-            }
-          }
-        }
+    Model[0].response.meta = {
+      pagination: {
+        numberOfResults: 10
       }
-    ]);
+    };
 
-    this.set('model', model);
     await render(TEMPLATE);
 
     assert.equal(
@@ -383,22 +376,16 @@ module('Integration | Component | table', function(hooks) {
     assert.expect(1);
 
     Model[0].response.rows = ROWS.slice(0, 4);
-    let model = merge({}, Model, [
-        {
-          response: {
-            meta: {
-              pagination: {
-                numberOfResults: 10
-              }
-            }
-          }
-        }
-      ]),
-      options = merge({}, Options, {
-        showTotals: { grandTotal: true, subtotal: 'os' }
-      });
+    Model[0].response.meta = {
+      pagination: {
+        numberOfResults: 10
+      }
+    };
 
-    this.set('model', model);
+    let options = merge({}, Options, {
+      showTotals: { grandTotal: true, subtotal: 'os' }
+    });
+
     this.set('options', options);
     await render(TEMPLATE);
 


### PR DESCRIPTION
Resolves HOTFIX

<!-- The above line will close the issue upon merge -->
## Description

some addons aren't using Ember.NativeArray yet so addressing by 'model.0' doesn't work.

## Proposed Changes
change to 'model.firstObject'

fix tests so it doesn't break 'firstObject' contract.

## Screenshots
