### PR TITLE
Fix: Tooltip of selected option of table selector doesn't hide

### DIFF
--- a/packages/reports/addon/components/navi-table-select-item.js
+++ b/packages/reports/addon/components/navi-table-select-item.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2019, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ *
+ * Usage: {{navi-table-select-item
+ *          option=option
+ *        }}
+ */
+
+import Component from '@ember/component';
+import layout from '../templates/components/navi-table-select-item';
+
+export default Component.extend({
+  layout,
+
+  /**
+   * @property {String} tagName
+   */
+  tagName: 'span'
+});

--- a/packages/reports/addon/templates/components/navi-table-select-item.hbs
+++ b/packages/reports/addon/templates/components/navi-table-select-item.hbs
@@ -1,0 +1,11 @@
+{{!-- Copyright 2019, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{option.longName}}
+{{#if option.description}}
+  {{ember-tooltip
+    text=option.description
+    side="right"
+    popperContainer="body"
+    effect="none"
+    tooltipClass="navi-table-select-tooltip"
+  }}
+{{/if}}

--- a/packages/reports/addon/templates/components/navi-table-select.hbs
+++ b/packages/reports/addon/templates/components/navi-table-select.hbs
@@ -1,4 +1,4 @@
-{{!-- Copyright 2017, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{!-- Copyright 2019, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 <span class="navi-table-select__header">
   Table
 </span>
@@ -10,15 +10,8 @@
   searchEnabled=searchEnabled
   tagName=tagName
   onchange=onChange
+  selectedItemComponent="navi-table-select-item"
   as | item |
 }}
-  {{item.longName}}
-  {{#if item.description}}
-    {{ember-tooltip
-      text=item.description
-      side="right"
-      popperContainer="body"
-      effect="none"
-    }}
-  {{/if}}
+  {{navi-table-select-item option=item}}
 {{/power-select}}

--- a/packages/reports/app/components/navi-table-select-item.js
+++ b/packages/reports/app/components/navi-table-select-item.js
@@ -1,0 +1,1 @@
+export { default } from 'navi-reports/components/navi-table-select-item';

--- a/packages/reports/app/styles/navi-reports/components/navi-table-select.less
+++ b/packages/reports/app/styles/navi-reports/components/navi-table-select.less
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018, Yahoo Holdings Inc.
+ * Copyright 2019, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 .navi-table-select {
@@ -21,18 +21,22 @@
       border: 0;
       font-size: 14px;
       height: 24px;
-    }
 
-    .ember-power-select-selected-item,
-    .ember-power-select-placeholder {
-      margin-left: 18px;
-      & > div {
-        display: inline;
+      .ember-tooltip-target {
+        margin-left: 18px;
       }
     }
   }
 
   &__dropdown-list {
     font-size: 14px;
+
+    .ember-power-select-option span {
+      display: flex;
+    }
   }
+}
+
+.navi-table-select-tooltip {
+  left: 5px !important;
 }

--- a/packages/reports/tests/integration/components/navi-table-select-test.js
+++ b/packages/reports/tests/integration/components/navi-table-select-test.js
@@ -31,7 +31,9 @@ module('Integration | Component | navi table select', function(hooks) {
 
     assert.dom('.navi-table-select__header').hasText('Table', 'The header text equals `table`');
 
-    assert.dom('.ember-power-select-selected-item').hasText('network', 'The selected item equals `network`');
+    assert
+      .dom('.navi-table-select__dropdown .ember-power-select-trigger span')
+      .hasText('network', 'The selected item equals `network`');
   });
 
   test('trigger dropdown', async function(assert) {
@@ -50,7 +52,9 @@ module('Integration | Component | navi table select', function(hooks) {
 
     await clickTrigger();
     await nativeMouseUp($('.ember-power-select-option:contains(network2)')[0]);
-    assert.dom('.ember-power-select-selected-item').hasText('network2', 'The selected item equals `network2`');
+    assert
+      .dom('.navi-table-select__dropdown .ember-power-select-trigger span')
+      .hasText('network2', 'The selected item equals `network2`');
   });
 
   test('enable search', async function(assert) {


### PR DESCRIPTION
## Description

Tooltip of selected option of table selector doesn't hide when opening the dropdown.

## Proposed Changes

Creating a separate component for the option items as well as passing it to `selectedItemComponent` seems to solve the issue.

## Screenshots

![Aug-02-2019 16-37-57](https://user-images.githubusercontent.com/13946669/62404233-8595c000-b547-11e9-9dbe-39aadd869a04.gif)

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
