### PR TITLE
Enum parameterized metric support

### DIFF
--- a/packages/core/addon/components/navi-visualizations/table.js
+++ b/packages/core/addon/components/navi-visualizations/table.js
@@ -349,7 +349,6 @@ export default Component.extend({
      * @action updateColumnOrder
      */
     updateColumnOrder(newColumnOrder) {
-      debugger;
       this.onUpdateReport('updateColumnOrder', newColumnOrder);
     },
 

--- a/packages/core/addon/components/navi-visualizations/table.js
+++ b/packages/core/addon/components/navi-visualizations/table.js
@@ -349,6 +349,7 @@ export default Component.extend({
      * @action updateColumnOrder
      */
     updateColumnOrder(newColumnOrder) {
+      debugger;
       this.onUpdateReport('updateColumnOrder', newColumnOrder);
     },
 

--- a/packages/data/addon/mirage/fixtures/bard-meta-metrics.js
+++ b/packages/data/addon/mirage/fixtures/bard-meta-metrics.js
@@ -115,6 +115,23 @@ export default {
           defaultValue: 'USD'
         }
       }
+    },
+    {
+      category: 'Clicks',
+      name: 'buttons',
+      longName: 'button click count',
+      type: 'number',
+      parameters: {
+        type: {
+          type: 'enum',
+          values: [
+            { id: 'l', description: 'Left' },
+            { id: 'r', description: 'Right' },
+            { id: 'm', description: 'Middle' }
+          ],
+          defaultValue: 'l'
+        }
+      }
     }
   ],
 

--- a/packages/data/addon/services/metric-parameter.js
+++ b/packages/data/addon/services/metric-parameter.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018, Yahoo Holdings Inc.
+ * Copyright 2019, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Ember service that can fetch metric parameters
@@ -9,13 +9,33 @@ import Service from '@ember/service';
 import { inject as service } from '@ember/service';
 import { get } from '@ember/object';
 import { assert } from '@ember/debug';
+import { resolve } from 'rsvp';
+import { isEmpty } from '@ember/utils';
 
 export default Service.extend({
+  init() {
+    this._super(...arguments);
+    /**
+     * @property {Object} _supportedHandlers List of parametery types supported.
+     */
+    this._supportedHandlers = {
+      dimension: this._dimension.bind(this),
+      enum: this._enum.bind(this)
+    };
+  },
+
   /**
    * @private
    * @property {Ember.Service} dimensionService
    */
   _dimensionService: service('bard-dimensions'),
+
+  /**
+   * @returns {Array} list of paramter types this service supports
+   */
+  supportedTypes() {
+    return Object.keys(this._supportedHandlers);
+  },
 
   /**
    * @method fetchAllValues
@@ -24,9 +44,31 @@ export default Service.extend({
    * @param {Object} parameter - metric parameter objects
    * @returns {Promise} response with dimension values
    */
-  fetchAllValues({ type, dimensionName }) {
-    assert(`Fetching values of type: '${type}' is not supported`, type === 'dimension');
+  fetchAllValues(meta) {
+    assert(`Fetching values of type: '${meta.type}' is not supported`, this.supportedTypes().includes(meta.type));
 
+    return this._supportedHandlers[meta.type](meta);
+  },
+
+  /**
+   * @private
+   * Fetches dimension values from service
+   * @param {Object} meta - parameterized metric metadata
+   * @returns {Promise} response with dimension values
+   */
+  _dimension({ dimensionName }) {
     return get(this, '_dimensionService').all(dimensionName);
+  },
+
+  /**
+   * @private
+   * Fetches dimension values from meta for enum type
+   * @param {Object} meta - parameterized metric metadata
+   * @returns {Promise} response with dimension values
+   */
+  _enum(meta) {
+    return resolve(
+      meta.values.map(value => (isEmpty(value.name) ? Object.assign({}, value, { name: value.description }) : value))
+    );
   }
 });

--- a/packages/data/addon/services/metric-parameter.js
+++ b/packages/data/addon/services/metric-parameter.js
@@ -10,7 +10,6 @@ import { inject as service } from '@ember/service';
 import { get } from '@ember/object';
 import { assert } from '@ember/debug';
 import { resolve } from 'rsvp';
-import { isEmpty } from '@ember/utils';
 
 export default Service.extend({
   init() {
@@ -67,8 +66,6 @@ export default Service.extend({
    * @returns {Promise} response with dimension values
    */
   _enum(meta) {
-    return resolve(
-      meta.values.map(value => (isEmpty(value.name) ? Object.assign({}, value, { name: value.description }) : value))
-    );
+    return resolve(meta.values);
   }
 });

--- a/packages/data/addon/services/metric-parameter.js
+++ b/packages/data/addon/services/metric-parameter.js
@@ -31,7 +31,7 @@ export default Service.extend({
   _dimensionService: service('bard-dimensions'),
 
   /**
-   * @returns {Array} list of paramter types this service supports
+   * @returns {Array} list of parameter types this service supports
    */
   supportedTypes() {
     return Object.keys(this._supportedHandlers);

--- a/packages/data/tests/unit/services/metric-parameter-test.js
+++ b/packages/data/tests/unit/services/metric-parameter-test.js
@@ -11,11 +11,11 @@ let MetadataService,
   Rows = A([
     {
       id: '-1',
-      name: 'NULL'
+      description: 'NULL'
     },
     {
       id: '-2',
-      name: 'UNKNOWN'
+      description: 'UNKNOWN'
     }
   ]),
   Server;
@@ -87,7 +87,7 @@ module('Unit | Service | metric parameter', function(hooks) {
     const results = await service.fetchAllValues(parameter);
 
     assert.deepEqual(
-      [{ id: 1, description: 'One', name: 'One' }, { id: 2, description: 'Two', name: 'Two' }],
+      [{ id: 1, description: 'One' }, { id: 2, description: 'Two' }],
       results,
       'Enum paramter type returns correct values from meta.'
     );

--- a/packages/data/tests/unit/services/metric-parameter-test.js
+++ b/packages/data/tests/unit/services/metric-parameter-test.js
@@ -76,4 +76,20 @@ module('Unit | Service | metric parameter', function(hooks) {
       'fetch all values throws exception for an invalid parameter'
     );
   });
+
+  test('fetchAllValues - enum type', async function(assert) {
+    let service = this.owner.lookup('service:metric-parameter'),
+      parameter = {
+        type: 'enum',
+        values: [{ id: 1, description: 'One' }, { id: 2, description: 'Two' }]
+      };
+
+    const results = await service.fetchAllValues(parameter);
+
+    assert.deepEqual(
+      [{ id: 1, description: 'One', name: 'One' }, { id: 2, description: 'Two', name: 'Two' }],
+      results,
+      'Enum paramter type returns correct values from meta.'
+    );
+  });
 });

--- a/packages/directory/tests/dummy/mirage/bard-lite/dimensions/displayCurrency.js
+++ b/packages/directory/tests/dummy/mirage/bard-lite/dimensions/displayCurrency.js
@@ -1,100 +1,86 @@
 export default [
   {
     id: '-1',
-    name: 'NULL',
+    description: 'NULL',
     planRate: '',
-    description: '',
     decimalUnits: '0'
   },
   {
     id: '-2',
-    name: 'UNKNOWN',
+    description: 'UNKNOWN',
     planRate: '',
-    description: '',
     decimalUnits: '0'
   },
   {
     id: 'AED',
-    name: 'Dirhams',
+    description: 'Dirhams',
     planRate: '3.6729',
-    description: '',
     decimalUnits: '2'
   },
   {
     id: 'AFA',
-    name: 'Afghanis',
+    description: 'Afghanis',
     planRate: '',
-    description: '',
     decimalUnits: '0'
   },
   {
     id: 'ALL',
-    name: 'Leke',
+    description: 'Leke',
     planRate: '',
-    description: '',
     decimalUnits: '2'
   },
   {
     id: 'AMD',
-    name: 'Drams',
+    description: 'Drams',
     planRate: '',
-    description: '',
     decimalUnits: '2'
   },
   {
     id: 'ANG',
-    name: 'Guilders',
+    description: 'Guilders',
     planRate: '',
-    description: '',
     decimalUnits: '2'
   },
   {
     id: 'AOA',
-    name: 'Kwanza',
+    description: 'Kwanza',
     planRate: '',
-    description: '',
     decimalUnits: '2'
   },
   {
     id: 'ARS',
-    name: 'Pesos',
+    description: 'Pesos',
     planRate: '15.2109',
-    description: '',
     decimalUnits: '2'
   },
   {
     id: 'AUD',
-    name: 'Dollars',
+    description: 'Dollars',
     planRate: '1.31613583',
-    description: '',
     decimalUnits: '2'
   },
   {
     id: 'CAD',
-    name: 'Dollars',
+    description: 'Dollars',
     planRate: '1.3386',
-    description: '',
     decimalUnits: '2'
   },
   {
     id: 'USD',
-    name: 'Dollars',
+    description: 'Dollars',
     planRate: '1.0',
-    description: '',
     decimalUnits: '2'
   },
   {
     id: 'EUR',
-    name: 'Euro',
+    description: 'Euro',
     planRate: '0.9154994',
-    description: '',
     decimalUnits: '2'
   },
   {
     id: 'INR',
-    name: 'Rupees',
+    description: 'Rupees',
     planRate: '66.86651',
-    description: '',
     decimalUnits: '2'
   }
 ];

--- a/packages/reports/addon/components/metric-config.js
+++ b/packages/reports/addon/components/metric-config.js
@@ -55,7 +55,10 @@ export default Component.extend({
   _fetchAllParams: observer('metric', function() {
     let promises = {},
       parameterObj = get(this, 'metric.parameters') || {},
-      parameters = arr(Object.entries(parameterObj)).filter(([, paramMeta]) => get(paramMeta, 'type') === 'dimension'),
+      supportedTypes = get(this, 'parameterService').supportedTypes(),
+      parameters = arr(Object.entries(parameterObj)).filter(([, paramMeta]) =>
+        supportedTypes.includes(get(paramMeta, 'type'))
+      ),
       allParametersMap = {},
       allParamValues = [];
 
@@ -66,7 +69,7 @@ export default Component.extend({
     let promiseHash = hash(promises).then(res => {
       //add property param to every element in each array
       forIn(res, (values, key) => {
-        let valArray = values.toArray();
+        let valArray = Array.isArray(values) ? values : values.toArray();
         valArray.forEach(val => {
           set(val, 'param', key);
 

--- a/packages/reports/addon/templates/components/metric-config.hbs
+++ b/packages/reports/addon/templates/components/metric-config.hbs
@@ -24,7 +24,7 @@
           items=params
           shouldOpenAllGroups=true
           groupByField="param"
-          sortByField="name"
+          sortByField="description"
           as | param |
         }}
           <label class="grouped-list__item-label">
@@ -32,7 +32,7 @@
               class="checkbox-selector__checkbox"
               type="checkbox" onchange={{action "paramToggled" metric param}}
               checked={{get parametersChecked (concat param.param "|" param.id)}}>
-            {{param.name}} ({{param.id}})
+            {{param.description}} ({{param.id}})
           </label>
 
           {{navi-icon

--- a/packages/reports/tests/dummy/mirage/bard-lite/dimensions/displayCurrency.js
+++ b/packages/reports/tests/dummy/mirage/bard-lite/dimensions/displayCurrency.js
@@ -1,100 +1,86 @@
 export default [
   {
     id: '-1',
-    name: 'NULL',
+    description: 'NULL',
     planRate: '',
-    description: '',
     decimalUnits: '0'
   },
   {
     id: '-2',
-    name: 'UNKNOWN',
+    description: 'UNKNOWN',
     planRate: '',
-    description: '',
     decimalUnits: '0'
   },
   {
     id: 'AED',
-    name: 'Dirhams',
+    description: 'Dirhams',
     planRate: '3.6729',
-    description: '',
     decimalUnits: '2'
   },
   {
     id: 'AFA',
-    name: 'Afghanis',
+    description: 'Afghanis',
     planRate: '',
-    description: '',
     decimalUnits: '0'
   },
   {
     id: 'ALL',
-    name: 'Leke',
+    description: 'Leke',
     planRate: '',
-    description: '',
     decimalUnits: '2'
   },
   {
     id: 'AMD',
-    name: 'Drams',
+    description: 'Drams',
     planRate: '',
-    description: '',
     decimalUnits: '2'
   },
   {
     id: 'ANG',
-    name: 'Guilders',
+    description: 'Guilders',
     planRate: '',
-    description: '',
     decimalUnits: '2'
   },
   {
     id: 'AOA',
-    name: 'Kwanza',
+    description: 'Kwanza',
     planRate: '',
-    description: '',
     decimalUnits: '2'
   },
   {
     id: 'ARS',
-    name: 'Pesos',
+    description: 'Pesos',
     planRate: '15.2109',
-    description: '',
     decimalUnits: '2'
   },
   {
     id: 'AUD',
-    name: 'Dollars',
+    description: 'Dollars',
     planRate: '1.31613583',
-    description: '',
     decimalUnits: '2'
   },
   {
     id: 'CAD',
-    name: 'Dollars',
+    description: 'Dollars',
     planRate: '1.3386',
-    description: '',
     decimalUnits: '2'
   },
   {
     id: 'USD',
-    name: 'Dollars',
+    description: 'Dollars',
     planRate: '1.0',
-    description: '',
     decimalUnits: '2'
   },
   {
     id: 'EUR',
-    name: 'Euro',
+    description: 'Euro',
     planRate: '0.9154994',
-    description: '',
     decimalUnits: '2'
   },
   {
     id: 'INR',
-    name: 'Rupees',
+    description: 'Rupees',
     planRate: '66.86651',
-    description: '',
     decimalUnits: '2'
   }
 ];

--- a/packages/reports/tests/integration/components/metric-config-test.js
+++ b/packages/reports/tests/integration/components/metric-config-test.js
@@ -31,6 +31,10 @@ module('Integration | Component | metric config', function(hooks) {
           type: 'dimension',
           dimensionName: 'property'
         },
+        embargo: {
+          type: 'enum',
+          values: [{ id: 'Y', description: 'Embargo enforced' }, { id: 'N', description: 'No Embargo' }]
+        },
         invalid: {
           type: 'invalid',
           name: 'invalid'
@@ -110,7 +114,7 @@ module('Integration | Component | metric config', function(hooks) {
   });
 
   test('grouped list', async function(assert) {
-    assert.expect(2);
+    assert.expect(3);
 
     await clickTrigger('.metric-config__dropdown-trigger');
 
@@ -122,8 +126,16 @@ module('Integration | Component | metric config', function(hooks) {
 
     assert.deepEqual(
       findAll('.grouped-list__group-header').map(el => el.textContent.trim()),
-      ['currency (14)', 'property (4)'],
+      ['currency (14)', 'property (4)', 'embargo (2)'],
       'The group headers reflect the two parameters in the metric'
+    );
+
+    const embargoList = findAll('.grouped-list__group-header').find(el => el.textContent.startsWith('embargo'))
+      .nextElementSibling;
+    assert.deepEqual(
+      [...embargoList.querySelectorAll('li')].map(el => el.textContent.trim()),
+      ['Embargo enforced (Y)', 'No Embargo (N)'],
+      'Enum elements are correctly displayed'
     );
   });
 


### PR DESCRIPTION
## Description

Add support for enum parameterized metric types as outlined in fili RFC https://github.com/yahoo/fili/pull/618

## Proposed Changes

- update parameterized-metric service to support enum metadata.
- make sure metric-config allows usage of enum metadata.

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
