### PR TITLE
Fix: Dashboard creation for ember 2.x

### DIFF
--- a/packages/dashboards/addon/routes/dashboards/new.js
+++ b/packages/dashboards/addon/routes/dashboards/new.js
@@ -71,7 +71,6 @@ export default Route.extend({
    * @returns {DS.Model} route model
    */
   _newModel(title = 'Untitled Dashboard') {
-    debugger;
     return get(this, 'user')
       .findOrRegister()
       .then(author =>

--- a/packages/dashboards/addon/routes/dashboards/new.js
+++ b/packages/dashboards/addon/routes/dashboards/new.js
@@ -30,8 +30,13 @@ export default Route.extend({
    * @override
    * @returns {DS.Model} route model
    */
-  model() {
-    const { queryParams = {} } = this.get('router.currentRoute');
+  model(_, transition) {
+    const queryParams =
+      (transition &&
+        (transition.queryParams || //Ember2.x support
+          (transition.to && transition.to.queryParams))) ||
+      {};
+
     return this._newModel(queryParams.title);
   },
 
@@ -42,8 +47,12 @@ export default Route.extend({
    * @param dashboard - resolved dashboard model
    * @override
    */
-  afterModel(dashboard) {
-    const { queryParams } = this.get('router.currentRoute');
+  afterModel(dashboard, transition) {
+    const queryParams =
+      (transition &&
+        (transition.queryParams || //Ember2.x support
+          (transition.to && transition.to.queryParams))) ||
+      {};
 
     // If an initial widget was given in the query params, create it
     if (queryParams.unsavedWidgetId) {
@@ -62,6 +71,7 @@ export default Route.extend({
    * @returns {DS.Model} route model
    */
   _newModel(title = 'Untitled Dashboard') {
+    debugger;
     return get(this, 'user')
       .findOrRegister()
       .then(author =>

--- a/packages/dashboards/tests/unit/routes/dashboards/new-test.js
+++ b/packages/dashboards/tests/unit/routes/dashboards/new-test.js
@@ -59,9 +59,7 @@ module('Unit | Route | dashboards/new', function(hooks) {
     assert.expect(1);
 
     await run(async () => {
-      Route.set('router.currentRoute.queryParams', { title: 'Dashing Dashboard' });
-
-      const routeModel = await Route.model();
+      const routeModel = await Route.model(null, { queryParams: { title: 'Dashing Dashboard' } });
       //We don't need to match on the createdOn and updatedOn timestamps so just set them to null
       assert.deepEqual(
         Object.assign({}, routeModel.toJSON(), { createdOn: null, updatedOn: null }),
@@ -87,7 +85,6 @@ module('Unit | Route | dashboards/new', function(hooks) {
     Route.afterModel(dashboard);
 
     /* == With unsavedWidgetId == */
-    Route.set('router.currentRoute.queryParams', { unsavedWidgetId: 10 });
     Route.replaceWith = destinationRoute => {
       assert.equal(
         destinationRoute,
@@ -95,6 +92,6 @@ module('Unit | Route | dashboards/new', function(hooks) {
         'Route redirects to dashboard/:id/widgets/new route when unsavedWidgetId is given'
       );
     };
-    Route.afterModel(dashboard);
+    Route.afterModel(dashboard, { queryParams: { unsavedWidgetId: 10 } });
   });
 });


### PR DESCRIPTION
## Description

issue that users using ember 2.x are not able to create new dashboards

## Proposed Changes

- `currentRoute` is a property on `router` in 3.x, not 2.x... use alternative method to get queryParams from transition object in model hooks

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
