### PR TITLE
Fix tooltip problem

### DIFF
--- a/packages/reports/addon/templates/components/dimension-selector.hbs
+++ b/packages/reports/addon/templates/components/dimension-selector.hbs
@@ -19,7 +19,7 @@
     </label>
     {{#unless (eq item.category "Time Grain")}}
       {{#navi-icon "question-circle-o" class="grouped-list__item-info"}}
-        {{#ember-tooltip side="right" popperContainer="body"}}
+        {{#ember-tooltip side="right" popperContainer="body" effect="none"}}
           {{#if item.extended.isPending}}
             {{loading-message}}
           {{else}}

--- a/packages/reports/addon/templates/components/dimension-selector.hbs
+++ b/packages/reports/addon/templates/components/dimension-selector.hbs
@@ -19,7 +19,7 @@
     </label>
     {{#unless (eq item.category "Time Grain")}}
       {{#navi-icon "question-circle-o" class="grouped-list__item-info"}}
-        {{#ember-tooltip side="right"}}
+        {{#ember-tooltip side="right" popperContainer="body"}}
           {{#if item.extended.isPending}}
             {{loading-message}}
           {{else}}

--- a/packages/reports/addon/templates/components/editable-label.hbs
+++ b/packages/reports/addon/templates/components/editable-label.hbs
@@ -17,7 +17,7 @@
     {{value}}
     <span>
       {{navi-icon "pencil" class="editable-label__icon"}}
-      {{ember-tooltip text="Rename" popperContainer="body"}}
+      {{ember-tooltip text="Rename" popperContainer="body" effect="none"}}
     </span>
   </span>
 {{/if}}

--- a/packages/reports/addon/templates/components/editable-label.hbs
+++ b/packages/reports/addon/templates/components/editable-label.hbs
@@ -17,7 +17,7 @@
     {{value}}
     <span>
       {{navi-icon "pencil" class="editable-label__icon"}}
-      {{ember-tooltip text="Rename"}}
+      {{ember-tooltip text="Rename" popperContainer="body"}}
     </span>
   </span>
 {{/if}}

--- a/packages/reports/addon/templates/components/favorite-item.hbs
+++ b/packages/reports/addon/templates/components/favorite-item.hbs
@@ -1,3 +1,3 @@
 {{!-- Copyright 2017, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 {{navi-icon (if isFavorite "star" "star-o")}}
-{{ember-tooltip text="Favorite"}}
+{{ember-tooltip text="Favorite" popperContainer="body"}}

--- a/packages/reports/addon/templates/components/favorite-item.hbs
+++ b/packages/reports/addon/templates/components/favorite-item.hbs
@@ -1,3 +1,3 @@
 {{!-- Copyright 2017, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 {{navi-icon (if isFavorite "star" "star-o")}}
-{{ember-tooltip text="Favorite" popperContainer="body"}}
+{{ember-tooltip text="Favorite" popperContainer="body" effect="none"}}

--- a/packages/reports/addon/templates/components/metric-selector.hbs
+++ b/packages/reports/addon/templates/components/metric-selector.hbs
@@ -19,7 +19,7 @@
     </label>
 
     {{#navi-icon "question-circle-o" class="grouped-list__item-info"}}
-      {{#ember-tooltip side="right" popperContainer="body"}}
+      {{#ember-tooltip side="right" popperContainer="body" effect="none"}}
         {{#if metric.extended.isPending}}
           {{loading-message}}
         {{else}}
@@ -43,7 +43,7 @@
         class=(concat (if (get metricsFiltered metric.name) "checkbox-selector__filter--active ") "checkbox-selector__filter metric-selector__filter")
         click=(action onToggleMetricFilter metric)
       }}
-        {{#ember-tooltip side="right" popperContainer="body"}}
+        {{#ember-tooltip side="right" popperContainer="body" effect="none"}}
           {{#if (has-parameters metric)}}
             {{#if (has-unfiltered-parameters metric request)}}
               Add next filter

--- a/packages/reports/addon/templates/components/metric-selector.hbs
+++ b/packages/reports/addon/templates/components/metric-selector.hbs
@@ -19,7 +19,7 @@
     </label>
 
     {{#navi-icon "question-circle-o" class="grouped-list__item-info"}}
-      {{#ember-tooltip side="right"}}
+      {{#ember-tooltip side="right" popperContainer="body"}}
         {{#if metric.extended.isPending}}
           {{loading-message}}
         {{else}}
@@ -43,7 +43,7 @@
         class=(concat (if (get metricsFiltered metric.name) "checkbox-selector__filter--active ") "checkbox-selector__filter metric-selector__filter")
         click=(action onToggleMetricFilter metric)
       }}
-        {{#ember-tooltip side="right"}}
+        {{#ember-tooltip side="right" popperContainer="body"}}
           {{#if (has-parameters metric)}}
             {{#if (has-unfiltered-parameters metric request)}}
               Add next filter

--- a/packages/reports/addon/templates/components/navi-table-select.hbs
+++ b/packages/reports/addon/templates/components/navi-table-select.hbs
@@ -17,6 +17,7 @@
     {{ember-tooltip
       text=item.description
       side="right"
+      popperContainer="body"
     }}
   {{/if}}
 {{/power-select}}

--- a/packages/reports/addon/templates/components/navi-table-select.hbs
+++ b/packages/reports/addon/templates/components/navi-table-select.hbs
@@ -18,6 +18,7 @@
       text=item.description
       side="right"
       popperContainer="body"
+      effect="none"
     }}
   {{/if}}
 {{/power-select}}

--- a/packages/reports/app/styles/navi-reports/common/ember-tooltips.less
+++ b/packages/reports/app/styles/navi-reports/common/ember-tooltips.less
@@ -2,10 +2,6 @@
  * Copyright 2019, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
-
-@import 'breadcrumb';
-@import 'print';
-@import 'report';
-@import 'report-controls';
-@import 'report-not-found';
-@import 'ember-tooltips';
+.ember-tooltip {
+  z-index: 10;
+}


### PR DESCRIPTION
## Description
Tooltips on an element/component that have overflow: hidden will hide part of the tooltips

## Proposed Changes
- Use body as base of the tooltip as mentioned here: https://github.com/sir-dunxalot/ember-tooltips/blob/master/UPGRADING-3.x.md#my-tooltips-appear-clipped-use-within-elements-using-overflow-hidden

## Screenshots
Before 
<img width="333" alt="Screen Shot 2019-05-28 at 11 39 57 AM" src="https://user-images.githubusercontent.com/23023478/58495536-5aed4c80-813d-11e9-91c7-f421f0568f89.png">

After
![Screen Shot 2019-05-24 at 4 28 32 PM](https://user-images.githubusercontent.com/23023478/58357583-ff6f4600-7e40-11e9-9125-b8c37ec0d5e3.png)
