### PR TITLE
Update: Keep expanded dashboards filters view in flow of document

### DIFF
--- a/packages/dashboards/addon/templates/components/navi-dashboard.hbs
+++ b/packages/dashboards/addon/templates/components/navi-dashboard.hbs
@@ -105,11 +105,11 @@
       {{/dashboard-actions/add-widget}}
     {{/if}}
   </div>
-
-  {{#if (feature-flag "enableDashboardFilters")}}
-    {{dashboard-filters dashboard=dashboard}}
-  {{/if}}
 </div>
+
+{{#if (feature-flag "enableDashboardFilters")}}
+  {{dashboard-filters dashboard=dashboard}}
+{{/if}}
 
 <div class="navi-dashboard__body">
   {{#if dashboard.widgets.length}}

--- a/packages/dashboards/app/styles/navi-dashboards/common.less
+++ b/packages/dashboards/app/styles/navi-dashboards/common.less
@@ -31,10 +31,6 @@
 .navi-dashboard,
 .navi-dashboard-collection-container,
 .navi-dashboard-container {
-  .page-header {
-    margin-bottom: 20px;
-  }
-
   .page-title {
     font-family: @font-family-thin;
     font-size: 30px;

--- a/packages/dashboards/app/styles/navi-dashboards/components/dashboard-filters.less
+++ b/packages/dashboards/app/styles/navi-dashboards/components/dashboard-filters.less
@@ -46,9 +46,9 @@
     background-color: @navi-white;
     box-shadow: 0px 2px 2px 0px #a0a0a0;
     display: block;
-    left: 0;
+    margin-left: -20px;
     padding: 0 100px 10px 20px;
-    position: absolute;
+    position: relative;
     width: 100vw;
     z-index: 5;
 

--- a/packages/dashboards/app/styles/navi-dashboards/components/dashboard-filters.less
+++ b/packages/dashboards/app/styles/navi-dashboards/components/dashboard-filters.less
@@ -46,10 +46,8 @@
     background-color: @navi-white;
     box-shadow: 0px 2px 2px 0px #a0a0a0;
     display: block;
-    margin-left: -20px;
     padding: 0 100px 10px 20px;
     position: relative;
-    width: 100vw;
     z-index: 5;
 
     &__add-filter-button {
@@ -112,6 +110,7 @@
     cursor: pointer;
     display: inline-block;
     font-size: 18px;
+    margin-left: 10px;
     user-select: none;
   }
 

--- a/packages/dashboards/app/styles/navi-dashboards/components/navi-dashboard.less
+++ b/packages/dashboards/app/styles/navi-dashboards/components/navi-dashboard.less
@@ -30,7 +30,7 @@
   }
 
   &__widgets {
-    overflow-y: scroll;
+    overflow-y: auto;
   }
 
   .page-header {

--- a/packages/dashboards/app/styles/navi-dashboards/components/navi-dashboard.less
+++ b/packages/dashboards/app/styles/navi-dashboards/components/navi-dashboard.less
@@ -30,6 +30,7 @@
 
   &__widgets {
     margin-bottom: 20px;
+    padding-top: 20px;
   }
 
   .page-header {

--- a/packages/dashboards/app/styles/navi-dashboards/components/navi-dashboard.less
+++ b/packages/dashboards/app/styles/navi-dashboards/components/navi-dashboard.less
@@ -21,7 +21,8 @@
     .display-flex;
     .flex-1;
     flex-flow: column;
-    overflow-y: auto;
+    overflow-y: hidden;
+    padding: 20px 0;
   }
 
   &__fav-icon {
@@ -29,8 +30,7 @@
   }
 
   &__widgets {
-    margin-bottom: 20px;
-    padding-top: 20px;
+    overflow-y: scroll;
   }
 
   .page-header {

--- a/packages/dashboards/app/styles/navi-dashboards/components/navi-dashboard.less
+++ b/packages/dashboards/app/styles/navi-dashboards/components/navi-dashboard.less
@@ -22,7 +22,6 @@
     .flex-1;
     flex-flow: column;
     overflow-y: hidden;
-    padding: 20px 0;
   }
 
   &__fav-icon {
@@ -31,6 +30,7 @@
 
   &__widgets {
     overflow-y: auto;
+    padding: 20px 0;
   }
 
   .page-header {

--- a/packages/dashboards/app/styles/navi-dashboards/components/navi-dashboard.less
+++ b/packages/dashboards/app/styles/navi-dashboards/components/navi-dashboard.less
@@ -21,7 +21,7 @@
     .display-flex;
     .flex-1;
     flex-flow: column;
-    overflow-y: hidden;
+    overflow-y: auto;
   }
 
   &__fav-icon {
@@ -29,7 +29,6 @@
   }
 
   &__widgets {
-    overflow-y: auto;
     padding: 20px 0;
   }
 

--- a/packages/dashboards/app/styles/navi-dashboards/views/navi-dashboards.less
+++ b/packages/dashboards/app/styles/navi-dashboards/views/navi-dashboards.less
@@ -7,4 +7,5 @@
   .display-flex;
   .flex-1;
   flex-flow: column;
+  max-height: 100%;
 }

--- a/packages/dashboards/app/styles/navi-dashboards/views/navi-dashboards.less
+++ b/packages/dashboards/app/styles/navi-dashboards/views/navi-dashboards.less
@@ -8,4 +8,5 @@
   .flex-1;
   flex-flow: column;
   max-height: 100%;
+  overflow: hidden;
 }

--- a/packages/dashboards/tests/dummy/app/styles/app.less
+++ b/packages/dashboards/tests/dummy/app/styles/app.less
@@ -15,6 +15,19 @@ body > .ember-view,
   flex-flow: column;
 }
 
+.navi-dashboard-container,
+.navi-dashboard-collection-container {
+  & > .page-header,
+  & > .navi-collection,
+  & > a {
+    padding: 0 10px;
+  }
+
+  .navi-report-widget {
+    padding: 0 10px;
+  }
+}
+
 // Blue Palette
 // -----------
 @blue-200: #2698b8;

--- a/packages/dashboards/tests/dummy/app/styles/app.less
+++ b/packages/dashboards/tests/dummy/app/styles/app.less
@@ -6,7 +6,6 @@ body {
   font-family: 'HelveticaNeue-Light', 'HelveticaNeueW01-Light', Helvetica, Arial, sans-serif;
   height: 100vh;
   margin: 0;
-  padding: 10px;
 }
 
 body > .ember-view,


### PR DESCRIPTION
## Description
Expanded dashboard filter view can block a lot of the view of the dashboard without being able to scroll to the part of the dashboard that is blocked. 

## Proposed Changes
- Use position: relative on the expanded dashboard filters view 
- Move dashboard filters outside of the dashboard header.
- Add internal padding to the scrolled div.

## Screenshots (updated by @Alex-Aralis )
![May-31-2019 11-17-49](https://user-images.githubusercontent.com/17508658/58719632-cd586980-8395-11e9-8759-c5e69f11927a.gif)
