### PR TITLE
Fix: Global dashboard filters not applying

### DIFF
--- a/packages/dashboards/addon/services/dashboard-data.js
+++ b/packages/dashboards/addon/services/dashboard-data.js
@@ -113,7 +113,7 @@ export default Service.extend({
     const requestClone = request.clone();
 
     this._getValidGlobalFilters(dashboard, request)
-      .filter(filter => filter.rawValues.length > 0)
+      .filter(filter => filter.get('rawValues').length > 0)
       .forEach(filter => requestClone.addRawFilter(filter));
 
     return requestClone;


### PR DESCRIPTION
## Description
Global dashboard filters are not applying to each widget request anymore on an Ember 2.x app.

## Proposed Changes

- Use `get` when accessing `rawValues` on filter application to ensure computed property is accessed correctly
- Test filter application using actual fragments rather than shallow objects

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
