### PR TITLE
Update: Check if report needs rerun

### DIFF
--- a/packages/reports/addon/controllers/reports/report.js
+++ b/packages/reports/addon/controllers/reports/report.js
@@ -20,6 +20,11 @@ export default Controller.extend({
   showSaveAs: false,
 
   /**
+   * @property {Object} modifiedRequest - the serialized request after calling `onUpdateReport`
+   */
+  modifiedRequest: null,
+
+  /**
    * @property {String} reportState - state of the the report
    */
   reportState: computed({

--- a/packages/reports/addon/controllers/reports/report/view.js
+++ b/packages/reports/addon/controllers/reports/report/view.js
@@ -3,10 +3,26 @@
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import Ember from 'ember';
+import { computed } from '@ember/object';
+import isEqual from 'lodash/isEqual';
 
 export default Ember.Controller.extend({
   /*
    * @property {Controller} reportController
    */
-  reportController: Ember.inject.controller('reports.report')
+  reportController: Ember.inject.controller('reports.report'),
+
+  /*
+   * @property {Boolean} hasRequestRun
+   */
+  hasRequestRun: computed('reportController.modifiedRequest', 'model.request', function() {
+    const modifiedRequest = this.get('reportController.modifiedRequest');
+
+    if (!modifiedRequest) {
+      // no changes have been made yet
+      return true;
+    }
+
+    return isEqual(modifiedRequest, this.model.get('request'));
+  })
 });

--- a/packages/reports/addon/routes/reports/report.js
+++ b/packages/reports/addon/routes/reports/report.js
@@ -73,7 +73,10 @@ export default Route.extend({
    */
   setupController(controller) {
     this._super(...arguments);
-    controller.set('showSaveAs', false);
+    controller.setProperties({
+      showSaveAs: false,
+      modifiedRequest: null
+    });
   },
 
   /**
@@ -208,6 +211,15 @@ export default Route.extend({
       controller.set('reportState', state);
     },
 
+    /*
+     * @action setModifiedRequest
+     * @param {Object} request
+     */
+    setModifiedRequest(request) {
+      const controller = this.controllerFor(this.routeName);
+      controller.set('modifiedRequest', request);
+    },
+
     /**
      * @action onUpdateVisualizationConfig
      *
@@ -237,6 +249,8 @@ export default Route.extend({
       if (actionType) {
         get(this, 'updateReportActionDispatcher').dispatch(actionType, this, ...args);
       }
+
+      this.send('setModifiedRequest', this.currentModel.get('request').serialize());
     },
 
     /**

--- a/packages/reports/addon/templates/components/report-view.hbs
+++ b/packages/reports/addon/templates/components/report-view.hbs
@@ -11,7 +11,7 @@
                 validVisualizations=validVisualizations
                 onVisualizationTypeUpdate=(route-action 'onVisualizationTypeUpdate')
             }}
-            {{#if hasReportRun}}
+            {{#if hasRequestRun}}
                 {{#unless isEditingVisualization}}
                     <div class='clickable report-view__visualization-edit-btn' onclick={{action 'toggleEditVisualization' this}}>
                         Edit {{visualizationTypeLabel}}
@@ -28,7 +28,7 @@
             response=response
             container=this
             annotationData=annotationData
-            isEditing=isEditingVisualization
+            isEditing=(and isEditingVisualization hasRequestRun)
             onUpdateReport=(pipe
                 (route-action 'onUpdateReport')
                 (route-action 'validate' report)
@@ -41,7 +41,7 @@
         }}
     {{/if}}
 </div>
-{{#if (and isEditingVisualization hasReportRun)}}
+{{#if (and isEditingVisualization hasRequestRun)}}
     <div class='report-view__visualization-edit'>
         <div class='report-view__visualization-edit-header'>
             <div class='clickable report-view__visualization-edit-btn' onclick={{action 'toggleEditVisualization' this}}> Edit {{visualizationTypeLabel}}

--- a/packages/reports/addon/templates/print/reports/report/view.hbs
+++ b/packages/reports/addon/templates/print/reports/report/view.hbs
@@ -1,5 +1,5 @@
 {{!-- Copyright 2017, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 {{print-report-view
     report=(model-for (parent-route))
-    response=model
+    response=model.response
 }}

--- a/packages/reports/addon/templates/reports/report/view.hbs
+++ b/packages/reports/addon/templates/reports/report/view.hbs
@@ -1,6 +1,6 @@
 {{!-- Copyright 2017, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 {{report-view
-    hasReportRun=reportController.didReportComplete
+    hasRequestRun=hasRequestRun
     report=(model-for (parent-route))
-    response=model
+    response=model.response
 }}

--- a/packages/reports/tests/acceptance/navi-report-test.js
+++ b/packages/reports/tests/acceptance/navi-report-test.js
@@ -1353,9 +1353,9 @@ test('Disabled Visualization Edit', function(assert) {
 });
 
 test('Disabled Visualization Edit While Editing', function(assert) {
-  assert.expect(4);
+  assert.expect(9);
 
-  visit('/reports/1/view');
+  visit('/reports/2/view');
   click('.report-view__visualization-edit-btn');
   andThen(() => {
     assert.ok(
@@ -1364,17 +1364,42 @@ test('Disabled Visualization Edit While Editing', function(assert) {
     );
   });
 
+  // Make a change that does NOT invalidate visualization
+  fillIn('.table-header-cell.dateTime input', 'Foo');
+  triggerEvent('.table-header-cell.dateTime input', 'blur');
+  andThen(() => {
+    assert.ok(
+      find('.report-view__visualization-edit').is(':visible'),
+      'Visualization edit panel is still visible after making changes that do not change the request'
+    );
+
+    assert.ok(
+      find('.report-view__visualization-edit-btn').is(':visible'),
+      'Visualization edit button is is still visible after making changes that do not change the request'
+    );
+
+    assert.notOk(
+      find('.report-view__info-text').is(':visible'),
+      'Notification to run is not visible after making changes that do not change the request'
+    );
+  });
+
   // Make a change that invalidates visualization
   click('.grouped-list__item:contains(Product Family) .checkbox-selector__checkbox');
   andThen(() => {
     assert.notOk(
       find('.report-view__visualization-edit').is(':visible'),
-      'Visualization edit panel is hidden when there are request changes that have not been run'
+      'Visualization edit panel is no longer visible when there are request changes that have not been run'
     );
 
     assert.notOk(
       find('.report-view__visualization-edit-btn').is(':visible'),
-      'Visualization edit button is hidden when there are request changes that have not been run'
+      'Visualization edit button is no longer visible when there are request changes that have not been run'
+    );
+
+    assert.ok(
+      find('.report-view__info-text').is(':visible'),
+      'Notification to run is visible when there are request changes that have not been run'
     );
   });
 
@@ -1383,7 +1408,12 @@ test('Disabled Visualization Edit While Editing', function(assert) {
   andThen(() => {
     assert.ok(
       find('.report-view__visualization-edit-btn').is(':visible'),
-      'Visualization edit button is back after running report'
+      'Visualization edit button is visible again after running the report'
+    );
+
+    assert.notOk(
+      find('.report-view__info-text').is(':visible'),
+      'Notification to run is no longer visible after running the report'
     );
   });
 });


### PR DESCRIPTION
## Description
This tries to solve 2 UX issues:
1. We don't always need to rerun the report, the "Run request to update Table" message should not be displayed after changes like column title/format and the run button should be disabled.
2. editing mode of table remains "on" even if report is changed and `visualization-config` is hidden:
![Apr-04-2019 14-33-39](https://user-images.githubusercontent.com/13946669/55590066-bf180500-56e6-11e9-8a3f-3be923383baf.gif)

## Proposed Changes
Bringing back here something similar to what we had before - a property controller `hasRequestRun` (`hasReportRun` is too confusing with the report completed status)
the main difference is that `previousRequest` lives in the `reports.report` controller rather that the `view` router so it can be accessed from both `runReport` in the `view` route and `onUpdateReport` in the `report` route. Not sure if it's a bad practice to read controller properties from child routes.

## Screenshots
![Apr-04-2019 14-38-54](https://user-images.githubusercontent.com/13946669/55590379-8e849b00-56e7-11e9-9c11-63746c63db6b.gif)

## Tests
TODO, would like to get some input before
