### PR TITLE
Fix: Save button should not be visible when user is not allowed to edit dashboard

### DIFF
--- a/packages/core/addon/mirage/fixtures/dashboard-widget.js
+++ b/packages/core/addon/mirage/fixtures/dashboard-widget.js
@@ -230,5 +230,48 @@ export default [
     ],
     createdOn: '2016-01-01 00:00:00',
     updatedOn: '2016-01-01 00:00:00'
+  },
+  {
+    id: 6,
+    dashboardId: 4,
+    authorId: 'ciela',
+    title: 'Clicks',
+    visualization: {
+      type: 'line-chart',
+      version: 1,
+      metadata: {
+        axis: {
+          y: {
+            series: {
+              type: 'metric',
+              config: {
+                metrics: ['adClicks', 'navClicks']
+              }
+            }
+          }
+        }
+      }
+    },
+    requests: [
+      {
+        logicalTable: {
+          table: 'network',
+          timeGrain: 'day'
+        },
+        metrics: [{ metric: 'adClicks' }, { metric: 'navClicks' }],
+        dimensions: [],
+        filters: [],
+        intervals: [
+          {
+            end: 'current',
+            start: 'P7D'
+          }
+        ],
+        bardVersion: 'v1',
+        requestVersion: 'v1'
+      }
+    ],
+    createdOn: '2016-01-01 00:00:00',
+    updatedOn: '2016-01-01 00:00:00'
   }
 ];

--- a/packages/core/addon/mirage/fixtures/dashboard.js
+++ b/packages/core/addon/mirage/fixtures/dashboard.js
@@ -78,7 +78,7 @@ export default [
     id: 4,
     title: 'Dashboard 4',
     authorId: 'ciela',
-    dashboardWidgetIds: [],
+    dashboardWidgetIds: [6],
     createdOn: '2016-01-01 00:00:00',
     updatedOn: '2016-01-01 00:00:00',
     deliveryRuleIds: [],
@@ -92,8 +92,8 @@ export default [
     ],
     presentation: {
       version: 1,
-      layout: [], //TODO
-      columns: 15
+      layout: [{ column: 0, row: 0, height: 6, width: 9, widgetId: 6 }],
+      columns: 40
     }
   },
   {

--- a/packages/dashboards/addon/templates/components/navi-dashboard.hbs
+++ b/packages/dashboards/addon/templates/components/navi-dashboard.hbs
@@ -160,7 +160,9 @@
 
 {{#if dashboard.hasDirtyAttributes}}
   <div class="navi-dashboard__save-dialogue">
-    <button onclick={{route-action "saveDashboard"}} class="btn btn-secondary navi-dashboard__save-button">Save Changes</button>
+    {{#if dashboard.canUserEdit}}
+      <button onclick={{route-action "saveDashboard"}} class="btn btn-secondary navi-dashboard__save-button">Save Changes</button>
+    {{/if}}
     <button onclick={{route-action "revertDashboard"}} class="btn btn-secondary navi-dashboard__revert-button">Revert Changes</button>
   </div>
 {{/if}}

--- a/packages/dashboards/tests/acceptance/add-widget-test.js
+++ b/packages/dashboards/tests/acceptance/add-widget-test.js
@@ -30,7 +30,9 @@ module('Acceptance | Add New Widget', function(hooks) {
     await visit('/dashboards/1/');
     assert.dom('.navi-widget').exists({ count: 3 }, 'dashboard 1 initially has 3 widgets');
 
-    assert.notOk(!!findAll('[data-gs-id="6"]').length, 'widget 4 is not present');
+    const NEW_WIDGET_ID = 7;
+
+    assert.notOk(!!findAll(`[data-gs-id="${NEW_WIDGET_ID}"]`).length, 'widget 4 is not present');
 
     //Make a new widget
     const store = getContext().owner.lookup('service:store');
@@ -50,8 +52,10 @@ module('Acceptance | Add New Widget', function(hooks) {
 
     assert.dom('.navi-widget').exists({ count: 4 }, 'visiting the add route adds a widget to dashboard 1');
 
-    assert.ok(!!findAll('[data-gs-id="6"]').length, 'widget 4 is present');
+    assert.ok(!!findAll(`[data-gs-id="${NEW_WIDGET_ID}"]`).length, 'widget 4 is present');
 
-    assert.dom('[data-gs-id="6"]').hasAttribute('data-gs-y', '8', 'widget 4 was added to the next available row');
+    assert
+      .dom(`[data-gs-id="${NEW_WIDGET_ID}"]`)
+      .hasAttribute('data-gs-y', '8', 'widget 4 was added to the next available row');
   });
 });

--- a/packages/dashboards/tests/acceptance/add-widget-test.js
+++ b/packages/dashboards/tests/acceptance/add-widget-test.js
@@ -32,7 +32,7 @@ module('Acceptance | Add New Widget', function(hooks) {
 
     const NEW_WIDGET_ID = 7;
 
-    assert.notOk(!!findAll(`[data-gs-id="${NEW_WIDGET_ID}"]`).length, 'widget 4 is not present');
+    assert.notOk(!!findAll(`[data-gs-id="${NEW_WIDGET_ID}"]`).length, '4th widget is not present');
 
     //Make a new widget
     const store = getContext().owner.lookup('service:store');
@@ -52,10 +52,10 @@ module('Acceptance | Add New Widget', function(hooks) {
 
     assert.dom('.navi-widget').exists({ count: 4 }, 'visiting the add route adds a widget to dashboard 1');
 
-    assert.ok(!!findAll(`[data-gs-id="${NEW_WIDGET_ID}"]`).length, 'widget 4 is present');
+    assert.ok(!!findAll(`[data-gs-id="${NEW_WIDGET_ID}"]`).length, '4th widget is present');
 
     assert
       .dom(`[data-gs-id="${NEW_WIDGET_ID}"]`)
-      .hasAttribute('data-gs-y', '8', 'widget 4 was added to the next available row');
+      .hasAttribute('data-gs-y', '8', '4th widget was added to the next available row');
   });
 });

--- a/packages/dashboards/tests/acceptance/dashboards-test.js
+++ b/packages/dashboards/tests/acceptance/dashboards-test.js
@@ -43,7 +43,22 @@ module('Acceptance | Dashboards', function(hooks) {
   });
 
   test('updates to dashboard layout', async function(assert) {
-    assert.expect(2);
+    assert.expect(5);
+
+    await visit('/dashboards/4');
+
+    //trigger a change
+    run(() => {
+      $('.grid-stack').trigger('resizestop');
+    });
+
+    assert
+      .dom('.navi-dashboard__save-button')
+      .isNotVisible('Save button is not visible when user cannot edit the dashboard.');
+
+    assert
+      .dom('.navi-dashboard__revert-button')
+      .isVisible('Revert button is visible even when user cannot edit the dashboard.');
 
     await visit('/dashboards/1');
 
@@ -77,6 +92,8 @@ module('Acceptance | Dashboards', function(hooks) {
       ],
       "Moving widget locations updates the dashboard's layout property"
     );
+
+    assert.dom('.navi-dashboard__save-button').isVisible('Save button is visible when user can edit the dashboard.');
   });
 
   test('empty dashboard', async function(assert) {

--- a/packages/dashboards/tests/unit/routes/dashboards/dashboard/clone-test.js
+++ b/packages/dashboards/tests/unit/routes/dashboards/dashboard/clone-test.js
@@ -16,21 +16,21 @@ const CLONED_MODEL = {
         column: 0,
         height: 4,
         row: 0,
-        widgetId: 6,
+        widgetId: 7,
         width: 6
       },
       {
         column: 6,
         height: 4,
         row: 0,
-        widgetId: 7,
+        widgetId: 8,
         width: 6
       },
       {
         column: 0,
         height: 4,
         row: 4,
-        widgetId: 8,
+        widgetId: 9,
         width: 12
       }
     ],


### PR DESCRIPTION
## Description

Save button should not be visible when the user is not allowed to edit the dashboard.

## Proposed Changes

Wrap the button in `if dashboard.canUserEdit`

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
