### PR TITLE
New: Synchronous get method to bard-dimensions

### DIFF
--- a/packages/data/addon/adapters/dimensions/keg.js
+++ b/packages/data/addon/adapters/dimensions/keg.js
@@ -129,15 +129,23 @@ export default EmberObject.extend({
   },
 
   /**
+   * @method getById - Finds a dimension value object by its id
+   * @param {String} dimension - dimension name
+   * @param {String} value - the value to be looked up
+   * @returns {Object} - The dimension value object
+   */
+  getById(dimension, value) {
+    return get(this, 'keg').getById(`${KEG_NAMESPACE}/${dimension}`, value);
+  },
+
+  /**
    * @method findById - Finds a dimension value object by its id
    * @param {String} dimension - dimension name
    * @param {String} value - the value to be looked up
    * @returns {Promise} - Promise with the response
    */
   findById(dimension, value) {
-    let keg = get(this, 'keg');
-
-    return Promise.resolve(keg.getById(`${KEG_NAMESPACE}/${dimension}`, value));
+    return Promise.resolve(this.getById(dimension, value));
   },
 
   /**

--- a/packages/data/addon/services/bard-dimensions.js
+++ b/packages/data/addon/services/bard-dimensions.js
@@ -186,6 +186,16 @@ export default Service.extend({
   },
 
   /**
+   * @method getById - Returns the dimension value object for a bard dimension where identifierField value matches value
+   * @param {String} dimension - dimension name
+   * @param {Object} value - the value to be looked up
+   * @returns {Object} - The bard dimension model object
+   */
+  getById(dimension, value) {
+    return get(this, '_kegAdapter').getById(dimension, value);
+  },
+
+  /**
    * @method findById - Returns the dimension value object for a bard dimension where identifierField value matches value
    * @param {String} dimension - dimension name
    * @param {Object} value - the value to be looked up

--- a/packages/data/tests/unit/adapters/dimensions/keg-test.js
+++ b/packages/data/tests/unit/adapters/dimensions/keg-test.js
@@ -116,7 +116,19 @@ module('Unit | Adapters | Dimensions | Keg', function(hooks) {
   });
 
   test('getById', function(assert) {
-    assert.expect(1);
+    assert.expect(3);
+
+    assert.deepEqual(
+      Adapter.getById('unknownDimensionName', '1'),
+      undefined,
+      'getById() returns undefined for an unknown dimension'
+    );
+
+    assert.deepEqual(
+      Adapter.getById('dimensionOne', 'unkownDimensionId'),
+      undefined,
+      'getById() returns undefined for an known dimension with an unknown id'
+    );
 
     assert.deepEqual(
       Adapter.getById('dimensionOne', '1').get('id'),

--- a/packages/data/tests/unit/adapters/dimensions/keg-test.js
+++ b/packages/data/tests/unit/adapters/dimensions/keg-test.js
@@ -115,6 +115,16 @@ module('Unit | Adapters | Dimensions | Keg', function(hooks) {
     });
   });
 
+  test('getById', function(assert) {
+    assert.expect(1);
+
+    assert.deepEqual(
+      Adapter.getById('dimensionOne', '1').get('id'),
+      1,
+      'getById() returns the expected response object for Test dimension, identifierField and query'
+    );
+  });
+
   test('pushMany', function(assert) {
     assert.expect(2);
     Adapter.pushMany('dimensionOne', [{ id: 22, foo: 'bar' }, { id: 44, foo: 'baz' }]);

--- a/packages/data/tests/unit/services/bard-dimensions-test.js
+++ b/packages/data/tests/unit/services/bard-dimensions-test.js
@@ -297,7 +297,13 @@ module('Unit | Service | Dimensions', function(hooks) {
   });
 
   test('getById', function(assert) {
-    assert.expect(1);
+    assert.expect(2);
+
+    assert.deepEqual(
+      Service.getById(TestDimension, 'v1'),
+      undefined,
+      'getById returns undefined for unloaded dimension'
+    );
 
     let keg = Service.get('_kegAdapter.keg');
     keg.pushMany('dimension/dimensionOne', Response.rows, {

--- a/packages/data/tests/unit/services/bard-dimensions-test.js
+++ b/packages/data/tests/unit/services/bard-dimensions-test.js
@@ -296,6 +296,18 @@ module('Unit | Service | Dimensions', function(hooks) {
     });
   });
 
+  test('getById', function(assert) {
+    assert.expect(1);
+
+    let keg = Service.get('_kegAdapter.keg');
+    keg.pushMany('dimension/dimensionOne', Response.rows, {
+      modelFactory: Object
+    });
+
+    const dimensionId = get(Service.getById(TestDimension, 'v1'), 'id');
+    assert.deepEqual(dimensionId, 'v1', 'getById returns the expected dimension value');
+  });
+
   test('all and catch error', function(assert) {
     assert.expect(2);
 


### PR DESCRIPTION
## Description
The current findById method will return a not resolved promise even if the dimension value is already loaded in keg

## Proposed Changes
Add a `getById` method to `bard-dimensions` service and `keg` adapter

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
