### PR TITLE
Fix: Support Ember 2.x

### DIFF
--- a/packages/core/addon/components/navi-visualizations/bar-chart.js
+++ b/packages/core/addon/components/navi-visualizations/bar-chart.js
@@ -10,7 +10,7 @@
  */
 
 import LineChart from './line-chart';
-import { computed } from '@ember/object';
+import { computed, get } from '@ember/object';
 
 //TODO add a base class for charts
 export default LineChart.extend({
@@ -27,6 +27,6 @@ export default LineChart.extend({
    * @property {String} c3ChartType - c3 chart type
    */
   c3ChartType: computed('chartType', function() {
-    return this.chartType;
+    return get(this, 'chartType');
   })
 });

--- a/packages/core/addon/components/navi-visualizations/line-chart.js
+++ b/packages/core/addon/components/navi-visualizations/line-chart.js
@@ -234,7 +234,7 @@ export default Component.extend({
       return area ? `area-${curve}` : curve;
     }
 
-    return get(this, 'chartType');
+    return this.chartType;
   }),
 
   /**

--- a/packages/core/addon/components/navi-visualizations/line-chart.js
+++ b/packages/core/addon/components/navi-visualizations/line-chart.js
@@ -127,15 +127,15 @@ export default Component.extend({
     return merge(
       {},
       DEFAULT_OPTIONS,
-      this.options,
-      this.dataConfig,
-      this.dataSelectionConfig,
-      { tooltip: this.chartTooltip },
+      get(this, 'options'),
+      get(this, 'dataConfig'),
+      get(this, 'dataSelectionConfig'),
+      { tooltip: get(this, 'chartTooltip') },
       { point },
       { axis: { x: { type: 'category' } } }, // Override old 'timeseries' config saved in db
-      this.yAxisLabelConfig,
-      this.yAxisDataFormat,
-      this.xAxisTickValues
+      get(this, 'yAxisLabelConfig'),
+      get(this, 'yAxisDataFormat'),
+      get(this, 'xAxisTickValues')
     );
   }),
 
@@ -212,7 +212,7 @@ export default Component.extend({
 
     return {
       data: {
-        type: this.c3ChartType,
+        type: get(this, 'c3ChartType'),
         json: seriesData,
         selection: {
           enabled: true
@@ -225,7 +225,7 @@ export default Component.extend({
    * @property {String} c3ChartType - c3 chart type to determine line behavior
    */
   c3ChartType: computed('options', 'chartType', function() {
-    const options = merge({}, DEFAULT_OPTIONS, this.options),
+    const options = merge({}, DEFAULT_OPTIONS, get(this, 'options')),
       { curve, area } = options.style;
 
     if (curve === 'line') {
@@ -234,7 +234,7 @@ export default Component.extend({
       return area ? `area-${curve}` : curve;
     }
 
-    return this.chartType;
+    return get(this, 'chartType');
   }),
 
   /**

--- a/packages/core/addon/components/visualization-config/line-chart.js
+++ b/packages/core/addon/components/visualization-config/line-chart.js
@@ -54,7 +54,7 @@ export default Component.extend({
      * @param {String|Boolean} - value to update the setting with.
      */
     onUpdateStyle(field, value) {
-      const { options } = this;
+      const options = get(this, 'options');
       let newOptions = copy(options);
       set(newOptions, 'style', Object.assign({}, newOptions.style, { [field]: value }));
       this.onUpdateConfig(newOptions);


### PR DESCRIPTION
## Description
Fixes issue where charts wouldn't work with old ember versions

## Proposed Changes

- Make sure we use `get` until we drop 2.x support

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
