### PR TITLE
Update: Field selection on contains filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ lerna-debug.log
 *.iml
 .idea/
 .vscode
+jsconfig.json

--- a/packages/reports/addon/components/filter-builders/base.js
+++ b/packages/reports/addon/components/filter-builders/base.js
@@ -55,6 +55,11 @@ export default Ember.Component.extend({
         Ember.assign(changeSet, { values: [] });
       }
 
+      //switch field to primary key if operator does not allow choosing fields
+      if (get(this, 'primaryKeyField') && !operatorObject.showFields) {
+        Ember.assign(changeSet, { field: get(this, 'primaryKeyField') });
+      }
+
       this.onUpdateFilter(changeSet);
     }
   }

--- a/packages/reports/addon/components/filter-builders/base.js
+++ b/packages/reports/addon/components/filter-builders/base.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018, Yahoo Holdings Inc.
+ * Copyright 2019, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Base class for filter builders.
@@ -7,6 +7,7 @@
 import Ember from 'ember';
 import layout from 'navi-reports/templates/components/filter-builders/base';
 import { readOnly } from '@ember/object/computed';
+import { assign } from '@ember/polyfills';
 
 const { get } = Ember;
 
@@ -52,12 +53,12 @@ export default Ember.Component.extend({
        * unless operators share valuesComponent
        */
       if (get(this, 'filter.operator.valuesComponent') !== operatorObject.valuesComponent) {
-        Ember.assign(changeSet, { values: [] });
+        assign(changeSet, { values: [] });
       }
 
       //switch field to primary key if operator does not allow choosing fields
       if (get(this, 'primaryKeyField') && !operatorObject.showFields) {
-        Ember.assign(changeSet, { field: get(this, 'primaryKeyField') });
+        assign(changeSet, { field: get(this, 'primaryKeyField') });
       }
 
       this.onUpdateFilter(changeSet);

--- a/packages/reports/addon/components/filter-builders/dimension.js
+++ b/packages/reports/addon/components/filter-builders/dimension.js
@@ -9,10 +9,12 @@
  */
 import Ember from 'ember';
 import Base from './base';
-
-const { computed, get } = Ember;
+import { computed, get } from '@ember/object';
+import { readOnly } from '@ember/object/computed';
+import layout from 'navi-reports/templates/components/filter-builders/dimension';
 
 export default Base.extend({
+  layout,
   /**
    * @property {Object} requestFragment - filter fragment from request model
    */
@@ -47,16 +49,38 @@ export default Base.extend({
       {
         id: 'contains',
         longName: 'Contains',
-        valuesComponent: 'filter-values/multi-value-input'
+        valuesComponent: 'filter-values/multi-value-input',
+        showFields: true
       }
     ];
+  }),
+
+  /**
+   * @property {String} primaryKeyField - Primary Key Field used so we know what to use as default field for operators
+   */
+  primaryKeyField: readOnly('requestFragment.dimension.primaryKeyFieldName'),
+
+  /**
+   * @property {?Boolean} showFields - Whether to show the field chooser in the filter builder
+   */
+  showFields: readOnly('filter.operator.showFields'),
+
+  /**
+   * @property {Array} fields - List of fields that a user can choose from
+   */
+  fields: computed('requestFragment.dimension', function() {
+    let fields = get(this, 'requestFragment.dimension.fields');
+    if (fields) {
+      return fields.map(field => field.name);
+    }
+    return ['id', 'desc'];
   }),
 
   /**
    * @property {Object} filter
    * @override
    */
-  filter: computed('requestFragment.{operator,dimension,rawValues.[]}', function() {
+  filter: computed('requestFragment.{operator,dimension,rawValues.[],field}', function() {
     let dimensionFragment = get(this, 'requestFragment'),
       operatorId = get(dimensionFragment, 'operator'),
       operator = Ember.A(get(this, 'supportedOperators')).findBy('id', operatorId);
@@ -65,7 +89,19 @@ export default Base.extend({
       subject: get(dimensionFragment, 'dimension'),
       operator,
       values: get(dimensionFragment, 'rawValues'),
-      validations: get(dimensionFragment, 'validations')
+      validations: get(dimensionFragment, 'validations'),
+      field: get(dimensionFragment, 'field')
     };
-  })
+  }),
+
+  actions: {
+    /**
+     * Sets the field on the filter.
+     * @param {String} field - field to set
+     */
+    setField(field) {
+      const changeSet = { field };
+      this.onUpdateFilter(changeSet);
+    }
+  }
 });

--- a/packages/reports/addon/components/filter-builders/dimension.js
+++ b/packages/reports/addon/components/filter-builders/dimension.js
@@ -70,10 +70,7 @@ export default Base.extend({
    */
   fields: computed('requestFragment.dimension', function() {
     let fields = get(this, 'requestFragment.dimension.fields');
-    if (fields) {
-      return fields.map(field => field.name);
-    }
-    return ['id', 'desc'];
+    return fields ? fields.map(field => field.name) : ['id', 'desc'];
   }),
 
   /**

--- a/packages/reports/addon/templates/components/filter-builders/base.hbs
+++ b/packages/reports/addon/templates/components/filter-builders/base.hbs
@@ -1,3 +1,4 @@
+{{!-- Copyright 2019, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 <span class='filter-builder__subject'>
     {{displayName}}
 </span>

--- a/packages/reports/addon/templates/components/filter-builders/dimension.hbs
+++ b/packages/reports/addon/templates/components/filter-builders/dimension.hbs
@@ -1,0 +1,40 @@
+<span class='filter-builder-dimension__subject'>
+    {{displayName}}
+</span>
+{{#power-select
+    class='filter-builder-dimension__operator'
+    dropdownClass='filter-builder-dimension__operator-dropdown'
+    options=supportedOperators
+    selected=filter.operator
+    searchEnabled=false
+    tagName='span'
+    triggerClass='filter-builder-dimension__select-trigger'
+    onchange=(action 'setOperator')
+    as | operator |
+}}
+    {{operator.longName}}
+{{/power-select}}
+{{#if showFields}}
+  {{#power-select
+    searchEnabled=false
+    options=fields
+    selected=filter.field
+    tagName='span'
+    class='filter-builder-dimension__field'
+    dropdownClass='filter-builder-dimension__field-dropdown'
+    triggerClass='filter-builder-dimension__select-trigger'
+    matchTriggerWidth=false
+    onchange=(action 'setField')
+    as | field |
+  }}
+    field: {{field}}
+  {{/power-select}}
+{{/if}}
+<span class='filter-builder-dimension__values {{if showFields 'filter-builder-dimension__values--short'}}'>
+    {{component
+        filter.operator.valuesComponent
+        filter=filter
+        request=request
+        onUpdateFilter=onUpdateFilter
+    }}
+</span>

--- a/packages/reports/addon/templates/components/filter-builders/dimension.hbs
+++ b/packages/reports/addon/templates/components/filter-builders/dimension.hbs
@@ -1,3 +1,4 @@
+{{!-- Copyright 2019, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 <span class='filter-builder-dimension__subject'>
     {{displayName}}
 </span>
@@ -27,7 +28,7 @@
     onchange=(action 'setField')
     as | field |
   }}
-    field: {{field}}
+    {{field}}
   {{/power-select}}
 {{/if}}
 <span class='filter-builder-dimension__values {{if showFields 'filter-builder-dimension__values--short'}}'>

--- a/packages/reports/app/styles/navi-reports/components/filter-collection.less
+++ b/packages/reports/app/styles/navi-reports/components/filter-collection.less
@@ -38,7 +38,8 @@
   }
 
   .filter-builder {
-    &__operator {
+    &__operator,
+    &__field {
       flex: 1;
       margin: @filter-collection-column-margin;
     }
@@ -60,6 +61,29 @@
       flex: 3;
       margin: @filter-collection-column-margin;
       min-height: @filter-collection-row-height;
+    }
+
+    &__values--short {
+      flex: 2;
+    }
+  }
+
+  .filter-builder-dimension {
+    .filter-builder;
+    &__subject {
+      flex: 2;
+    }
+    &__operator {
+      flex: 2;
+    }
+    &__field {
+      flex: 1;
+    }
+    &__values {
+      flex: 6;
+    }
+    &__values--short {
+      flex: 5;
     }
   }
 

--- a/packages/reports/tests/acceptance/navi-report-test.js
+++ b/packages/reports/tests/acceptance/navi-report-test.js
@@ -2061,7 +2061,7 @@ test('dimension contains filter works by letting users select field', async func
     find('.filter-builder-dimension__field')
       .get(0)
       .innerText.trim(),
-    'field: key',
+    'key',
     'field shows key'
   );
 
@@ -2072,7 +2072,7 @@ test('dimension contains filter works by letting users select field', async func
     find('.filter-builder-dimension__field')
       .get(0)
       .innerText.trim(),
-    'field: desc',
+    'desc',
     'field shows desc'
   );
 
@@ -2088,7 +2088,7 @@ test('dimension contains filter works by letting users select field', async func
     find('.filter-builder-dimension__field')
       .get(0)
       .innerText.trim(),
-    'field: key',
+    'key',
     'field shows key after switching back'
   );
 

--- a/packages/reports/tests/acceptance/navi-report-test.js
+++ b/packages/reports/tests/acceptance/navi-report-test.js
@@ -1790,7 +1790,7 @@ test('filter - add and remove using filter icon', function(assert) {
   click('.grouped-list__item:contains(Operating System) .checkbox-selector__filter');
   andThen(() => {
     assert.ok(
-      find('.filter-builder__subject:contains(Operating System)').is(':visible'),
+      find('.filter-builder-dimension__subject:contains(Operating System)').is(':visible'),
       'The Operating System dimension filter is added'
     );
   });
@@ -1799,7 +1799,7 @@ test('filter - add and remove using filter icon', function(assert) {
   click('.grouped-list__item:contains(Operating System) .checkbox-selector__filter');
   andThen(() => {
     assert.notOk(
-      find('.filter-builder__subject:contains(Operating System)').is(':visible'),
+      find('.filter-builder-dimension__subject:contains(Operating System)').is(':visible'),
       'The Operating System dimension filter is removed when filter icon is clicked again'
     );
   });
@@ -1817,7 +1817,7 @@ test('filter - add and remove using filter icon', function(assert) {
   click('.grouped-list__item:contains(Ad Clicks) .checkbox-selector__filter');
   andThen(() => {
     assert.notOk(
-      find('.filter-builder__subject:contains(Ad Clicks)').is(':visible'),
+      find('.filter-builder-dimension__subject:contains(Ad Clicks)').is(':visible'),
       'The Ad Clicks metric filter is removed when filter icon is clicked again'
     );
   });
@@ -1889,7 +1889,7 @@ test('Test filter "Is Empty" is accepted', function(assert) {
   visit('/reports/1');
 
   click('.grouped-list__item:contains(Operating System) .checkbox-selector__filter');
-  selectChoose('.filter-collection__row:last-of-type .filter-builder__operator', 'Is Empty');
+  selectChoose('.filter-collection__row:last-of-type .filter-builder-dimension__operator', 'Is Empty');
   click('.navi-report__run-btn');
 
   andThen(() => {
@@ -1913,7 +1913,7 @@ test('Test filter "Is Not Empty" is accepted', function(assert) {
   visit('/reports/1');
 
   click('.grouped-list__item:contains(Operating System) .checkbox-selector__filter');
-  selectChoose('.filter-collection__row:last-of-type .filter-builder__operator', 'Is Not Empty');
+  selectChoose('.filter-collection__row:last-of-type .filter-builder-dimension__operator', 'Is Not Empty');
   click('.navi-report__run-btn');
 
   andThen(() => {
@@ -2044,6 +2044,68 @@ test('Filter with large cardinality dimensions value selection works', function(
       'The value is selected after a search is done'
     );
   });
+});
+
+test('dimension contains filter works by letting users select field', async function(assert) {
+  await visit('/reports/new');
+  await click('.grouped-list__item:Contains(Multi System Id) .checkbox-selector__filter');
+
+  assert.ok(find('.filter-builder-dimension__operator').get(0), 'Operator dropdown should exist for the dimension');
+  assert.notOk(find('.filter-builder-dimension__field').get(0), 'field dropdown does not exist');
+
+  await click('.filter-builder-dimension__operator .filter-builder-dimension__select-trigger');
+  await click('.filter-builder-dimension__operator-dropdown .ember-power-select-option:contains(Contains)');
+
+  assert.ok(find('.filter-builder-dimension__field').get(0), 'field dropdown is now showing');
+  assert.equal(
+    find('.filter-builder-dimension__field')
+      .get(0)
+      .innerText.trim(),
+    'field: key',
+    'field shows key'
+  );
+
+  await click('.filter-builder-dimension__field .filter-builder-dimension__select-trigger');
+  await click('.filter-builder-dimension__field-dropdown .ember-power-select-option:contains(desc)');
+
+  assert.equal(
+    find('.filter-builder-dimension__field')
+      .get(0)
+      .innerText.trim(),
+    'field: desc',
+    'field shows desc'
+  );
+
+  await click('.filter-builder-dimension__operator .filter-builder-dimension__select-trigger');
+  await click('.filter-builder-dimension__operator-dropdown .ember-power-select-option:contains(Equals)');
+
+  assert.notOk(find('.filter-builder-dimension__field').get(0), 'field dropdown does not exist');
+
+  await click('.filter-builder-dimension__operator .filter-builder-dimension__select-trigger');
+  await click('.filter-builder-dimension__operator-dropdown .ember-power-select-option:contains(Contains)');
+
+  assert.equal(
+    find('.filter-builder-dimension__field')
+      .get(0)
+      .innerText.trim(),
+    'field: key',
+    'field shows key after switching back'
+  );
+
+  await click('.filter-builder-dimension__field .filter-builder-dimension__select-trigger');
+  await click('.filter-builder-dimension__field-dropdown .ember-power-select-option:contains(desc)');
+
+  await fillIn('.filter-builder-dimension__values input', 'foo');
+  await triggerEvent('.filter-builder-dimension__values input', 'blur');
+
+  await click('.get-api__btn');
+
+  assert.ok(
+    find('.navi-modal__input')
+      .get(0)
+      .value.includes(encodeURIComponent('multiSystemId|desc-contains[foo]')),
+    'Generated API URL is correct'
+  );
 });
 
 test('adding metrics to reordered table keeps order', function(assert) {

--- a/packages/reports/tests/integration/components/filter-builders/dimension-test.js
+++ b/packages/reports/tests/integration/components/filter-builders/dimension-test.js
@@ -1,0 +1,108 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import { clickTrigger, nativeMouseUp } from 'ember-power-select/test-support/helpers';
+import hbs from 'htmlbars-inline-precompile';
+import Ember from 'ember';
+
+const filter = {
+  subject: {
+    longName: 'Device Type'
+  },
+  operator: {
+    id: 'in',
+    longName: 'Equals',
+    valuesComponent: 'mock/values-component'
+  },
+  values: [1, 2, 3]
+};
+
+const supportedOperators = [
+  { id: 'in', longName: 'Equals', valuesComponent: 'mock/values-component' },
+  {
+    id: 'notin',
+    longName: 'Not Equals',
+    valuesComponent: 'mock/values-component'
+  },
+  {
+    id: 'null',
+    longName: 'Is Empty',
+    valuesComponent: 'mock/another-values-component'
+  },
+  {
+    id: 'contains',
+    longName: 'Contains',
+    valuesComponent: 'mock/values-component',
+    showFields: true
+  }
+];
+
+const requestFragment = {
+  dimension: {
+    name: 'deviceType',
+    fields: [{ name: 'id' }, { name: 'desc' }, { name: 'foo' }],
+    primaryKeyFieldName: 'id'
+  }
+};
+
+moduleForComponent('filter-builders/dimension', 'Integration | Component | filter-builders/dimension', {
+  integration: true,
+
+  beforeEach() {
+    /*
+     * Normally supportedOperators will be provided by the child class,
+     * but to simplify testing we pass it in
+     */
+    this.setProperties({
+      filter,
+      supportedOperators,
+      requestFragment
+    });
+    this.register(
+      'component:mock/values-component',
+      Ember.Component.extend({
+        classNames: 'mock-value-component'
+      })
+    );
+    this.register('component:mock/another-values-component', Ember.Component.extend());
+  }
+});
+
+test('changing operator with field', function(assert) {
+  assert.expect(6);
+
+  this.set('onUpdateFilter', changeSet => {
+    assert.equal(changeSet.operator, 'contains', 'Selected operator is given to action');
+
+    this.set('filter.operator', this.supportedOperators.find(oper => oper.id === changeSet.operator));
+  });
+
+  this.render(
+    hbs`{{filter-builders/dimension filter=filter requestFragment=requestFragment supportedOperators=supportedOperators onUpdateFilter=(action onUpdateFilter)}}`
+  );
+
+  clickTrigger();
+  nativeMouseUp($('.ember-power-select-option:contains(Contains)')[0]);
+
+  assert.ok(this.$('.filter-builder-dimension__field').is(':visible'), 'Field dropdown is shown');
+
+  this.set('onUpdateFilter', changeSet => {
+    assert.equal(changeSet.field, 'desc', 'Selected field is given to action');
+
+    this.set('filter.field', changeSet.field);
+  });
+
+  clickTrigger('.filter-builder-dimension__field');
+  nativeMouseUp($('.ember-power-select-option:contains(desc)')[0]);
+
+  this.set('onUpdateFilter', changeSet => {
+    assert.equal(changeSet.operator, 'notin', 'Selected operator is given to action');
+    assert.equal(changeSet.field, 'id', 'field is switched back to id');
+
+    this.set('filter.operator', this.supportedOperators.find(oper => oper.id === changeSet.operator));
+    this.set('filter.field', changeSet.field);
+  });
+
+  clickTrigger('.filter-builder-dimension__operator');
+  nativeMouseUp($('.ember-power-select-option:contains(Not Equals)')[0]);
+
+  assert.notOk(this.$('.filter-builder__field').is(':visible'), 'Field dropdown is gone');
+});

--- a/packages/reports/tests/integration/components/filter-collection-test.js
+++ b/packages/reports/tests/integration/components/filter-collection-test.js
@@ -83,7 +83,7 @@ test('updating a filter', function(assert) {
       'Operator update is requested'
     );
   });
-  clickTrigger(`#${$('.filter-builder__operator:eq(1)').attr('id')}`);
+  clickTrigger('.filter-builder-dimension__operator');
   nativeMouseUp($('.ember-power-select-option:contains(Is Empty)')[0]);
 });
 


### PR DESCRIPTION
<!-- The above line will close the issue upon merge -->
## Description
Allows user to choose the field of a dimension when using the "Contains" operator. 

## Proposed Changes
Update the dimension filter builder to allow for field selection of the operator supports it. We must also make sure we switch the field back to the primary key when choosing operators that do not support field choice.

## Screenshots
![Screen Shot 2019-05-08 at 11 25 22 AM](https://user-images.githubusercontent.com/99422/57392401-4513e980-7186-11e9-87ca-9bbbdf5d663f.png)