### PR TITLE
Update: Hide datetime column on all timegrain

### DIFF
--- a/packages/core/addon/models/table.js
+++ b/packages/core/addon/models/table.js
@@ -23,7 +23,11 @@ const Validations = buildValidations(
         let request = get(options, 'request');
         return request && hasAllColumns(request, arr(columns));
       },
-      dependentKeys: ['model._request.dimensions.[]', 'model._request.metrics.[]']
+      dependentKeys: [
+        'model._request.dimensions.[]',
+        'model._request.metrics.[]',
+        'model._request.logicalTable.timeGrain.name'
+      ]
     })
   },
   {
@@ -54,7 +58,8 @@ export default VisualizationBase.extend(Validations, {
       metrics = get(request, 'metrics') || [],
       columns = get(this, 'metadata.columns'),
       // index column based on metricId or dimensionId
-      columnIndex = indexColumnById(columns);
+      columnIndex = indexColumnById(columns),
+      timeGrain = get(request, 'logicalTable.timeGrain.name');
 
     let dateColumn = {
       type: 'dateTime',
@@ -62,11 +67,12 @@ export default VisualizationBase.extend(Validations, {
       displayName: 'Date'
     };
 
-    let newColumns = [
-      dateColumn,
-      ...buildDimensionColumns(dimensions, columnIndex),
-      ...buildMetricColumns(metrics, columnIndex)
-    ];
+    let newColumns = [...buildDimensionColumns(dimensions, columnIndex), ...buildMetricColumns(metrics, columnIndex)];
+
+    //Add DateTime column when on timegrain other than All
+    if (timeGrain !== 'all') {
+      newColumns.unshift(dateColumn);
+    }
 
     set(this, 'metadata', {
       columns: columnTransform(newColumns, columns)
@@ -178,7 +184,9 @@ function columnTransform(newColumns, oldColumns) {
 
 /**
  * Determines if the columns include all dimensions
- * and metrics from the request
+ * and metrics from the request and if it should/does have
+ * a dateTime column based on the timeGrain
+ * (all timegrain shouldn't have dateTime column)
  *
  * @function hasAllColumns
  * @param {Object} request - request object
@@ -205,9 +213,16 @@ function hasAllColumns(request, columns) {
       })
     ),
     metrics = arr(get(request, 'metrics')).mapBy('canonicalName'),
-    requestFields = [...dimensions, ...metrics];
+    requestFields = [...dimensions, ...metrics],
+    timeGrain = get(request, 'logicalTable.timeGrain.name'),
+    shouldHaveDateTimeCol = timeGrain !== 'all',
+    doesHaveDateTimeCol = !!arr(columns).findBy('type', 'dateTime');
 
-  return requestFields.length === columnFields.length && requestFields.every(field => columnFields.includes(field));
+  return (
+    requestFields.length === columnFields.length &&
+    requestFields.every(field => columnFields.includes(field)) &&
+    shouldHaveDateTimeCol === doesHaveDateTimeCol
+  );
 }
 
 export function indexColumnById(columns) {

--- a/packages/core/addon/models/table.js
+++ b/packages/core/addon/models/table.js
@@ -61,18 +61,23 @@ export default VisualizationBase.extend(Validations, {
       columnIndex = indexColumnById(columns),
       timeGrain = get(request, 'logicalTable.timeGrain.name');
 
-    let dateColumn = {
-      type: 'dateTime',
-      attributes: { name: 'dateTime' },
-      displayName: 'Date'
-    };
+    //Only add dateColumn if timegrain is not 'all'
+    let dateColumn =
+      timeGrain !== 'all'
+        ? [
+            {
+              type: 'dateTime',
+              attributes: { name: 'dateTime' },
+              displayName: 'Date'
+            }
+          ]
+        : [];
 
-    let newColumns = [...buildDimensionColumns(dimensions, columnIndex), ...buildMetricColumns(metrics, columnIndex)];
-
-    //Add DateTime column when on timegrain other than All
-    if (timeGrain !== 'all') {
-      newColumns.unshift(dateColumn);
-    }
+    const newColumns = [
+      ...dateColumn,
+      ...buildDimensionColumns(dimensions, columnIndex),
+      ...buildMetricColumns(metrics, columnIndex)
+    ];
 
     set(this, 'metadata', {
       columns: columnTransform(newColumns, columns)

--- a/packages/reports/tests/acceptance/date-filter-test.js
+++ b/packages/reports/tests/acceptance/date-filter-test.js
@@ -41,12 +41,12 @@ test('dimension date range filter keeps values after save', async function(asser
 
   //Set low value
   await clickDropdown('.filter-values--dimension-date-range-input__low-value>.dropdown-date-picker__trigger');
-  await click('td.day:contains(4):first-of-type');
+  await click('.dropdown-date-picker__dropdown td.day:contains(4):not(.new):not(.old)');
   await click('.dropdown-date-picker__apply');
 
   //Set high value
   await clickDropdown('.filter-values--dimension-date-range-input__high-value>.dropdown-date-picker__trigger');
-  await click('td.day:contains(5):first-of-type');
+  await click('.dropdown-date-picker__dropdown td.day:contains(5):not(.new):not(.old)');
   await click('.dropdown-date-picker__apply');
 
   assert.ok(find('.filter-values--dimension-date-range-input__low-value:contains(4)'), 'The low value is set');


### PR DESCRIPTION
## Description
We recently decided that when the request has a timegrain of `all`, we will hide the dateTime column in the table visualization.

## Proposed Changes
- Change table model validations to check for the existence of the datetime column based on the timegrain
- Change `rebuildConfig` in table model to handle adding or removing the datetime column when the timegrain changes
