### PR TITLE
Fix: Don't do bower install as npm postinstall

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,10 @@ matrix:
 before_install:
   - npm config set spin false
   - npm --version
-  - npm install -g bower
-  - bower --version
 install:
   - travis_wait npm install
 script:
+  - lerna run test --scope $PACKAGE -- bower install || true
   - travis_wait lerna run test --scope $PACKAGE
 jobs:
   include:

--- a/package-lock.json
+++ b/package-lock.json
@@ -108,6 +108,12 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "bower": {
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.8.tgz",
+      "integrity": "sha512-1SrJnXnkP9soITHptSO+ahx3QKp3cVzn8poI6ujqc5SeOkg5iqM1pK9H+DSc2OQ8SnO0jC/NG4Ur/UIwy7574A==",
+      "dev": true
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",

--- a/package.json
+++ b/package.json
@@ -13,11 +13,12 @@
     "precommit": "pretty-quick --staged",
     "commitmsg": "validate-commit-msg -p eslint",
     "start": "lerna exec --scope navi-app npm start",
-    "postinstall": "lerna bootstrap --concurrency 2",
+    "postinstall": "lerna bootstrap --concurrency 2; lerna exec --ignore navi-data bower install",
     "test": "lerna run test",
     "lerna-ci-publish": "lerna publish --canary --force-publish=* --yes"
   },
   "devDependencies": {
+    "bower": "^1.8.8",
     "husky": "^0.14.3",
     "lerna": "^2.8.0",
     "prettier": "^1.13.5",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,7 +13,6 @@
   },
   "main": "index.js",
   "scripts": {
-    "postinstall": "bower install",
     "build": "ember build",
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint .",
@@ -32,7 +31,6 @@
   "devDependencies": {
     "@ember/jquery": "^0.5.2",
     "@ember/optional-features": "^0.6.3",
-    "bower": "^1.8.0",
     "broccoli-asset-rev": "^2.7.0",
     "ember-ajax": "^4.0.1",
     "ember-basic-dropdown-hover": "^0.6.0",

--- a/packages/core/.npmignore
+++ b/packages/core/.npmignore
@@ -16,6 +16,7 @@
 /.gitkeep
 /.template-lintrc.js
 /.travis.yml
+/bower.json
 /.watchmanconfig
 /**/.gitkeep
 /config/ember-try.js

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.0",
   "description": "Library of common logic, components, and styles for navi",
   "scripts": {
-    "postinstall": "bower install",
     "build": "ember build",
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint .",

--- a/packages/dashboards/package.json
+++ b/packages/dashboards/package.json
@@ -15,7 +15,6 @@
     "test": "tests"
   },
   "scripts": {
-    "postinstall": "bower install",
     "build": "ember build",
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint .",

--- a/packages/directory/.npmignore
+++ b/packages/directory/.npmignore
@@ -10,6 +10,7 @@
 .eslintrc.js
 .gitignore
 .watchmanconfig
+/bower.json
 .travis.yml
 ember-cli-build.js
 testem.js

--- a/packages/directory/package.json
+++ b/packages/directory/package.json
@@ -16,7 +16,6 @@
     "url": "https://github.com/yahoo/navi/tree/master/packages/directory"
   },
   "scripts": {
-    "postinstall": "bower install",
     "build": "ember build",
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint .",

--- a/packages/reports/.npmignore
+++ b/packages/reports/.npmignore
@@ -10,6 +10,7 @@
 .gitignore
 .eslintrc.js
 .watchmanconfig
+/bower.json
 .travis.yml
 ember-cli-build.js
 testem.js

--- a/packages/reports/package.json
+++ b/packages/reports/package.json
@@ -15,7 +15,6 @@
     "url": "https://github.com/yahoo/navi/tree/master/packages/reports"
   },
   "scripts": {
-    "postinstall": "bower install",
     "build": "ember build",
     "start": "ember server",
     "test": "export COVERAGE=true; ember test --test-port 0"


### PR DESCRIPTION
## Description
Don't do bower install as package npm postinstall

## Proposed Changes
- Move bower to top level `devDependencies`
- Run bower install as top level post install
- Add `bower.json` to package level .npmignore
