### PR TITLE
Update: Add missing addSort methods to builder class

### DIFF
--- a/packages/data/addon/builder/request.js
+++ b/packages/data/addon/builder/request.js
@@ -52,6 +52,13 @@ export default EmberObject.extend({
   }),
 
   /**
+   * @property {Array} sort - list of sort objects
+   */
+  sort: computed(function() {
+    return [];
+  }),
+
+  /**
    * @method copy
    * @param {...Object} arguments - objects with properties to merge into copy
    * @returns {Object} copy of request
@@ -247,5 +254,33 @@ export default EmberObject.extend({
    */
   setHavings(...having) {
     return this._immutableSet('having', having);
+  },
+
+  /**
+   * @method addSort
+   * @param {String} metric
+   * @param {String} direction
+   * @returns {Object} copy of request with property updated
+   */
+  addSort(metric, direction = 'desc') {
+    return this._immutablePush('sort', [{ metric, direction }]);
+  },
+
+  /**
+   * @method addSorts
+   * @param {...Object} sort - objects with metric, direction
+   * @returns {Object} copy of request with property updated
+   */
+  addSorts(...sorts) {
+    return this._immutablePush('sort', sorts);
+  },
+
+  /**
+   * @method setSorts
+   * @param {...Object} sorts - objects with metric, and direction
+   * @returns {Object} copy of request with property updated
+   */
+  setSorts(...sorts) {
+    return this._immutableSet('sort', sorts);
   }
 });

--- a/packages/data/tests/unit/builder/request-test.js
+++ b/packages/data/tests/unit/builder/request-test.js
@@ -305,4 +305,78 @@ module('Unit | Builder | Request', function() {
 
     assert.notEqual(Request, updatedRequest, 'original request was not modified');
   });
+
+  test('sort', function(assert) {
+    assert.expect(6);
+
+    assert.deepEqual(Request.get('sort'), [], 'sort is initially an empty array');
+
+    /* == Add sort Shorthand == */
+    let updatedRequest = Request.addSort('pageViews');
+
+    assert.deepEqual(
+      updatedRequest.get('sort'),
+      [
+        {
+          metric: 'pageViews',
+          direction: 'desc'
+        }
+      ],
+      'sort can be updated with shorthand add function without specifying a sort direction'
+    );
+
+    /* == Add sort Shorthand == */
+    updatedRequest = Request.addSort('pageViews', 'asc');
+
+    assert.deepEqual(
+      updatedRequest.get('sort'),
+      [
+        {
+          metric: 'pageViews',
+          direction: 'asc'
+        }
+      ],
+      'sort can be updated with shorthand add function'
+    );
+
+    /* == Add sort == */
+    updatedRequest = updatedRequest.addSorts({
+      metric: 'adClicks',
+      direction: 'desc'
+    });
+
+    assert.deepEqual(
+      updatedRequest.get('sort'),
+      [
+        {
+          metric: 'pageViews',
+          direction: 'asc'
+        },
+        {
+          metric: 'adClicks',
+          direction: 'desc'
+        }
+      ],
+      'sort can be updated with add function'
+    );
+
+    /* == Set sort == */
+    updatedRequest = updatedRequest.setSorts({
+      metric: 'navClicks',
+      direction: 'asc'
+    });
+
+    assert.deepEqual(
+      updatedRequest.get('sort'),
+      [
+        {
+          metric: 'navClicks',
+          direction: 'asc'
+        }
+      ],
+      'sort can be replaced with set function'
+    );
+
+    assert.notEqual(Request, updatedRequest, 'original request was not modified');
+  });
 });


### PR DESCRIPTION
## Description
The request builder class is missing an addSort method

## Proposed Changes
- update the class and include three new methods
  - addSort
  - addSorts
  - setSorts

## Screenshots
NA

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
