### PR TITLE
Update: Remove metric requirement validation

### DIFF
--- a/packages/core/addon/manifests/bar-chart.js
+++ b/packages/core/addon/manifests/bar-chart.js
@@ -32,6 +32,6 @@ export default ManifestBase.extend({
    * @return {Boolean} - visualization type is valid
    */
   typeIsValid(request) {
-    return this.hasGroupBy(request) || this.hasMultipleTimeBuckets(request);
+    return this.hasMetric(request) && (this.hasGroupBy(request) || this.hasMultipleTimeBuckets(request));
   }
 });

--- a/packages/core/addon/manifests/base.js
+++ b/packages/core/addon/manifests/base.js
@@ -35,6 +35,24 @@ export default EmberObject.extend({
   },
 
   /**
+   * @method hasNoMetric
+   * @param {Object} request
+   * @returns {Boolean} has no metrics
+   */
+  hasNoMetric(request) {
+    return get(request, 'metrics.length') === 0;
+  },
+
+  /**
+   * @method hasMetric
+   * @param {Object} request
+   * @returns {Boolean} has some metrics
+   */
+  hasMetric(request) {
+    return !this.hasNoMetric(request);
+  },
+
+  /**
    * @method hasSingleTimeBucket
    * @param {Object} request
    * @returns {Boolean} has single time bucket
@@ -61,7 +79,7 @@ export default EmberObject.extend({
    * @returns {Boolean} has multiple metrics
    */
   hasMultipleMetrics(request) {
-    return !this.hasSingleMetric(request);
+    return !(this.hasSingleMetric(request) || this.hasNoMetric(request));
   },
 
   /**

--- a/packages/core/addon/manifests/line-chart.js
+++ b/packages/core/addon/manifests/line-chart.js
@@ -32,6 +32,6 @@ export default ManifestBase.extend({
    * @return {Boolean} - visualization type is valid
    */
   typeIsValid(request) {
-    return !this.hasSingleTimeBucket(request);
+    return this.hasMetric(request) && !this.hasSingleTimeBucket(request);
   }
 });

--- a/packages/core/addon/models/bard-request/request.js
+++ b/packages/core/addon/models/bard-request/request.js
@@ -39,8 +39,8 @@ const Validations = buildValidations({
   metrics: [
     validator('has-many'),
     validator('length', {
-      min: 1,
-      message: 'At least one metric should be selected'
+      min: 0,
+      message: 'Metrics can be emtpy'
     })
   ],
   having: [

--- a/packages/core/addon/models/bard-request/request.js
+++ b/packages/core/addon/models/bard-request/request.js
@@ -38,9 +38,9 @@ const Validations = buildValidations({
   ],
   metrics: [
     validator('has-many'),
-    validator('length', {
-      min: 0,
-      message: 'Metrics can be emtpy'
+    validator('collection', {
+      collection: true,
+      message: 'Must be a collection'
     })
   ],
   having: [

--- a/packages/core/tests/unit/models/bard-request/request-test.js
+++ b/packages/core/tests/unit/models/bard-request/request-test.js
@@ -1573,7 +1573,7 @@ module('Unit | Model Fragment | BardRequest - Request', function(hooks) {
   });
 
   test('Validations', async function(assert) {
-    assert.expect(14);
+    assert.expect(13);
 
     await settled();
     let mockModel = Store.peekRecord('fragments-mock', 1),
@@ -1613,12 +1613,7 @@ module('Unit | Model Fragment | BardRequest - Request', function(hooks) {
 
     request.validate().then(({ validations }) => {
       assert.ok(!validations.get('isValid'), 'Request is invalid');
-      assert.equal(validations.get('messages.length'), 3, 'Three Fields are invalid in the request model');
-      assert.equal(
-        validations.get('messages').objectAt(2),
-        'At least one metric should be selected',
-        'At least one metric should be selected is part of the messages'
-      );
+      assert.equal(validations.get('messages.length'), 2, 'Two Fields are invalid in the request model');
     });
 
     //setting intervals to empty
@@ -1626,9 +1621,9 @@ module('Unit | Model Fragment | BardRequest - Request', function(hooks) {
 
     request.validate().then(({ validations }) => {
       assert.ok(!validations.get('isValid'), 'Request is invalid');
-      assert.equal(validations.get('messages.length'), 4, 'Four Fields are invalid in the request model');
+      assert.equal(validations.get('messages.length'), 3, 'Three Fields are invalid in the request model');
       assert.equal(
-        validations.get('messages').objectAt(3),
+        validations.get('messages').objectAt(2),
         'Please select a date range',
         'Intervals missing is part of the messages'
       );

--- a/packages/dashboards/tests/acceptance/explore-widget-test.js
+++ b/packages/dashboards/tests/acceptance/explore-widget-test.js
@@ -242,9 +242,13 @@ test('Get API action - enabled/disabled', function(assert) {
     );
   });
 
-  // Remove all metrics to create an invalid request
+  // Remove all metrics
   click('.checkbox-selector--metric .grouped-list__item:contains(Ad Clicks) label');
   click('.checkbox-selector--metric .grouped-list__item:contains(Nav Link Clicks) label');
+
+  // Create empty filter to make request invalid
+  click('.grouped-list__item:Contains(Operating System) .checkbox-selector__filter');
+
   andThen(() => {
     assert.ok(
       $('.get-api').is('.navi-report-widget__action--is-disabled'),

--- a/packages/dashboards/tests/acceptance/report-action-test.js
+++ b/packages/dashboards/tests/acceptance/report-action-test.js
@@ -37,12 +37,9 @@ test('Add to dashboard button is hidden when there are unrun request changes', f
     );
   });
 
-  /*
-   * Change request
-   * Remove all metrics to create an invalid report
-   */
-  click('.checkbox-selector--metric .grouped-list__item:contains(Ad Clicks) .grouped-list__item-label');
-  click('.checkbox-selector--metric .grouped-list__item:contains(Nav Link Clicks) .grouped-list__item-label');
+  // Create empty filter to make request invalid
+  click('.grouped-list__item:Contains(Operating System) .checkbox-selector__filter');
+
   andThen(() => {
     assert.notOk(
       find('.navi-report__action:contains("Add to Dashboard")').is(':visible'),
@@ -50,8 +47,8 @@ test('Add to dashboard button is hidden when there are unrun request changes', f
     );
   });
 
-  // Reselect the merics and Run the report
-  click('.checkbox-selector--metric .grouped-list__item:contains(Nav Link Clicks) .grouped-list__item-label');
+  // Remove empty filter and run query
+  click('.grouped-list__item:Contains(Operating System) .checkbox-selector__filter');
   click('.navi-report__run-btn');
   andThen(() => {
     assert.ok(

--- a/packages/reports/tests/acceptance/navi-report-test.js
+++ b/packages/reports/tests/acceptance/navi-report-test.js
@@ -103,10 +103,12 @@ test('Clone invalid report', function(assert) {
 
 test('New report', function(assert) {
   assert.expect(4);
-
   visit('/reports/new');
 
-  /* == Run with errors == */
+  // add filter
+  click('.grouped-list__item:Contains(Operating System) .checkbox-selector__filter');
+
+  // run with errors
   click('.navi-report__run-btn');
   andThen(() => {
     assert.ok(
@@ -116,6 +118,7 @@ test('New report', function(assert) {
   });
 
   /* == Fix errors == */
+  click('.grouped-list__item:Contains(Operating System) .checkbox-selector__filter');
   click('.checkbox-selector--metric .grouped-list__item:contains(Ad Clicks) .grouped-list__item-label');
   click('.navi-report__run-btn');
   andThen(() => {
@@ -765,9 +768,13 @@ test('Get API action - enabled/disabled', function(assert) {
     assert.notOk($('.get-api').is('.navi-report__action--is-disabled'), 'Get API action is enabled for a valid report');
   });
 
-  // Remove all metrics to create an invalid report
+  // Remove all metrics
   click('.checkbox-selector--metric .grouped-list__item:contains(Ad Clicks) .grouped-list__item-label');
   click('.checkbox-selector--metric .grouped-list__item:contains(Nav Link Clicks) .grouped-list__item-label');
+
+  // add filter
+  click('.grouped-list__item:Contains(Operating System) .checkbox-selector__filter');
+
   andThen(() => {
     assert.ok(
       $('.get-api').is('.navi-report__action--is-disabled'),


### PR DESCRIPTION
## Description
Fili is removing the requirement to choose a metric. We will be too. this will allow dimension only reporting.

Update ember data model for request to require selecting a metric.

Make sure alerts is good. make sure adapter handles empty metrics correctly.

## Proposed Changes
- Remove request model validation that requires at least one metric.

## Screenshots
![image](https://user-images.githubusercontent.com/17508658/55741385-bf6c1500-59f2-11e9-985e-c626d6833271.png)

![image](https://user-images.githubusercontent.com/17508658/55741448-df033d80-59f2-11e9-9a69-14c004237409.png)

![image](https://user-images.githubusercontent.com/17508658/55741483-f3dfd100-59f2-11e9-90a4-b09ec088ff5f.png)
