### PR TITLE
Fix: Autocomplete on metric/dimension search boxes

### DIFF
--- a/packages/reports/addon/templates/components/navi-list-selector.hbs
+++ b/packages/reports/addon/templates/components/navi-list-selector.hbs
@@ -13,8 +13,9 @@
     {{navi-icon 'search' class='navi-list-selector__search-icon'}}
     {{input
       placeholder=(concat 'Search ' (capitalize title)) 
-      value=query 
-      autocomplete=false 
+      value=query
+      type="search" 
+      autocomplete="off" 
       spellcheck=false 
       class='navi-list-selector__search-input'
     }}

--- a/packages/reports/app/styles/navi-reports/components/navi-list-selector.less
+++ b/packages/reports/app/styles/navi-reports/components/navi-list-selector.less
@@ -10,6 +10,14 @@
   font-family: @font-family-sans-serif;
   min-height: 0;
 
+  /* clears the 'X' from Chrome */
+  input[type='search']::-webkit-search-decoration,
+  input[type='search']::-webkit-search-cancel-button,
+  input[type='search']::-webkit-search-results-button,
+  input[type='search']::-webkit-search-results-decoration {
+    display: none;
+  }
+
   &__content {
     flex: 1;
     margin: 5px 0;


### PR DESCRIPTION
<!-- The above line will close the issue upon merge -->
## Description
Chrome has been going really aggressive with autofill suggestions.  Shows up on dimension and metric search boxes.  Chrome has said for semantically ambiguous inputs it will try to figure out how to autofill, and outright ignores `autocomplete=off` or `=false`.  All tickets have been closed as "won't fix"

## Proposed Changes
To fix this, it seems we need to hint that semantically these are search boxes and turn `autocomplete=off`. Chrome does seem to respect autofill being off on search type boxes.

Chrome also adds a clear button, which would make the one we put in redundant. However, this is not supported in firefox, so I have hidden the chrome's provided one in favor of cross-browser feature parity. 

## Screenshots
No visual difference
