### PR TITLE
Create findContains and findAllContains utils. (Alex version)

### DIFF
--- a/packages/core/test-support/helpers/contains-helpers.js
+++ b/packages/core/test-support/helpers/contains-helpers.js
@@ -27,3 +27,62 @@ export function buttonContains(text) {
 export function linkContains(text) {
   return findByContains('a', text);
 }
+
+/**
+ * This function allows us to keep using the jquery notation for :contains without using jquery
+ *
+ * Example:
+ * Jquery: $(.class-thing:contains(blah) .metric .test:contains(other))
+ *
+ * findByContains:
+ * [...findByContains('.class-thing', 'blah').querySelectorAll('.metric .test')].find(el => el.innerText.trim().includes('other'))
+ *
+ * Non-Jquery Equivalent: [
+ *    ...[
+ *      ...document.querySelectorAll(
+ *        (.class-thing)
+ *      )].find(el => el.innerText.trim().includes('blah'))
+ *    .querySelectorAll('.metric .test')
+ *  ]
+ *  .find(el => el.innerText.trim().includes('other'))
+ *
+ * findContains: findContains(.class-thing:contains(blah) .metric .test:contains(other))
+ *
+ * @param {String} selector - jquery or native style selector
+ * @param {HTMLElement} [baseElement] - optional parameter to use as base element to select off of
+ * @returns {HTMLElement} - Element based on text it (or its parent) contains
+ */
+export function findContains(selector, baseElement) {
+  let nativeSelector,
+    parentElement = baseElement || document;
+
+  if (selector.includes(':contains(')) {
+    let splits = selector.split(':contains(');
+    let firstSelector = splits.shift(); //Selector without the :contains operator
+    let restOfSelector = splits.join(':contains('); //We only want to split on the first instance of :contains(, so join the rest back together if there were more
+    let endOfContentIndex = findEndOfContentIndex(restOfSelector);
+    let content = restOfSelector.substring(0, endOfContentIndex);
+    let nextSelector = restOfSelector.substring(endOfContentIndex + 1).trim();
+    let filteredElement = [...parentElement.querySelectorAll(firstSelector)].find(el =>
+      el.innerText.trim().includes(content)
+    );
+
+    /**
+     * If the :contains was used at the very end of the selector, return the element we found here
+     * Else recursively find element from rest of selector using the found element as the base
+     */
+    return nextSelector ? findContains(nextSelector, filteredElement) : filteredElement;
+  } else {
+    nativeSelector = selector;
+  }
+
+  return parentElement.querySelector(nativeSelector);
+}
+
+/**
+ * @param {String} str - String with the content ended with a ) and possibly another selector following that
+ * @returns {Number} Index of the ) character that closes the :contains( expression that precedes the input string
+ */
+function findEndOfContentIndex(str) {
+  return str.includes(':contains(') ? str.lastIndexOf(')', str.indexOf(':contains')) : str.lastIndexOf(')');
+}

--- a/packages/core/test-support/helpers/contains-helpers.js
+++ b/packages/core/test-support/helpers/contains-helpers.js
@@ -31,11 +31,11 @@ export function linkContains(text) {
 /**
  * This function allows us to keep using the jquery notation for :contains without using jquery
  *
+ * Need quotes around content with parentheses -- e.g. class:contains("(content)")
+ *
+ *
  * Example:
  * Jquery: $(.class-thing:contains(blah) .metric .test:contains(other))
- *
- * findByContains:
- * [...findByContains('.class-thing', 'blah').querySelectorAll('.metric .test')].find(el => el.innerText.trim().includes('other'))
  *
  * Non-Jquery Equivalent: [
  *    ...[
@@ -53,36 +53,22 @@ export function linkContains(text) {
  * @returns {HTMLElement} - Element based on text it (or its parent) contains
  */
 export function findContains(selector, baseElement) {
-  let nativeSelector,
-    parentElement = baseElement || document;
+  let parentElement = baseElement || document;
 
   if (selector.includes(':contains(')) {
-    let splits = selector.split(':contains(');
-    let firstSelector = splits.shift(); //Selector without the :contains operator
-    let restOfSelector = splits.join(':contains('); //We only want to split on the first instance of :contains(, so join the rest back together if there were more
-    let endOfContentIndex = findEndOfContentIndex(restOfSelector);
-    let content = restOfSelector.substring(0, endOfContentIndex);
-    let nextSelector = restOfSelector.substring(endOfContentIndex + 1).trim();
-    let filteredElement = [...parentElement.querySelectorAll(firstSelector)].find(el =>
-      el.innerText.trim().includes(content)
-    );
+    let regex = /^(.*?):contains\((["']?)(.*?)\2\)(.*)$/;
+    let matches = regex.exec(selector);
+    let firstSelector = matches[1];
+    let content = matches[3];
+    let nextSelector = matches[4];
+    let filteredElement = [...parentElement.querySelectorAll(firstSelector)].find(el => el.innerText.includes(content));
 
     /**
      * If the :contains was used at the very end of the selector, return the element we found here
      * Else recursively find element from rest of selector using the found element as the base
      */
     return nextSelector ? findContains(nextSelector, filteredElement) : filteredElement;
-  } else {
-    nativeSelector = selector;
   }
 
-  return parentElement.querySelector(nativeSelector);
-}
-
-/**
- * @param {String} str - String with the content ended with a ) and possibly another selector following that
- * @returns {Number} Index of the ) character that closes the :contains( expression that precedes the input string
- */
-function findEndOfContentIndex(str) {
-  return str.includes(':contains(') ? str.lastIndexOf(')', str.indexOf(':contains')) : str.lastIndexOf(')');
+  return parentElement.querySelector(selector);
 }

--- a/packages/core/tests/integration/helpers/contains-helpers-test.js
+++ b/packages/core/tests/integration/helpers/contains-helpers-test.js
@@ -1,0 +1,70 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { findContains } from '../../helpers/contains-helpers';
+import { find } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('helper:contains-helpers', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('findContains', async function(assert) {
+    assert.expect(7);
+
+    await render(hbs`
+      <div id=test123 class=test-div>Test1
+        <span class=test-span>Span1</span>
+        <span class=test-span>Span2</span>
+        <span class=test-span>Span3</span>
+      </div>
+      <div id=copy-test-div class=test-div>Test1
+        <span class=test-span>Span1 Copy</span>
+        <span class=test-span>Span2 Copy</span>
+        <span class=test-span>Span3 Copy</span>
+      </div>
+      <div class=test-div>Test2
+        <span class=test-span>Span4
+          <div class=inner-test-div>Inner Div 1</div>
+        </span>
+        <span class=test-span>Span5
+          <div class=inner-test-div>Inner Div 2</div>
+        </span>
+      </div>
+      <div class=test-div>Test3
+        <span class=test-span>(Other) Span</span>
+        <span class=test-span>Other Span</span>
+      </div>
+    `);
+
+    assert.ok(findContains('#test123').textContent.includes('Test1'), 'Native selector without contains works');
+
+    assert.ok(findContains('.test-div:contains(Test2)').textContent.includes('Test2'), 'Finds element by text content');
+
+    assert.ok(
+      findContains('.test-div:contains(Test2) .test-span').textContent.includes('Span4'),
+      'Uses the correct parent element to select an inner element'
+    );
+
+    assert.equal(
+      findContains('.test-div:contains(Test2) .test-span:contains(Span5) .inner-test-div').textContent.trim(),
+      'Inner Div 2',
+      'Multiple contains within one selector are handled correctly'
+    );
+
+    assert.ok(
+      findContains('.test-span:contains("(Other) Span")').textContent.includes('(Other) Span'),
+      'Content with parentheses is selected on correctly'
+    );
+
+    let baseElement = find('#copy-test-div');
+    assert.ok(
+      findContains('.test-span:contains(Span1)', baseElement).textContent.includes('Span1 Copy'),
+      'The correct element is selected when a base element is given'
+    );
+
+    assert.ok(
+      findContains('.test-div:contains("Test2")').textContent.includes('Test2'),
+      'Content wrapped in quotes is accepted'
+    );
+  });
+});

--- a/packages/core/tests/integration/helpers/contains-helpers-test.js
+++ b/packages/core/tests/integration/helpers/contains-helpers-test.js
@@ -1,44 +1,57 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import { findContains } from '../../helpers/contains-helpers';
+import { findContains, findAllContains } from '../../helpers/contains-helpers';
 import { find } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+
+const TEMPLATE = hbs`
+  <div id=test123 class=test-div>Test1
+    <span class=test-span>Span1</span>
+    <span class=test-span>Span2</span>
+    <span class=test-span>Span3</span>
+  </div>
+  <div id=copy-test-div class=test-div>Test1
+    <span class=test-span>Span1 Copy</span>
+    <span class=test-span>Span2 Copy</span>
+    <span class=test-span>Span3 Copy</span>
+  </div>
+  <div class=test-div>Test2
+    <span class=test-span>Span4
+      <div class=inner-test-div>Inner Div 1</div>
+    </span>
+    <span class=test-span>Span5
+      <div class=inner-test-div>Inner Div 2</div>
+    </span>
+  </div>
+  <div class=test-div>Test3
+    <span class=test-span>(Other) Span</span>
+    <span class=test-span>Other Span</span>
+  </div>`;
 
 module('helper:contains-helpers', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('findContains', async function(assert) {
-    assert.expect(7);
+  hooks.beforeEach(async function() {
+    await render(TEMPLATE);
+  });
 
-    await render(hbs`
-      <div id=test123 class=test-div>Test1
-        <span class=test-span>Span1</span>
-        <span class=test-span>Span2</span>
-        <span class=test-span>Span3</span>
-      </div>
-      <div id=copy-test-div class=test-div>Test1
-        <span class=test-span>Span1 Copy</span>
-        <span class=test-span>Span2 Copy</span>
-        <span class=test-span>Span3 Copy</span>
-      </div>
-      <div class=test-div>Test2
-        <span class=test-span>Span4
-          <div class=inner-test-div>Inner Div 1</div>
-        </span>
-        <span class=test-span>Span5
-          <div class=inner-test-div>Inner Div 2</div>
-        </span>
-      </div>
-      <div class=test-div>Test3
-        <span class=test-span>(Other) Span</span>
-        <span class=test-span>Other Span</span>
-      </div>
-    `);
+  test('findContains', async function(assert) {
+    assert.expect(9);
 
     assert.ok(findContains('#test123').textContent.includes('Test1'), 'Native selector without contains works');
 
     assert.ok(findContains('.test-div:contains(Test2)').textContent.includes('Test2'), 'Finds element by text content');
+
+    assert.ok(
+      findContains('.test-div:Contains("Test2")').textContent.includes('Test2'),
+      'Capitalizations of contains and quoted content are accepted'
+    );
+
+    assert.ok(
+      findContains(".test-div:contains('Test2')").textContent.includes('Test2'),
+      'Single quotes around content works'
+    );
 
     assert.ok(
       findContains('.test-div:contains(Test2) .test-span').textContent.includes('Span4'),
@@ -66,5 +79,25 @@ module('helper:contains-helpers', function(hooks) {
       findContains('.test-div:contains("Test2")').textContent.includes('Test2'),
       'Content wrapped in quotes is accepted'
     );
+  });
+
+  test('findAllContains', async function(assert) {
+    assert.expect(4);
+
+    let allTest1Spans = findAllContains('.test-div:contains(Test1) .test-span');
+
+    assert.equal(allTest1Spans.length, 6, 'The right number of elements are returned');
+
+    assert.deepEqual(
+      allTest1Spans.map(el => el.textContent.trim()),
+      ['Span1', 'Span2', 'Span3', 'Span1 Copy', 'Span2 Copy', 'Span3 Copy'],
+      'The correct spans are selected'
+    );
+
+    let noMatches = findAllContains('.there-should-be-no-matches:contains(anything)');
+
+    assert.ok(Array.isArray(noMatches), 'An array is returned');
+
+    assert.equal(noMatches.length, 0, "Empty array is returned when the selector doesn't match any elements");
   });
 });

--- a/packages/core/tests/integration/helpers/contains-helpers-test.js
+++ b/packages/core/tests/integration/helpers/contains-helpers-test.js
@@ -82,7 +82,7 @@ module('helper:contains-helpers', function(hooks) {
   });
 
   test('findAllContains', async function(assert) {
-    assert.expect(4);
+    assert.expect(13);
 
     let allTest1Spans = findAllContains('.test-div:contains(Test1) .test-span');
 
@@ -99,5 +99,82 @@ module('helper:contains-helpers', function(hooks) {
     assert.ok(Array.isArray(noMatches), 'An array is returned');
 
     assert.equal(noMatches.length, 0, "Empty array is returned when the selector doesn't match any elements");
+
+    assert.deepEqual(
+      findAllContains('#ember-testing :contains(Span4) div').map(el => el.textContent.trim().replace(/\s+/g, ' ')),
+      [
+        'Test1 Span1 Span2 Span3',
+        'Test1 Span1 Copy Span2 Copy Span3 Copy',
+        'Test2 Span4 Inner Div 1 Span5 Inner Div 2',
+        'Inner Div 1',
+        'Inner Div 2',
+        'Test3 (Other) Span Other Span'
+      ],
+      'Does not return duplicates'
+    );
+
+    assert.deepEqual(
+      findAllContains('#ember-testing :CoNtainS(Span4) div').map(el => el.textContent.trim().replace(/\s+/g, ' ')),
+      [
+        'Test1 Span1 Span2 Span3',
+        'Test1 Span1 Copy Span2 Copy Span3 Copy',
+        'Test2 Span4 Inner Div 1 Span5 Inner Div 2',
+        'Inner Div 1',
+        'Inner Div 2',
+        'Test3 (Other) Span Other Span'
+      ],
+      'Works with any contains casing'
+    );
+
+    assert.deepEqual(
+      findAllContains('#ember-testing\n:contains(Span4)\ndiv').map(el => el.textContent.trim().replace(/\s+/g, ' ')),
+      [
+        'Test1 Span1 Span2 Span3',
+        'Test1 Span1 Copy Span2 Copy Span3 Copy',
+        'Test2 Span4 Inner Div 1 Span5 Inner Div 2',
+        'Inner Div 1',
+        'Inner Div 2',
+        'Test3 (Other) Span Other Span'
+      ],
+      'Works multiline'
+    );
+
+    assert.equal(findAllContains(':contains(Span1 Copy)').length, 6, ':contains of nothing searches from root');
+
+    assert.deepEqual(
+      findAllContains('#ember-testing :contains(Span1):contains(Copy)').map(el =>
+        el.textContent.trim().replace(/\s+/g, ' ')
+      ),
+      [
+        'Test1 Span1 Span2 Span3 Test1 Span1 Copy Span2 Copy Span3 Copy Test2 Span4 Inner Div 1 Span5 Inner Div 2 Test3 (Other) Span Other Span',
+        'Test1 Span1 Copy Span2 Copy Span3 Copy',
+        'Span1 Copy'
+      ],
+      'ajoined :contains behaves conjunctively'
+    );
+
+    assert.deepEqual(
+      findAllContains('.test-div:contains(Span1)').map(el => el.textContent.trim().replace(/\s+/g, ' ')),
+      ['Test1 Span1 Span2 Span3', 'Test1 Span1 Copy Span2 Copy Span3 Copy'],
+      'ajoined :contains behave conjunctively'
+    );
+
+    assert.deepEqual(
+      findAllContains('.test-div ~ :contains(Span1)').map(el => el.textContent.trim().replace(/\s+/g, ' ')),
+      ['Test1 Span1 Copy Span2 Copy Span3 Copy'],
+      'works with ~'
+    );
+
+    assert.deepEqual(
+      findAllContains('.test-div > :contains(Inner Div 1)').map(el => el.textContent.trim().replace(/\s+/g, ' ')),
+      ['Span4 Inner Div 1'],
+      'works with >'
+    );
+
+    assert.deepEqual(
+      findAllContains('#test123 + :contains(Span)').map(el => el.textContent.trim().replace(/\s+/g, ' ')),
+      ['Test1 Span1 Copy Span2 Copy Span3 Copy'],
+      'works with +'
+    );
   });
 });


### PR DESCRIPTION
## Description
Right now, findByContains is not very helpful for complicated selectors with multiple `:contains` calls in its jquery equivalent.  I've created a new PR that handles, and tests, more edge cases and and has better behavior.

## Proposed Changes
- Add `findContains` and `findAllContains` to support using jquery style contains selectors without using jquery
- Eventually replace `findByContains` implementation with this one