### PR TITLE
Fix: Spot check content type headers

### DIFF
--- a/packages/dashboards/tests/acceptance/dashboards-test.js
+++ b/packages/dashboards/tests/acceptance/dashboards-test.js
@@ -383,8 +383,16 @@ module('Acceptance | Dashboards', function(hooks) {
     assert.expect(8);
 
     server.patch('/dashboards/1', (_, request) => {
-      assert.equal(request.requestHeaders['content-type'], 'application/vnd.api+json');
-      assert.equal(request.requestHeaders.accept, 'application/vnd.api+json');
+      assert.equal(
+        request.requestHeaders['content-type'],
+        'application/vnd.api+json',
+        'Request header content-type is correct JSON-API mime type'
+      );
+      assert.equal(
+        request.requestHeaders.accept,
+        'application/vnd.api+json',
+        'Request header accept is correct JSON-API mime type'
+      );
 
       return new Response(500);
     });

--- a/packages/dashboards/tests/acceptance/dashboards-test.js
+++ b/packages/dashboards/tests/acceptance/dashboards-test.js
@@ -380,9 +380,14 @@ module('Acceptance | Dashboards', function(hooks) {
   });
 
   test('Failing to save a new widget', async function(assert) {
-    assert.expect(6);
+    assert.expect(8);
 
-    server.patch('/dashboards/1', () => new Response(500));
+    server.patch('/dashboards/1', (_, request) => {
+      assert.equal(request.requestHeaders['content-type'], 'application/vnd.api+json');
+      assert.equal(request.requestHeaders.accept, 'application/vnd.api+json');
+
+      return new Response(500);
+    });
 
     // Create and save
     await visit('/dashboards/1/widgets/new');

--- a/packages/reports/tests/acceptance/navi-report-test.js
+++ b/packages/reports/tests/acceptance/navi-report-test.js
@@ -209,7 +209,7 @@ module('Acceptance | Navi Report', function(hooks) {
   });
 
   test('Revert and Save report', async function(assert) {
-    assert.expect(2);
+    assert.expect(4);
 
     await visit('/reports');
     await visit('/reports/new');
@@ -217,6 +217,15 @@ module('Acceptance | Navi Report', function(hooks) {
     //Add three metrics and save the report
     await click($('.checkbox-selector--metric .grouped-list__item:contains(Page Views) .grouped-list__item-label')[0]);
     await click('.navi-report__save-btn');
+
+    server.patch('/reports/:id', function({ reports }, request) {
+      assert.equal(request.requestHeaders['content-type'], 'application/vnd.api+json');
+      assert.equal(request.requestHeaders.accept, 'application/vnd.api+json');
+      const id = request.params.id;
+      let attrs = this.normalizedRequestAttrs();
+
+      return reports.find(id).update(attrs);
+    });
 
     //remove a metric and save the report
     await click(

--- a/packages/reports/tests/acceptance/navi-report-test.js
+++ b/packages/reports/tests/acceptance/navi-report-test.js
@@ -219,8 +219,16 @@ module('Acceptance | Navi Report', function(hooks) {
     await click('.navi-report__save-btn');
 
     server.patch('/reports/:id', function({ reports }, request) {
-      assert.equal(request.requestHeaders['content-type'], 'application/vnd.api+json');
-      assert.equal(request.requestHeaders.accept, 'application/vnd.api+json');
+      assert.equal(
+        request.requestHeaders['content-type'],
+        'application/vnd.api+json',
+        'Request header content-type is correct JSON-API mime type'
+      );
+      assert.equal(
+        request.requestHeaders.accept,
+        'application/vnd.api+json',
+        'Request header accept is correct JSON-API mime type'
+      );
       const id = request.params.id;
       let attrs = this.normalizedRequestAttrs();
 


### PR DESCRIPTION
## Description

Adds tests that asserts content-type

## Proposed Changes

- add a couple spot check tests that checks to see if content-type headers ar what we expect

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
