### PR TITLE
Update: Fix direct query param fetch from transition object deprecation

### DIFF
--- a/packages/app/package-lock.json
+++ b/packages/app/package-lock.json
@@ -3127,6 +3127,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
+      "optional": true,
       "requires": {
         "hoek": "2.x.x"
       }
@@ -4734,6 +4735,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "dev": true,
+      "optional": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -5497,7 +5499,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "delegate": {
       "version": "3.2.0",
@@ -11700,7 +11703,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "fake-xml-http-request": {
       "version": "2.0.0",
@@ -12377,24 +12381,29 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -12404,13 +12413,17 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -12418,34 +12431,43 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -12454,25 +12476,29 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -12481,13 +12507,15 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -12503,7 +12531,8 @@
         },
         "glob": {
           "version": "7.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -12517,13 +12546,15 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -12532,7 +12563,8 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -12541,7 +12573,8 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -12551,46 +12584,58 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -12598,7 +12643,8 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -12607,21 +12653,25 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
         },
         "ms": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -12632,7 +12682,8 @@
         },
         "node-pre-gyp": {
           "version": "0.12.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -12650,7 +12701,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -12660,13 +12712,15 @@
         },
         "npm-bundled": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -12676,7 +12730,8 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -12688,38 +12743,46 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -12729,19 +12792,22 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -12753,7 +12819,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
             }
@@ -12761,7 +12828,8 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -12776,7 +12844,8 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -12785,43 +12854,52 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.7.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -12830,7 +12908,8 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -12839,21 +12918,25 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -12868,13 +12951,15 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -12883,13 +12968,17 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -13645,7 +13734,8 @@
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -14418,7 +14508,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "jsesc": {
       "version": "0.5.0",
@@ -16111,6 +16202,131 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "navi-core": {
+      "version": "0.1.0",
+      "dev": true,
+      "requires": {
+        "@html-next/vertical-collection": "^1.0.0-beta.12",
+        "ember-auto-import": "^1.2.21",
+        "ember-cli-babel": "^7.1.2",
+        "ember-cli-format-number": "2.0.0",
+        "ember-cli-htmlbars": "^3.0.0",
+        "ember-cli-string-helpers": "^1.8.1",
+        "ember-collection": "1.0.0-alpha.9",
+        "ember-composable-helpers": "^2.1.0",
+        "ember-concurrency": "~0.8.27",
+        "ember-copy": "^1.0.0",
+        "ember-cp-validations": "^4.0.0-beta.6",
+        "ember-data-model-fragments": "~4.0.0",
+        "ember-debounced-properties": "0.0.5",
+        "ember-fetch": "^6.5.1",
+        "ember-get-config": "0.2.4",
+        "ember-lodash": "^4.19.4",
+        "ember-math-helpers": "^2.3.0",
+        "ember-moment": "7.5.0",
+        "ember-radio-button": "^1.2.1",
+        "ember-resize": "^0.2.4",
+        "ember-sortable": "1.12.3",
+        "ember-tether": "^1.0.0",
+        "ember-toggle": "^5.2.1",
+        "ember-tooltips": "^2.10.0",
+        "ember-truth-helpers": "^2.0.0",
+        "json-url": "~2.4.1",
+        "resize-observer-polyfill": "^1.5.1"
+      }
+    },
+    "navi-dashboards": {
+      "version": "0.1.0",
+      "dev": true,
+      "requires": {
+        "ember-ajax": "^5.0.0",
+        "ember-cli-babel": "^7.5.0",
+        "ember-cli-htmlbars": "^3.0.1",
+        "ember-collection": "1.0.0-alpha.9",
+        "ember-composable-helpers": "^2.2.0",
+        "ember-concurrency": "~0.8.27",
+        "ember-cp-validations": "^3.5.4",
+        "ember-data-model-fragments": "~4.0.0",
+        "ember-get-config": "0.2.4",
+        "ember-gridstack": "1.3.0",
+        "ember-lodash": "^4.19.4",
+        "ember-math-helpers": "^2.10.0",
+        "ember-modal-dialog": "^2.4.3",
+        "ember-moment": "7.8.1",
+        "ember-promise-helpers": "^1.0.6",
+        "ember-route-action-helper": "^2.0.6",
+        "ember-sortable": "1.12.6",
+        "ember-tag-input": "^1.2.2",
+        "ember-tether": "^1.0.0",
+        "ember-toggle": "5.3.2",
+        "ember-tooltips": "^3.2.0",
+        "ember-transition-helper": "^1.0.0",
+        "ember-truth-helpers": "^2.1.0",
+        "ember-uuid": "^1.0.1",
+        "liquid-fire": "^0.29.5"
+      }
+    },
+    "navi-data": {
+      "version": "0.1.0",
+      "dev": true,
+      "requires": {
+        "ember-ajax": "^3.1.0",
+        "ember-cli-babel": "^7.1.2",
+        "ember-cli-htmlbars": "^3.0.0",
+        "ember-get-config": "0.2.4",
+        "ember-lodash": "^4.19.4"
+      }
+    },
+    "navi-directory": {
+      "version": "0.1.0",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.1.2",
+        "ember-cli-htmlbars": "^3.0.0",
+        "ember-data-model-fragments": "~4.0.0",
+        "ember-get-config": "^0.2.4",
+        "ember-light-table": "^1.13.1",
+        "ember-power-select": "^2.2.3",
+        "ember-responsive": "^3.0.0-beta.3",
+        "ember-tether": "^1.0.0"
+      }
+    },
+    "navi-reports": {
+      "version": "0.1.0",
+      "dev": true,
+      "requires": {
+        "@ember/jquery": "^0.6.0",
+        "@ember/optional-features": "^0.6.4",
+        "@html-next/vertical-collection": "^1.0.0-beta.12",
+        "ember-ajax": "^5.0.0",
+        "ember-cli-babel": "^7.1.2",
+        "ember-cli-clipboard": "^0.8.1",
+        "ember-cli-htmlbars": "^3.0.0",
+        "ember-cli-node-assets": "0.2.2",
+        "ember-cli-shims": "^1.2.0",
+        "ember-cli-string-helpers": "^1.6.0",
+        "ember-collection": "1.0.0-alpha.9",
+        "ember-compatibility-helpers": "^1.2.0",
+        "ember-composable-helpers": "^2.2.0",
+        "ember-concurrency": "~0.8.27",
+        "ember-cp-validations": "^3.5.4",
+        "ember-data-model-fragments": "~4.0.0",
+        "ember-modal-dialog": "^2.4.1",
+        "ember-moment": "7.8.1",
+        "ember-pluralize": "0.2.0",
+        "ember-promise-helpers": "^1.0.6",
+        "ember-radio-button": "^1.2.1",
+        "ember-route-action-helper": "2.0.6",
+        "ember-tag-input": "1.2.1",
+        "ember-tether": "^1.0.0",
+        "ember-toggle": "5.3.2",
+        "ember-tooltips": "^3.2.0",
+        "ember-truth-helpers": "^2.0.0",
+        "ember-uuid": "^1.0.0",
+        "ember-validators": "^1.1.1",
+        "liquid-fire": "^0.29.2"
+      }
+    },
     "negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
@@ -16329,7 +16545,8 @@
       "dependencies": {
         "ansi-align": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
           "dev": true,
           "requires": {
             "string-width": "^2.0.0"
@@ -16337,12 +16554,14 @@
         },
         "ansi-regex": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
@@ -16350,12 +16569,14 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "boxen": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
           "dev": true,
           "requires": {
             "ansi-align": "^2.0.0",
@@ -16369,7 +16590,8 @@
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -16378,22 +16600,26 @@
         },
         "builtins": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
           "dev": true
         },
         "camelcase": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "dev": true
         },
         "capture-stack-trace": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
           "dev": true
         },
         "chalk": {
           "version": "2.3.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -16403,17 +16629,20 @@
         },
         "ci-info": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
           "dev": true
         },
         "cli-boxes": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
           "dev": true
         },
         "cliui": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
           "dev": true,
           "requires": {
             "string-width": "^2.1.1",
@@ -16423,12 +16652,14 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "color-convert": {
           "version": "1.9.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
           "dev": true,
           "requires": {
             "color-name": "^1.1.1"
@@ -16436,17 +16667,20 @@
         },
         "color-name": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "configstore": {
           "version": "3.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
           "dev": true,
           "requires": {
             "dot-prop": "^4.1.0",
@@ -16459,7 +16693,8 @@
         },
         "create-error-class": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
           "dev": true,
           "requires": {
             "capture-stack-trace": "^1.0.0"
@@ -16467,7 +16702,8 @@
         },
         "cross-spawn": {
           "version": "5.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
           "requires": {
             "lru-cache": "^4.0.1",
@@ -16477,22 +16713,26 @@
         },
         "crypto-random-string": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
           "dev": true
         },
         "decamelize": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
           "dev": true
         },
         "deep-extend": {
           "version": "0.4.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
           "dev": true
         },
         "dot-prop": {
           "version": "4.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
           "dev": true,
           "requires": {
             "is-obj": "^1.0.0"
@@ -16500,22 +16740,26 @@
         },
         "dotenv": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==",
           "dev": true
         },
         "duplexer3": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
           "dev": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         },
         "execa": {
           "version": "0.7.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "dev": true,
           "requires": {
             "cross-spawn": "^5.0.1",
@@ -16529,7 +16773,8 @@
         },
         "find-up": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
             "locate-path": "^2.0.0"
@@ -16537,22 +16782,26 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true
         },
         "get-caller-file": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
           "dev": true
         },
         "get-stream": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         },
         "glob": {
           "version": "7.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -16565,7 +16814,8 @@
         },
         "global-dirs": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
           "dev": true,
           "requires": {
             "ini": "^1.3.4"
@@ -16573,7 +16823,8 @@
         },
         "got": {
           "version": "6.7.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
           "dev": true,
           "requires": {
             "create-error-class": "^3.0.0",
@@ -16591,32 +16842,38 @@
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true
         },
         "has-flag": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
         "hosted-git-info": {
           "version": "2.6.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
           "dev": true
         },
         "import-lazy": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
           "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
             "once": "^1.3.0",
@@ -16625,22 +16882,26 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true
         },
         "invert-kv": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
           "dev": true
         },
         "is-ci": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
           "dev": true,
           "requires": {
             "ci-info": "^1.0.0"
@@ -16648,12 +16909,14 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "is-installed-globally": {
           "version": "0.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
           "dev": true,
           "requires": {
             "global-dirs": "^0.1.0",
@@ -16662,17 +16925,20 @@
         },
         "is-npm": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
           "dev": true
         },
         "is-obj": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
           "dev": true
         },
         "is-path-inside": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
           "dev": true,
           "requires": {
             "path-is-inside": "^1.0.1"
@@ -16680,27 +16946,32 @@
         },
         "is-redirect": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
           "dev": true
         },
         "is-retry-allowed": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
           "dev": true
         },
         "is-stream": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
           "dev": true
         },
         "latest-version": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
           "dev": true,
           "requires": {
             "package-json": "^4.0.0"
@@ -16708,7 +16979,8 @@
         },
         "lcid": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
           "dev": true,
           "requires": {
             "invert-kv": "^1.0.0"
@@ -16716,7 +16988,8 @@
         },
         "libnpx": {
           "version": "10.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-X28coei8/XRCt15cYStbLBph+KGhFra4VQhRBPuH/HHMkC5dxM8v24RVgUsvODKCrUZ0eTgiTqJp6zbl0sskQQ==",
           "dev": true,
           "requires": {
             "dotenv": "^5.0.1",
@@ -16731,7 +17004,8 @@
         },
         "locate-path": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
             "p-locate": "^2.0.0",
@@ -16740,12 +17014,14 @@
         },
         "lowercase-keys": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
           "dev": true
         },
         "lru-cache": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
           "dev": true,
           "requires": {
             "pseudomap": "^1.0.2",
@@ -16754,7 +17030,8 @@
         },
         "make-dir": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
           "dev": true,
           "requires": {
             "pify": "^3.0.0"
@@ -16762,7 +17039,8 @@
         },
         "mem": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
           "dev": true,
           "requires": {
             "mimic-fn": "^1.0.0"
@@ -16770,12 +17048,14 @@
         },
         "mimic-fn": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
           "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -16783,12 +17063,14 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "npm": {
           "version": "5.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-pt5ClxEmY/dLpb60SmGQQBKi3nB6Ljx1FXmpoCUdAULlGqGVn2uCyXxPCWFbcuHGthT7qGiaGa1wOfs/UjGYMw==",
           "dev": true,
           "requires": {
             "JSONStream": "~1.3.1",
@@ -16891,7 +17173,8 @@
           "dependencies": {
             "JSONStream": {
               "version": "1.3.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
               "dev": true,
               "requires": {
                 "jsonparse": "^1.2.0",
@@ -16900,54 +17183,64 @@
               "dependencies": {
                 "jsonparse": {
                   "version": "1.3.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
                   "dev": true
                 },
                 "through": {
                   "version": "2.3.8",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
                   "dev": true
                 }
               }
             },
             "abbrev": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
               "dev": true
             },
             "ansi-regex": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
               "dev": true
             },
             "ansicolors": {
               "version": "0.3.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
               "dev": true
             },
             "ansistyles": {
               "version": "0.1.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
               "dev": true
             },
             "aproba": {
               "version": "1.1.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw==",
               "dev": true
             },
             "archy": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
               "dev": true
             },
             "bluebird": {
               "version": "3.5.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
               "dev": true
             },
             "cacache": {
               "version": "9.2.9",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-ghg1j5OyTJ6qsrqU++dN23QiTDxb5AZCFGsF3oB+v9v/gY+F4X8L/0gdQMEjd+8Ot3D29M2etX5PKozHRn2JQw==",
               "dev": true,
               "requires": {
                 "bluebird": "^3.5.0",
@@ -16967,7 +17260,8 @@
               "dependencies": {
                 "lru-cache": {
                   "version": "4.1.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
                   "dev": true,
                   "requires": {
                     "pseudomap": "^1.0.2",
@@ -16976,36 +17270,42 @@
                   "dependencies": {
                     "pseudomap": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
                       "dev": true
                     },
                     "yallist": {
                       "version": "2.1.2",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
                       "dev": true
                     }
                   }
                 },
                 "y18n": {
                   "version": "3.2.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
                   "dev": true
                 }
               }
             },
             "call-limit": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-b9YbA/PaQqLNDsK2DwK9DnGZH+o=",
               "dev": true
             },
             "chownr": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
               "dev": true
             },
             "cmd-shim": {
               "version": "2.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
               "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
@@ -17014,7 +17314,8 @@
             },
             "columnify": {
               "version": "1.5.4",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
               "dev": true,
               "requires": {
                 "strip-ansi": "^3.0.0",
@@ -17023,7 +17324,8 @@
               "dependencies": {
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "dev": true,
                   "requires": {
                     "ansi-regex": "^2.0.0"
@@ -17031,14 +17333,16 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                       "dev": true
                     }
                   }
                 },
                 "wcwidth": {
                   "version": "1.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
                   "dev": true,
                   "requires": {
                     "defaults": "^1.0.3"
@@ -17046,7 +17350,8 @@
                   "dependencies": {
                     "defaults": {
                       "version": "1.0.3",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
                       "dev": true,
                       "requires": {
                         "clone": "^1.0.2"
@@ -17054,7 +17359,8 @@
                       "dependencies": {
                         "clone": {
                           "version": "1.0.2",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
                           "dev": true
                         }
                       }
@@ -17065,7 +17371,8 @@
             },
             "config-chain": {
               "version": "1.1.11",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
               "dev": true,
               "requires": {
                 "ini": "^1.3.4",
@@ -17074,24 +17381,28 @@
               "dependencies": {
                 "proto-list": {
                   "version": "1.2.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
                   "dev": true
                 }
               }
             },
             "debuglog": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
               "dev": true
             },
             "detect-indent": {
               "version": "5.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
               "dev": true
             },
             "dezalgo": {
               "version": "1.0.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
               "dev": true,
               "requires": {
                 "asap": "^2.0.0",
@@ -17100,19 +17411,22 @@
               "dependencies": {
                 "asap": {
                   "version": "2.0.5",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-UidltQw1EEkOUtfc/ghe+bqWlY8=",
                   "dev": true
                 }
               }
             },
             "editor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
               "dev": true
             },
             "fs-vacuum": {
               "version": "1.2.10",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
               "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
@@ -17122,7 +17436,8 @@
             },
             "fs-write-stream-atomic": {
               "version": "1.0.10",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
               "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
@@ -17133,7 +17448,8 @@
             },
             "fstream": {
               "version": "1.0.11",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
               "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
@@ -17144,7 +17460,8 @@
             },
             "fstream-npm": {
               "version": "1.2.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-iBHpm/LmD1qw0TlHMAqVd9rwdU6M+EHRUnPkXpRi5G/Hf0FIFH+oZFryodAU2MFNfGRh/CzhUFlMKV3pdeOTDw==",
               "dev": true,
               "requires": {
                 "fstream-ignore": "^1.0.0",
@@ -17153,7 +17470,8 @@
               "dependencies": {
                 "fstream-ignore": {
                   "version": "1.0.5",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
                   "dev": true,
                   "requires": {
                     "fstream": "^1.0.0",
@@ -17163,7 +17481,8 @@
                   "dependencies": {
                     "minimatch": {
                       "version": "3.0.4",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                       "dev": true,
                       "requires": {
                         "brace-expansion": "^1.1.7"
@@ -17171,7 +17490,8 @@
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.8",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                           "dev": true,
                           "requires": {
                             "balanced-match": "^1.0.0",
@@ -17180,12 +17500,14 @@
                           "dependencies": {
                             "balanced-match": {
                               "version": "1.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                               "dev": true
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                               "dev": true
                             }
                           }
@@ -17198,7 +17520,8 @@
             },
             "glob": {
               "version": "7.1.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
               "dev": true,
               "requires": {
                 "fs.realpath": "^1.0.0",
@@ -17211,12 +17534,14 @@
               "dependencies": {
                 "fs.realpath": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
                   "dev": true
                 },
                 "minimatch": {
                   "version": "3.0.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                   "dev": true,
                   "requires": {
                     "brace-expansion": "^1.1.7"
@@ -17224,7 +17549,8 @@
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.8",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                       "dev": true,
                       "requires": {
                         "balanced-match": "^1.0.0",
@@ -17233,12 +17559,14 @@
                       "dependencies": {
                         "balanced-match": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                           "dev": true
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                           "dev": true
                         }
                       }
@@ -17247,39 +17575,46 @@
                 },
                 "path-is-absolute": {
                   "version": "1.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
                   "dev": true
                 }
               }
             },
             "graceful-fs": {
               "version": "4.1.11",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
               "dev": true
             },
             "has-unicode": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
               "dev": true
             },
             "hosted-git-info": {
               "version": "2.5.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
               "dev": true
             },
             "iferr": {
               "version": "0.1.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
               "dev": true
             },
             "imurmurhash": {
               "version": "0.1.4",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
               "dev": true
             },
             "inflight": {
               "version": "1.0.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
               "dev": true,
               "requires": {
                 "once": "^1.3.0",
@@ -17288,17 +17623,20 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
               "dev": true
             },
             "ini": {
               "version": "1.3.4",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
               "dev": true
             },
             "init-package-json": {
               "version": "1.10.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-zYc6FneWvvuZYSsodioLY5P9j2o=",
               "dev": true,
               "requires": {
                 "glob": "^7.1.1",
@@ -17313,7 +17651,8 @@
               "dependencies": {
                 "promzard": {
                   "version": "0.3.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
                   "dev": true,
                   "requires": {
                     "read": "1"
@@ -17323,22 +17662,26 @@
             },
             "lazy-property": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc=",
               "dev": true
             },
             "lockfile": {
               "version": "1.0.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Jjj8OaAzHpysGgS3F5mTHJxQ33k=",
               "dev": true
             },
             "lodash._baseindexof": {
               "version": "3.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
               "dev": true
             },
             "lodash._baseuniq": {
               "version": "4.6.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
               "dev": true,
               "requires": {
                 "lodash._createset": "~4.0.0",
@@ -17347,29 +17690,34 @@
               "dependencies": {
                 "lodash._createset": {
                   "version": "4.0.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=",
                   "dev": true
                 },
                 "lodash._root": {
                   "version": "3.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
                   "dev": true
                 }
               }
             },
             "lodash._bindcallback": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
               "dev": true
             },
             "lodash._cacheindexof": {
               "version": "3.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
               "dev": true
             },
             "lodash._createcache": {
               "version": "3.1.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
               "dev": true,
               "requires": {
                 "lodash._getnative": "^3.0.0"
@@ -17377,37 +17725,44 @@
             },
             "lodash._getnative": {
               "version": "3.9.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
               "dev": true
             },
             "lodash.clonedeep": {
               "version": "4.5.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
               "dev": true
             },
             "lodash.restparam": {
               "version": "3.6.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
               "dev": true
             },
             "lodash.union": {
               "version": "4.6.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
               "dev": true
             },
             "lodash.uniq": {
               "version": "4.5.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
               "dev": true
             },
             "lodash.without": {
               "version": "4.4.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=",
               "dev": true
             },
             "lru-cache": {
               "version": "4.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
               "dev": true,
               "requires": {
                 "pseudomap": "^1.0.2",
@@ -17416,19 +17771,22 @@
               "dependencies": {
                 "pseudomap": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
                   "dev": true
                 },
                 "yallist": {
                   "version": "2.1.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
                   "dev": true
                 }
               }
             },
             "mississippi": {
               "version": "1.3.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-0gFYPrEjJ+PFwWQqQEqcrPlONPU=",
               "dev": true,
               "requires": {
                 "concat-stream": "^1.5.0",
@@ -17445,7 +17803,8 @@
               "dependencies": {
                 "concat-stream": {
                   "version": "1.6.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
                   "dev": true,
                   "requires": {
                     "inherits": "^2.0.3",
@@ -17455,14 +17814,16 @@
                   "dependencies": {
                     "typedarray": {
                       "version": "0.0.6",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
                       "dev": true
                     }
                   }
                 },
                 "duplexify": {
                   "version": "3.5.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-GqdzAC4VeEV+nZ1KULDMquvL1gQ=",
                   "dev": true,
                   "requires": {
                     "end-of-stream": "1.0.0",
@@ -17473,7 +17834,8 @@
                   "dependencies": {
                     "end-of-stream": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
                       "dev": true,
                       "requires": {
                         "once": "~1.3.0"
@@ -17481,7 +17843,8 @@
                       "dependencies": {
                         "once": {
                           "version": "1.3.3",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
                           "dev": true,
                           "requires": {
                             "wrappy": "1"
@@ -17491,14 +17854,16 @@
                     },
                     "stream-shift": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
                       "dev": true
                     }
                   }
                 },
                 "end-of-stream": {
                   "version": "1.4.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
                   "dev": true,
                   "requires": {
                     "once": "^1.4.0"
@@ -17506,7 +17871,8 @@
                 },
                 "flush-write-stream": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
                   "dev": true,
                   "requires": {
                     "inherits": "^2.0.1",
@@ -17515,7 +17881,8 @@
                 },
                 "from2": {
                   "version": "2.3.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
                   "dev": true,
                   "requires": {
                     "inherits": "^2.0.1",
@@ -17524,7 +17891,8 @@
                 },
                 "parallel-transform": {
                   "version": "1.1.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
                   "dev": true,
                   "requires": {
                     "cyclist": "~0.2.2",
@@ -17534,14 +17902,16 @@
                   "dependencies": {
                     "cyclist": {
                       "version": "0.2.2",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
                       "dev": true
                     }
                   }
                 },
                 "pump": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
                   "dev": true,
                   "requires": {
                     "end-of-stream": "^1.1.0",
@@ -17550,7 +17920,8 @@
                 },
                 "pumpify": {
                   "version": "1.3.5",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs=",
                   "dev": true,
                   "requires": {
                     "duplexify": "^3.1.2",
@@ -17560,7 +17931,8 @@
                 },
                 "stream-each": {
                   "version": "1.2.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-HpXUdXP1gNgU3A/4zQ9m8c5TyZE=",
                   "dev": true,
                   "requires": {
                     "end-of-stream": "^1.1.0",
@@ -17569,14 +17941,16 @@
                   "dependencies": {
                     "stream-shift": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
                       "dev": true
                     }
                   }
                 },
                 "through2": {
                   "version": "2.0.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
                   "dev": true,
                   "requires": {
                     "readable-stream": "^2.1.5",
@@ -17585,7 +17959,8 @@
                   "dependencies": {
                     "xtend": {
                       "version": "4.0.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
                       "dev": true
                     }
                   }
@@ -17594,7 +17969,8 @@
             },
             "mkdirp": {
               "version": "0.5.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "dev": true,
               "requires": {
                 "minimist": "0.0.8"
@@ -17602,14 +17978,16 @@
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
                   "dev": true
                 }
               }
             },
             "move-concurrently": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
               "dev": true,
               "requires": {
                 "aproba": "^1.1.1",
@@ -17622,7 +18000,8 @@
               "dependencies": {
                 "copy-concurrently": {
                   "version": "1.0.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-Rft4ZiSaHKiJqlcI5svSc+dbslA=",
                   "dev": true,
                   "requires": {
                     "aproba": "^1.1.1",
@@ -17635,7 +18014,8 @@
                 },
                 "run-queue": {
                   "version": "1.0.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
                   "dev": true,
                   "requires": {
                     "aproba": "^1.1.1"
@@ -17645,7 +18025,8 @@
             },
             "node-gyp": {
               "version": "3.6.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
               "dev": true,
               "requires": {
                 "fstream": "^1.0.0",
@@ -17665,7 +18046,8 @@
               "dependencies": {
                 "minimatch": {
                   "version": "3.0.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                   "dev": true,
                   "requires": {
                     "brace-expansion": "^1.1.7"
@@ -17673,7 +18055,8 @@
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.8",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                       "dev": true,
                       "requires": {
                         "balanced-match": "^1.0.0",
@@ -17682,12 +18065,14 @@
                       "dependencies": {
                         "balanced-match": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                           "dev": true
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                           "dev": true
                         }
                       }
@@ -17696,7 +18081,8 @@
                 },
                 "nopt": {
                   "version": "3.0.6",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
                   "dev": true,
                   "requires": {
                     "abbrev": "1"
@@ -17706,7 +18092,8 @@
             },
             "nopt": {
               "version": "4.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
               "dev": true,
               "requires": {
                 "abbrev": "1",
@@ -17715,7 +18102,8 @@
             },
             "normalize-package-data": {
               "version": "2.4.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
               "dev": true,
               "requires": {
                 "hosted-git-info": "^2.1.4",
@@ -17726,7 +18114,8 @@
               "dependencies": {
                 "is-builtin-module": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
                   "dev": true,
                   "requires": {
                     "builtin-modules": "^1.0.0"
@@ -17734,7 +18123,8 @@
                   "dependencies": {
                     "builtin-modules": {
                       "version": "1.1.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
                       "dev": true
                     }
                   }
@@ -17743,12 +18133,14 @@
             },
             "npm-cache-filename": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
               "dev": true
             },
             "npm-install-checks": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-1K7N/VGlPjcjt7L5Oy7ijjB7wNc=",
               "dev": true,
               "requires": {
                 "semver": "^2.3.0 || 3.x || 4 || 5"
@@ -17756,7 +18148,8 @@
             },
             "npm-package-arg": {
               "version": "5.1.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-wJBsrf0qpypPT7A0LART18hCdyhpCMxeTtcb0X4IZO2jsP6Om7EHN1d9KSKiqD+KVH030RVNpWS9thk+pb7wzA==",
               "dev": true,
               "requires": {
                 "hosted-git-info": "^2.4.2",
@@ -17767,7 +18160,8 @@
             },
             "npm-registry-client": {
               "version": "8.4.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-PVNfqq0lyRdFnE//nDmn3CC9uqTsr8Bya9KPLIevlXMfkP0m4RpCVyFFk0W1Gfx436kKwyhLA6J+lV+rgR81gQ==",
               "dev": true,
               "requires": {
                 "concat-stream": "^1.5.2",
@@ -17785,7 +18179,8 @@
               "dependencies": {
                 "concat-stream": {
                   "version": "1.6.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
                   "dev": true,
                   "requires": {
                     "inherits": "^2.0.3",
@@ -17795,7 +18190,8 @@
                   "dependencies": {
                     "typedarray": {
                       "version": "0.0.6",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
                       "dev": true
                     }
                   }
@@ -17804,12 +18200,14 @@
             },
             "npm-user-validate": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-jOyg9c6gTU6TUZ73LQVXp1Ei6VE=",
               "dev": true
             },
             "npmlog": {
               "version": "4.1.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
               "dev": true,
               "requires": {
                 "are-we-there-yet": "~1.1.2",
@@ -17820,7 +18218,8 @@
               "dependencies": {
                 "are-we-there-yet": {
                   "version": "1.1.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
                   "dev": true,
                   "requires": {
                     "delegates": "^1.0.0",
@@ -17829,19 +18228,22 @@
                   "dependencies": {
                     "delegates": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
                       "dev": true
                     }
                   }
                 },
                 "console-control-strings": {
                   "version": "1.1.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
                   "dev": true
                 },
                 "gauge": {
                   "version": "2.7.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
                   "dev": true,
                   "requires": {
                     "aproba": "^1.0.3",
@@ -17856,17 +18258,20 @@
                   "dependencies": {
                     "object-assign": {
                       "version": "4.1.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                       "dev": true
                     },
                     "signal-exit": {
                       "version": "3.0.2",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
                       "dev": true
                     },
                     "string-width": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                       "dev": true,
                       "requires": {
                         "code-point-at": "^1.0.0",
@@ -17876,12 +18281,14 @@
                       "dependencies": {
                         "code-point-at": {
                           "version": "1.1.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                           "dev": true
                         },
                         "is-fullwidth-code-point": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                           "dev": true,
                           "requires": {
                             "number-is-nan": "^1.0.0"
@@ -17889,7 +18296,8 @@
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.1",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                               "dev": true
                             }
                           }
@@ -17898,7 +18306,8 @@
                     },
                     "strip-ansi": {
                       "version": "3.0.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                       "dev": true,
                       "requires": {
                         "ansi-regex": "^2.0.0"
@@ -17906,14 +18315,16 @@
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.1.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                           "dev": true
                         }
                       }
                     },
                     "wide-align": {
                       "version": "1.1.2",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
                       "dev": true,
                       "requires": {
                         "string-width": "^1.0.2"
@@ -17923,14 +18334,16 @@
                 },
                 "set-blocking": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
                   "dev": true
                 }
               }
             },
             "once": {
               "version": "1.4.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "dev": true,
               "requires": {
                 "wrappy": "1"
@@ -17938,12 +18351,14 @@
             },
             "opener": {
               "version": "1.4.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg=",
               "dev": true
             },
             "osenv": {
               "version": "0.1.4",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
               "dev": true,
               "requires": {
                 "os-homedir": "^1.0.0",
@@ -17952,19 +18367,22 @@
               "dependencies": {
                 "os-homedir": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
                   "dev": true
                 },
                 "os-tmpdir": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
                   "dev": true
                 }
               }
             },
             "pacote": {
               "version": "2.7.38",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-XxHUyHQB7QCVBxoXeVu0yKxT+2PvJucsc0+1E+6f95lMUxEAYERgSAc71ckYXrYr35Ew3xFU/LrhdIK21GQFFA==",
               "dev": true,
               "requires": {
                 "bluebird": "^3.5.0",
@@ -17992,7 +18410,8 @@
               "dependencies": {
                 "make-fetch-happen": {
                   "version": "2.4.13",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-73CsTlMRSLdGr7VvOE8iYl/ejOSIxyfRYg7jZhepGGEqIlgdq6FLe2DEAI5bo813Jdg5fS/Ku62SRQ/UpT6NJA==",
                   "dev": true,
                   "requires": {
                     "agentkeepalive": "^3.3.0",
@@ -18010,7 +18429,8 @@
                   "dependencies": {
                     "agentkeepalive": {
                       "version": "3.3.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha512-9yhcpXti2ZQE7bxuCsjjWNIZoQOd9sZ1ZBovHG0YeCRohFv73SLvcm73PC9T3olM4GyozaQb+4MGdQpcD8m7NQ==",
                       "dev": true,
                       "requires": {
                         "humanize-ms": "^1.2.1"
@@ -18018,7 +18438,8 @@
                       "dependencies": {
                         "humanize-ms": {
                           "version": "1.2.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
                           "dev": true,
                           "requires": {
                             "ms": "^2.0.0"
@@ -18026,7 +18447,8 @@
                           "dependencies": {
                             "ms": {
                               "version": "2.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                               "dev": true
                             }
                           }
@@ -18035,12 +18457,14 @@
                     },
                     "http-cache-semantics": {
                       "version": "3.7.3",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-LzXFMuzSnx5UE7mvgztySjxvf3I=",
                       "dev": true
                     },
                     "http-proxy-agent": {
                       "version": "2.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-RkgqLwUjpNYIJVFwn0acs+SoX/Q=",
                       "dev": true,
                       "requires": {
                         "agent-base": "4",
@@ -18049,7 +18473,8 @@
                       "dependencies": {
                         "agent-base": {
                           "version": "4.1.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-IOF0Ac1Js8B2v1akvGxbQ2/6jVU=",
                           "dev": true,
                           "requires": {
                             "es6-promisify": "^5.0.0"
@@ -18057,7 +18482,8 @@
                           "dependencies": {
                             "es6-promisify": {
                               "version": "5.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                               "dev": true,
                               "requires": {
                                 "es6-promise": "^4.0.3"
@@ -18065,7 +18491,8 @@
                               "dependencies": {
                                 "es6-promise": {
                                   "version": "4.1.1",
-                                  "bundled": true,
+                                  "resolved": false,
+                                  "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
                                   "dev": true
                                 }
                               }
@@ -18074,7 +18501,8 @@
                         },
                         "debug": {
                           "version": "2.6.8",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
                           "dev": true,
                           "requires": {
                             "ms": "2.0.0"
@@ -18082,7 +18510,8 @@
                           "dependencies": {
                             "ms": {
                               "version": "2.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                               "dev": true
                             }
                           }
@@ -18091,7 +18520,8 @@
                     },
                     "https-proxy-agent": {
                       "version": "2.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-/6pLb69YasNAwYoUBDHna31/KUQ=",
                       "dev": true,
                       "requires": {
                         "agent-base": "^4.1.0",
@@ -18100,7 +18530,8 @@
                       "dependencies": {
                         "agent-base": {
                           "version": "4.1.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-IOF0Ac1Js8B2v1akvGxbQ2/6jVU=",
                           "dev": true,
                           "requires": {
                             "es6-promisify": "^5.0.0"
@@ -18108,7 +18539,8 @@
                           "dependencies": {
                             "es6-promisify": {
                               "version": "5.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                               "dev": true,
                               "requires": {
                                 "es6-promise": "^4.0.3"
@@ -18116,7 +18548,8 @@
                               "dependencies": {
                                 "es6-promise": {
                                   "version": "4.1.1",
-                                  "bundled": true,
+                                  "resolved": false,
+                                  "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
                                   "dev": true
                                 }
                               }
@@ -18125,7 +18558,8 @@
                         },
                         "debug": {
                           "version": "2.6.8",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
                           "dev": true,
                           "requires": {
                             "ms": "2.0.0"
@@ -18133,7 +18567,8 @@
                           "dependencies": {
                             "ms": {
                               "version": "2.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                               "dev": true
                             }
                           }
@@ -18142,7 +18577,8 @@
                     },
                     "node-fetch-npm": {
                       "version": "2.0.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha512-W3onhopST5tqpX0/MGSL47pDQLLKobNR83AvkiOWQKaw54h+uYUfzeLAxCiyhWlUOiuI+GIb4O9ojLaAFlhCCA==",
                       "dev": true,
                       "requires": {
                         "encoding": "^0.1.11",
@@ -18152,7 +18588,8 @@
                       "dependencies": {
                         "encoding": {
                           "version": "0.1.12",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
                           "dev": true,
                           "requires": {
                             "iconv-lite": "~0.4.13"
@@ -18160,14 +18597,16 @@
                           "dependencies": {
                             "iconv-lite": {
                               "version": "0.4.18",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA==",
                               "dev": true
                             }
                           }
                         },
                         "json-parse-helpfulerror": {
                           "version": "1.0.3",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
                           "dev": true,
                           "requires": {
                             "jju": "^1.1.0"
@@ -18175,7 +18614,8 @@
                           "dependencies": {
                             "jju": {
                               "version": "1.3.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo=",
                               "dev": true
                             }
                           }
@@ -18184,7 +18624,8 @@
                     },
                     "socks-proxy-agent": {
                       "version": "3.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha512-YJcT+SNNBgFoK/NpO20PChz0VnBOhkjG3X10BwlrYujd0NZlSsH1jbxSQ1S0njt3sOvzwQ2PvGqqUIvP4rNk/w==",
                       "dev": true,
                       "requires": {
                         "agent-base": "^4.0.1",
@@ -18193,7 +18634,8 @@
                       "dependencies": {
                         "agent-base": {
                           "version": "4.1.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-IOF0Ac1Js8B2v1akvGxbQ2/6jVU=",
                           "dev": true,
                           "requires": {
                             "es6-promisify": "^5.0.0"
@@ -18201,7 +18643,8 @@
                           "dependencies": {
                             "es6-promisify": {
                               "version": "5.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                               "dev": true,
                               "requires": {
                                 "es6-promise": "^4.0.3"
@@ -18209,7 +18652,8 @@
                               "dependencies": {
                                 "es6-promise": {
                                   "version": "4.1.1",
-                                  "bundled": true,
+                                  "resolved": false,
+                                  "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
                                   "dev": true
                                 }
                               }
@@ -18218,7 +18662,8 @@
                         },
                         "socks": {
                           "version": "1.1.10",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
                           "dev": true,
                           "requires": {
                             "ip": "^1.1.4",
@@ -18227,12 +18672,14 @@
                           "dependencies": {
                             "ip": {
                               "version": "1.1.5",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
                               "dev": true
                             },
                             "smart-buffer": {
                               "version": "1.1.15",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY=",
                               "dev": true
                             }
                           }
@@ -18243,7 +18690,8 @@
                 },
                 "minimatch": {
                   "version": "3.0.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                   "dev": true,
                   "requires": {
                     "brace-expansion": "^1.1.7"
@@ -18251,7 +18699,8 @@
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.8",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                       "dev": true,
                       "requires": {
                         "balanced-match": "^1.0.0",
@@ -18260,12 +18709,14 @@
                       "dependencies": {
                         "balanced-match": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                           "dev": true
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                           "dev": true
                         }
                       }
@@ -18274,7 +18725,8 @@
                 },
                 "npm-pick-manifest": {
                   "version": "1.0.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-MKxNdeyOZysPRTTbHtW0M5Fw38Jo/3ARsoGw5qjCfS+XGjvNB/Gb4qtAZUFmKPM2mVum+eX559eHvKywU856BQ==",
                   "dev": true,
                   "requires": {
                     "npm-package-arg": "^5.1.2",
@@ -18283,7 +18735,8 @@
                 },
                 "promise-retry": {
                   "version": "1.1.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
                   "dev": true,
                   "requires": {
                     "err-code": "^1.0.0",
@@ -18292,14 +18745,16 @@
                   "dependencies": {
                     "err-code": {
                       "version": "1.1.2",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
                       "dev": true
                     }
                   }
                 },
                 "protoduck": {
                   "version": "4.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-/kh02MeRM2bP2erRJFOiLNNlf44=",
                   "dev": true,
                   "requires": {
                     "genfun": "^4.0.1"
@@ -18307,14 +18762,16 @@
                   "dependencies": {
                     "genfun": {
                       "version": "4.0.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-7RAEHy5KfxsKOEZtF6XD4n3x38E=",
                       "dev": true
                     }
                   }
                 },
                 "tar-fs": {
                   "version": "1.15.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-7M+TXpQUk9gVECjmNuUc5MPKfyA=",
                   "dev": true,
                   "requires": {
                     "chownr": "^1.0.1",
@@ -18325,7 +18782,8 @@
                   "dependencies": {
                     "pump": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
                       "dev": true,
                       "requires": {
                         "end-of-stream": "^1.1.0",
@@ -18334,7 +18792,8 @@
                       "dependencies": {
                         "end-of-stream": {
                           "version": "1.4.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
                           "dev": true,
                           "requires": {
                             "once": "^1.4.0"
@@ -18346,7 +18805,8 @@
                 },
                 "tar-stream": {
                   "version": "1.5.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
                   "dev": true,
                   "requires": {
                     "bl": "^1.0.0",
@@ -18357,7 +18817,8 @@
                   "dependencies": {
                     "bl": {
                       "version": "1.2.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
                       "dev": true,
                       "requires": {
                         "readable-stream": "^2.0.5"
@@ -18365,7 +18826,8 @@
                     },
                     "end-of-stream": {
                       "version": "1.4.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
                       "dev": true,
                       "requires": {
                         "once": "^1.4.0"
@@ -18373,7 +18835,8 @@
                     },
                     "xtend": {
                       "version": "4.0.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
                       "dev": true
                     }
                   }
@@ -18382,17 +18845,20 @@
             },
             "path-is-inside": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
               "dev": true
             },
             "promise-inflight": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
               "dev": true
             },
             "read": {
               "version": "1.0.7",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
               "dev": true,
               "requires": {
                 "mute-stream": "~0.0.4"
@@ -18400,14 +18866,16 @@
               "dependencies": {
                 "mute-stream": {
                   "version": "0.0.7",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
                   "dev": true
                 }
               }
             },
             "read-cmd-shim": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
               "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.2"
@@ -18415,7 +18883,8 @@
             },
             "read-installed": {
               "version": "4.0.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
               "dev": true,
               "requires": {
                 "debuglog": "^1.0.1",
@@ -18429,14 +18898,16 @@
               "dependencies": {
                 "util-extend": {
                   "version": "1.0.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
                   "dev": true
                 }
               }
             },
             "read-package-json": {
               "version": "2.0.9",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-vuV8p921IgyelL4UOKv3FsRuRZSaRn30HanLAOKargsr8TbBEq+I3MgloSRXYuKhNdYP1wlEGilMWAIayA2RFg==",
               "dev": true,
               "requires": {
                 "glob": "^7.1.1",
@@ -18447,7 +18918,8 @@
               "dependencies": {
                 "json-parse-helpfulerror": {
                   "version": "1.0.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
                   "dev": true,
                   "requires": {
                     "jju": "^1.1.0"
@@ -18455,7 +18927,8 @@
                   "dependencies": {
                     "jju": {
                       "version": "1.3.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo=",
                       "dev": true
                     }
                   }
@@ -18464,7 +18937,8 @@
             },
             "read-package-tree": {
               "version": "5.1.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-FCX1aT3GWyY658wzDICef4p+n0dB+ENRct8E/Qyvppj6xVpOYerBHfUu7OP5Rt1/393Tdglguf5ju5DEX4wZNg==",
               "dev": true,
               "requires": {
                 "debuglog": "^1.0.1",
@@ -18476,7 +18950,8 @@
             },
             "readable-stream": {
               "version": "2.3.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-WgTfBeT1f+Pw3Gj90R3FyXx+b00=",
               "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -18490,22 +18965,26 @@
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                   "dev": true
                 },
                 "isarray": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                   "dev": true
                 },
                 "process-nextick-args": {
                   "version": "1.0.7",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
                   "dev": true
                 },
                 "string_decoder": {
                   "version": "1.0.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
                   "dev": true,
                   "requires": {
                     "safe-buffer": "~5.1.0"
@@ -18513,14 +18992,16 @@
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                   "dev": true
                 }
               }
             },
             "readdir-scoped-modules": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
               "dev": true,
               "requires": {
                 "debuglog": "^1.0.1",
@@ -18531,7 +19012,8 @@
             },
             "request": {
               "version": "2.81.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
               "dev": true,
               "requires": {
                 "aws-sign2": "~0.6.0",
@@ -18560,22 +19042,26 @@
               "dependencies": {
                 "aws-sign2": {
                   "version": "0.6.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
                   "dev": true
                 },
                 "aws4": {
                   "version": "1.6.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
                   "dev": true
                 },
                 "caseless": {
                   "version": "0.12.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
                   "dev": true
                 },
                 "combined-stream": {
                   "version": "1.0.5",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
                   "dev": true,
                   "requires": {
                     "delayed-stream": "~1.0.0"
@@ -18583,24 +19069,28 @@
                   "dependencies": {
                     "delayed-stream": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
                       "dev": true
                     }
                   }
                 },
                 "extend": {
                   "version": "3.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
                   "dev": true
                 },
                 "forever-agent": {
                   "version": "0.6.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
                   "dev": true
                 },
                 "form-data": {
                   "version": "2.1.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
                   "dev": true,
                   "requires": {
                     "asynckit": "^0.4.0",
@@ -18610,14 +19100,16 @@
                   "dependencies": {
                     "asynckit": {
                       "version": "0.4.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
                       "dev": true
                     }
                   }
                 },
                 "har-validator": {
                   "version": "4.2.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
                   "dev": true,
                   "requires": {
                     "ajv": "^4.9.1",
@@ -18626,7 +19118,8 @@
                   "dependencies": {
                     "ajv": {
                       "version": "4.11.8",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
                       "dev": true,
                       "requires": {
                         "co": "^4.6.0",
@@ -18635,12 +19128,14 @@
                       "dependencies": {
                         "co": {
                           "version": "4.6.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
                           "dev": true
                         },
                         "json-stable-stringify": {
                           "version": "1.0.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
                           "dev": true,
                           "requires": {
                             "jsonify": "~0.0.0"
@@ -18648,7 +19143,8 @@
                           "dependencies": {
                             "jsonify": {
                               "version": "0.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
                               "dev": true
                             }
                           }
@@ -18657,14 +19153,16 @@
                     },
                     "har-schema": {
                       "version": "1.0.5",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
                       "dev": true
                     }
                   }
                 },
                 "hawk": {
                   "version": "3.1.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
                   "dev": true,
                   "requires": {
                     "boom": "2.x.x",
@@ -18675,7 +19173,8 @@
                   "dependencies": {
                     "boom": {
                       "version": "2.10.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
                       "dev": true,
                       "requires": {
                         "hoek": "2.x.x"
@@ -18683,7 +19182,8 @@
                     },
                     "cryptiles": {
                       "version": "2.0.5",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
                       "dev": true,
                       "requires": {
                         "boom": "2.x.x"
@@ -18691,12 +19191,14 @@
                     },
                     "hoek": {
                       "version": "2.16.3",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
                       "dev": true
                     },
                     "sntp": {
                       "version": "1.0.9",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
                       "dev": true,
                       "requires": {
                         "hoek": "2.x.x"
@@ -18706,7 +19208,8 @@
                 },
                 "http-signature": {
                   "version": "1.1.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
                   "dev": true,
                   "requires": {
                     "assert-plus": "^0.2.0",
@@ -18716,12 +19219,14 @@
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.2.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
                       "dev": true
                     },
                     "jsprim": {
                       "version": "1.4.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
                       "dev": true,
                       "requires": {
                         "assert-plus": "1.0.0",
@@ -18732,22 +19237,26 @@
                       "dependencies": {
                         "assert-plus": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                           "dev": true
                         },
                         "extsprintf": {
                           "version": "1.0.2",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
                           "dev": true
                         },
                         "json-schema": {
                           "version": "0.2.3",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
                           "dev": true
                         },
                         "verror": {
                           "version": "1.3.6",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
                           "dev": true,
                           "requires": {
                             "extsprintf": "1.0.2"
@@ -18757,7 +19266,8 @@
                     },
                     "sshpk": {
                       "version": "1.13.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
                       "dev": true,
                       "requires": {
                         "asn1": "~0.2.3",
@@ -18772,17 +19282,20 @@
                       "dependencies": {
                         "asn1": {
                           "version": "0.2.3",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
                           "dev": true
                         },
                         "assert-plus": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                           "dev": true
                         },
                         "bcrypt-pbkdf": {
                           "version": "1.0.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
                           "dev": true,
                           "optional": true,
                           "requires": {
@@ -18791,7 +19304,8 @@
                         },
                         "dashdash": {
                           "version": "1.14.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
                           "dev": true,
                           "requires": {
                             "assert-plus": "^1.0.0"
@@ -18799,7 +19313,8 @@
                         },
                         "ecc-jsbn": {
                           "version": "0.1.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
                           "dev": true,
                           "optional": true,
                           "requires": {
@@ -18808,7 +19323,8 @@
                         },
                         "getpass": {
                           "version": "0.1.7",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
                           "dev": true,
                           "requires": {
                             "assert-plus": "^1.0.0"
@@ -18816,13 +19332,15 @@
                         },
                         "jsbn": {
                           "version": "0.1.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
                           "dev": true,
                           "optional": true
                         },
                         "tweetnacl": {
                           "version": "0.14.5",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
                           "dev": true,
                           "optional": true
                         }
@@ -18832,22 +19350,26 @@
                 },
                 "is-typedarray": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
                   "dev": true
                 },
                 "isstream": {
                   "version": "0.1.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
                   "dev": true
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
                   "dev": true
                 },
                 "mime-types": {
                   "version": "2.1.15",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
                   "dev": true,
                   "requires": {
                     "mime-db": "~1.27.0"
@@ -18855,34 +19377,40 @@
                   "dependencies": {
                     "mime-db": {
                       "version": "1.27.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
                       "dev": true
                     }
                   }
                 },
                 "oauth-sign": {
                   "version": "0.8.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
                   "dev": true
                 },
                 "performance-now": {
                   "version": "0.2.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
                   "dev": true
                 },
                 "qs": {
                   "version": "6.4.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
                   "dev": true
                 },
                 "stringstream": {
                   "version": "0.0.5",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
                   "dev": true
                 },
                 "tough-cookie": {
                   "version": "2.3.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
                   "dev": true,
                   "requires": {
                     "punycode": "^1.4.1"
@@ -18890,14 +19418,16 @@
                   "dependencies": {
                     "punycode": {
                       "version": "1.4.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
                       "dev": true
                     }
                   }
                 },
                 "tunnel-agent": {
                   "version": "0.6.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
                   "dev": true,
                   "requires": {
                     "safe-buffer": "^5.0.1"
@@ -18907,12 +19437,14 @@
             },
             "retry": {
               "version": "0.10.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
               "dev": true
             },
             "rimraf": {
               "version": "2.6.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
               "dev": true,
               "requires": {
                 "glob": "^7.0.5"
@@ -18920,17 +19452,20 @@
             },
             "safe-buffer": {
               "version": "5.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
               "dev": true
             },
             "semver": {
               "version": "5.3.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
               "dev": true
             },
             "sha": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-YDCCL70smCOUn49y7WQR7lzyWq4=",
               "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
@@ -18939,17 +19474,20 @@
             },
             "slide": {
               "version": "1.1.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
               "dev": true
             },
             "sorted-object": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw=",
               "dev": true
             },
             "sorted-union-stream": {
               "version": "2.1.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
               "dev": true,
               "requires": {
                 "from2": "^1.3.0",
@@ -18958,7 +19496,8 @@
               "dependencies": {
                 "from2": {
                   "version": "1.3.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
                   "dev": true,
                   "requires": {
                     "inherits": "~2.0.1",
@@ -18967,7 +19506,8 @@
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.1.14",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                       "dev": true,
                       "requires": {
                         "core-util-is": "~1.0.0",
@@ -18978,17 +19518,20 @@
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                           "dev": true
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
                           "dev": true
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
                           "dev": true
                         }
                       }
@@ -18997,7 +19540,8 @@
                 },
                 "stream-iterate": {
                   "version": "1.2.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
                   "dev": true,
                   "requires": {
                     "readable-stream": "^2.1.5",
@@ -19006,7 +19550,8 @@
                   "dependencies": {
                     "stream-shift": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
                       "dev": true
                     }
                   }
@@ -19015,7 +19560,8 @@
             },
             "ssri": {
               "version": "4.1.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-WUbCdgSAMQjTFZRWvSPpauryvREEA+Krn19rx67UlJEJx/M192ZHxMmJXjZ4tkdFm+Sb0SXGlENeQVlA5wY7kA==",
               "dev": true,
               "requires": {
                 "safe-buffer": "^5.1.0"
@@ -19023,7 +19569,8 @@
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
                 "ansi-regex": "^3.0.0"
@@ -19031,14 +19578,16 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "3.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
                   "dev": true
                 }
               }
             },
             "tar": {
               "version": "2.2.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
               "dev": true,
               "requires": {
                 "block-stream": "*",
@@ -19048,7 +19597,8 @@
               "dependencies": {
                 "block-stream": {
                   "version": "0.0.9",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
                   "dev": true,
                   "requires": {
                     "inherits": "~2.0.0"
@@ -19058,22 +19608,26 @@
             },
             "text-table": {
               "version": "0.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
               "dev": true
             },
             "uid-number": {
               "version": "0.0.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
               "dev": true
             },
             "umask": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
               "dev": true
             },
             "unique-filename": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
               "dev": true,
               "requires": {
                 "unique-slug": "^2.0.0"
@@ -19081,7 +19635,8 @@
               "dependencies": {
                 "unique-slug": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
                   "dev": true,
                   "requires": {
                     "imurmurhash": "^0.1.4"
@@ -19091,12 +19646,14 @@
             },
             "unpipe": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
               "dev": true
             },
             "update-notifier": {
               "version": "2.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-G1g3z5DAc22IYncytmHBOPht5y8=",
               "dev": true,
               "requires": {
                 "boxen": "^1.0.0",
@@ -19111,7 +19668,8 @@
               "dependencies": {
                 "boxen": {
                   "version": "1.1.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-sbad1SIwXoB6md7ud329blFnsQI=",
                   "dev": true,
                   "requires": {
                     "ansi-align": "^2.0.0",
@@ -19125,7 +19683,8 @@
                   "dependencies": {
                     "ansi-align": {
                       "version": "2.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
                       "dev": true,
                       "requires": {
                         "string-width": "^2.0.0"
@@ -19133,17 +19692,20 @@
                     },
                     "camelcase": {
                       "version": "4.1.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
                       "dev": true
                     },
                     "cli-boxes": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
                       "dev": true
                     },
                     "string-width": {
                       "version": "2.1.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-AwZkVh/BRslCPsfZeP4kV0N/5tA=",
                       "dev": true,
                       "requires": {
                         "is-fullwidth-code-point": "^2.0.0",
@@ -19152,12 +19714,14 @@
                       "dependencies": {
                         "is-fullwidth-code-point": {
                           "version": "2.0.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
                           "dev": true
                         },
                         "strip-ansi": {
                           "version": "4.0.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                           "dev": true,
                           "requires": {
                             "ansi-regex": "^3.0.0"
@@ -19167,7 +19731,8 @@
                     },
                     "term-size": {
                       "version": "0.1.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-hzYLljlsq1dgljcUzaDQy+7K2co=",
                       "dev": true,
                       "requires": {
                         "execa": "^0.4.0"
@@ -19175,7 +19740,8 @@
                       "dependencies": {
                         "execa": {
                           "version": "0.4.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M=",
                           "dev": true,
                           "requires": {
                             "cross-spawn-async": "^2.1.1",
@@ -19188,7 +19754,8 @@
                           "dependencies": {
                             "cross-spawn-async": {
                               "version": "2.2.5",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
                               "dev": true,
                               "requires": {
                                 "lru-cache": "^4.0.0",
@@ -19197,12 +19764,14 @@
                             },
                             "is-stream": {
                               "version": "1.1.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
                               "dev": true
                             },
                             "npm-run-path": {
                               "version": "1.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
                               "dev": true,
                               "requires": {
                                 "path-key": "^1.0.0"
@@ -19210,17 +19779,20 @@
                             },
                             "object-assign": {
                               "version": "4.1.1",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                               "dev": true
                             },
                             "path-key": {
                               "version": "1.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68=",
                               "dev": true
                             },
                             "strip-eof": {
                               "version": "1.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
                               "dev": true
                             }
                           }
@@ -19229,7 +19801,8 @@
                     },
                     "widest-line": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
                       "dev": true,
                       "requires": {
                         "string-width": "^1.0.1"
@@ -19237,7 +19810,8 @@
                       "dependencies": {
                         "string-width": {
                           "version": "1.0.2",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                           "dev": true,
                           "requires": {
                             "code-point-at": "^1.0.0",
@@ -19247,12 +19821,14 @@
                           "dependencies": {
                             "code-point-at": {
                               "version": "1.1.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                               "dev": true
                             },
                             "is-fullwidth-code-point": {
                               "version": "1.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                               "dev": true,
                               "requires": {
                                 "number-is-nan": "^1.0.0"
@@ -19260,14 +19836,16 @@
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.1",
-                                  "bundled": true,
+                                  "resolved": false,
+                                  "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                                   "dev": true
                                 }
                               }
                             },
                             "strip-ansi": {
                               "version": "3.0.1",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                               "dev": true,
                               "requires": {
                                 "ansi-regex": "^2.0.0"
@@ -19275,7 +19853,8 @@
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.1.1",
-                                  "bundled": true,
+                                  "resolved": false,
+                                  "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                                   "dev": true
                                 }
                               }
@@ -19288,7 +19867,8 @@
                 },
                 "chalk": {
                   "version": "1.1.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                   "dev": true,
                   "requires": {
                     "ansi-styles": "^2.2.1",
@@ -19300,17 +19880,20 @@
                   "dependencies": {
                     "ansi-styles": {
                       "version": "2.2.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
                       "dev": true
                     },
                     "escape-string-regexp": {
                       "version": "1.0.5",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
                       "dev": true
                     },
                     "has-ansi": {
                       "version": "2.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
                       "dev": true,
                       "requires": {
                         "ansi-regex": "^2.0.0"
@@ -19318,14 +19901,16 @@
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.1.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                           "dev": true
                         }
                       }
                     },
                     "strip-ansi": {
                       "version": "3.0.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                       "dev": true,
                       "requires": {
                         "ansi-regex": "^2.0.0"
@@ -19333,21 +19918,24 @@
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.1.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                           "dev": true
                         }
                       }
                     },
                     "supports-color": {
                       "version": "2.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
                       "dev": true
                     }
                   }
                 },
                 "configstore": {
                   "version": "3.1.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-Rd+QcHPibfoc9LLVL1tgVF6qEdE=",
                   "dev": true,
                   "requires": {
                     "dot-prop": "^4.1.0",
@@ -19360,7 +19948,8 @@
                   "dependencies": {
                     "dot-prop": {
                       "version": "4.1.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-qEk/C3te7sglJbXHWH+n3nyoWcE=",
                       "dev": true,
                       "requires": {
                         "is-obj": "^1.0.0"
@@ -19368,14 +19957,16 @@
                       "dependencies": {
                         "is-obj": {
                           "version": "1.0.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
                           "dev": true
                         }
                       }
                     },
                     "make-dir": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
                       "dev": true,
                       "requires": {
                         "pify": "^2.3.0"
@@ -19383,14 +19974,16 @@
                       "dependencies": {
                         "pify": {
                           "version": "2.3.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                           "dev": true
                         }
                       }
                     },
                     "unique-string": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
                       "dev": true,
                       "requires": {
                         "crypto-random-string": "^1.0.0"
@@ -19398,7 +19991,8 @@
                       "dependencies": {
                         "crypto-random-string": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
                           "dev": true
                         }
                       }
@@ -19407,17 +20001,20 @@
                 },
                 "import-lazy": {
                   "version": "2.1.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
                   "dev": true
                 },
                 "is-npm": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
                   "dev": true
                 },
                 "latest-version": {
                   "version": "3.1.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
                   "dev": true,
                   "requires": {
                     "package-json": "^4.0.0"
@@ -19425,7 +20022,8 @@
                   "dependencies": {
                     "package-json": {
                       "version": "4.0.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
                       "dev": true,
                       "requires": {
                         "got": "^6.7.1",
@@ -19436,7 +20034,8 @@
                       "dependencies": {
                         "got": {
                           "version": "6.7.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
                           "dev": true,
                           "requires": {
                             "create-error-class": "^3.0.0",
@@ -19454,7 +20053,8 @@
                           "dependencies": {
                             "create-error-class": {
                               "version": "3.0.2",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
                               "dev": true,
                               "requires": {
                                 "capture-stack-trace": "^1.0.0"
@@ -19462,54 +20062,64 @@
                               "dependencies": {
                                 "capture-stack-trace": {
                                   "version": "1.0.0",
-                                  "bundled": true,
+                                  "resolved": false,
+                                  "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
                                   "dev": true
                                 }
                               }
                             },
                             "duplexer3": {
                               "version": "0.1.4",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
                               "dev": true
                             },
                             "get-stream": {
                               "version": "3.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
                               "dev": true
                             },
                             "is-redirect": {
                               "version": "1.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
                               "dev": true
                             },
                             "is-retry-allowed": {
                               "version": "1.1.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
                               "dev": true
                             },
                             "is-stream": {
                               "version": "1.1.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
                               "dev": true
                             },
                             "lowercase-keys": {
                               "version": "1.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
                               "dev": true
                             },
                             "timed-out": {
                               "version": "4.0.1",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
                               "dev": true
                             },
                             "unzip-response": {
                               "version": "2.0.1",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
                               "dev": true
                             },
                             "url-parse-lax": {
                               "version": "1.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
                               "dev": true,
                               "requires": {
                                 "prepend-http": "^1.0.1"
@@ -19517,7 +20127,8 @@
                               "dependencies": {
                                 "prepend-http": {
                                   "version": "1.0.4",
-                                  "bundled": true,
+                                  "resolved": false,
+                                  "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
                                   "dev": true
                                 }
                               }
@@ -19526,7 +20137,8 @@
                         },
                         "registry-auth-token": {
                           "version": "3.3.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
                           "dev": true,
                           "requires": {
                             "rc": "^1.1.6",
@@ -19535,7 +20147,8 @@
                           "dependencies": {
                             "rc": {
                               "version": "1.2.1",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
                               "dev": true,
                               "requires": {
                                 "deep-extend": "~0.4.0",
@@ -19546,17 +20159,20 @@
                               "dependencies": {
                                 "deep-extend": {
                                   "version": "0.4.2",
-                                  "bundled": true,
+                                  "resolved": false,
+                                  "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
                                   "dev": true
                                 },
                                 "minimist": {
                                   "version": "1.2.0",
-                                  "bundled": true,
+                                  "resolved": false,
+                                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                                   "dev": true
                                 },
                                 "strip-json-comments": {
                                   "version": "2.0.1",
-                                  "bundled": true,
+                                  "resolved": false,
+                                  "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
                                   "dev": true
                                 }
                               }
@@ -19565,7 +20181,8 @@
                         },
                         "registry-url": {
                           "version": "3.1.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
                           "dev": true,
                           "requires": {
                             "rc": "^1.0.1"
@@ -19573,7 +20190,8 @@
                           "dependencies": {
                             "rc": {
                               "version": "1.2.1",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
                               "dev": true,
                               "requires": {
                                 "deep-extend": "~0.4.0",
@@ -19584,17 +20202,20 @@
                               "dependencies": {
                                 "deep-extend": {
                                   "version": "0.4.2",
-                                  "bundled": true,
+                                  "resolved": false,
+                                  "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
                                   "dev": true
                                 },
                                 "minimist": {
                                   "version": "1.2.0",
-                                  "bundled": true,
+                                  "resolved": false,
+                                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                                   "dev": true
                                 },
                                 "strip-json-comments": {
                                   "version": "2.0.1",
-                                  "bundled": true,
+                                  "resolved": false,
+                                  "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
                                   "dev": true
                                 }
                               }
@@ -19607,7 +20228,8 @@
                 },
                 "semver-diff": {
                   "version": "2.1.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
                   "dev": true,
                   "requires": {
                     "semver": "^5.0.3"
@@ -19615,19 +20237,22 @@
                 },
                 "xdg-basedir": {
                   "version": "3.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
                   "dev": true
                 }
               }
             },
             "uuid": {
               "version": "3.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
               "dev": true
             },
             "validate-npm-package-license": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
               "dev": true,
               "requires": {
                 "spdx-correct": "~1.0.0",
@@ -19636,7 +20261,8 @@
               "dependencies": {
                 "spdx-correct": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
                   "dev": true,
                   "requires": {
                     "spdx-license-ids": "^1.0.2"
@@ -19644,21 +20270,24 @@
                   "dependencies": {
                     "spdx-license-ids": {
                       "version": "1.2.2",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
                       "dev": true
                     }
                   }
                 },
                 "spdx-expression-parse": {
                   "version": "1.0.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
                   "dev": true
                 }
               }
             },
             "validate-npm-package-name": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
               "dev": true,
               "requires": {
                 "builtins": "^1.0.3"
@@ -19666,14 +20295,16 @@
               "dependencies": {
                 "builtins": {
                   "version": "1.0.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
                   "dev": true
                 }
               }
             },
             "which": {
               "version": "1.2.14",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
               "dev": true,
               "requires": {
                 "isexe": "^2.0.0"
@@ -19681,14 +20312,16 @@
               "dependencies": {
                 "isexe": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
                   "dev": true
                 }
               }
             },
             "worker-farm": {
               "version": "1.3.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-QzMRK7SbF6oFC4eJXKayys9A5f8=",
               "dev": true,
               "requires": {
                 "errno": ">=0.1.1 <0.2.0-0",
@@ -19697,7 +20330,8 @@
               "dependencies": {
                 "errno": {
                   "version": "0.1.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
                   "dev": true,
                   "requires": {
                     "prr": "~0.0.0"
@@ -19705,26 +20339,30 @@
                   "dependencies": {
                     "prr": {
                       "version": "0.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
                       "dev": true
                     }
                   }
                 },
                 "xtend": {
                   "version": "4.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
                   "dev": true
                 }
               }
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
               "dev": true
             },
             "write-file-atomic": {
               "version": "2.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-0TZ20a+xcIl4u0+Mj5xDH2yOWdmQiXlKf9Hm+TgDXjTMsEYb+gDrmb8e8UNAzMCitX8NBqG4Z/FUQIyzv/R1JQ==",
               "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.11",
@@ -19736,7 +20374,8 @@
         },
         "npm-package-arg": {
           "version": "6.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-zYbhP2k9DbJhA0Z3HKUePUgdB1x7MfIfKssC+WLPFMKTBZKpZh5m13PgexJjCq6KW7j17r0jHWcCpxEqnnncSA==",
           "dev": true,
           "requires": {
             "hosted-git-info": "^2.6.0",
@@ -19747,7 +20386,8 @@
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "dev": true,
           "requires": {
             "path-key": "^2.0.0"
@@ -19755,12 +20395,14 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -19768,12 +20410,14 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true
         },
         "os-locale": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "dev": true,
           "requires": {
             "execa": "^0.7.0",
@@ -19783,12 +20427,14 @@
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "requires": {
             "os-homedir": "^1.0.0",
@@ -19797,12 +20443,14 @@
         },
         "p-finally": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
           "dev": true
         },
         "p-limit": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
           "dev": true,
           "requires": {
             "p-try": "^1.0.0"
@@ -19810,7 +20458,8 @@
         },
         "p-locate": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
             "p-limit": "^1.1.0"
@@ -19818,12 +20467,14 @@
         },
         "p-try": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
           "dev": true
         },
         "package-json": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
           "dev": true,
           "requires": {
             "got": "^6.7.1",
@@ -19834,42 +20485,50 @@
         },
         "path-exists": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true
         },
         "path-is-inside": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true
         },
         "pify": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         },
         "prepend-http": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
           "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
           "dev": true
         },
         "rc": {
           "version": "1.2.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
           "dev": true,
           "requires": {
             "deep-extend": "~0.4.0",
@@ -19880,7 +20539,8 @@
         },
         "registry-auth-token": {
           "version": "3.3.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
           "dev": true,
           "requires": {
             "rc": "^1.1.6",
@@ -19889,7 +20549,8 @@
         },
         "registry-url": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
           "dev": true,
           "requires": {
             "rc": "^1.0.1"
@@ -19897,17 +20558,20 @@
         },
         "require-directory": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
           "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
           "dev": true
         },
         "rimraf": {
           "version": "2.6.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "requires": {
             "glob": "^7.0.5"
@@ -19915,17 +20579,20 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
           "dev": true
         },
         "semver": {
           "version": "5.5.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
           "dev": true
         },
         "semver-diff": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
           "dev": true,
           "requires": {
             "semver": "^5.0.3"
@@ -19933,12 +20600,14 @@
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true
         },
         "shebang-command": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "dev": true,
           "requires": {
             "shebang-regex": "^1.0.0"
@@ -19946,17 +20615,20 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true
         },
         "string-width": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -19965,7 +20637,8 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0"
@@ -19973,17 +20646,20 @@
         },
         "strip-eof": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
           "dev": true
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true
         },
         "supports-color": {
           "version": "5.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -19991,7 +20667,8 @@
         },
         "term-size": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
           "dev": true,
           "requires": {
             "execa": "^0.7.0"
@@ -19999,12 +20676,14 @@
         },
         "timed-out": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
           "dev": true
         },
         "unique-string": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
           "dev": true,
           "requires": {
             "crypto-random-string": "^1.0.0"
@@ -20012,12 +20691,14 @@
         },
         "unzip-response": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
           "dev": true
         },
         "update-notifier": {
           "version": "2.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-+bTHAPv9TsEsgRWHJYd31WPYyGY=",
           "dev": true,
           "requires": {
             "boxen": "^1.2.1",
@@ -20034,7 +20715,8 @@
         },
         "url-parse-lax": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
           "dev": true,
           "requires": {
             "prepend-http": "^1.0.1"
@@ -20042,7 +20724,8 @@
         },
         "validate-npm-package-name": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
           "dev": true,
           "requires": {
             "builtins": "^1.0.3"
@@ -20050,7 +20733,8 @@
         },
         "which": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
@@ -20058,12 +20742,14 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "dev": true
         },
         "widest-line": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
           "dev": true,
           "requires": {
             "string-width": "^2.1.1"
@@ -20071,7 +20757,8 @@
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "dev": true,
           "requires": {
             "string-width": "^1.0.1",
@@ -20080,12 +20767,14 @@
           "dependencies": {
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
               "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
@@ -20093,7 +20782,8 @@
             },
             "string-width": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
                 "code-point-at": "^1.0.0",
@@ -20103,7 +20793,8 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -20113,12 +20804,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "write-file-atomic": {
           "version": "2.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.11",
@@ -20128,22 +20821,26 @@
         },
         "xdg-basedir": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
           "dev": true
         },
         "y18n": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
           "dev": true
         },
         "yallist": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         },
         "yargs": {
           "version": "11.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
           "dev": true,
           "requires": {
             "cliui": "^4.0.0",
@@ -20162,14 +20859,16 @@
           "dependencies": {
             "y18n": {
               "version": "3.2.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
               "dev": true
             }
           }
         },
         "yargs-parser": {
           "version": "9.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
           "dev": true,
           "requires": {
             "camelcase": "^4.1.0"
@@ -23235,7 +23934,8 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "type-check": {
       "version": "0.3.2",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1834,7 +1834,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -4494,6 +4495,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "dev": true,
+      "optional": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -5126,7 +5128,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -11226,7 +11229,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "fake-xml-http-request": {
       "version": "2.0.0",
@@ -11760,7 +11764,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -11778,11 +11783,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -11795,15 +11802,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -11906,7 +11916,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -11916,6 +11927,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -11928,17 +11940,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -11955,6 +11970,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -12027,7 +12043,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -12037,6 +12054,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -12112,7 +12130,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -12142,6 +12161,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -12159,6 +12179,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -12197,11 +12218,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -13569,7 +13592,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "jsesc": {
       "version": "0.5.0",
@@ -17727,7 +17751,8 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "type-check": {
       "version": "0.3.2",

--- a/packages/dashboards/addon/routes/dashboards/new.js
+++ b/packages/dashboards/addon/routes/dashboards/new.js
@@ -19,15 +19,19 @@ export default Route.extend({
   user: service(),
 
   /**
+   * @property {Service} router
+   */
+  router: service(),
+
+  /**
    * Sets the model for this route
    *
    * @method model
    * @override
-   * @param title - query param containing the title of dashboard
    * @returns {DS.Model} route model
    */
-  model(pathParams, { queryParams }) {
-    queryParams = queryParams || {};
+  model() {
+    const { queryParams = {} } = this.get('router.currentRoute');
     return this._newModel(queryParams.title);
   },
 
@@ -38,7 +42,9 @@ export default Route.extend({
    * @param dashboard - resolved dashboard model
    * @override
    */
-  afterModel(dashboard, { queryParams }) {
+  afterModel(dashboard) {
+    const { queryParams } = this.get('router.currentRoute');
+
     // If an initial widget was given in the query params, create it
     if (queryParams.unsavedWidgetId) {
       return this.replaceWith('dashboards.dashboard.widgets.add', get(dashboard, 'id'), { queryParams });

--- a/packages/dashboards/tests/unit/routes/dashboards/dashboard/widgets/new-test.js
+++ b/packages/dashboards/tests/unit/routes/dashboards/dashboard/widgets/new-test.js
@@ -61,7 +61,13 @@ module('Unit | Route | dashboards/dashboard/widgets/new', function(hooks) {
         Store.createRecord('dashboard', {
           id: 'dashboard1',
           author: 'navi_user'
-        })
+        }),
+
+      router: {
+        currentRoute: {
+          queryParams: {}
+        }
+      }
     });
 
     set(config, 'navi.defaultDataTable', 'tableA');
@@ -77,7 +83,7 @@ module('Unit | Route | dashboards/dashboard/widgets/new', function(hooks) {
     assert.expect(2);
 
     return settled().then(() => {
-      return Route.model(null, { queryParams: {} }).then(model => {
+      return Route.model().then(model => {
         assert.deepEqual(model.toJSON(), NEW_MODEL, 'A new widget model is returned');
 
         assert.equal(

--- a/packages/dashboards/tests/unit/routes/dashboards/new-test.js
+++ b/packages/dashboards/tests/unit/routes/dashboards/new-test.js
@@ -29,14 +29,20 @@ module('Unit | Route | dashboards/new', function(hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(function() {
-    Route = this.owner.lookup('route:dashboards/new');
+    Route = this.owner.factoryFor('route:dashboards/new').create({
+      router: {
+        currentRoute: {
+          queryParams: {}
+        }
+      }
+    });
   });
 
   test('model - new with default title', async function(assert) {
     assert.expect(1);
 
     await run(async () => {
-      const modelPromise = Route.model(null, {});
+      const modelPromise = Route.model();
 
       const routeModel = await modelPromise;
 
@@ -53,9 +59,9 @@ module('Unit | Route | dashboards/new', function(hooks) {
     assert.expect(1);
 
     await run(async () => {
-      const queryParams = { title: 'Dashing Dashboard' };
+      Route.set('router.currentRoute.queryParams', { title: 'Dashing Dashboard' });
 
-      const routeModel = await Route.model(null, { queryParams });
+      const routeModel = await Route.model();
       //We don't need to match on the createdOn and updatedOn timestamps so just set them to null
       assert.deepEqual(
         Object.assign({}, routeModel.toJSON(), { createdOn: null, updatedOn: null }),
@@ -69,7 +75,6 @@ module('Unit | Route | dashboards/new', function(hooks) {
     assert.expect(2);
 
     const dashboard = { id: 3 };
-    const queryParams = {};
 
     /* == Without unsavedWidgetId == */
     Route.replaceWith = destinationRoute => {
@@ -79,10 +84,10 @@ module('Unit | Route | dashboards/new', function(hooks) {
         'Route redirects to dashboard/:id route when unsavedWidgetId is not given'
       );
     };
-    Route.afterModel(dashboard, { queryParams });
+    Route.afterModel(dashboard);
 
     /* == With unsavedWidgetId == */
-    queryParams.unsavedWidgetId = 10;
+    Route.set('router.currentRoute.queryParams', { unsavedWidgetId: 10 });
     Route.replaceWith = destinationRoute => {
       assert.equal(
         destinationRoute,
@@ -90,6 +95,6 @@ module('Unit | Route | dashboards/new', function(hooks) {
         'Route redirects to dashboard/:id/widgets/new route when unsavedWidgetId is given'
       );
     };
-    Route.afterModel(dashboard, { queryParams });
+    Route.afterModel(dashboard);
   });
 });

--- a/packages/reports/addon/routes/reports/new.js
+++ b/packages/reports/addon/routes/reports/new.js
@@ -49,7 +49,7 @@ export default Route.extend({
     const queryParams =
       (transition &&
         (transition.queryParams || //Ember2.x support
-          transition.to.queryParams)) ||
+          (transition.to && transition.to.queryParams))) ||
       {};
 
     // Allow for a report to be passed through the URL

--- a/packages/reports/addon/routes/reports/new.js
+++ b/packages/reports/addon/routes/reports/new.js
@@ -45,7 +45,13 @@ export default Route.extend({
    * @override
    * @returns {Promise} route model
    */
-  model(params, { queryParams }) {
+  model(_, transition) {
+    const queryParams =
+      (transition &&
+        (transition.queryParams || //Ember2.x support
+          transition.to.queryParams)) ||
+      {};
+
     // Allow for a report to be passed through the URL
     if (queryParams.model) {
       return this._deserializeUrlModel(queryParams.model);

--- a/packages/reports/package-lock.json
+++ b/packages/reports/package-lock.json
@@ -1666,7 +1666,7 @@
     },
     "acorn-jsx": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
@@ -1675,7 +1675,7 @@
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
-          "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true
         }
@@ -2070,7 +2070,7 @@
     },
     "autoprefixer": {
       "version": "7.2.6",
-      "resolved": "http://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.6.tgz",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.6.tgz",
       "integrity": "sha512-Iq8TRIB+/9eQ8rbGhcP7ct5cYb/3qjNYAR2SnzLCEcwF6rvVOax8+9+fccgXk4bEhQGjOZd5TLhsksmAdsbGqQ==",
       "dev": true,
       "requires": {
@@ -2451,7 +2451,7 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
         }
       }
@@ -2483,7 +2483,7 @@
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
       "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
     },
     "babel-plugin-syntax-dynamic-import": {
@@ -2494,7 +2494,7 @@
     },
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
       "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
     },
     "babel-plugin-syntax-trailing-function-commas": {
@@ -2795,7 +2795,7 @@
     },
     "babel-plugin-undeclared-variables-check": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
       "integrity": "sha1-XPGqU52BP/ZOmWQSkK9iCWX2Xe4=",
       "requires": {
         "leven": "^1.0.2"
@@ -3103,39 +3103,6 @@
       "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.1.2.tgz",
       "integrity": "sha512-xVNN69YGDghOqCCtA6FI7avYrr02mTJjOgB0/f1VPD3pJC8QEvjTKWc4epDx8AqxxA75NI0QpVM2gPJXUbE4Tg=="
     },
-    "bl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.0.tgz",
-      "integrity": "sha512-wbgvOpqopSr7uq6fJrLH8EsvYMJf9gzfo2jCsL2eTy75qXPukA4pCgHamOQkZtY5vmfVtjB+P3LNlMHW5CEZXA==",
-      "requires": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
     "blank-object": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/blank-object/-/blank-object-1.0.2.tgz",
@@ -3149,7 +3116,7 @@
     },
     "bluebird": {
       "version": "2.11.0",
-      "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
       "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
     },
     "bn.js": {
@@ -3244,6 +3211,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
+      "optional": true,
       "requires": {
         "hoek": "2.x.x"
       }
@@ -3611,7 +3579,7 @@
         },
         "jsonfile": {
           "version": "2.4.0",
-          "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
           "dev": true,
           "requires": {
@@ -4709,7 +4677,7 @@
       "dependencies": {
         "commander": {
           "version": "2.8.1",
-          "resolved": "http://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "dev": true,
           "requires": {
@@ -4869,6 +4837,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -5272,7 +5241,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "create-ecdh": {
       "version": "4.0.3",
@@ -5540,7 +5510,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "delegate": {
       "version": "3.2.0",
@@ -6339,7 +6310,7 @@
         },
         "babel-core": {
           "version": "5.8.38",
-          "resolved": "http://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
+          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
           "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
           "dev": true,
           "requires": {
@@ -6393,7 +6364,7 @@
         },
         "babylon": {
           "version": "5.8.38",
-          "resolved": "http://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
           "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
           "dev": true
         },
@@ -6508,7 +6479,7 @@
         },
         "core-js": {
           "version": "1.2.7",
-          "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
           "dev": true
         },
@@ -6525,7 +6496,7 @@
         },
         "ember-cli-babel": {
           "version": "5.2.8",
-          "resolved": "http://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.8.tgz",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.8.tgz",
           "integrity": "sha512-Mt9OOB5RaZwjde+LYef8EgwNVCAzsYDv4ktshblaXxr4m/Xm5/7/rxEu42RNrYkoy/qWpT9uhaD+JKK4riMf+w==",
           "dev": true,
           "requires": {
@@ -6547,7 +6518,7 @@
         },
         "globals": {
           "version": "6.4.1",
-          "resolved": "http://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
           "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08=",
           "dev": true
         },
@@ -6569,13 +6540,13 @@
         },
         "json5": {
           "version": "0.4.0",
-          "resolved": "http://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
           "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0=",
           "dev": true
         },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         },
@@ -6590,7 +6561,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -6909,7 +6880,7 @@
         },
         "babel-core": {
           "version": "5.8.38",
-          "resolved": "http://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
+          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
           "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
           "dev": true,
           "requires": {
@@ -6963,7 +6934,7 @@
         },
         "babylon": {
           "version": "5.8.38",
-          "resolved": "http://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
           "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
           "dev": true
         },
@@ -7078,7 +7049,7 @@
         },
         "core-js": {
           "version": "1.2.7",
-          "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
           "dev": true
         },
@@ -7095,7 +7066,7 @@
         },
         "ember-cli-babel": {
           "version": "5.2.8",
-          "resolved": "http://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.8.tgz",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.8.tgz",
           "integrity": "sha512-Mt9OOB5RaZwjde+LYef8EgwNVCAzsYDv4ktshblaXxr4m/Xm5/7/rxEu42RNrYkoy/qWpT9uhaD+JKK4riMf+w==",
           "dev": true,
           "requires": {
@@ -7117,7 +7088,7 @@
         },
         "globals": {
           "version": "6.4.1",
-          "resolved": "http://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
           "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08=",
           "dev": true
         },
@@ -7139,13 +7110,13 @@
         },
         "json5": {
           "version": "0.4.0",
-          "resolved": "http://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
           "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0=",
           "dev": true
         },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         },
@@ -7160,7 +7131,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -7706,7 +7677,7 @@
         },
         "jsonfile": {
           "version": "2.4.0",
-          "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
           "dev": true,
           "requires": {
@@ -7824,7 +7795,7 @@
         },
         "babel-core": {
           "version": "5.8.38",
-          "resolved": "http://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
+          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
           "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
           "dev": true,
           "requires": {
@@ -7878,7 +7849,7 @@
         },
         "babylon": {
           "version": "5.8.38",
-          "resolved": "http://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
           "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
           "dev": true
         },
@@ -7993,7 +7964,7 @@
         },
         "core-js": {
           "version": "1.2.7",
-          "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
           "dev": true
         },
@@ -8010,7 +7981,7 @@
         },
         "ember-cli-babel": {
           "version": "5.2.8",
-          "resolved": "http://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.8.tgz",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.8.tgz",
           "integrity": "sha512-Mt9OOB5RaZwjde+LYef8EgwNVCAzsYDv4ktshblaXxr4m/Xm5/7/rxEu42RNrYkoy/qWpT9uhaD+JKK4riMf+w==",
           "dev": true,
           "requires": {
@@ -8054,7 +8025,7 @@
         },
         "globals": {
           "version": "6.4.1",
-          "resolved": "http://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
           "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08=",
           "dev": true
         },
@@ -8076,13 +8047,13 @@
         },
         "json5": {
           "version": "0.4.0",
-          "resolved": "http://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
           "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0=",
           "dev": true
         },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         },
@@ -8097,7 +8068,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -10299,7 +10270,7 @@
         },
         "babel-core": {
           "version": "5.8.38",
-          "resolved": "http://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
+          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
           "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
           "dev": true,
           "requires": {
@@ -10353,7 +10324,7 @@
         },
         "babylon": {
           "version": "5.8.38",
-          "resolved": "http://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
           "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
           "dev": true
         },
@@ -10468,7 +10439,7 @@
         },
         "core-js": {
           "version": "1.2.7",
-          "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
           "dev": true
         },
@@ -10485,7 +10456,7 @@
         },
         "ember-cli-babel": {
           "version": "5.2.8",
-          "resolved": "http://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.8.tgz",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.8.tgz",
           "integrity": "sha512-Mt9OOB5RaZwjde+LYef8EgwNVCAzsYDv4ktshblaXxr4m/Xm5/7/rxEu42RNrYkoy/qWpT9uhaD+JKK4riMf+w==",
           "dev": true,
           "requires": {
@@ -10507,7 +10478,7 @@
         },
         "globals": {
           "version": "6.4.1",
-          "resolved": "http://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
           "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08=",
           "dev": true
         },
@@ -10529,13 +10500,13 @@
         },
         "json5": {
           "version": "0.4.0",
-          "resolved": "http://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
           "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0=",
           "dev": true
         },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         },
@@ -10550,7 +10521,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -10825,7 +10796,7 @@
         },
         "babel-core": {
           "version": "5.8.38",
-          "resolved": "http://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
+          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
           "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
           "dev": true,
           "requires": {
@@ -10890,7 +10861,7 @@
         },
         "babylon": {
           "version": "5.8.38",
-          "resolved": "http://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
           "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
           "dev": true
         },
@@ -10994,7 +10965,7 @@
         },
         "core-js": {
           "version": "1.2.7",
-          "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
           "dev": true
         },
@@ -11011,7 +10982,7 @@
         },
         "ember-cli-babel": {
           "version": "5.2.8",
-          "resolved": "http://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.8.tgz",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.8.tgz",
           "integrity": "sha512-Mt9OOB5RaZwjde+LYef8EgwNVCAzsYDv4ktshblaXxr4m/Xm5/7/rxEu42RNrYkoy/qWpT9uhaD+JKK4riMf+w==",
           "dev": true,
           "requires": {
@@ -11046,7 +11017,7 @@
         },
         "globals": {
           "version": "6.4.1",
-          "resolved": "http://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
           "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08=",
           "dev": true
         },
@@ -11068,19 +11039,19 @@
         },
         "json5": {
           "version": "0.4.0",
-          "resolved": "http://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
           "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0=",
           "dev": true
         },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -12804,7 +12775,7 @@
         },
         "babel-core": {
           "version": "5.8.38",
-          "resolved": "http://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
+          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
           "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
           "requires": {
             "babel-plugin-constant-folding": "^1.0.1",
@@ -12857,7 +12828,7 @@
         },
         "babylon": {
           "version": "5.8.38",
-          "resolved": "http://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
           "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0="
         },
         "broccoli-babel-transpiler": {
@@ -12934,7 +12905,7 @@
           "dependencies": {
             "fs-tree-diff": {
               "version": "0.3.1",
-              "resolved": "http://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.3.1.tgz",
               "integrity": "sha1-QahO40mUvVZMY9mFLxEJxd5/kpA=",
               "requires": {
                 "debug": "^2.2.0",
@@ -13006,7 +12977,7 @@
         },
         "core-js": {
           "version": "1.2.7",
-          "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
         },
         "detect-indent": {
@@ -13021,7 +12992,7 @@
         },
         "ember-cli-babel": {
           "version": "5.1.5",
-          "resolved": "http://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.1.5.tgz",
           "integrity": "sha1-yaXPmgB4HFVw/ENCKemrhaVWYbA=",
           "requires": {
             "broccoli-babel-transpiler": "^5.4.5",
@@ -13041,7 +13012,7 @@
         },
         "globals": {
           "version": "6.4.1",
-          "resolved": "http://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
           "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08="
         },
         "home-or-tmp": {
@@ -13060,12 +13031,12 @@
         },
         "json5": {
           "version": "0.4.0",
-          "resolved": "http://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
           "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
         },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
         },
         "minimatch": {
@@ -13078,7 +13049,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "path-exists": {
@@ -14022,7 +13993,7 @@
     },
     "ember-resize": {
       "version": "0.0.17",
-      "resolved": "http://registry.npmjs.org/ember-resize/-/ember-resize-0.0.17.tgz",
+      "resolved": "https://registry.npmjs.org/ember-resize/-/ember-resize-0.0.17.tgz",
       "integrity": "sha1-Qr14lM1+1ovciP3bQO/KGBR/a9U=",
       "dev": true,
       "requires": {
@@ -14044,7 +14015,7 @@
         },
         "babel-core": {
           "version": "5.8.38",
-          "resolved": "http://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
+          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
           "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
           "dev": true,
           "requires": {
@@ -14098,7 +14069,7 @@
         },
         "babylon": {
           "version": "5.8.38",
-          "resolved": "http://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
           "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
           "dev": true
         },
@@ -14213,7 +14184,7 @@
         },
         "core-js": {
           "version": "1.2.7",
-          "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
           "dev": true
         },
@@ -14230,7 +14201,7 @@
         },
         "ember-cli-babel": {
           "version": "5.2.8",
-          "resolved": "http://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.8.tgz",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.8.tgz",
           "integrity": "sha512-Mt9OOB5RaZwjde+LYef8EgwNVCAzsYDv4ktshblaXxr4m/Xm5/7/rxEu42RNrYkoy/qWpT9uhaD+JKK4riMf+w==",
           "dev": true,
           "requires": {
@@ -14265,7 +14236,7 @@
         },
         "globals": {
           "version": "6.4.1",
-          "resolved": "http://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
           "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08=",
           "dev": true
         },
@@ -14287,13 +14258,13 @@
         },
         "json5": {
           "version": "0.4.0",
-          "resolved": "http://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
           "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0=",
           "dev": true
         },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         },
@@ -14308,7 +14279,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -16560,7 +16531,7 @@
     },
     "eslint": {
       "version": "4.19.1",
-      "resolved": "http://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
       "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
       "dev": true,
       "requires": {
@@ -16729,7 +16700,7 @@
     },
     "espree": {
       "version": "3.5.4",
-      "resolved": "http://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
       "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
       "requires": {
@@ -17064,7 +17035,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "fake-xml-http-request": {
       "version": "2.0.0",
@@ -17074,13 +17046,13 @@
     },
     "faker": {
       "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/faker/-/faker-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-3.1.0.tgz",
       "integrity": "sha1-D5CPr05uwCUk5UpX5DLFwBPgjJ8=",
       "dev": true
     },
     "fast-deep-equal": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
       "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
       "dev": true
     },
@@ -17474,7 +17446,7 @@
       "dependencies": {
         "async": {
           "version": "0.2.10",
-          "resolved": "http://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
           "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
           "dev": true
         }
@@ -17709,24 +17681,29 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -17736,13 +17713,17 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -17750,34 +17731,43 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -17786,25 +17776,29 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -17813,13 +17807,15 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -17835,7 +17831,8 @@
         },
         "glob": {
           "version": "7.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -17849,13 +17846,15 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -17864,7 +17863,8 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -17873,7 +17873,8 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -17883,46 +17884,58 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -17930,7 +17943,8 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -17939,21 +17953,25 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
         },
         "ms": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -17964,7 +17982,8 @@
         },
         "node-pre-gyp": {
           "version": "0.12.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -17982,7 +18001,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -17992,13 +18012,15 @@
         },
         "npm-bundled": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -18008,7 +18030,8 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -18020,38 +18043,46 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -18061,19 +18092,22 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -18085,7 +18119,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
             }
@@ -18093,7 +18128,8 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -18108,7 +18144,8 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -18117,43 +18154,52 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.7.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -18162,7 +18208,8 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -18171,21 +18218,25 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -18200,13 +18251,15 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -18215,13 +18268,17 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "dev": true
+          "resolved": false,
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -18803,7 +18860,7 @@
       "dependencies": {
         "rsvp": {
           "version": "3.2.1",
-          "resolved": "http://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
           "integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo="
         }
       }
@@ -18848,7 +18905,8 @@
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -18882,7 +18940,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
@@ -19052,7 +19110,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -19267,7 +19325,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -19438,7 +19496,7 @@
         },
         "async": {
           "version": "1.5.2",
-          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
@@ -19593,7 +19651,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "jsesc": {
       "version": "2.5.2",
@@ -19645,27 +19704,6 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true,
       "optional": true
-    },
-    "json-url": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/json-url/-/json-url-2.4.0.tgz",
-      "integrity": "sha512-7Lf04BOvdVAd5fFBymUBdOuhKKSv/IWGQgNHOs1wRjc+MkUfu67+jAMoAORzytawgzLatpLyQ2yXoHBNgGeAzw==",
-      "requires": {
-        "babel-runtime": "^6",
-        "bluebird": "^3.0.6",
-        "lz-string": "^1.4.4",
-        "lzma": "^2.3.2",
-        "msgpack5": "^4.2.1",
-        "node-lzw": "^0.3.1",
-        "urlsafe-base64": "^1.0.0"
-      },
-      "dependencies": {
-        "bluebird": {
-          "version": "3.5.4",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
-          "integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw=="
-        }
-      }
     },
     "json5": {
       "version": "2.1.0",
@@ -20914,16 +20952,6 @@
         }
       }
     },
-    "lz-string": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
-      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY="
-    },
-    "lzma": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/lzma/-/lzma-2.3.2.tgz",
-      "integrity": "sha1-N4OySFi5wOdHoN88vx+1/KqSxEE="
-    },
     "magic-string": {
       "version": "0.24.1",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.24.1.tgz",
@@ -21036,7 +21064,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
@@ -21202,7 +21230,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "minipass": {
@@ -21290,7 +21318,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -21354,41 +21382,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
-    "msgpack5": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/msgpack5/-/msgpack5-4.2.1.tgz",
-      "integrity": "sha512-Xo7nE9ZfBVonQi1rSopNAqPdts/QHyuSEUwIEzAkB+V2FtmkkLUbP6MyVqVVQxsZYI65FpvW3Bb8Z9ZWEjbgHQ==",
-      "requires": {
-        "bl": "^2.0.1",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.3.6",
-        "safe-buffer": "^5.1.2"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
     "mustache": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.0.1.tgz",
@@ -21440,6 +21433,50 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "navi-core": {
+      "version": "0.1.0",
+      "dev": true,
+      "requires": {
+        "@html-next/vertical-collection": "^1.0.0-beta.12",
+        "ember-auto-import": "^1.2.21",
+        "ember-cli-babel": "^7.1.2",
+        "ember-cli-format-number": "2.0.0",
+        "ember-cli-htmlbars": "^3.0.0",
+        "ember-cli-string-helpers": "^1.8.1",
+        "ember-collection": "1.0.0-alpha.9",
+        "ember-composable-helpers": "^2.1.0",
+        "ember-concurrency": "~0.8.27",
+        "ember-copy": "^1.0.0",
+        "ember-cp-validations": "^4.0.0-beta.6",
+        "ember-data-model-fragments": "~4.0.0",
+        "ember-debounced-properties": "0.0.5",
+        "ember-fetch": "^6.5.1",
+        "ember-get-config": "0.2.4",
+        "ember-lodash": "^4.19.4",
+        "ember-math-helpers": "^2.3.0",
+        "ember-moment": "7.5.0",
+        "ember-radio-button": "^1.2.1",
+        "ember-resize": "^0.2.4",
+        "ember-sortable": "1.12.3",
+        "ember-tether": "^1.0.0",
+        "ember-toggle": "^5.2.1",
+        "ember-tooltips": "^2.10.0",
+        "ember-truth-helpers": "^2.0.0",
+        "json-url": "~2.4.1",
+        "resize-observer-polyfill": "^1.5.1"
+      }
+    },
+    "navi-data": {
+      "version": "0.1.0",
+      "dev": true,
+      "requires": {
+        "ember-ajax": "^3.1.0",
+        "ember-cli-babel": "^7.1.2",
+        "ember-cli-htmlbars": "^3.0.0",
+        "ember-get-config": "0.2.4",
+        "ember-lodash": "^4.19.4"
+      }
     },
     "negotiator": {
       "version": "0.6.2",
@@ -21550,11 +21587,6 @@
           }
         }
       }
-    },
-    "node-lzw": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/node-lzw/-/node-lzw-0.3.1.tgz",
-      "integrity": "sha1-9Q43lol2rKgzIAKLkfEB30pDay0="
     },
     "node-modules-path": {
       "version": "1.0.2",
@@ -21668,7 +21700,7 @@
     },
     "numeral": {
       "version": "1.5.6",
-      "resolved": "http://registry.npmjs.org/numeral/-/numeral-1.5.6.tgz",
+      "resolved": "https://registry.npmjs.org/numeral/-/numeral-1.5.6.tgz",
       "integrity": "sha1-ODHbloRRuc9q/5v5WSXx7443sz8=",
       "dev": true
     },
@@ -21860,7 +21892,7 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "requires": {
         "lcid": "^1.0.0"
@@ -22289,7 +22321,7 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         }
@@ -22376,7 +22408,8 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
     },
     "process-relative-require": {
       "version": "1.0.0",
@@ -22587,7 +22620,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -22798,7 +22831,7 @@
     },
     "recast": {
       "version": "0.10.33",
-      "resolved": "http://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
       "integrity": "sha1-lCgI96oBbx+nFCxGHX5XBKqo1pc=",
       "requires": {
         "ast-types": "0.8.12",
@@ -22809,7 +22842,7 @@
       "dependencies": {
         "ast-types": {
           "version": "0.8.12",
-          "resolved": "http://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz",
+          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz",
           "integrity": "sha1-oNkOQ1G7iHcWyD/WN+v4GK9K38w="
         }
       }
@@ -22886,7 +22919,7 @@
     },
     "regexpp": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
       "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
       "dev": true
     },
@@ -23266,7 +23299,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
         "ret": "~0.1.10"
@@ -24155,7 +24188,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -24441,7 +24474,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
@@ -24683,7 +24716,8 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "type-check": {
       "version": "0.3.2",
@@ -24956,11 +24990,6 @@
       "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
       "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
       "dev": true
-    },
-    "urlsafe-base64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/urlsafe-base64/-/urlsafe-base64-1.0.0.tgz",
-      "integrity": "sha1-I/iQaabGL0bPOh07ABac77kL4MY="
     },
     "use": {
       "version": "3.1.1",
@@ -25377,7 +25406,7 @@
     },
     "yargs": {
       "version": "3.27.0",
-      "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
       "integrity": "sha1-ISBUaTFuk5Ex1Z8toMbX+YIh6kA=",
       "requires": {
         "camelcase": "^1.2.1",


### PR DESCRIPTION
Resolves #427 

## Description
Fix direct query param fetch from transition object deprecation

## Proposed Changes

- Update the query param usage in route model hooks to use routeInfo or the transition.to object as required

## Screenshots
NA

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
