### PR TITLE
Fix: Fix dashboard filter values.

### DIFF
--- a/packages/core/addon/models/bard-request/request.js
+++ b/packages/core/addon/models/bard-request/request.js
@@ -308,11 +308,35 @@ export default Fragment.extend(Validations, {
    * @returns {Void}
    */
   addFilter(filterObj) {
+    this._addFilter(filterObj, 'values');
+  },
+
+  /**
+   * Adds a filter using raw values
+   * to the filters array unless a duplicate filter is already present
+   *
+   * @method addRawFilter
+   * @param {Object} filterObj
+   * @returns {Void}
+   */
+  addRawFilter(filterObj) {
+    this._addFilter(filterObj, 'rawValues');
+  },
+
+  /**
+   * adds filter with the request unless a duplicate filter is already present
+   * @private
+   * @method _addFilter
+   * @param {Object} filterObj
+   * @param {String} field
+   * @returns {void}
+   */
+  _addFilter(filterObj, valueParam) {
     let newFilter = this.store.createFragment('bard-request/fragments/filter', {
         dimension: get(filterObj, 'dimension'),
         operator: get(filterObj, 'operator'),
         field: get(filterObj, 'field'),
-        values: arr(get(filterObj, 'values'))
+        [valueParam]: arr(get(filterObj, valueParam))
       }),
       filters = get(this, 'filters'),
       existingFilter = filters.find(filter => isEqual(filter.serialize(), newFilter.serialize()));

--- a/packages/dashboards/addon/services/dashboard-data.js
+++ b/packages/dashboards/addon/services/dashboard-data.js
@@ -112,7 +112,7 @@ export default Service.extend({
   _applyFilters(dashboard, request) {
     const requestClone = request.clone();
 
-    this._getValidGlobalFilters(dashboard, request).forEach(filter => requestClone.addFilter(filter));
+    this._getValidGlobalFilters(dashboard, request).forEach(filter => requestClone.addRawFilter(filter));
 
     return requestClone;
   },

--- a/packages/dashboards/tests/acceptance/dashboard-filter-test.js
+++ b/packages/dashboards/tests/acceptance/dashboard-filter-test.js
@@ -9,7 +9,7 @@ module('Acceptance | Dashboard Filters', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  test('Test dashbaord filter flow', async function(assert) {
+  test('dashboard filter flow', async function(assert) {
     await visit('/dashboards/1/view');
 
     let dataRequests = [];
@@ -33,6 +33,7 @@ module('Acceptance | Dashboard Filters', function(hooks) {
       dataRequests.every(request => request.queryParams.filters == 'property|id-in[1]'),
       'each widget request has the right filter with property in 1'
     );
+    assert.equal(dataRequests.length, 3, 'three data requests were made (one for each widget)');
     dataRequests = [];
 
     await fillIn('.filter-builder-dimension__values input', '2');
@@ -42,6 +43,7 @@ module('Acceptance | Dashboard Filters', function(hooks) {
       dataRequests.every(request => request.queryParams.filters == 'property|id-in[1,2]'),
       'each widget request has the right filter with values of both 1 and 2'
     );
+    assert.equal(dataRequests.length, 3, 'three data requests were made (one for each widget)');
 
     await click('.dashboard-filters-expanded__add-filter-button');
     await selectChoose('.dashboard-dimension-selector', 'Platform');
@@ -60,6 +62,7 @@ module('Acceptance | Dashboard Filters', function(hooks) {
       dataRequests.every(request => request.queryParams.filters == 'platform|desc-contains[win],property|id-in[1,2]'),
       'each widget request has both filters present after new one is added'
     );
+    assert.equal(dataRequests.length, 3, 'three data requests were made (one for each widget)');
     dataRequests = [];
 
     await click('.filter-collection__remove:nth-child(1)');

--- a/packages/dashboards/tests/acceptance/dashboard-filter-test.js
+++ b/packages/dashboards/tests/acceptance/dashboard-filter-test.js
@@ -1,0 +1,91 @@
+import { click, fillIn, visit, triggerKeyEvent } from '@ember/test-helpers';
+import { selectChoose } from 'ember-power-select/test-support';
+import { module, test } from 'qunit';
+import config from 'ember-get-config';
+import { setupApplicationTest } from 'ember-qunit';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+module('Acceptance | Dashboard Filters', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  test('Test dashbaord filter flow', async function(assert) {
+    await visit('/dashboards/1/view');
+
+    let dataRequests = [];
+
+    server.urlPrefix = `${config.navi.dataSources[0].uri}/v1`;
+    server.pretender.handledRequest = (verb, url, req) => {
+      if (verb == 'GET' && url.includes('/v1/data')) {
+        dataRequests.push(req);
+      }
+    };
+
+    await click('.dashboard-filters__expand-button');
+    await click('.dashboard-filters-expanded__add-filter-button');
+
+    await selectChoose('.dashboard-dimension-selector', 'Property');
+
+    await fillIn('.filter-builder-dimension__values input', '1');
+    await selectChoose('.filter-builder-dimension__values', '.item-row', 0);
+
+    assert.ok(
+      dataRequests.every(request => request.queryParams.filters == 'property|id-in[1]'),
+      'each widget request has the right filter with property in 1'
+    );
+    dataRequests = [];
+
+    await fillIn('.filter-builder-dimension__values input', '2');
+    await selectChoose('.filter-builder-dimension__values', '.item-row', 0);
+
+    assert.ok(
+      dataRequests.every(request => request.queryParams.filters == 'property|id-in[1,2]'),
+      'each widget request has the right filter with values of both 1 and 2'
+    );
+
+    await click('.dashboard-filters-expanded__add-filter-button');
+    await selectChoose('.dashboard-dimension-selector', 'Platform');
+
+    await selectChoose('.filter-collection__row:nth-child(2) .filter-builder-dimension__operator', 'Contains');
+    await selectChoose('.filter-builder-dimension__field', 'desc');
+    await fillIn('.filter-collection__row:nth-child(2) .filter-builder-dimension__values input', 'win');
+    dataRequests = [];
+    await triggerKeyEvent(
+      '.filter-collection__row:nth-child(2) .filter-builder-dimension__values input',
+      'keydown',
+      'Enter'
+    );
+
+    assert.ok(
+      dataRequests.every(request => request.queryParams.filters == 'platform|desc-contains[win],property|id-in[1,2]'),
+      'each widget request has both filters present after new one is added'
+    );
+    dataRequests = [];
+
+    await click('.filter-collection__remove:nth-child(1)');
+
+    assert.ok(
+      dataRequests.every(request => request.queryParams.filters == 'platform|desc-contains[win]'),
+      'each widget request has the right filters after one has been removed'
+    );
+    dataRequests = [];
+
+    //test dashboard has the filter on save
+    let dashboardBody = {};
+
+    server.urlPrefix = config.navi.appPersistence.uri;
+    server.pretender.handledRequest = (verb, url, req) => {
+      if (verb == 'PATCH' && url.includes('/dashboards/1')) {
+        dashboardBody = JSON.parse(req.requestBody);
+      }
+    };
+
+    await click('.navi-dashboard__save-button');
+
+    assert.deepEqual(
+      dashboardBody.data.attributes.filters,
+      [{ dimension: 'platform', field: 'desc', operator: 'contains', values: ['win'] }],
+      'Correct filters are saved with the dashboard'
+    );
+  });
+});

--- a/packages/dashboards/tests/unit/services/dashboard-data-test.js
+++ b/packages/dashboards/tests/unit/services/dashboard-data-test.js
@@ -235,7 +235,7 @@ module('Unit | Service | dashboard data', function(hooks) {
       serialize() {
         return cloneDeep(this);
       },
-      addFilter(filter) {
+      addRawFilter(filter) {
         this.filters.push(filter);
       },
       logicalTable: {


### PR DESCRIPTION
<!-- The above line will close the issue upon merge -->

## Description

Bug where widgets do not get the values of the global dashboard filters added correctly to the request.

## Proposed Changes

- request `addFilter` does not do well when the input is already a data fragment class, so added`addRawFilter` which copies filter values via 'rawValues' which works better in that case and does not break things that are currently using `addFilter`
- big acceptance test

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
