### PR TITLE
Update: Add license to PR Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,15 @@
 Resolves #
 
 <!-- The above line will close the issue upon merge -->
+
 ## Description
 
-
 ## Proposed Changes
+
 -
 
 ## Screenshots
+
+## License
+
+I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.


### PR DESCRIPTION
## Description
Add license to PR Template

```
Ben Pearson [8:45 AM]
Hi Balaji,

We are in the process of removing the need for contributors to sign a CLA when they submit PR's to our projects by adding a new section to our projects' pull request templates.

This file: https://github.com/yahoo/navi/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Should have the following content at the bottom of it:

## License
I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Once this statement is in place, I will turn off the CLA checker for this repo. From here on, the only people who need to sign our CLA is anyone that is not a Verizon Media employee who is granted write access to the repository. For everyone who is submitting a PR, this statement is sufficient. We hope this will reduce some friction associated with CLA's while still giving us a comparable level of protection.
```

## Proposed Changes
- Add license line to PR Template

## Screenshots
NA