### PR TITLE
Fix: Tooltips in reports and directory

### DIFF
--- a/packages/dashboards/addon/templates/components/dashboard-action-list.hbs
+++ b/packages/dashboards/addon/templates/components/dashboard-action-list.hbs
@@ -1,13 +1,12 @@
-{{!-- Copyright 2018, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{!-- Copyright 2019, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 {{#with item as | dashboard |}}
-
   {{!-- Clone action enabled at all times --}}
   <li class="action">
     {{#link-to "dashboards.dashboard.clone" dashboard.id
       classNames="clone"
     }}
       {{navi-icon "copy" class="navi-icon__copy"}}
-      {{ember-tooltip text="Clone"}}
+      {{ember-tooltip text="Clone the dashboard"}}
     {{/link-to}}
   </li>
 
@@ -20,7 +19,7 @@
       tagName="li"
     }}
       {{navi-icon "download" class="navi-icon__download"}}
-      {{ember-tooltip text="PDF Export"}}
+      {{ember-tooltip text="Export the dashboard"}}
     {{/dashboard-actions/export}}
   {{/if}}
 
@@ -33,9 +32,7 @@
     disabled=(not item.validations.isTruelyValid)
   }}
     {{navi-icon "share" class="navi-icon__share"}}
-    {{#ember-tooltip}}
-      Share
-    {{/ember-tooltip}}
+    {{ember-tooltip text="Share the dashboard"}}
   {{/common-actions/share}}
 
   {{!-- Delete action visible when user owns the Dashboard --}}
@@ -44,6 +41,7 @@
     {{#if (feature-flag "enableScheduleDashboards")}}
       {{#dashboard-actions/schedule
         tagName="li"
+        id=(concat "navi-dashboard-action-schedule-" index)
         model=dashboard
         classNames="action schedule"
         disabled=(not item.validations.isTruelyValid)
@@ -51,7 +49,7 @@
         onRevert=(delivery-rule-action "REVERT_DELIVERY_RULE")
         onDelete=(delivery-rule-action "DELETE_DELIVERY_RULE")
       }}
-        {{#ember-tooltip}}
+        {{#ember-tooltip targetId=(concat "navi-dashboard-action-schedule-" index)}}
           {{if item.validations.isTruelyValid "Schedule the dashboard" "Validate dashboard to enable scheduling"}}
         {{/ember-tooltip}}
       {{/dashboard-actions/schedule}}

--- a/packages/directory/addon/templates/components/dir-asset-row-actions.hbs
+++ b/packages/directory/addon/templates/components/dir-asset-row-actions.hbs
@@ -2,5 +2,6 @@
 {{#lazy-render target=rowElement}}
   {{component (get assetActionComponents type)
     item=value
+    index=row.rowId
   }}
 {{/lazy-render}}

--- a/packages/directory/app/styles/navi-directory/components/dir-asset-row-actions.less
+++ b/packages/directory/app/styles/navi-directory/components/dir-asset-row-actions.less
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018, Yahoo Holdings Inc.
+ * Copyright 2019, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 .dir-asset-row-actions {
@@ -14,6 +14,9 @@
     text-align: left;
 
     .action {
+      height: 17px;
+      line-height: 17px;
+      margin-bottom: 2px;
       margin-right: 15px;
       visibility: hidden;
     }
@@ -30,7 +33,6 @@
     }
   }
 
-  .edit,
   .clone,
   .export,
   .share,
@@ -38,11 +40,23 @@
   .schedule,
   button {
     color: @navi-gray-500;
-    line-height: 17px;
+    cursor: pointer;
+    font-size: 14px;
+    height: 17px;
     padding: 0;
     vertical-align: bottom;
+
     &:hover {
       color: @navi-black;
+    }
+
+    &:disabled,
+    &.disabled {
+      cursor: not-allowed;
+
+      &:hover {
+        color: @navi-gray-500;
+      }
     }
   }
 }

--- a/packages/reports/addon/templates/components/common-actions/share.hbs
+++ b/packages/reports/addon/templates/components/common-actions/share.hbs
@@ -1,7 +1,7 @@
-{{!-- Copyright 2018, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{!-- Copyright 2019, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 
 {{!-- Check if in need of disabling the button on click --}}
-<button class="btn" type="button" disabled={{disabled}}  onclick={{toggle "showModal" this}}>
+<button class="btn" type="button" disabled={{disabled}} onclick={{toggle "showModal" this}}>
   {{yield}}
 </button>
 

--- a/packages/reports/addon/templates/components/navi-action-list.hbs
+++ b/packages/reports/addon/templates/components/navi-action-list.hbs
@@ -1,4 +1,4 @@
-{{!-- Copyright 2018, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{!-- Copyright 2019, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 {{#with item as | report |}}
 
   {{!-- Clone only enabled on a saved report --}}
@@ -28,9 +28,10 @@
     classNames="navi-reports-index__report-control action export"
     classNameBindings="item.request.validations.isTruelyValid::navi-report__action-link--force-disabled"
     tagName="li"
+    id=(concat "navi-report-action-export-" index)
   }}
     {{navi-icon "download"}}
-    {{#ember-tooltip}}
+    {{#ember-tooltip targetId=(concat "navi-report-action-export-" index)}}
       {{if item.request.validations.isTruelyValid "Export the report" "Run a valid report to enable export"}}
     {{/ember-tooltip}}
   {{/component}}
@@ -38,6 +39,7 @@
   {{!-- Share only enabled on a saved report --}}
   {{#common-actions/share
     tagName="li"
+    id=(concat "navi-report-action-share-" index)
     pageTitle=report.title
     buildUrl=(action "buildUrl" report)
     disabled=item.isNew
@@ -45,7 +47,7 @@
     classNameBindings="item.isNew:navi-report__action--is-disabled"
   }}
     {{navi-icon "share"}}
-    {{#ember-tooltip}}
+    {{#ember-tooltip targetId=(concat "navi-report-action-share-" index)}}
       {{if item.isNew "Save report to enable share" "Share the report"}}
     {{/ember-tooltip}}
   {{/common-actions/share}}
@@ -57,6 +59,7 @@
       {{#common-actions/schedule
         model=report
         tagName="li"
+        id=(concat "navi-report-action-schedule-" index)
         classNames="navi-reports-index__report-control action schedule"
         disabled=(not item.request.validations.isTruelyValid)
         onSave=(delivery-rule-action "SAVE_DELIVERY_RULE")
@@ -64,7 +67,7 @@
         onDelete=(delivery-rule-action "DELETE_DELIVERY_RULE")
         classNameBindings="item.request.validations.isTruelyValid::navi-report__action--is-disabled"
       }}
-        {{#ember-tooltip}}
+        {{#ember-tooltip targetId=(concat "navi-report-action-schedule-" index)}}
           {{if item.request.validations.isTruelyValid "Schedule the report" "Validate report to enable scheduling"}}
         {{/ember-tooltip}}
       {{/common-actions/schedule}}
@@ -72,7 +75,7 @@
     {{!-- Delete Action enabled on an owned report --}}
     {{#common-actions/delete
       tagName="li"
-      classNames="action delete"
+      classNames="navi-reports-index__report-control action delete"
       model=report
       warnMsg=(if (await report.loadDeliveryRuleForUser)
             "Are you sure you want to delete this report and the associated schedule?"

--- a/packages/reports/addon/templates/components/navi-collection.hbs
+++ b/packages/reports/addon/templates/components/navi-collection.hbs
@@ -49,6 +49,7 @@
               {{#lazy-render target=(concat ".navi-collection__row" index)}}
                 {{component config.actions
                   item=item
+                  index=index
                 }}
               {{/lazy-render}}
             </td>

--- a/packages/reports/addon/templates/components/report-actions/multiple-format-export.hbs
+++ b/packages/reports/addon/templates/components/report-actions/multiple-format-export.hbs
@@ -1,6 +1,6 @@
-{{!-- Copyright 2017, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{!-- Copyright 2019, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 
-{{#basic-dropdown-hover openDelay=0 renderInPlace=true as |dd|}}
+{{#basic-dropdown-hover delay=0 renderInPlace=true as |dd|}}
   {{#dd.trigger onMouseDown=(action "open")}}
     {{yield}}
   {{/dd.trigger}}

--- a/packages/reports/addon/templates/partials/report-actions.hbs
+++ b/packages/reports/addon/templates/partials/report-actions.hbs
@@ -1,4 +1,4 @@
-{{!-- Copyright 2018, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{!-- Copyright 2019, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 
 {{!-- Add to Dashboard visible if a report has been run--}}
 {{#if (and (feature-flag "dashboards") model.request.validations.isTruelyValid)}}
@@ -13,8 +13,8 @@
     }}
       {{navi-icon "th-large" class="navi-report__action-icon"}}
       Add to Dashboard
-      {{ember-tooltip text="Add visualization to Dashboard"}}
     {{/report-actions/add-to-dashboard}}
+    {{ember-tooltip text="Add visualization to Dashboard"}}
   </li>
 {{/if}}
 
@@ -28,10 +28,10 @@
   }}
     {{navi-icon "code" class="navi-report__action-icon"}}
     Copy API Query
-    {{#ember-tooltip}}
-      {{if model.request.validations.isTruelyValid "Copy API Query of the report" "Run a valid report to enable Copy API Query"}}
-    {{/ember-tooltip}}
   {{/common-actions/get-api}}
+  {{#ember-tooltip}}
+    {{if model.request.validations.isTruelyValid "Copy API Query of the report" "Run a valid report to enable Copy API Query"}}
+  {{/ember-tooltip}}
 </li>
 
 {{!-- Clone only enabled on a Saved report --}}
@@ -44,10 +44,10 @@
   }}
     {{navi-icon "copy" class="navi-report__action-icon"}}
     Clone
-    {{#ember-tooltip}}
-      {{if model.isNew "Save report to enable clone" "Clone the report"}}
-    {{/ember-tooltip}}
   {{/link-to}}
+  {{#ember-tooltip}}
+    {{if model.isNew "Save report to enable clone" "Clone the report"}}
+  {{/ember-tooltip}}
 </li>
 
 {{!-- Export only enabled on a valid report --}}
@@ -61,10 +61,10 @@
   }}
     {{navi-icon "download" class="navi-report__action-icon"}}
     Export
-    {{#ember-tooltip}}
-      {{if model.request.validations.isTruelyValid "Export the report" "Run a valid report to enable export"}}
-    {{/ember-tooltip}}
   {{/component}}
+  {{#ember-tooltip}}
+    {{if model.request.validations.isTruelyValid "Export the report" "Run a valid report to enable export"}}
+  {{/ember-tooltip}}
 </li>
 
 {{!-- Share only enabled on a Valid saved report --}}
@@ -76,10 +76,10 @@
   }}
     {{navi-icon "share" class="navi-report__action-icon"}}
     Share
-    {{#ember-tooltip}}
-      {{if model.isNew "Save report to enable share" "Share the report"}}
-    {{/ember-tooltip}}
   {{/common-actions/share}}
+  {{#ember-tooltip}}
+    {{if model.isNew "Save report to enable share" "Share the report"}}
+  {{/ember-tooltip}}
 </li>
 
 {{#if model.isOwner}}
@@ -95,8 +95,8 @@
         onSave=(delivery-rule-action "SAVE_DELIVERY_RULE")
       }}
         Schedule
-        {{ember-tooltip text="Schedule a report run"}}
       {{/common-actions/schedule}}
+      {{ember-tooltip text="Schedule a report run"}}
     </li>
   {{/if}}
 
@@ -108,7 +108,7 @@
     }}
       {{navi-icon "trash-o" class="navi-report__action-icon"}}
       Delete
-      {{ember-tooltip text="Delete the report"}}
     {{/common-actions/delete}}
+    {{ember-tooltip text="Delete the report"}}
   </li>
 {{/if}}

--- a/packages/reports/app/styles/navi-reports/components/reports-index.less
+++ b/packages/reports/app/styles/navi-reports/components/reports-index.less
@@ -18,19 +18,21 @@
   }
 
   &__report-control {
-    margin-left: 0;
-    margin-right: 15px;
     display: inline-block;
+    margin: 0 15px 2px 0;
   }
 
-  .edit,
   .clone,
   .export,
   .share,
+  .schedule,
   .delete {
+    color: @navi-gray-500;
+    cursor: pointer;
+    height: 17px;
     line-height: 17px;
     vertical-align: bottom;
-    color: @navi-gray-500;
+
     &:hover {
       color: @navi-black;
     }
@@ -49,6 +51,7 @@
   cursor: pointer;
   font-family: @font-family-sans-serif;
   font-size: 14px;
+  height: 17px;
   line-height: 17px;
   margin: 0;
   padding: 0;
@@ -56,5 +59,14 @@
 
   &:hover {
     color: @navi-black;
+  }
+
+  &:disabled,
+  &.disabled {
+    cursor: not-allowed;
+
+    &:hover {
+      color: @navi-gray-500;
+    }
   }
 }


### PR DESCRIPTION
## Description

This fixed a few issues with the tooltips:

❌ Current (second row is an unsaved report):
- **export** expands vertically
- **export** remains visible when not hovering
- **schedule** is never visible
- for unsaved reports, **share** is never visible and button cursor/color styles are not disabled
- overall vertical alignment

![old-1](https://user-images.githubusercontent.com/13946669/60471969-cb472c00-9c1b-11e9-8bb1-e918cfd024ab.gif)

✅ Fixed:

![fixed-1](https://user-images.githubusercontent.com/13946669/60471971-cedab300-9c1b-11e9-849a-4ba637fb49d3.gif)

❌ Current:
- line breaks in **export**
- **export** remains visible when not hovering

![old-2](https://user-images.githubusercontent.com/13946669/60471970-cd10ef80-9c1b-11e9-99cb-7610de315a27.gif)

✅ Fixed:

![fixed-2](https://user-images.githubusercontent.com/13946669/60471975-d0a47680-9c1b-11e9-9c48-b48de5188019.gif)

## Proposed Changes

- fix parent elements of some tooltips, manually set `targetId` attribute  when necessary.
- setting `delay=0` instead of only `openDelay=0` for `basic-dropdown-hover` seems to fix the issue of export remaining visible.
- css changes

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
