### PR TITLE
Fix: Metric header alignment

### DIFF
--- a/packages/core/app/styles/navi-core/visualizations/table.less
+++ b/packages/core/app/styles/navi-core/visualizations/table.less
@@ -135,17 +135,6 @@
         &__title {
           flex: 1;
           overflow: hidden;
-          /* autoprefixer: off */
-          display: -webkit-box;
-          -webkit-line-clamp: @navi-table-max-wrap;
-          -webkit-box-orient: vertical;
-          /* autoprefixer: on */
-
-          &:hover {
-            /* autoprefixer: off */
-            -webkit-line-clamp: 40;
-            /* autoprefixer: on */
-          }
 
           &--custom-name {
             text-decoration: underline;
@@ -350,13 +339,11 @@
   }
 }
 
-@supports not (-webkit-line-clamp: @navi-table-max-wrap) {
-  .table-header-cell__title {
-    line-height: @navi-header-line-height;
-    max-height: @navi-header-line-height * @navi-table-max-wrap;
-    &:hover {
-      max-height: @navi-header-line-height * 40;
-    }
+.table-header-cell__title {
+  line-height: @navi-header-line-height;
+  max-height: @navi-header-line-height * @navi-table-max-wrap;
+  &:hover {
+    max-height: @navi-header-line-height * 40;
   }
 }
 


### PR DESCRIPTION
## Description

Fixes issue where metric table headers are left aligned.

## Proposed Changes

- clean-css, the minify module that ember uses, is dropping `-webkit-box-orient` property

As we already have a fallback for browsers that don't support line clamp we should just use that method instead.  We can optionally go with lineclamp once it's well supported among browsers and tools.

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
