### PR TITLE
Fix: Next day selection bug.

### DIFF
--- a/packages/reports/addon/components/pick-range-container.js
+++ b/packages/reports/addon/components/pick-range-container.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2019, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Description:
@@ -103,16 +103,29 @@ export default PickObjectContainer.extend({
       this.send('stagePropertyChange', '_start', start);
     },
 
+    /**
+     * Used to set the end of the advanced range selector
+     * @param {String} - date entered into box, could be date or macro.
+     */
+    setAdvancedEnd(end) {
+      end = this.parseDate(end); //convert from string
+
+      set(this, 'prevEndDate', end);
+
+      this.send('stagePropertyChange', '_end', end);
+    },
+
+    /**
+     * Used to set date when picking from calendar picker.
+     * @param {String} - date string chosen from calendar
+     */
     setEnd(end) {
       end = this.parseDate(end); //convert from string
 
-      /*
-       *If moment object, add one time period to end date to match exclusive interval
-       *Do not increment when date is the same as the old value
-       */
-      if (moment.isMoment(end) && !end.isSame(get(this, 'prevEndDate'))) {
+      if (moment.isMoment(end)) {
         end = end.clone().add(1, this.get('dateTimePeriod'));
       }
+
       set(this, 'prevEndDate', end);
 
       this.send('stagePropertyChange', '_end', end);

--- a/packages/reports/addon/components/pick-range-container.js
+++ b/packages/reports/addon/components/pick-range-container.js
@@ -107,7 +107,7 @@ export default PickObjectContainer.extend({
      * Used to set the end of the advanced range selector
      * @param {String} - date entered into box, could be date or macro.
      */
-    setAdvancedEnd(end) {
+    setExclusiveEnd(end) {
       end = this.parseDate(end); //convert from string
 
       set(this, 'prevEndDate', end);

--- a/packages/reports/addon/templates/components/navi-date-range-picker.hbs
+++ b/packages/reports/addon/templates/components/navi-date-range-picker.hbs
@@ -86,7 +86,7 @@
                                     {{input
                                         classNames='navi-date-input navi-date-range-picker__end-input'
                                         value=(readonly dateStrings.end)
-                                        focus-out=(action 'setAdvancedEnd' target=container)
+                                        focus-out=(action 'setExclusiveEnd' target=container)
                                     }}
                                 </fieldset>
                                 <div class='navi-date-range-picker__controls--footer'>

--- a/packages/reports/addon/templates/components/navi-date-range-picker.hbs
+++ b/packages/reports/addon/templates/components/navi-date-range-picker.hbs
@@ -86,7 +86,7 @@
                                     {{input
                                         classNames='navi-date-input navi-date-range-picker__end-input'
                                         value=(readonly dateStrings.end)
-                                        focus-out=(action 'setEnd' target=container)
+                                        focus-out=(action 'setAdvancedEnd' target=container)
                                     }}
                                 </fieldset>
                                 <div class='navi-date-range-picker__controls--footer'>

--- a/packages/reports/tests/integration/components/navi-date-range-picker-test.js
+++ b/packages/reports/tests/integration/components/navi-date-range-picker-test.js
@@ -452,6 +452,35 @@ test('Select custom interval', function(assert) {
   this.$('.btn.btn-primary').click();
 });
 
+test('Select date for the next day', function(assert) {
+  assert.expect(1);
+
+  this.interval = new Interval(moment('04-01-2019', 'MM-DD-YYYY'), moment('04-03-2019', 'MM-DD-YYYY'));
+
+  this.render(`
+          {{navi-date-range-picker
+              dateTimePeriod='day'
+              interval=interval
+              onSetInterval=(action setInterval)
+          }}
+      `);
+
+  // Select first date after new selected date
+  this.$('.datepicker:eq(1) td.day:not(.old):contains(3):eq(0)').click();
+  this.set('setInterval', interval => {
+    let selectedStart = moment('04-01-2019', 'MM-DD-YYYY'),
+      selectedEnd = moment('04-03-2019', 'MM-DD-YYYY');
+
+    assert.ok(
+      interval.isEqual(new Interval(selectedStart, selectedEnd.add(1, 'day'))),
+      'Interval comes from date picker and end date is one more than selected'
+    );
+  });
+
+  // Click apply
+  this.$('.btn.btn-primary').click();
+});
+
 /* == Calendar Bug - Date increments on apply == */
 
 test('Custom Range Date doesn`t increment on apply', function(assert) {
@@ -509,10 +538,7 @@ test('Editing custom interval - string', function(assert) {
     let selectedStart = moment('10-15-2014', 'MM-DD-YYYY'),
       selectedEnd = moment('10-25-2014', 'MM-DD-YYYY');
 
-    assert.ok(
-      interval.isEqual(new Interval(selectedStart, selectedEnd.add(1, 'day'))),
-      'Interval comes from date inputs and end date is one more than date entered'
-    );
+    assert.ok(interval.isEqual(new Interval(selectedStart, selectedEnd)), 'Interval comes from date inputs');
   });
 
   // Click apply


### PR DESCRIPTION
<!-- The above line will close the issue upon merge -->
## Description
Bug reported that opening date picker in report builder, they couldn't select the next day if they already specified an interval.

reproduce step:
* Create a report with a custom date range and run it.
* open up custom date range and try to pick the day after your previous range selection as the end range
* Note that it won't let you pick the date.

## Proposed Changes
Found code that won't adjust the end correctly if date selected is the same day as the previous interval. Because the switching between inclusive-inclusive and inclusive-exclusive this doesn't work well.

Noticed that the advanced editor when you select a date, it will increase the date by 1 if you focus out.  Since this already is inclusive-exclusive range it shouldn't adjust. So created a separate setEnd action. So that logic from selecting a date from date picker, and selecting a date with advanced editor is handled separatly.