### PR TITLE
Fix: Column reordering firing events

### DIFF
--- a/packages/core/app/styles/navi-core/visualizations/table.less
+++ b/packages/core/app/styles/navi-core/visualizations/table.less
@@ -359,3 +359,11 @@
     }
   }
 }
+
+.sortable-item {
+  transition: all 0.125s;
+
+  &.is-dragging {
+    transition-duration: 0s;
+  }
+}


### PR DESCRIPTION
## Description

Found column reordering not firing event to reorder the table columns.  Bug in upstream library of heroku/ember-sortable ticket had a workaround.

## Proposed Changes

- CSS as described in here https://github.com/heroku/ember-sortable/issues/234

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
