### PR TITLE
Fix: Saving a schedule in the dashboard view never finishes

### DIFF
--- a/packages/dashboards/addon/routes/dashboards.js
+++ b/packages/dashboards/addon/routes/dashboards.js
@@ -4,62 +4,10 @@
  */
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
-import { get } from '@ember/object';
 
 export default Route.extend({
   /**
    * @property {Service} naviNotifications
    */
-  naviNotifications: service(),
-
-  actions: {
-    /**
-     * @action saveDeliveryRule
-     * @param {DS.Model} rule - object to save
-     */
-    saveDeliveryRule(rule) {
-      return rule.save();
-    },
-
-    /**
-     * @action revertDeliveryRule
-     * @param {DS.Model} rule - object to revert
-     */
-    revertDeliveryRule(rule) {
-      if (rule && !get(rule, 'isNew')) {
-        rule.rollbackAttributes();
-      }
-    },
-
-    /**
-     * @action deleteDeliveryRule
-     * @param {DS.Model} rule - object to delete
-     */
-    deleteDeliveryRule(rule) {
-      rule.deleteRecord();
-
-      return rule
-        .save()
-        .then(() => {
-          // Make sure record is cleaned up locally
-          rule.unloadRecord();
-
-          get(this, 'naviNotifications').add({
-            message: `Dashboard delivery schedule successfully removed!`,
-            type: 'success',
-            timeout: 'short'
-          });
-        })
-        .catch(() => {
-          // Rollback delete action
-          rule.rollbackAttributes();
-
-          get(this, 'naviNotifications').add({
-            message: `OOPS! An error occurred while removing the dashboard delivery schedule.`,
-            type: 'danger',
-            timeout: 'short'
-          });
-        });
-    }
-  }
+  naviNotifications: service()
 });

--- a/packages/dashboards/addon/templates/components/navi-dashboard.hbs
+++ b/packages/dashboards/addon/templates/components/navi-dashboard.hbs
@@ -75,9 +75,9 @@
           model=dashboard
           classNames="action schedule"
           disabled=(not dashboard.validations.isTruelyValid)
-          onSave=(route-action "saveDeliveryRule")
-          onRevert=(route-action "revertDeliveryRule")
-          onDelete=(route-action "deleteDeliveryRule")
+          onSave=(delivery-rule-action "SAVE_DELIVERY_RULE")
+          onRevert=(delivery-rule-action "REVERT_DELIVERY_RULE")
+          onDelete=(delivery-rule-action "DELETE_DELIVERY_RULE")
         }}
           Schedule
         {{/dashboard-actions/schedule}}

--- a/packages/dashboards/tests/acceptance/schedule-modal-test.js
+++ b/packages/dashboards/tests/acceptance/schedule-modal-test.js
@@ -76,13 +76,41 @@ module('Acceptances | Navi Dashboard Schedule Modal', function(hooks) {
       .hasText('navi_user@navi.io', 'Recipients field is set by the saved delivery rule');
   });
 
-  test('open schedule modal in dashboard view', async function(assert) {
-    assert.expect(1);
+  test('schedule modal in dashboard view', async function(assert) {
+    assert.expect(4);
     await visit('/dashboards/2/view');
 
     // Click "Schedule"
     await click('.schedule-action__button');
 
     assert.dom('.schedule-modal__header').isVisible('Schedule modal pops up when action is clicked');
+
+    assert
+      .dom('.schedule-modal__dropdown--frequency .ember-power-select-selected-item')
+      .hasText('Week', 'Frequency field is set to Week');
+
+    // Set frequency to Day
+    await click('.schedule-modal__dropdown--frequency .ember-power-select-trigger');
+    await click($('.ember-power-select-option:contains(Day)')[0]);
+
+    //Save the schedule
+    await click('.schedule-modal__save-btn');
+
+    assert
+      .dom('.success .notification-text')
+      .hasText(
+        'Dashboard delivery schedule successfully saved!',
+        'Successful notification is shown after clicking save'
+      );
+
+    // Close the modal
+    await click('.schedule-modal__cancel-btn');
+
+    // Reopen the modal
+    await click('.schedule-action__button');
+
+    assert
+      .dom('.schedule-modal__dropdown--frequency .ember-power-select-selected-item')
+      .hasText('Day', 'Changes are saved');
   });
 });


### PR DESCRIPTION
## Description
Saving a schedule from the dashboard view would never stop saving.

## Proposed Changes
- Use delivery-action-consumer actions to handle changes to the schedule modal like we do in dashboard and report collections