### PR TITLE
Update: Nudge the goal-gauge legend a little up

### DIFF
--- a/packages/reports/app/styles/navi-reports/components/print-report-view.less
+++ b/packages/reports/app/styles/navi-reports/components/print-report-view.less
@@ -8,5 +8,9 @@
 
   &__visualization {
     min-height: unset;
+
+    .c3-chart-arcs-title {
+      transform: translateY(-@print-margin);
+    }
   }
 }


### PR DESCRIPTION
## Description

Goal-gauge legend is partially hidden when printing with pupeteer

## Proposed Changes

Nudge it up a little

## Screenshots

Hardly changes viz for phantom
![gauge-phantom-diff](https://user-images.githubusercontent.com/13946669/56920042-0344be00-6a77-11e9-94a8-03da13c51fa9.gif)

\* might add more changes to this PR after testing dashboards printing
