### PR TITLE
Make rebuilding demo simpler.

### DIFF
--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -82,9 +82,16 @@ Make use of the many generators for code, try `ember help generate` for more det
 
 ### Building Demo App
 
-From this directory (`packages/app`), run:
+The demo app should be rebuild automatically when a publish build executes on Travis. To rebuild manually, 
+from this directory (`packages/app`), run:
+```
+BUILD_NAVI_DEMO=true ember github-pages:commit --message 'update gh-pages' --destination ../../
+```
 
-- `BUILD_NAVI_DEMO=true node node_modules/ember-cli/bin/ember github-pages:commit --message "update gh-pages" --destination ../../`
+This will commit the latest demo-app changes on the `gh-pages` branch. 
+
+You can also execute `npm run-script deploy-demo-app` from this directory,
+but that will `git push` the changes to `origin`.
 
 #### Deploying
 

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -80,6 +80,12 @@ Make use of the many generators for code, try `ember help generate` for more det
 - `ember build` (development)
 - `ember build --environment production` (production)
 
+### Building Demo App
+
+From `packages/app`, run:
+
+- `BUILD_NAVI_DEMO=true ember github-pages:commit --message "Initial gh-pages release" --destination ../../`
+
 #### Deploying
 
 Specify what it takes to deploy your app.

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -82,9 +82,9 @@ Make use of the many generators for code, try `ember help generate` for more det
 
 ### Building Demo App
 
-From `packages/app`, run:
+From this directory (`packages/app`), run:
 
-- `BUILD_NAVI_DEMO=true ember github-pages:commit --message "Initial gh-pages release" --destination ../../`
+- `BUILD_NAVI_DEMO=true node node_modules/ember-cli/bin/ember github-pages:commit --message "update gh-pages" --destination ../../`
 
 #### Deploying
 

--- a/packages/app/app/templates/components/top-bar.hbs
+++ b/packages/app/app/templates/components/top-bar.hbs
@@ -1,7 +1,7 @@
 {{!-- Copyright 2017, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 <div class="top-bar__left">
   {{#link-to "landing"}}
-    <img class="top-bar__graph-logo" src="/img/navi-graph.svg" alt="Navi Graph logo">
+    <img class="top-bar__graph-logo" src="img/navi-graph.svg" alt="Navi Graph logo">
     <span class="top-bar__logo-title">navi</span>
   {{/link-to}}
 </div>

--- a/packages/app/config/environment.js
+++ b/packages/app/config/environment.js
@@ -63,7 +63,7 @@ module.exports = function(environment) {
 
   if (environment === 'production') {
     ENV['ember-cli-mirage'] = {
-      enabled: false //set to true for gh-pages
+      enabled: process.env.BUILD_NAVI_DEMO === 'true'
     };
   }
 

--- a/packages/app/config/environment.js
+++ b/packages/app/config/environment.js
@@ -65,6 +65,9 @@ module.exports = function(environment) {
     ENV['ember-cli-mirage'] = {
       enabled: process.env.BUILD_NAVI_DEMO === 'true'
     };
+    if (process.env.BUILD_NAVI_DEMO === 'true') {
+      ENV['rootURL'] = '/navi/';
+    }
   }
 
   return ENV;

--- a/packages/app/ember-cli-build.js
+++ b/packages/app/ember-cli-build.js
@@ -9,6 +9,10 @@ module.exports = function(defaults) {
     },
     'ember-cli-babel': {
       includePolyfill: true
+    },
+    /* fingerprint is disabled for the demo build, which is otherwise like production */
+    fingerprint: {
+      enabled: EmberApp.env() === 'production' && process.env.BUILD_NAVI_DEMO !== 'true'
     }
   });
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -46,6 +46,7 @@
     "ember-cli-eslint": "^4.2.3",
     "ember-cli-flash": "^1.3.16",
     "ember-cli-format-number": "2.0.0",
+    "ember-cli-github-pages": "^0.2.2",
     "ember-cli-htmlbars": "^3.0.0",
     "ember-cli-htmlbars-inline-precompile": "^1.0.3",
     "ember-cli-inject-live-reload": "^1.8.2",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -17,7 +17,8 @@
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint .",
     "start": "ember serve",
-    "test": "export COVERAGE=true; ember test --test-port 0"
+    "test": "export COVERAGE=true; ember test --test-port 0",
+    "deploy-demo-app": "export BUILD_NAVI_DEMO=true; ember github-pages:commit --message 'update gh-pages' --destination ../../; git push origin gh-pages:gh-pages"
   },
   "dependencies": {
     "compression": "^1.6.2",

--- a/scripts/ci-publish.sh
+++ b/scripts/ci-publish.sh
@@ -8,3 +8,7 @@ npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
 
 # Publish dev build via lerna
 npm run-script lerna-ci-publish
+
+echo Publishing demo app
+cd package/app
+npm run-script deploy-demo-app


### PR DESCRIPTION
* Adds an environment variable `BUILD_NAVI_DEMO` for use when building the demo app to enable mirage
* Adds a shell script that can be run to update the demo app on the gh-pages branch. It will remove all the old javascript/css from the gh-pages branch and also add the short SHA to the HTML `<head>` to make it easier to see which version is running.

Once this is merged I can send a second PR updating the gh-pages demo app to the newest master (and update the gh-pages README.md instructions for rebuilding the docs).