### PR TITLE
Fix: Ember 2.x fixes for dashboard filters

### DIFF
--- a/packages/app/testem.js
+++ b/packages/app/testem.js
@@ -9,7 +9,6 @@ module.exports = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
-        '--disable-gpu',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
         '--mute-audio',

--- a/packages/core/testem.js
+++ b/packages/core/testem.js
@@ -9,7 +9,6 @@ module.exports = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
         '--disable-dev-shm-usage',
-        '--disable-gpu',
         '--disable-software-rasterizer',
         '--headless',
         '--headless',

--- a/packages/dashboards/addon/controllers/dashboards/dashboard/view.js
+++ b/packages/dashboards/addon/controllers/dashboards/dashboard/view.js
@@ -29,6 +29,8 @@ export default Controller.extend({
    */
   queryParams: ['filters'],
 
+  filters: null,
+
   actions: {
     /**
      * @action updateFilter

--- a/packages/dashboards/addon/controllers/dashboards/dashboard/view.js
+++ b/packages/dashboards/addon/controllers/dashboards/dashboard/view.js
@@ -29,6 +29,9 @@ export default Controller.extend({
    */
   queryParams: ['filters'],
 
+  /**
+   * @property {String} filters query param holding encoded filters for the dashboard
+   */
   filters: null,
 
   actions: {

--- a/packages/dashboards/addon/routes/dashboards/dashboard/view.js
+++ b/packages/dashboards/addon/routes/dashboards/dashboard/view.js
@@ -123,7 +123,9 @@ export default Route.extend({
       }
 
       //Remove all filters from the fragment array
-      modelFilters.length = 0;
+      if (modelFilters.get('length') > 0) {
+        modelFilters.removeAt(0, modelFilters.get('length'));
+      }
 
       decompressedFilters.filters.map(fil => {
         const newFragmentFields = {

--- a/packages/dashboards/package-lock.json
+++ b/packages/dashboards/package-lock.json
@@ -1918,8 +1918,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -5122,7 +5121,6 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -5836,8 +5834,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "delegate": {
       "version": "3.2.0",
@@ -14868,8 +14865,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "fake-xml-http-request": {
       "version": "2.0.0",
@@ -17464,8 +17460,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "jsdom": {
       "version": "12.2.0",
@@ -25921,8 +25916,7 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "type-check": {
       "version": "0.3.2",

--- a/packages/dashboards/testem.js
+++ b/packages/dashboards/testem.js
@@ -9,7 +9,6 @@ module.exports = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
-        '--disable-gpu',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
         '--mute-audio',

--- a/packages/data/testem.js
+++ b/packages/data/testem.js
@@ -9,7 +9,6 @@ module.exports = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
-        '--disable-gpu',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
         '--mute-audio',

--- a/packages/directory/testem.js
+++ b/packages/directory/testem.js
@@ -9,7 +9,6 @@ module.exports = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
-        '--disable-gpu',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
         '--mute-audio',

--- a/packages/reports/testem.js
+++ b/packages/reports/testem.js
@@ -10,7 +10,6 @@ module.exports = {
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
         '--remote-debugging-port=9222',
-        '--disable-gpu',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
         '--mute-audio',


### PR DESCRIPTION
<!-- The above line will close the issue upon merge -->

## Description

Ember 2.x fixes for dashboard filter query string support.

## Proposed Changes

- setting ember array length to 0 doesn't clear it in 2.x because they aren't Native arrays yet and length is a computed prop. So clearing it via removeAt is the best way to truncate.
- need a default value for the filters queryParam so when removed during save it doesn't error out passing a null as string.
- removed disable-gpu in testem so local tests work again.

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
