### PR TITLE
consistent version of route-action-helper across the app

### DIFF
--- a/packages/reports/package-lock.json
+++ b/packages/reports/package-lock.json
@@ -15277,9 +15277,9 @@
       "integrity": "sha512-EiTo5YQS0Duy0xp9gCP8ekzv9vxirNi7MnIB4zWs+thtWp/mEKgf5mkiiLU2+oo8C5DuavVHhoPQDmyxh8Io1Q=="
     },
     "ember-route-action-helper": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/ember-route-action-helper/-/ember-route-action-helper-2.0.6.tgz",
-      "integrity": "sha1-HVBFQ1DXESvjJqtEBY8GzykdX9k=",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/ember-route-action-helper/-/ember-route-action-helper-2.0.7.tgz",
+      "integrity": "sha512-8GEnB9hfPdh5U19ubmojVZQBu6aUIfQuiv6xnsdss7V3TMspjI1Ak8lqoqEzww8Dv+sxv8YWma0IhKPFxrVJag==",
       "requires": {
         "ember-cli-babel": "^6.8.1",
         "ember-getowner-polyfill": "^2.0.0"

--- a/packages/reports/package.json
+++ b/packages/reports/package.json
@@ -44,7 +44,7 @@
     "ember-pluralize": "0.2.0",
     "ember-promise-helpers": "^1.0.6",
     "ember-radio-button": "^1.2.1",
-    "ember-route-action-helper": "2.0.6",
+    "ember-route-action-helper": "^2.0.7",
     "ember-tag-input": "1.2.1",
     "ember-tether": "^1.0.0",
     "ember-toggle": "5.3.2",


### PR DESCRIPTION
For #447 

## Description
consistent version of route-action-helper across the app

## Proposed Changes

- update the version in reports to latest

## Screenshots
NA

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
