### PR TITLE
Dashboard widget warning symbol

### DIFF
--- a/packages/core/addon/mirage/fixtures/dashboard.js
+++ b/packages/core/addon/mirage/fixtures/dashboard.js
@@ -43,6 +43,12 @@ export default [
         operator: 'notin',
         field: 'id',
         values: ['2', '3', '4']
+      },
+      {
+        dimension: 'eventId',
+        operator: 'in',
+        field: 'id',
+        values: ['1']
       }
     ],
     presentation: {

--- a/packages/core/tests/unit/models/dashboard-test.js
+++ b/packages/core/tests/unit/models/dashboard-test.js
@@ -47,6 +47,12 @@ module('Unit | Model | dashboard', function(hooks) {
               field: 'id',
               operator: 'notin',
               values: ['2', '3', '4']
+            },
+            {
+              dimension: 'eventId',
+              field: 'id',
+              operator: 'in',
+              values: ['1']
             }
           ],
           presentation: {

--- a/packages/dashboards/addon/components/navi-widget.js
+++ b/packages/dashboards/addon/components/navi-widget.js
@@ -11,6 +11,7 @@
  *   }}
  */
 import Component from '@ember/component';
+import { A as arr } from '@ember/array';
 import { get, computed } from '@ember/object';
 import layout from '../templates/components/navi-widget';
 
@@ -54,5 +55,15 @@ export default Component.extend({
       let { column: x, row: y, height, width } = layout;
       return { id, x, y, height, width };
     }
+  }),
+
+  filterErrors: computed('data.isFulfilled', function() {
+    const filterErrors = arr(get(this, 'data.firstObject.response.meta.errors')).filterBy('title', 'Invalid Filter');
+
+    return (
+      arr(filterErrors)
+        .mapBy('detail')
+        .join('\n') || null
+    );
   })
 });

--- a/packages/dashboards/addon/components/navi-widget.js
+++ b/packages/dashboards/addon/components/navi-widget.js
@@ -57,6 +57,9 @@ export default Component.extend({
     }
   }),
 
+  /**
+   * @property {String} filterErrors - Error messaging for filters that couldn't be applied to the widget
+   */
   filterErrors: computed('data.isFulfilled', function() {
     const filterErrors = arr(get(this, 'data.firstObject.response.meta.errors')).filterBy('title', 'Invalid Filter');
 

--- a/packages/dashboards/addon/components/navi-widget.js
+++ b/packages/dashboards/addon/components/navi-widget.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2019, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Usage:
@@ -11,7 +11,6 @@
  *   }}
  */
 import Component from '@ember/component';
-import { A as arr } from '@ember/array';
 import { get, computed } from '@ember/object';
 import layout from '../templates/components/navi-widget';
 
@@ -61,12 +60,12 @@ export default Component.extend({
    * @property {String} filterErrors - Error messaging for filters that couldn't be applied to the widget
    */
   filterErrors: computed('data.isFulfilled', function() {
-    const filterErrors = arr(get(this, 'data.firstObject.response.meta.errors')).filterBy('title', 'Invalid Filter');
+    const filterErrors = get(this, 'data.firstObject.response.meta.errors') || [];
+    const filterErrorMessages = filterErrors
+      .filter(e => e.title === 'Invalid Filter')
+      .map(e => e.detail)
+      .join('\n');
 
-    return (
-      arr(filterErrors)
-        .mapBy('detail')
-        .join('\n') || null
-    );
+    return filterErrorMessages ? `Unable to apply filter(s):\n${filterErrorMessages}` : null;
   })
 });

--- a/packages/dashboards/addon/templates/components/dashboard-action-list.hbs
+++ b/packages/dashboards/addon/templates/components/dashboard-action-list.hbs
@@ -7,7 +7,7 @@
       classNames="clone"
     }}
       {{navi-icon "copy" class="navi-icon__copy"}}
-      {{tooltip-on-component text="Clone" enableLazyRendering=true}}
+      {{ember-tooltip text="Clone"}}
     {{/link-to}}
   </li>
 
@@ -20,7 +20,7 @@
       tagName="li"
     }}
       {{navi-icon "download" class="navi-icon__download"}}
-      {{tooltip-on-component text="PDF Export" enableLazyRendering=true}}
+      {{ember-tooltip text="PDF Export"}}
     {{/dashboard-actions/export}}
   {{/if}}
 
@@ -33,9 +33,9 @@
     disabled=(not item.validations.isTruelyValid)
   }}
     {{navi-icon "share" class="navi-icon__share"}}
-    {{#tooltip-on-component enableLazyRendering=true}}
+    {{#ember-tooltip}}
       Share
-    {{/tooltip-on-component}}
+    {{/ember-tooltip}}
   {{/common-actions/share}}
 
   {{!-- Delete action visible when user owns the Dashboard --}}
@@ -51,9 +51,9 @@
         onRevert=(delivery-rule-action "REVERT_DELIVERY_RULE")
         onDelete=(delivery-rule-action "DELETE_DELIVERY_RULE")
       }}
-        {{#tooltip-on-component enableLazyRendering=true}}
+        {{#ember-tooltip}}
           {{if item.validations.isTruelyValid "Schedule the dashboard" "Validate dashboard to enable scheduling"}}
-        {{/tooltip-on-component}}
+        {{/ember-tooltip}}
       {{/dashboard-actions/schedule}}
     {{/if}}
 
@@ -65,7 +65,7 @@
       deleteAction=(item-action "DELETE_ITEM" dashboard)
     }}
       {{navi-icon "trash-o" class="navi-icon__delete"}}
-      {{tooltip-on-component text="Delete the dashboard" enableLazyRendering=true}}
+      {{ember-tooltip text="Delete the dashboard"}}
     {{/common-actions/delete}}
   {{/if}}
 {{/with}}

--- a/packages/dashboards/addon/templates/components/navi-widget.hbs
+++ b/packages/dashboards/addon/templates/components/navi-widget.hbs
@@ -21,9 +21,7 @@
           classNames="navi-widget__action navi-widget__explore-btn"
       }}
         {{navi-icon "pencil" class="navi-icon__edit" }}
-        {{#ember-tooltip popperContainer="body"}}
-          Explore
-        {{/ember-tooltip}}
+        {{ember-tooltip popperContainer="body" text="Explore"}}
       {{/link-to}}
       {{#if canEdit}}
         {{#common-actions/delete
@@ -32,9 +30,7 @@
            deleteAction=(route-action "deleteWidget")
         }}
           {{navi-icon "trash-o" class="navi-icon__delete"}}
-          {{#ember-tooltip popperContainer="body"}}
-            Delete
-          {{/ember-tooltip}}
+          {{ember-tooltip popperContainer="body" text="Delete"}}
         {{/common-actions/delete}}
       {{/if}}
     </div>

--- a/packages/dashboards/addon/templates/components/navi-widget.hbs
+++ b/packages/dashboards/addon/templates/components/navi-widget.hbs
@@ -5,14 +5,25 @@
   as |item|
 }}
   <div class="navi-widget__header">
-    <div class="navi-widget__title">{{model.title}}</div>
+    <div class="navi-widget__title">
+      {{model.title}}
+      {{#if filterErrors}}
+        {{#navi-icon "exclamation-triangle" class="navi-widget__filter-errors-icon"}}
+          {{#ember-tooltip popperContainer="body"}}
+            {{filterErrors}}
+          {{/ember-tooltip}}
+        {{/navi-icon}}
+      {{/if}}
+    </div>
     <div class="navi-widget__actions">
       {{#link-to
         "dashboards.dashboard.widgets.widget.view" model.dashboard.id model.id
           classNames="navi-widget__action navi-widget__explore-btn"
       }}
         {{navi-icon "pencil" class="navi-icon__edit" }}
-        {{tooltip-on-component text="Explore" enableLazyRendering=true}}
+        {{#ember-tooltip popperContainer="body"}}
+          Explore
+        {{/ember-tooltip}}
       {{/link-to}}
       {{#if canEdit}}
         {{#common-actions/delete
@@ -21,7 +32,9 @@
            deleteAction=(route-action "deleteWidget")
         }}
           {{navi-icon "trash-o" class="navi-icon__delete"}}
-          {{tooltip-on-component text="Delete" enableLazyRendering=true}}
+          {{#ember-tooltip popperContainer="body"}}
+            Delete
+          {{/ember-tooltip}}
         {{/common-actions/delete}}
       {{/if}}
     </div>

--- a/packages/dashboards/addon/templates/components/navi-widget.hbs
+++ b/packages/dashboards/addon/templates/components/navi-widget.hbs
@@ -7,12 +7,14 @@
   <div class="navi-widget__header">
     <div class="navi-widget__title">
       {{model.title}}
-      {{#if filterErrors}}
-        {{#navi-icon "exclamation-triangle" class="navi-widget__filter-errors-icon"}}
-          {{#ember-tooltip popperContainer="body"}}
-            {{filterErrors}}
-          {{/ember-tooltip}}
-        {{/navi-icon}}
+      {{#if (is-fulfilled data)}}
+        {{#if filterErrors}}
+          {{#navi-icon "exclamation-triangle" class="navi-widget__filter-errors-icon"}}
+            {{#ember-tooltip popperContainer="body"}}
+              {{filterErrors}}
+            {{/ember-tooltip}}
+          {{/navi-icon}}
+        {{/if}}
       {{/if}}
     </div>
     <div class="navi-widget__actions">

--- a/packages/dashboards/addon/templates/dashboards/dashboard/widgets/widget.hbs
+++ b/packages/dashboards/addon/templates/dashboards/dashboard/widgets/widget.hbs
@@ -40,9 +40,9 @@
 
           {{navi-icon "code" class="navi-report-widget__icon"}}
           Copy API Query
-          {{#tooltip-on-component enableLazyRendering=true}}
+          {{#ember-tooltip}}
             {{if model.request.validations.isTruelyValid "Copy API Query" "Run a valid report to copy"}}
-          {{/tooltip-on-component}}
+          {{/ember-tooltip}}
         {{/common-actions/get-api}}
       </li>
 
@@ -57,9 +57,9 @@
         }}
           {{navi-icon "download" class="navi-report-widget__icon"}}
           Export
-          {{#tooltip-on-component enableLazyRendering=true}}
+          {{#ember-tooltip}}
             {{if model.validations.isTruelyValid "Export the report" "Run a valid report to enable export"}}
-          {{/tooltip-on-component}}
+          {{/ember-tooltip}}
         {{/component}}
       </li>
 
@@ -79,9 +79,9 @@
           }}
             {{navi-icon "share" class="navi-report-widget__icon"}}
             Share
-            {{#tooltip-on-component enableLazyRendering=true}}
+            {{#ember-tooltip}}
               {{if model.request.validations.isTruelyValid "Share" "Run a valid report to share"}}
-            {{/tooltip-on-component}}
+            {{/ember-tooltip}}
           {{/common-actions/share}}
         </li>
       {{/if}}

--- a/packages/dashboards/app/styles/navi-dashboards/components/navi-widget.less
+++ b/packages/dashboards/app/styles/navi-dashboards/components/navi-widget.less
@@ -34,6 +34,11 @@
     }
   }
 
+  &__filter-errors-icon {
+    color: @navi-yellow;
+    font-size: @font-size-base-large;
+  }
+
   &__actions {
     align-items: center;
     .display-flex;

--- a/packages/dashboards/tests/acceptance/dashboards-test.js
+++ b/packages/dashboards/tests/acceptance/dashboards-test.js
@@ -211,10 +211,12 @@ module('Acceptance | Dashboards', function(hooks) {
       el.textContent.replace(/\s+/g, ' ').trim()
     );
 
-    assert.equal(filters.length, 3, 'correct number of filters');
+    assert.equal(filters.length, 4, 'correct number of filters');
 
     assert.ok(
-      filters.every(filter => /^Property (contains|not equals|equals) (.*?\d+.*?)(, .*?\d+.*?)*$/.test(filter)),
+      filters.every(filter =>
+        /^(Property|EventId) (contains|not equals|equals) (.*?\d+.*?)(, .*?\d+.*?)*$/.test(filter)
+      ),
       'correct format of filters'
     );
   });

--- a/packages/dashboards/tests/integration/components/navi-widget-test.js
+++ b/packages/dashboards/tests/integration/components/navi-widget-test.js
@@ -259,7 +259,7 @@ module('Integration | Component | navi widget', function(hooks) {
 
     //Tooltip contains all error messages separated by new line characters
     assertTooltipContent(assert, {
-      contentString: `Dimension A doesn't exist in this widget's logical table\nDimension B doesn't exist in this widget's logical table`
+      contentString: `Unable to apply filter(s):\nDimension A doesn't exist in this widget's logical table\nDimension B doesn't exist in this widget's logical table`
     });
 
     let newDataPromise = resolve(


### PR DESCRIPTION
## Description
Sometimes filters applied to a dashboard cannot be applied to all widgets due to widgets having different logical tables with different 

## Proposed Changes
- Add a warning icon next to the title of a widget that could not apply all global dashboard 

## Screenshots
<img width="333" alt="Screen Shot 2019-05-28 at 2 58 22 PM" src="https://user-images.githubusercontent.com/23023478/58508167-0eb00580-8159-11e9-9eb7-bd77f9ee26e6.png">
filters 
