### PR TITLE
Fix: Metric selector is missing in Ember 2.x

### DIFF
--- a/packages/core/addon/components/visualization-config/wrapper.js
+++ b/packages/core/addon/components/visualization-config/wrapper.js
@@ -40,13 +40,16 @@ export default Component.extend({
    * @property {Boolean} showMetricSelect - whether to display the metric select
    */
   showMetricSelect: computed('visualization', 'series', function() {
-    const series = get(this, 'series'),
-      { visualization: { type }, request } = this,
-      visualizationManifest = getOwner(this).lookup(`manifest:${type}`);
+    const seriesType = get(this, 'series.type'),
+      visualizationType = get(this, 'visualization.type'),
+      request = get(this, 'request'),
+      visualizationManifest = getOwner(this).lookup(`manifest:${visualizationType}`);
 
-    return ['line-chart', 'bar-chart', 'pie-chart'].includes(type) &&
-      series.type === 'dimension' &&
-      visualizationManifest.hasMultipleMetrics(request);
+    return (
+      ['line-chart', 'bar-chart', 'pie-chart'].includes(visualizationType) &&
+      seriesType === 'dimension' &&
+      visualizationManifest.hasMultipleMetrics(request)
+    );
   }),
 
   /**
@@ -72,6 +75,6 @@ export default Component.extend({
       const newConfig = copy(get(this, 'visualization.metadata'));
       set(newConfig, 'axis.y.series.config.metric', metric);
       this.onUpdateConfig(newConfig);
-    },
+    }
   }
 });


### PR DESCRIPTION
## Description

This is embarrassing since @cythrawll had a comment on this exactly in #457.
Nothing was broken but didn't notice the selector was missing.

## Proposed Changes

Change `{ visualization: { type } } = this` to `get(this, 'visualization.type')`.

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
