### PR TITLE
Fix: Stop dimension filter initial loading of large dimensions.

### DIFF
--- a/packages/reports/addon/components/filter-values/dimension-select.js
+++ b/packages/reports/addon/components/filter-values/dimension-select.js
@@ -53,8 +53,6 @@ export default Ember.Component.extend({
       dimensionService = get(this, '_dimensionService'),
       metadataService = get(this, '_metadataService');
 
-    console.log(get(metadataService.getById('dimension', dimensionName), 'cardinality'));
-
     if (get(metadataService.getById('dimension', dimensionName), 'cardinality') <= LOAD_CARDINALITY) {
       return dimensionService.all(dimensionName);
     }

--- a/packages/reports/addon/components/filter-values/dimension-select.js
+++ b/packages/reports/addon/components/filter-values/dimension-select.js
@@ -8,13 +8,16 @@
  *       onUpdateFilter=(action 'update')
  *   }}
  */
+import { computed, get } from '@ember/object';
+import { featureFlag } from 'navi-core/helpers/feature-flag';
+import { inject as service } from '@ember/service';
+import config from 'ember-get-config';
 import Ember from 'ember';
 import layout from '../../templates/components/filter-values/dimension-select';
-import { featureFlag } from 'navi-core/helpers/feature-flag';
-
-const { computed, get } = Ember;
 
 const SEARCH_DEBOUNCE_TIME = 200;
+
+const LOAD_CARDINALITY = config.navi.searchThresholds.contains;
 
 export default Ember.Component.extend({
   layout,
@@ -25,7 +28,12 @@ export default Ember.Component.extend({
    * @private
    * @property {Ember.Service} _dimensionService
    */
-  _dimensionService: Ember.inject.service('bard-dimensions'),
+  _dimensionService: service('bard-dimensions'),
+
+  /**
+   * @property _metadataService
+   */
+  _metadataService: service('bard-metadata'),
 
   /**
    * @property {String} dimensionName - name of dimension to be filtered
@@ -42,9 +50,16 @@ export default Ember.Component.extend({
    */
   dimensionOptions: computed('filter.subject', function() {
     let dimensionName = get(this, 'dimensionName'),
-      dimensionService = get(this, '_dimensionService');
+      dimensionService = get(this, '_dimensionService'),
+      metadataService = get(this, '_metadataService');
 
-    return dimensionService.all(dimensionName);
+    console.log(get(metadataService.getById('dimension', dimensionName), 'cardinality'));
+
+    if (get(metadataService.getById('dimension', dimensionName), 'cardinality') <= LOAD_CARDINALITY) {
+      return dimensionService.all(dimensionName);
+    }
+
+    return undefined;
   }),
 
   /**

--- a/packages/reports/tests/acceptance/navi-report-test.js
+++ b/packages/reports/tests/acceptance/navi-report-test.js
@@ -1959,15 +1959,22 @@ test("Report with an unknown table doesn't crash", function(assert) {
 });
 
 test('Filter with large cardinality dimensions value selection works', function(assert) {
-  assert.expect(1);
-  let options,
-    option,
+  assert.expect(2);
+  let option,
     dropdownSelector = '.filter-values--dimension-select';
   visit('/reports/new');
 
   // Load table A as it has the large cardinality dimensions, and choose a large cardinality dimension
   andThen(() => {
     selectChoose('.navi-table-select__dropdown', 'Table A');
+    click('.grouped-list__item:Contains(EventId) .grouped-list__item-label');
+    click('.grouped-list__item:Contains(Network Sessions) .grouped-list__item-label');
+    click('.navi-report__footer button:Contains(Run)');
+  });
+
+  // Grab one of the dim names after running a report
+  andThen(() => {
+    option = find('.table-cell-content.dimension')[0].textContent.trim();
     click('.grouped-list__item:Contains(EventId) .checkbox-selector__filter');
   });
 
@@ -1976,18 +1983,18 @@ test('Filter with large cardinality dimensions value selection works', function(
     click(dropdownSelector + ' .ember-power-select-trigger');
   });
 
-  // Parse the options from the dropdown, and then select the second item.
+  // Parse the options from the dropdown, and then select the first item.
   andThen(() => {
-    options = find('.filter-values--dimension-select__dropdown .item-row-content')
-      .toArray()
-      .map(e => e.textContent.replace(/\(\d+\)/, '').trim());
-    option = options[1];
-    selectChoose(dropdownSelector, 2);
+    let message = find(
+      '.filter-values--dimension-select__dropdown .ember-power-select-option--search-message'
+    )[0].textContent.trim();
+    assert.equal(message, 'Type to search', 'Message is correct');
   });
 
   // Simulate typing a search which pulls large cardinality dimension values from the server
   andThen(() => {
     selectSearch(dropdownSelector, option.toLowerCase().substring(0, 3));
+    click('.filter-values--dimension-select__dropdown .ember-power-select-option:contains(' + option + ')');
   });
 
   // Check if the selected item is still selected after the search

--- a/packages/reports/tests/acceptance/report-visualizations-test.js
+++ b/packages/reports/tests/acceptance/report-visualizations-test.js
@@ -32,18 +32,28 @@ test('filter changes line chart series', function(assert) {
       });
 
     click('.checkbox-selector__filter', property);
-    selectChoose('.filter-values--dimension-select', '.ember-power-select-option', 0);
-    click('.navi-report__run-btn');
+  });
 
-    andThen(() => {
-      assert.deepEqual(
-        find('.c3-legend-item')
-          .toArray()
-          .map(el => el.textContent.trim()),
-        ['Property 1'],
-        'With filter, only the filtered series is shown'
-      );
-    });
+  andThen(() => {
+    selectSearch('.filter-values--dimension-select', 'Property');
+  });
+
+  andThen(() => {
+    selectChoose('.filter-values--dimension-select', '.ember-power-select-option', 0);
+  });
+
+  andThen(() => {
+    click('.navi-report__run-btn');
+  });
+
+  andThen(() => {
+    assert.deepEqual(
+      find('.c3-legend-item')
+        .toArray()
+        .map(el => el.textContent.trim()),
+      ['Property 1'],
+      'With filter, only the filtered series is shown'
+    );
   });
 });
 


### PR DESCRIPTION
Resolves #344 

## Description
For large dimensions you must paste the term 2 or 3 times before the value shows up in the results. In some cases it briefly flashes the value but then disappears from the results list.

## Proposed Changes
- Stop loading all dimensions on initial filter dimension selector focus for large dimensions as defined by `config.navi.searchThresholds.contains`.

## Screenshots

No initial load all on focus for large cardinality dimension:
![image](https://user-images.githubusercontent.com/17508658/55575621-e7970380-56d4-11e9-8725-f30a7481fe30.png)

Load after value input:
![image](https://user-images.githubusercontent.com/17508658/55575983-c4b91f00-56d5-11e9-9f45-f3022bb5f055.png)
