### PR TITLE
Update: Add search placeholder to dashboard filter add component

### DIFF
--- a/packages/core/addon/components/power-select-search.js
+++ b/packages/core/addon/components/power-select-search.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2019, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ *
+ * Usage:
+ *   Pass to power-select component as "beforeOptionsComponent"
+ *   {{power-select
+ *     beforeOptionsComponent="power-select-search"
+ *   }}
+ */
+
+import BeforeOptionsComponent from 'ember-power-select/components/power-select/before-options';
+import layout from '../templates/components/power-select-search';
+
+export default BeforeOptionsComponent.extend({
+  layout
+});

--- a/packages/core/addon/templates/components/power-select-search.hbs
+++ b/packages/core/addon/templates/components/power-select-search.hbs
@@ -1,0 +1,17 @@
+{{!-- Copyright 2019, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{#if searchEnabled}}
+  <div class="ember-power-select-search navi-power-select-search">
+    {{navi-icon "search"}}
+    <input type="search" autocomplete="off"
+      autocorrect="off" autocapitalize="off"
+      spellcheck="false" role="combobox"
+      class="ember-power-select-search-input navi-power-select-search-input"
+      value={{select.searchText}}
+      aria-controls={{listboxId}}
+      placeholder={{searchPlaceholder}}
+      oninput={{onInput}}
+      onfocus={{onFocus}}
+      onblur={{onBlur}}
+      onkeydown={{action "onKeydown"}}>
+  </div>
+{{/if}}

--- a/packages/core/app/components/power-select-search.js
+++ b/packages/core/app/components/power-select-search.js
@@ -1,0 +1,1 @@
+export { default } from 'navi-core/components/power-select-search';

--- a/packages/core/app/styles/navi-core/components/index.less
+++ b/packages/core/app/styles/navi-core/components/index.less
@@ -13,3 +13,4 @@
 @import 'subtotal-dimension-select-trigger';
 @import 'navi-info-message';
 @import 'navi-loader';
+@import 'power-select-search';

--- a/packages/core/app/styles/navi-core/components/power-select-search.less
+++ b/packages/core/app/styles/navi-core/components/power-select-search.less
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2019, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+
+.navi-power-select-search {
+  border-bottom: 1px solid #aaaaaa;
+  color: @navi-gray-500;
+  display: flex;
+  flex-direction: row;
+
+  i.fa-search {
+    font-size: @font-size-base-large;
+    padding-top: 2px;
+  }
+
+  &-input.ember-power-select-search-input {
+    border: none;
+
+    &:focus {
+      border: none;
+    }
+  }
+}

--- a/packages/core/tests/integration/components/power-select-search-test.js
+++ b/packages/core/tests/integration/components/power-select-search-test.js
@@ -1,0 +1,57 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, blur, focus, triggerEvent, triggerKeyEvent } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | power-select-search', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('power-select-search', async function(assert) {
+    assert.expect(10);
+
+    this.set('searchEnabled', true);
+    this.set('placeholder', 'This is a placeholder');
+    this.set('select', {
+      searchText: '',
+      actions: {
+        search() {
+          return null; /*noop run on component teardown*/
+        }
+      }
+    });
+    this.set('onInput', () => assert.ok(true, 'onInput action is called on input'));
+    this.set('onFocus', () => assert.ok(true, 'onFocus action is called on focus'));
+    this.set('onBlur', () => assert.ok(true, 'onBlur action is called on blur'));
+    this.set('onKeydown', () => assert.ok(true, 'onKeydown action is called on keydown'));
+
+    await render(hbs`{{power-select-search
+      searchEnabled=searchEnabled
+      searchPlaceholder=placeholder
+      select=select
+      onInput=onInput
+      onFocus=onFocus
+      onBlur=onBlur
+      onKeydown=onKeydown
+    }}`);
+
+    assert.dom('.navi-power-select-search').isVisible('Renders when searchEnabled is true');
+
+    assert.dom('input').hasNoValue('No value when select.searchText is empty');
+    assert
+      .dom('input')
+      .hasAttribute('placeholder', 'This is a placeholder', 'Placeholder is used when no value is present');
+
+    this.set('select', { searchText: 'Some value' });
+
+    assert.dom('input').hasValue('Some value', 'Value is displayed when select.searchText is populated');
+    assert.dom('.fa-search').isVisible('Search icon is shown');
+
+    await focus('input');
+    await blur('input');
+    await triggerEvent('input', 'input');
+    await triggerKeyEvent('input', 'keydown', 8);
+
+    this.set('searchEnabled', false);
+    assert.dom('.navi-power-select-search').isNotVisible('Does not render when searchEnabled is true');
+  });
+});

--- a/packages/dashboards/addon/templates/components/dashboard-dimension-selector.hbs
+++ b/packages/dashboards/addon/templates/components/dashboard-dimension-selector.hbs
@@ -6,6 +6,7 @@
     searchField="longName"
     placeholder="Select a Dimension"
     searchPlaceholder="Search"
+    beforeOptionsComponent="power-select-search"
     as |dimension|
   }}
     {{dimension.longName}}

--- a/packages/dashboards/addon/templates/components/dashboard-dimension-selector.hbs
+++ b/packages/dashboards/addon/templates/components/dashboard-dimension-selector.hbs
@@ -5,6 +5,7 @@
     onchange=(action "change")
     searchField="longName"
     placeholder="Select a Dimension"
+    searchPlaceholder="Search"
     as |dimension|
   }}
     {{dimension.longName}}


### PR DESCRIPTION
## Description
Poor indication that a search bar is available when adding a filter in dashboard filters

## Proposed Changes

- Add custom search component to power-select with better indication

## Screenshots
![Screen Shot 2019-06-27 at 4 47 56 PM](https://user-images.githubusercontent.com/23023478/60303241-81003b00-98fb-11e9-818f-8103f05df526.png)

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
