### PR TITLE
Fix: Fix publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,13 @@ env:
   global:
     - NODE_VERSION=8.16.0
   matrix:
-    - PACKAGE=navi-webservice
     - PACKAGE=navi-app
     - PACKAGE=navi-core
     - PACKAGE=navi-dashboards
     - PACKAGE=navi-data
     - PACKAGE=navi-directory
     - PACKAGE=navi-reports
+    - PACKAGE=navi-webservice
 # safelist
 branches:
   only:


### PR DESCRIPTION
## Description

Publish seems to be running under navi-webservice which means installs aren't happening correctly.

## Proposed Changes

- Move navi-webservice to bottom so publish runs under navi-app

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
