### PR TITLE
Fix: Don't apply global dashboard filters that don't have values

### DIFF
--- a/packages/dashboards/addon/services/dashboard-data.js
+++ b/packages/dashboards/addon/services/dashboard-data.js
@@ -112,7 +112,9 @@ export default Service.extend({
   _applyFilters(dashboard, request) {
     const requestClone = request.clone();
 
-    this._getValidGlobalFilters(dashboard, request).forEach(filter => requestClone.addRawFilter(filter));
+    this._getValidGlobalFilters(dashboard, request)
+      .filter(filter => filter.rawValues.length > 0)
+      .forEach(filter => requestClone.addRawFilter(filter));
 
     return requestClone;
   },

--- a/packages/dashboards/tests/unit/services/dashboard-data-test.js
+++ b/packages/dashboards/tests/unit/services/dashboard-data-test.js
@@ -63,7 +63,7 @@ module('Unit | Service | dashboard data', function(hooks) {
 
     assert.deepEqual(service.fetchDataForWidgets(1, []), {}, 'no widgets returns empty data object');
 
-    const makeRequest = (data, filters) => ({
+    const makeRequest = (data, filters = []) => ({
       clone() {
         return cloneDeep(this);
       },
@@ -78,7 +78,7 @@ module('Unit | Service | dashboard data', function(hooks) {
         timeGrain: { dimensionIds: [] }
       },
       data,
-      filters: filters || []
+      filters
     });
 
     const dashboard = {
@@ -205,8 +205,9 @@ module('Unit | Service | dashboard data', function(hooks) {
   test('global filter application and error injection.', async function(assert) {
     assert.expect(4);
 
-    const VALID_FILTERS = ['dim1', 'dim3'];
-    const DASHBOARD_FILTERS = ['dim1', 'dim2'];
+    const VALID_FILTERS = ['dim1', 'dim3', 'dim4'];
+    const DASHBOARD_FILTERS = ['dim1', 'dim2', 'dim4'];
+    const NO_VALUE_FILTERS = ['dim4'];
 
     const service = this.owner.factoryFor('service:dashboard-data').create({
       _fetch(request) {
@@ -222,7 +223,11 @@ module('Unit | Service | dashboard data', function(hooks) {
       }
     });
 
-    const makeFilter = ({ dimension }) => ({ dimension: { name: dimension } });
+    const makeFilter = ({ dimension }) => {
+      const rawValues = NO_VALUE_FILTERS.includes(dimension) ? [] : ['1'];
+
+      return { dimension: { name: dimension }, rawValues };
+    };
 
     const dashboard = {
       filters: DASHBOARD_FILTERS.map(dimension => makeFilter({ dimension }))


### PR DESCRIPTION
## Description
Removing the last value of a global dashboard filter would result in decorating widget requests with a filter with no values which would result in a bad request error.

## Proposed Changes

- Don't apply filters that don't have at least one value

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
