### PR TITLE
Update: Add hooks to metric selector

### DIFF
--- a/packages/reports/addon/helpers/can-having.js
+++ b/packages/reports/addon/helpers/can-having.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2019, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+import { helper } from '@ember/component/helper';
+
+/**
+ * Overridable helper that decides if a metric is allowed to have a filter on the base metric
+ * filters may only be alllowed on parameterized versions for example and choosing a
+ * valid default may not be appropriate.
+ * @param {array} params
+ * @return {Boolean}
+ */
+export function canHaving(/* params, hash */) {
+  return true;
+}
+
+export default helper(canHaving);

--- a/packages/reports/addon/templates/components/metric-selector.hbs
+++ b/packages/reports/addon/templates/components/metric-selector.hbs
@@ -1,4 +1,4 @@
-{{!-- Copyright 2018, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{!-- Copyright 2019, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 {{#navi-list-selector
    items=allMetrics
    searchField="longName"
@@ -28,7 +28,7 @@
       {{/ember-tooltip}}
     {{/navi-icon}}
 
-    <div class="metric-selector__icon-set">
+    <div class="metric-selector__icon-set {{if (not (can-having metric)) "metric-selector__icon-set--no-filter"}}">
       {{#if (get metric "hasParameters")}}
         {{metric-config
           metric=metric
@@ -38,27 +38,29 @@
           onToggleParameterizedMetricFilter=(update-report-action "TOGGLE_PARAMETERIZED_METRIC_FILTER")
         }}
       {{/if}}
-      {{#navi-icon
-        "filter"
-        class=(concat (if (get metricsFiltered metric.name) "checkbox-selector__filter--active ") "checkbox-selector__filter metric-selector__filter")
-        click=(action onToggleMetricFilter metric)
-      }}
-        {{#ember-tooltip side="right" popperContainer="body" effect="none"}}
-          {{#if (has-parameters metric)}}
-            {{#if (has-unfiltered-parameters metric request)}}
-              Add next filter
+      {{#if (can-having metric)}}
+        {{#navi-icon
+          "filter"
+          class=(concat (if (get metricsFiltered metric.name) "checkbox-selector__filter--active ") "checkbox-selector__filter metric-selector__filter")
+          click=(action onToggleMetricFilter metric)
+        }}
+          {{#ember-tooltip side="right" popperContainer="body" effect="none"}}
+            {{#if (has-parameters metric)}}
+              {{#if (has-unfiltered-parameters metric request)}}
+                Add next filter
+              {{else}}
+                Remove all
+              {{/if}}
             {{else}}
-              Remove all
+              {{#if (get metricsFiltered metric.name)}}
+                Remove Filter
+              {{else}}
+                Add Filter
+              {{/if}}
             {{/if}}
-          {{else}}
-            {{#if (get metricsFiltered metric.name)}}
-              Remove Filter
-            {{else}}
-              Add Filter
-            {{/if}}
-          {{/if}}
-        {{/ember-tooltip}}
-      {{/navi-icon}}
+          {{/ember-tooltip}}
+        {{/navi-icon}}
+      {{/if}}
     </div>
   {{/grouped-list}}
 {{/navi-list-selector}}

--- a/packages/reports/addon/templates/components/report-builder.hbs
+++ b/packages/reports/addon/templates/components/report-builder.hbs
@@ -23,6 +23,7 @@
         class="report-builder__container report-builder__metric-selector"
         request=request
         onAddMetric=(update-report-action "ADD_METRIC")
+        onAddMetricWithParameter=(update-report-action "ADD_METRIC_WITH_PARAM")
         onRemoveMetric=(update-report-action "REMOVE_METRIC")
         onToggleMetricFilter=(update-report-action "TOGGLE_METRIC_FILTER")
       }}

--- a/packages/reports/app/helpers/can-having.js
+++ b/packages/reports/app/helpers/can-having.js
@@ -1,0 +1,1 @@
+export { default, canHaving } from 'navi-reports/helpers/can-having';

--- a/packages/reports/app/styles/navi-reports/components/metric-selector.less
+++ b/packages/reports/app/styles/navi-reports/components/metric-selector.less
@@ -8,6 +8,11 @@
     align-items: center;
     display: flex;
     margin: 0 15px 0 auto;
+    &--no-filter {
+      .metric-config > div:first-child {
+        margin: 0 5px;
+      }
+    }
   }
 
   &__filter {

--- a/packages/reports/tests/integration/components/metric-selector-test.js
+++ b/packages/reports/tests/integration/components/metric-selector-test.js
@@ -22,6 +22,13 @@ module('Integration | Component | metric selector', function(hooks) {
     setupMock();
 
     this.owner.register('helper:update-report-action', buildHelper(() => {}), { instantiate: false });
+    this.owner.register(
+      'helper:can-having',
+      buildHelper(([metric]) => {
+        return get(metric, 'name') !== 'regUsers';
+      }),
+      { instantiate: false }
+    );
 
     this.set('addMetric', () => {});
     this.set('removeMetric', () => {});
@@ -248,5 +255,11 @@ module('Integration | Component | metric selector', function(hooks) {
       ['Page Views', 'Total Page Views', 'Additive Page Views', 'Total Page Views WoW'],
       'The search results are ranked based on relevance'
     );
+  });
+
+  test('hide filter if metric not allowed to show filter on base metric', function(assert) {
+    assert.dom('.metric-selector__icon-set--no-filter').exists({ count: 1 });
+    assert.dom('.metric-selector__icon-set--no-filter .metric-selector__filter').doesNotExist();
+    assert.dom('.metric-selector__icon-set .metric-selector__filter').exists();
   });
 });

--- a/packages/reports/tests/integration/helpers/can-having-test.js
+++ b/packages/reports/tests/integration/helpers/can-having-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Helper | can-having', function(hooks) {
+  setupRenderingTest(hooks);
+
+  // Replace this with your real tests.
+  test('it renders', async function(assert) {
+    this.set('inputValue', { metric: 'm1' });
+
+    await render(hbs`{{can-having inputValue}}`);
+
+    assert.equal(this.element.textContent.trim(), 'true');
+  });
+});


### PR DESCRIPTION
## Description

Adds hooks to metric selector component to allow customizations

## Proposed Changes

- Add can-having helper to decide if a metric is allowed to be filtered as a base metric, currently always returns true, allowed to be overridden in other systems
- Pass in route action for adding metrics with parameters so that downstream overrides can make use of it.

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
