### PR TITLE
Fix: Report run button always runs when clicked

### DIFF
--- a/packages/reports/addon/routes/reports/report.js
+++ b/packages/reports/addon/routes/reports/report.js
@@ -129,6 +129,15 @@ export default Route.extend({
     },
 
     /**
+     * @action forceRun
+     * transition to view subroute since the running is not handled here.
+     * @see routes.reports.report.view.actions.forceRun
+     */
+    forceRun(report) {
+      this.send('runReport', report);
+    },
+
+    /**
      * @action cancelReport
      * transition to edit subroute
      */

--- a/packages/reports/addon/routes/reports/report/view.js
+++ b/packages/reports/addon/routes/reports/report/view.js
@@ -132,6 +132,16 @@ export default Route.extend({
     },
 
     /**
+     * Forces the report to be rerun, used when user explicitly pushes run button.
+     *
+     * @action forceRun
+     * @returns {Transition} - refreshes model transition
+     */
+    forceRun() {
+      return this.refresh();
+    },
+
+    /**
      * Code to run before validating the request
      *
      * @action beforeValidate

--- a/packages/reports/addon/templates/reports/report.hbs
+++ b/packages/reports/addon/templates/reports/report.hbs
@@ -51,7 +51,7 @@
         class="btn btn-primary navi-report__run-btn"
         onclick={{pipe
           (route-action "validate" model)
-          (route-action "runReport" model)
+          (route-action "forceRun" model)
         }}
       >
         Run

--- a/packages/reports/tests/acceptance/navi-report-test.js
+++ b/packages/reports/tests/acceptance/navi-report-test.js
@@ -1752,4 +1752,39 @@ module('Acceptance | Navi Report', function(hooks) {
       'When not loading a report, the standard footer buttons are available'
     );
   });
+
+  test('Recreating same report after revert runs', async function(assert) {
+    await visit('/reports/2/view');
+
+    const columns = () => findAll('.table-widget__table-headers .table-header-cell').map(el => el.textContent.trim());
+    assert.deepEqual(columns(), ['Date', 'Property', 'Ad Clicks', 'Nav Clicks'], 'Report loads with expected columns');
+
+    await click(
+      findAll('.checkbox-selector--metric .grouped-list__item')
+        .find(el => el.textContent.trim() == 'Page Views')
+        .querySelector('.grouped-list__item-label')
+    );
+    await click('.navi-report__run-btn');
+    assert.deepEqual(
+      columns(),
+      ['Date', 'Property', 'Ad Clicks', 'Nav Clicks', 'Page Views'],
+      'Report changed and ran successfully'
+    );
+
+    await click('.navi-report__revert-btn');
+    assert.deepEqual(columns(), ['Date', 'Property', 'Ad Clicks', 'Nav Clicks'], 'Report revertted successfully');
+
+    //make same changes and make sure it's runnable
+    await click(
+      findAll('.checkbox-selector--metric .grouped-list__item')
+        .find(el => el.textContent.trim() == 'Page Views')
+        .querySelector('.grouped-list__item-label')
+    );
+    await click('.navi-report__run-btn');
+    assert.deepEqual(
+      columns(),
+      ['Date', 'Property', 'Ad Clicks', 'Nav Clicks', 'Page Views'],
+      'Report changed and ran successfully'
+    );
+  });
 });

--- a/packages/reports/tests/unit/routes/reports/report/view-test.js
+++ b/packages/reports/tests/unit/routes/reports/report/view-test.js
@@ -94,7 +94,7 @@ module('Unit | Route | reports/report/view', function(hooks) {
   });
 
   test('runReport action', function(assert) {
-    assert.expect(1);
+    assert.expect(2);
 
     let route = this.owner.factoryFor('route:reports/report/view').create({
       _hasRequestRun() {
@@ -114,5 +114,8 @@ module('Unit | Route | reports/report/view', function(hooks) {
     };
     route._hasRequestRun = () => false;
     route.send('runReport');
+
+    route._hasRequestRun = () => true;
+    route.send('forceRun');
   });
 });


### PR DESCRIPTION
## Description

Found bug that sometimes the Run button in reports won't run the report, even though you should.  This puts the report in an awkward state that's not easily correctable by the user.

See acceptance test for an example of this bad behavior.  changing a report, reverting, and changing it back to the same report breaks the run button functionality.

## Proposed Changes

- Change behavior of run button so that it will always run the report when clicked.

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
