### PR TITLE
Update: Change series order colors

### DIFF
--- a/packages/core/app/styles/navi-core/utils/colors.less
+++ b/packages/core/app/styles/navi-core/utils/colors.less
@@ -16,16 +16,16 @@
  */
 
 //Graph Stroke Colors
-@graph-stroke-0: @denali-graph-red;
-@graph-stroke-1: @denali-graph-blue;
-@graph-stroke-2: @denali-graph-green;
+@graph-stroke-0: @denali-graph-green;
+@graph-stroke-1: @denali-graph-yellow;
+@graph-stroke-2: @denali-graph-teal;
 @graph-stroke-3: @denali-graph-violet;
-@graph-stroke-4: @denali-graph-yellow;
-@graph-stroke-5: @denali-graph-purple;
+@graph-stroke-4: @denali-graph-pink;
+@graph-stroke-5: @denali-graph-blue;
 @graph-stroke-6: @denali-graph-orange;
-@graph-stroke-7: @denali-graph-pink;
-@graph-stroke-8: @denali-graph-violet;
-@graph-stroke-9: @denali-graph-teal;
+@graph-stroke-7: @denali-graph-purple;
+@graph-stroke-8: @denali-graph-dkgreen;
+@graph-stroke-9: @denali-graph-red;
 
 @chart-max-series: 10;
 


### PR DESCRIPTION
Resolves #443

<!-- The above line will close the issue upon merge -->

## Description

The order we have graph colors to make sure we have enough contrast previously was from the hip.  The design language we are using actually has a specification for this. 

## Proposed Changes

- Change color order for visualizations series according to our design language

## Screenshots
![Screen Shot 2019-07-18 at 4 31 43 PM](https://user-images.githubusercontent.com/99422/61493599-95bf7400-a979-11e9-8c40-503ba2170a9a.png)
![Screen Shot 2019-07-18 at 4 31 55 PM](https://user-images.githubusercontent.com/99422/61493604-98ba6480-a979-11e9-8cdc-e54aea95250f.png)



## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
