### PR TITLE
Fix: Notification to rerun is always visible when editing a widget

### DIFF
--- a/packages/dashboards/addon/controllers/dashboards/dashboard/widgets/widget/view.js
+++ b/packages/dashboards/addon/controllers/dashboards/dashboard/widgets/widget/view.js
@@ -1,12 +1,13 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2019, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
-import Ember from 'ember';
+import ReportViewController from 'navi-reports/controllers/reports/report/view';
+import { inject as controller } from '@ember/controller';
 
-export default Ember.Controller.extend({
+export default ReportViewController.extend({
   /*
    * @property {Controller} reportController
    */
-  reportController: Ember.inject.controller('dashboards.dashboard.widgets.widget')
+  reportController: controller('dashboards.dashboard.widgets.widget')
 });

--- a/packages/dashboards/tests/acceptance/explore-widget-test.js
+++ b/packages/dashboards/tests/acceptance/explore-widget-test.js
@@ -124,12 +124,33 @@ test('Exploring a widget', function(assert) {
 });
 
 test('Changing and saving a widget', function(assert) {
-  assert.expect(1);
+  assert.expect(4);
 
   // Add a metric to widget 2, save, and return to dashboard route
   visit('/dashboards/1/widgets/2/view');
+
+  andThen(() => {
+    assert.notOk(
+      find('.report-view__info-text').is(':visible'),
+      'Notification to run is not visible before making changes'
+    );
+  });
+
   click('.checkbox-selector--metric .grouped-list__item:contains(Total Clicks) label');
+
+  andThen(() => {
+    assert.ok(find('.report-view__info-text').is(':visible'), 'Notification to run is visible after making changes');
+  });
+
   click('.navi-report-widget__save-btn');
+
+  andThen(() => {
+    assert.notOk(
+      find('.report-view__info-text').is(':visible'),
+      'Notification to run is no longer visible after saving the report'
+    );
+  });
+
   visit('/dashboards/1');
 
   andThen(() => {


### PR DESCRIPTION
## Description
This bug was probably introduced in #352 when `hasRequestRun` was added only to report/view controller and not to widget/view

## Proposed Changes
- Inherit from the report/view controller to include this method
- add tests

## Screenshots
![Apr-29-2019 16-20-35](https://user-images.githubusercontent.com/13946669/56932965-c12d7380-6a9a-11e9-8d48-f236aec6988e.gif)
