### PR TITLE
Dashboards style changes

### DIFF
--- a/packages/core/app/styles/navi-core/variables/colors.less
+++ b/packages/core/app/styles/navi-core/variables/colors.less
@@ -12,6 +12,7 @@
 @navi-gray-600: #787d82;
 @navi-gray-700: #464e56;
 @navi-gray-800: #2d353e;
+@denali-gray-100: #f8f8f8;
 
 // blue
 @navi-blue-100: #f5f8fe;
@@ -48,7 +49,7 @@
 @gray-table-header: @navi-gray-500;
 @gray-date-picker: @navi-gray-300;
 @navi-placeholder-gray: @navi-gray-700;
-@navi-container-gray: @navi-gray-100;
+@navi-container-gray: @denali-gray-100;
 @table-header-gray: @navi-gray-600;
 @navi-light-gray: @navi-gray-300;
 @navi-light-gray-1: @navi-gray-400;
@@ -84,5 +85,5 @@
 @navi-error-color: @navi-red;
 
 @nv-color-background-primary: @navi-white;
-@nv-color-background-secondary: @navi-gray-100;
+@nv-color-background-secondary: @denali-gray-100;
 @nv-color-border: @navi-gray-300;

--- a/packages/dashboards/addon/components/dashboard-filters.js
+++ b/packages/dashboards/addon/components/dashboard-filters.js
@@ -13,7 +13,7 @@ import layout from '../templates/components/dashboard-filters';
 export default Component.extend({
   layout,
   classNames: ['dashboard-filters'],
-  classNameBindings: ['isCollapsed:collapsed:expanded'],
+  classNameBindings: ['isCollapsed:dashboard-filters--collapsed:dashboard-filters--expanded'],
 
   /**
    * @property {Boolean} isCollapsed

--- a/packages/dashboards/addon/components/dashboard-filters.js
+++ b/packages/dashboards/addon/components/dashboard-filters.js
@@ -13,6 +13,7 @@ import layout from '../templates/components/dashboard-filters';
 export default Component.extend({
   layout,
   classNames: ['dashboard-filters'],
+  classNameBindings: ['isCollapsed:collapsed:expanded'],
 
   /**
    * @property {Boolean} isCollapsed

--- a/packages/dashboards/addon/templates/dashboards/index.hbs
+++ b/packages/dashboards/addon/templates/dashboards/index.hbs
@@ -2,10 +2,8 @@
 <div class="page-header">
   <div class="page-title">Dashboard</div>
 </div>
-{{#link-to "dashboards.new"}}
-  <button class="btn btn-primary dashboards-index__new-btn">
-    + New Dashboard
-  </button>
+{{#link-to "dashboards.new" class="btn btn-primary dashboards-index__new-btn"}}
+  + New Dashboard
 {{/link-to}}
 {{navi-collection
   items=model.dashboards

--- a/packages/dashboards/app/styles/navi-dashboards/components/dashboard-filters.less
+++ b/packages/dashboards/app/styles/navi-dashboards/components/dashboard-filters.less
@@ -12,7 +12,7 @@
   flex: 0 0 auto;
   width: 100%;
 
-  &.collapsed {
+  &--collapsed {
     border-bottom: 2px solid @navi-gray-300;
     padding-bottom: 10px;
   }

--- a/packages/dashboards/app/styles/navi-dashboards/components/dashboard-filters.less
+++ b/packages/dashboards/app/styles/navi-dashboards/components/dashboard-filters.less
@@ -12,6 +12,11 @@
   flex: 0 0 auto;
   width: 100%;
 
+  &.collapsed {
+    border-bottom: 2px solid @navi-gray-300;
+    padding-bottom: 10px;
+  }
+
   &-collapsed {
     cursor: pointer;
 

--- a/packages/dashboards/app/styles/navi-dashboards/components/navi-dashboard.less
+++ b/packages/dashboards/app/styles/navi-dashboards/components/navi-dashboard.less
@@ -22,8 +22,12 @@
   &__body {
     .display-flex;
     .flex-1;
+
+    background-color: @denali-gray-100;
+    border-bottom: 2px solid @navi-gray-300;
     flex-flow: column;
     overflow-y: hidden;
+    padding-bottom: 10px;
   }
 
   &__fav-icon {

--- a/packages/dashboards/app/styles/navi-dashboards/components/navi-widget.less
+++ b/packages/dashboards/app/styles/navi-dashboards/components/navi-widget.less
@@ -5,6 +5,7 @@
 
 .navi-widget {
   .grid-stack-item-content {
+    background-color: white;
     border: 1px solid #f1f1f1;
     border-bottom-color: rgba(0, 0, 0, 0.2);
     .display-flex;

--- a/packages/dashboards/app/styles/navi-dashboards/views/navi-dashboards.less
+++ b/packages/dashboards/app/styles/navi-dashboards/views/navi-dashboards.less
@@ -11,6 +11,7 @@
   overflow: auto;
   
   .dashboards-index__new-btn {
+    margin-left: 10px;
     width: 138px;
   }
 }

--- a/packages/dashboards/app/styles/navi-dashboards/views/navi-dashboards.less
+++ b/packages/dashboards/app/styles/navi-dashboards/views/navi-dashboards.less
@@ -9,4 +9,8 @@
   flex-flow: column;
   max-height: 100%;
   overflow: auto;
+  
+  .dashboards-index__new-btn {
+    width: 138px;
+  }
 }

--- a/packages/dashboards/app/styles/navi-dashboards/views/navi-dashboards.less
+++ b/packages/dashboards/app/styles/navi-dashboards/views/navi-dashboards.less
@@ -11,7 +11,7 @@
   overflow: auto;
   
   .dashboards-index__new-btn {
-    margin-left: 10px;
+    margin: 20px 0 0 10px;
     width: 138px;
   }
 }

--- a/packages/dashboards/tests/dummy/app/styles/app.less
+++ b/packages/dashboards/tests/dummy/app/styles/app.less
@@ -6,6 +6,7 @@ body {
   font-family: 'HelveticaNeue-Light', 'HelveticaNeueW01-Light', Helvetica, Arial, sans-serif;
   height: 100vh;
   margin: 0;
+  padding-bottom: 30px;
 }
 
 body > .ember-view,

--- a/packages/dashboards/tests/dummy/app/styles/app.less
+++ b/packages/dashboards/tests/dummy/app/styles/app.less
@@ -6,7 +6,6 @@ body {
   font-family: 'HelveticaNeue-Light', 'HelveticaNeueW01-Light', Helvetica, Arial, sans-serif;
   height: 100vh;
   margin: 0;
-  padding-bottom: 30px;
 }
 
 body > .ember-view,


### PR DESCRIPTION
## Description
Styling update for dashboards to add some contrast. Apps using the latest version of Navi should update their styles to accommodate the background added here.

## Proposed Changes

- Add light gray background to dashboards
- Use that same light gray consistently as our background throughout navi
- Make `+ New Dashboard` button consistent with the `+ New Report` button
- Add border to collapsed dashboard filters view

These changes don't seem to affect the print view.

## Screenshots
![Screen Shot 2019-06-07 at 4 55 41 PM](https://user-images.githubusercontent.com/23023478/59135661-6c0c3980-8945-11e9-951a-6c83ae9eee59.png)
![Screen Shot 2019-06-07 at 4 55 35 PM](https://user-images.githubusercontent.com/23023478/59135662-6c0c3980-8945-11e9-9aa5-2b46960cfbfa.png)

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
