### PR TITLE
Fix: Content type not being sent.

### DIFF
--- a/packages/core/addon/adapters/base-json-adapter.js
+++ b/packages/core/addon/adapters/base-json-adapter.js
@@ -33,6 +33,10 @@ export default DS.JSONAPIAdapter.extend(AdapterFetch, {
   ajaxOptions() {
     let hash = this._super(...arguments);
     hash.credentials = 'include';
+    hash.headers = {
+      Accept: 'application/vnd.api+json',
+      'Content-Type': 'application/vnd.api+json'
+    };
     return hash;
   },
 


### PR DESCRIPTION
<!-- The above line will close the issue upon merge -->

## Description

ember-fetch no longer sends right content type for JSONAPI adapter see:
https://github.com/ember-cli/ember-fetch/issues/87

## Proposed Changes

- explicitly set headers

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
