### PR TITLE
Fix: Save As modal closes after success

### DIFF
--- a/packages/reports/addon/controllers/reports/report.js
+++ b/packages/reports/addon/controllers/reports/report.js
@@ -15,6 +15,11 @@ const REPORT_STATE = {
 
 export default Controller.extend({
   /**
+   * @property {String} showSaveAs - whether the save as dialog is showing
+   */
+  showSaveAs: false,
+
+  /**
    * @property {String} reportState - state of the the report
    */
   reportState: computed({
@@ -55,5 +60,14 @@ export default Controller.extend({
    */
   didReportFail: computed('reportState', function() {
     return get(this, 'reportState') === REPORT_STATE.FAILED;
-  })
+  }),
+
+  actions: {
+    /**
+     * Closes save as modal
+     */
+    closeSaveAs() {
+      this.set('showSaveAs', false);
+    }
+  }
 });

--- a/packages/reports/addon/controllers/reports/report.js
+++ b/packages/reports/addon/controllers/reports/report.js
@@ -15,7 +15,7 @@ const REPORT_STATE = {
 
 export default Controller.extend({
   /**
-   * @property {String} showSaveAs - whether the save as dialog is showing
+   * @property {Boolean} showSaveAs - whether the save as dialog is showing
    */
   showSaveAs: false,
 

--- a/packages/reports/addon/routes/reports/report.js
+++ b/packages/reports/addon/routes/reports/report.js
@@ -68,6 +68,15 @@ export default Route.extend({
   },
 
   /**
+   * @param {Controller} controller
+   * @override
+   */
+  setupController(controller) {
+    this._super(...arguments);
+    controller.set('showSaveAs', false);
+  },
+
+  /**
    * @method _findByTempId
    * @private
    * @param {String} id - temp id of local report

--- a/packages/reports/addon/routes/reports/report/save-as.js
+++ b/packages/reports/addon/routes/reports/report/save-as.js
@@ -79,6 +79,7 @@ export default Route.extend({
         this._onSaveAsSuccess();
         // Roll back old report to revert any changes applied to original report
         oldReport.rollbackAttributes();
+        this.controllerFor('reports.report').send('closeSaveAs');
         // Switch to the newly created report
         return this.replaceWith('reports.report.view', get(report, 'id'));
       })

--- a/packages/reports/addon/templates/reports/report.hbs
+++ b/packages/reports/addon/templates/reports/report.hbs
@@ -78,7 +78,7 @@
             onclick={{pipe
               (route-action "validate" model)
               (route-action "runReport" model)
-              (toggle "showModal" this)
+              (toggle "showSaveAs" this)
           }}>
             Save As ...
           </button>
@@ -109,5 +109,5 @@
 
 {{report-actions/save-as
   model=model
-  showModal=showModal
+  showModal=showSaveAs
 }}

--- a/packages/reports/tests/acceptance/navi-report-test.js
+++ b/packages/reports/tests/acceptance/navi-report-test.js
@@ -366,7 +366,7 @@ test('Cancel Save As report', function(assert) {
 });
 
 test('Save As report', function(assert) {
-  assert.expect(6);
+  assert.expect(7);
 
   visit('/reports/1');
   let container = Application.__container__;
@@ -404,6 +404,8 @@ test('Save As report', function(assert) {
       '(New Copy) Hyrule News',
       'New Saved Report is being viewed'
     );
+
+    assert.notOk(find('.save-as__save-as-modal-btn').is(':visible'), 'Save As Modal not visible after save');
   });
 
   visit('/reports/1');

--- a/packages/reports/tests/acceptance/navi-report-test.js
+++ b/packages/reports/tests/acceptance/navi-report-test.js
@@ -371,6 +371,15 @@ test('Save As report', function(assert) {
   visit('/reports/1');
   let container = Application.__container__;
 
+  const saveAsVisible = () => {
+    let el = find('.save-as__save-as-modal-btn');
+    if (el instanceof $) {
+      //use this to normalize, we can remove this once jquery is gone.
+      el = el[0];
+    }
+    return Boolean(el && el.offsetParent);
+  };
+
   // Change the Dim
   click('.checkbox-selector--dimension .grouped-list__item:contains(Week) .grouped-list__item-label');
 
@@ -379,7 +388,7 @@ test('Save As report', function(assert) {
 
   // The Modal with buttons is Visible
   andThen(() => {
-    assert.ok(find('.save-as__save-as-modal-btn').is(':visible'), 'Save As Modal is visible with save as key');
+    assert.ok(saveAsVisible(), 'Save As Modal is visible with save as key');
   });
 
   // Press the save as
@@ -405,7 +414,7 @@ test('Save As report', function(assert) {
       'New Saved Report is being viewed'
     );
 
-    assert.notOk(find('.save-as__save-as-modal-btn').is(':visible'), 'Save As Modal not visible after save');
+    assert.notOk(saveAsVisible(), 'Save As Modal not visible after save');
   });
 
   visit('/reports/1');


### PR DESCRIPTION
<!-- The above line will close the issue upon merge -->
## Description
Save As modal no longer closes after successful save.


## Proposed Changes
Change modal state to controller, send actions to controller
