### PR TITLE
Use y grid lines and provide better alignment for x axis labels

### DIFF
--- a/packages/core/addon/chart-builders/date-time.js
+++ b/packages/core/addon/chart-builders/date-time.js
@@ -83,7 +83,10 @@ export const GROUP = {
       year: {
         xValueCount: 366,
         getXValue: dateTime => dateTime.dayOfYear(),
-        getXDisplay: x => 'Day ' + x,
+        getXDisplay: x =>
+          moment()
+            .dayOfYear(x)
+            .format('MMM'),
         getSeries: dateTime => dateTime.format('YYYY')
       }
     }

--- a/packages/core/addon/components/navi-visualizations/line-chart.js
+++ b/packages/core/addon/components/navi-visualizations/line-chart.js
@@ -123,15 +123,15 @@ export default Component.extend({
     return merge(
       {},
       DEFAULT_OPTIONS,
-      get(this, 'options'),
-      get(this, 'dataConfig'),
-      get(this, 'dataSelectionConfig'),
-      { tooltip: get(this, 'chartTooltip') },
+      this.options,
+      this.dataConfig,
+      this.dataSelectionConfig,
+      { tooltip: this.chartTooltip },
       { point },
       { axis: { x: { type: 'category' } } }, // Override old 'timeseries' config saved in db
-      get(this, 'yAxisLabelConfig'),
-      get(this, 'yAxisDataFormat'),
-      get(this, 'xAxisTickValues')
+      this.yAxisLabelConfig,
+      this.yAxisDataFormat,
+      this.xAxisTickValues
     );
   }),
 
@@ -261,15 +261,10 @@ export default Component.extend({
     return owner.factoryFor(registryEntry);
   }),
 
-  xAxisTickValues: computed('model.firstObject', 'seriesConfig', function() {
-    const chartGrain = get(this, 'seriesConfig.config.timeGrain');
-    if (chartGrain !== 'year') {
-      return {};
-    }
-    const requestGrain =
-      get(this, 'model.firstObject.request.logicalTable.timeGrain.name') ||
-      get(this, 'model.firstObject.request.logicalTable.timeGrain');
-
+  /**
+   * @property {Object} xAxisTickValuesByGrain - x axis tick positions for day/week/month grain on year chart grain
+   */
+  xAxisTickValuesByGrain: computed(function() {
     const dayValues = [];
     for (let i = 0; i < 12; i++) {
       dayValues.push(
@@ -280,13 +275,27 @@ export default Component.extend({
       );
     }
 
-    const values = {
+    return {
       day: dayValues,
       // week.by.year in date-time is hardcoded to YEAR_WITH_53_ISOWEEKS (2015)
       week: [1, 5, 9, 13, 18, 22, 26, 31, 35, 39, 44, 48],
       month: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
-    }[requestGrain];
+    };
+  }),
 
+  /**
+   * @property {Object} xAxisTickValues - explicity specifies x axis tick positions for year chart grain
+   */
+  xAxisTickValues: computed('model.firstObject', 'seriesConfig', function() {
+    const chartGrain = get(this, 'seriesConfig.config.timeGrain');
+    if (chartGrain !== 'year') {
+      return {};
+    }
+    const requestGrain =
+      get(this, 'model.firstObject.request.logicalTable.timeGrain.name') ||
+      get(this, 'model.firstObject.request.logicalTable.timeGrain');
+
+    const values = this.xAxisTickValuesByGrain[requestGrain];
     return {
       axis: {
         x: {

--- a/packages/core/addon/components/navi-visualizations/line-chart.js
+++ b/packages/core/addon/components/navi-visualizations/line-chart.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018, Yahoo Holdings Inc.
+ * Copyright 2019, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Usage:
@@ -51,7 +51,7 @@ const DEFAULT_OPTIONS = {
     }
   },
   grid: {
-    x: { show: true }
+    y: { show: true }
   },
   point: {
     r: 0,

--- a/packages/core/app/styles/navi-core/variables/colors.less
+++ b/packages/core/app/styles/navi-core/variables/colors.less
@@ -13,6 +13,7 @@
 @navi-gray-700: #464e56;
 @navi-gray-800: #2d353e;
 @denali-gray-100: #f8f8f8;
+@denali-gray-200: #eaeaea;
 
 // blue
 @navi-blue-100: #f5f8fe;

--- a/packages/core/app/styles/navi-core/visualizations/line-chart.less
+++ b/packages/core/app/styles/navi-core/visualizations/line-chart.less
@@ -20,7 +20,7 @@
       }
     }
     path {
-      stroke: none;
+      stroke: @denali-gray-200;
     }
   }
 
@@ -29,7 +29,7 @@
   }
 
   .c3-grid line {
-    stroke: @navi-gray-200;
+    stroke: @denali-gray-200;
   }
 
   .c3-legend-item text {

--- a/packages/core/tests/unit/chart-builders/date-test.js
+++ b/packages/core/tests/unit/chart-builders/date-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { get } from '@ember/object';
 import Object from '@ember/object';
 import BuilderClass from 'navi-core/chart-builders/date-time';
-import TooltipTemplate from '../../../../navi-core/templates/chart-tooltips/date';
+import TooltipTemplate from 'navi-core/templates/chart-tooltips/date';
 
 const DateChartBuilder = BuilderClass.create();
 
@@ -148,7 +148,7 @@ module('Unit | Chart Builders | Date Time', function() {
       {
         x: {
           rawValue: 1,
-          displayValue: 'Day 1'
+          displayValue: 'Jan'
         },
         '2016': 1,
         '2015': 3

--- a/packages/core/tests/unit/components/navi-visualizations/line-chart-test.js
+++ b/packages/core/tests/unit/components/navi-visualizations/line-chart-test.js
@@ -6,6 +6,7 @@ import { run } from '@ember/runloop';
 import moment from 'moment';
 import { setupMock, teardownMock } from '../../../helpers/mirage-helper';
 import merge from 'lodash/merge';
+import { GROUP } from 'navi-core/chart-builders/date-time';
 
 let MetadataService;
 
@@ -547,5 +548,96 @@ module('Unit | Component | line chart', function(hooks) {
       tooltip.get('rowData.firstObject').hasOwnProperty('navClicks'),
       'New response has tooltip render has the right rowData'
     );
+  });
+
+  test('xAxisTickValues', function(assert) {
+    assert.expect(4);
+
+    const getModelDataFor = (start, end, timeGrain) => {
+      return {
+        response: {
+          rows: [
+            {
+              dateTime: start,
+              uniqueIdentifier: 172933788
+            },
+            {
+              dateTime: end,
+              uniqueIdentifier: 183206656
+            }
+          ]
+        },
+        request: {
+          logicalTable: {
+            timeGrain
+          },
+          intervals: [
+            {
+              start,
+              end
+            }
+          ]
+        }
+      };
+    };
+
+    let component = this.owner.factoryFor('component:navi-visualizations/line-chart').create();
+
+    component.set('options', {
+      axis: {
+        y: {
+          series: {
+            type: 'metric',
+            config: {
+              timeGrain: 'year'
+            }
+          }
+        }
+      }
+    });
+
+    const allMonths = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+    let grain = 'day';
+    component.set('model', A([getModelDataFor('2018-01-01T00:00:00.000Z', '2019-06-01T00:00:00.000Z', grain)]));
+    let xAxisTickValues = component.get('xAxisTickValues');
+    assert.deepEqual(
+      xAxisTickValues.axis.x.tick.values.map(x => GROUP[grain].by.year.getXDisplay(x + 1)),
+      allMonths,
+      `Create label for each month on ${grain} grain year chart`
+    );
+
+    grain = 'week';
+    component.set('model', A([getModelDataFor('2018-01-01 00:00:00.000', '2019-06-01 00:00:00.000', grain)]));
+    xAxisTickValues = component.get('xAxisTickValues');
+    assert.deepEqual(
+      xAxisTickValues.axis.x.tick.values.map(x => GROUP[grain].by.year.getXDisplay(x + 1)),
+      allMonths,
+      `Create label for each month on ${grain} grain year chart`
+    );
+
+    grain = 'month';
+    component.set('model', A([getModelDataFor('2018-01-01 00:00:00.000', '2019-06-01 00:00:00.000', grain)]));
+    xAxisTickValues = component.get('xAxisTickValues');
+    assert.deepEqual(
+      xAxisTickValues.axis.x.tick.values.map(x => GROUP[grain].by.year.getXDisplay(x + 1)),
+      allMonths,
+      `Create label for each month on ${grain} grain year chart`
+    );
+
+    component.set('options', {
+      axis: {
+        y: {
+          series: {
+            type: 'metric'
+          }
+        }
+      }
+    });
+
+    grain = 'day';
+    component.set('model', A([getModelDataFor('2018-01-01T00:00:00.000Z', '2019-06-01T00:00:00.000Z', grain)]));
+    xAxisTickValues = component.get('xAxisTickValues');
+    assert.deepEqual(xAxisTickValues, {}, 'Does not generate custom values for non-year timeGrain series');
   });
 });

--- a/packages/core/tests/unit/components/navi-visualizations/line-chart-test.js
+++ b/packages/core/tests/unit/components/navi-visualizations/line-chart-test.js
@@ -209,7 +209,7 @@ module('Unit | Component | line chart', function(hooks) {
           }
         },
         grid: {
-          x: { show: true }
+          y: { show: true }
         },
         point: {
           r: 0,

--- a/packages/reports/app/styles/navi-reports/components/report-view.less
+++ b/packages/reports/app/styles/navi-reports/components/report-view.less
@@ -63,7 +63,7 @@
     flex-flow: column;
     flex: 1;
     min-width: 0;
-    padding: 0 20px 10px 0px;
+    padding: 0 20px 10px 0;
   }
 
   &__visualization-no-results {

--- a/packages/reports/app/styles/navi-reports/components/report-view.less
+++ b/packages/reports/app/styles/navi-reports/components/report-view.less
@@ -55,7 +55,7 @@
     align-items: center;
     display: flex;
     justify-content: space-between;
-    margin: 10px 10px 5px;
+    margin: 10px 10px 25px;
   }
 
   &__visualization-main {
@@ -63,6 +63,7 @@
     flex-flow: column;
     flex: 1;
     min-width: 0;
+    padding: 0 20px 10px 0px;
   }
 
   &__visualization-no-results {


### PR DESCRIPTION
Update to #415 

## Description
The x axis grid lines don't always align to useful positions and it becomes confusing when x axis labels closely but don't perfectly align with them. 

## Proposed Changes

- Update grid lines to be on the y axis 
- Provide fixed x axis label positions for year chart grain

## Screenshots
<img width="700" src="https://user-images.githubusercontent.com/12093492/60292558-02979f00-98e3-11e9-84b7-204f49e1efb1.png">

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
