### PR TITLE
Ember c3 upgrade

### DIFF
--- a/packages/app/bower.json
+++ b/packages/app/bower.json
@@ -3,8 +3,6 @@
   "dependencies": {
     "pretender": "~1.1.0",
     "numeral": "~1.5.3",
-    "d3": "3.5.17",
-    "c3": "0.4.20",
     "bootstrap-datepicker": "1.4.0"
   }
 }

--- a/packages/app/package-lock.json
+++ b/packages/app/package-lock.json
@@ -405,12 +405,12 @@
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
         },
         "regexpu-core": {
-          "version": "4.5.4",
-          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
-          "integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.5.tgz",
+          "integrity": "sha512-FpI67+ky9J+cDizQUJlIlNZFKual/lUkFr1AG6zOCpwZ9cLrg8UUVakyUQJD7fCDIe9Z2nwTQJNPyonatNmDFQ==",
           "requires": {
             "regenerate": "^1.4.0",
-            "regenerate-unicode-properties": "^8.0.2",
+            "regenerate-unicode-properties": "^8.1.0",
             "regjsgen": "^0.5.0",
             "regjsparser": "^0.6.0",
             "unicode-match-property-ecmascript": "^1.0.4",
@@ -577,12 +577,12 @@
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
         },
         "regexpu-core": {
-          "version": "4.5.4",
-          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
-          "integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.5.tgz",
+          "integrity": "sha512-FpI67+ky9J+cDizQUJlIlNZFKual/lUkFr1AG6zOCpwZ9cLrg8UUVakyUQJD7fCDIe9Z2nwTQJNPyonatNmDFQ==",
           "requires": {
             "regenerate": "^1.4.0",
-            "regenerate-unicode-properties": "^8.0.2",
+            "regenerate-unicode-properties": "^8.1.0",
             "regjsgen": "^0.5.0",
             "regjsparser": "^0.6.0",
             "unicode-match-property-ecmascript": "^1.0.4",
@@ -841,12 +841,12 @@
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
         },
         "regexpu-core": {
-          "version": "4.5.4",
-          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
-          "integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.5.tgz",
+          "integrity": "sha512-FpI67+ky9J+cDizQUJlIlNZFKual/lUkFr1AG6zOCpwZ9cLrg8UUVakyUQJD7fCDIe9Z2nwTQJNPyonatNmDFQ==",
           "requires": {
             "regenerate": "^1.4.0",
-            "regenerate-unicode-properties": "^8.0.2",
+            "regenerate-unicode-properties": "^8.1.0",
             "regjsgen": "^0.5.0",
             "regjsparser": "^0.6.0",
             "unicode-match-property-ecmascript": "^1.0.4",
@@ -1718,9 +1718,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
-          "integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
+          "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
           "dev": true
         }
       }
@@ -1787,6 +1787,17 @@
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
         "repeat-string": "^1.5.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "alter": {
@@ -1831,6 +1842,12 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
           "dev": true
         },
         "string-width": {
@@ -2440,11 +2457,11 @@
       }
     },
     "babel-plugin-ember-modules-api-polyfill": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.9.0.tgz",
-      "integrity": "sha512-c03h50291phJ2gQxo/aIOvFQE2c6glql1A7uagE3XbPXpKVAJOUxtVDjvWG6UAB6BC5ynsJfMWvY0w4TPRKIHQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.11.0.tgz",
+      "integrity": "sha512-S3bw77LglkWIstoF+hBLyRPyyNAUsdzqK6zLxktuM6EniVt06st/ikhPDUttMWixS2LNA+jnBfGerYO1D/VvDw==",
       "requires": {
-        "ember-rfc176-data": "^0.3.9"
+        "ember-rfc176-data": "^0.3.11"
       }
     },
     "babel-plugin-eval": {
@@ -3044,12 +3061,6 @@
             "is-data-descriptor": "^1.0.0",
             "kind-of": "^6.0.2"
           }
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
         }
       }
     },
@@ -3127,9 +3138,9 @@
       "dev": true
     },
     "bluebird": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-      "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
       "dev": true
     },
     "bn.js": {
@@ -3213,6 +3224,15 @@
         "which": "^1.3.1"
       },
       "dependencies": {
+        "ansi-escapes": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.2.1.tgz",
+          "integrity": "sha512-Cg3ymMAdN10wOk/VYfLV7KCQyv7EDirJ64500sU7n9UlmioEtDuU5Gd+hj73hXSU/ex7tHJSssmyftDdkMLO8Q==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.5.2"
+          }
+        },
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -3245,6 +3265,15 @@
           "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
           "dev": true
         },
+        "cli-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^3.1.0"
+          }
+        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -3255,9 +3284,9 @@
           }
         },
         "execa": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-2.0.3.tgz",
-          "integrity": "sha512-iM124nlyGSrXmuyZF1EMe83ESY2chIYVyDRZKgmcDynid2Q2v/+GuE7gNMl6Sy9Niwf4MC0DDxagOxeMPjuLsw==",
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-2.0.4.tgz",
+          "integrity": "sha512-VcQfhuGD51vQUQtKIq2fjGDLDbL6N1DTQVpYzxZ7LPIXw3HqTuIz6uxRmpV1qf8i31LHf2kjiaGI+GdHwRgbnQ==",
           "dev": true,
           "requires": {
             "cross-spawn": "^6.0.5",
@@ -3293,6 +3322,15 @@
             }
           }
         },
+        "figures": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-3.0.0.tgz",
+          "integrity": "sha512-HKri+WoWoUgr83pehn/SIgLOMZ9nAWC6dcGj26RY2R4F50u4+RTUz0RCrUlOV3nKRAICW1UGzyb+kcX2qK1S/g==",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
         "get-stream": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
@@ -3303,25 +3341,31 @@
           }
         },
         "inquirer": {
-          "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
-          "integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.1.tgz",
+          "integrity": "sha512-uxNHBeQhRXIoHWTSNYUFhQVrHYFThIt6IVo2fFmSe8aBwdR3/w6b58hJpiL/fMukFkvGzjg+hSxFtwvVmKZmXw==",
           "dev": true,
           "requires": {
-            "ansi-escapes": "^3.2.0",
+            "ansi-escapes": "^4.2.1",
             "chalk": "^2.4.2",
-            "cli-cursor": "^2.1.0",
+            "cli-cursor": "^3.1.0",
             "cli-width": "^2.0.0",
             "external-editor": "^3.0.3",
-            "figures": "^2.0.0",
-            "lodash": "^4.17.12",
-            "mute-stream": "0.0.7",
+            "figures": "^3.0.0",
+            "lodash": "^4.17.15",
+            "mute-stream": "0.0.8",
             "run-async": "^2.2.0",
             "rxjs": "^6.4.0",
-            "string-width": "^2.1.0",
+            "string-width": "^4.1.0",
             "strip-ansi": "^5.1.0",
             "through": "^2.3.6"
           }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
         },
         "is-stream": {
           "version": "2.0.0",
@@ -3339,6 +3383,12 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "mute-stream": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+          "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
           "dev": true
         },
         "npm-run-path": {
@@ -3371,11 +3421,32 @@
           "integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==",
           "dev": true
         },
+        "restore-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+          "dev": true,
+          "requires": {
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
+        },
+        "string-width": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.1.0.tgz",
+          "integrity": "sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^5.2.0"
+          }
         },
         "strip-ansi": {
           "version": "5.2.0",
@@ -3492,6 +3563,12 @@
             "supports-color": "^5.3.0"
           }
         },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
@@ -3520,6 +3597,12 @@
           "requires": {
             "has-flag": "^3.0.0"
           }
+        },
+        "type-fest": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+          "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+          "dev": true
         }
       }
     },
@@ -4601,11 +4684,14 @@
         "y18n": "^4.0.0"
       },
       "dependencies": {
-        "bluebird": {
-          "version": "3.5.5",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-          "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
-          "dev": true
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
         },
         "y18n": {
           "version": "4.0.0",
@@ -4990,6 +5076,14 @@
         "center-align": "^0.1.1",
         "right-align": "^0.1.1",
         "wordwrap": "0.0.2"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "dev": true
+        }
       }
     },
     "clone": {
@@ -5243,6 +5337,15 @@
         "through2": "^3.0.1"
       },
       "dependencies": {
+        "ansi-escapes": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.2.1.tgz",
+          "integrity": "sha512-Cg3ymMAdN10wOk/VYfLV7KCQyv7EDirJ64500sU7n9UlmioEtDuU5Gd+hj73hXSU/ex7tHJSssmyftDdkMLO8Q==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.5.2"
+          }
+        },
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -5275,6 +5378,15 @@
           "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
           "dev": true
         },
+        "cli-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^3.1.0"
+          }
+        },
         "external-editor": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -5286,25 +5398,82 @@
             "tmp": "^0.0.33"
           }
         },
-        "inquirer": {
-          "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
-          "integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
+        "figures": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-3.0.0.tgz",
+          "integrity": "sha512-HKri+WoWoUgr83pehn/SIgLOMZ9nAWC6dcGj26RY2R4F50u4+RTUz0RCrUlOV3nKRAICW1UGzyb+kcX2qK1S/g==",
           "dev": true,
           "requires": {
-            "ansi-escapes": "^3.2.0",
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "inquirer": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.1.tgz",
+          "integrity": "sha512-uxNHBeQhRXIoHWTSNYUFhQVrHYFThIt6IVo2fFmSe8aBwdR3/w6b58hJpiL/fMukFkvGzjg+hSxFtwvVmKZmXw==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^4.2.1",
             "chalk": "^2.4.2",
-            "cli-cursor": "^2.1.0",
+            "cli-cursor": "^3.1.0",
             "cli-width": "^2.0.0",
             "external-editor": "^3.0.3",
-            "figures": "^2.0.0",
-            "lodash": "^4.17.12",
-            "mute-stream": "0.0.7",
+            "figures": "^3.0.0",
+            "lodash": "^4.17.15",
+            "mute-stream": "0.0.8",
             "run-async": "^2.2.0",
             "rxjs": "^6.4.0",
-            "string-width": "^2.1.0",
+            "string-width": "^4.1.0",
             "strip-ansi": "^5.1.0",
             "through": "^2.3.6"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+          "dev": true
+        },
+        "mute-stream": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+          "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+          "dev": true
+        },
+        "onetime": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+          "dev": true,
+          "requires": {
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "string-width": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.1.0.tgz",
+          "integrity": "sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^5.2.0"
           }
         },
         "strip-ansi": {
@@ -5343,14 +5512,6 @@
       "dev": true,
       "requires": {
         "bluebird": "^3.1.1"
-      },
-      "dependencies": {
-        "bluebird": {
-          "version": "3.5.5",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-          "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
-          "dev": true
-        }
       }
     },
     "constants-browserify": {
@@ -5428,13 +5589,12 @@
       "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
     },
     "core-js-compat": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.1.4.tgz",
-      "integrity": "sha512-Z5zbO9f1d0YrJdoaQhphVAnKPimX92D6z8lCGphH89MNRxlL1prI9ExJPqVwP0/kgkQCv8c4GJGT8X16yUncOg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.2.1.tgz",
+      "integrity": "sha512-MwPZle5CF9dEaMYdDeWm73ao/IflDH+FjeJCWEADcEgFSE9TLimFKwJsfmkwzI8eC0Aj0mgvMDjeQjrElkz4/A==",
       "requires": {
-        "browserslist": "^4.6.2",
-        "core-js-pure": "3.1.4",
-        "semver": "^6.1.1"
+        "browserslist": "^4.6.6",
+        "semver": "^6.3.0"
       },
       "dependencies": {
         "browserslist": {
@@ -5453,11 +5613,6 @@
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
-    },
-    "core-js-pure": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.1.4.tgz",
-      "integrity": "sha512-uJ4Z7iPNwiu1foygbcZYJsJs1jiXrTTCvxfLDXNhI/I+NHbSIEyr548y4fcsCEyWY0XgfAG/qqaunJ1SThHenA=="
     },
     "core-object": {
       "version": "3.1.5",
@@ -5788,12 +5943,6 @@
             "is-data-descriptor": "^1.0.0",
             "kind-of": "^6.0.2"
           }
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
         }
       }
     },
@@ -6015,9 +6164,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.218",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.218.tgz",
-      "integrity": "sha512-+ABuwQH2bEUbJTMPUMfP9mjBFtbLgDjlrkg3QGQZwr/RJB7aJZBm8g3SK/lR/J76P6l/4a6RgW2yQjZQDdjtFw=="
+      "version": "1.3.230",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.230.tgz",
+      "integrity": "sha512-r0RljY5DZi9RX4v8mjHxJkDWnQe+nsrkGlHtrDF2uvZcvAkw+iglvlQi1794gZhwRtJoDOomMJlDHL2LfXSCZA=="
     },
     "elliptic": {
       "version": "6.5.0",
@@ -6250,275 +6399,6 @@
         "ember-basic-dropdown": "^1.1.2",
         "ember-cli-babel": "^7.1.2",
         "ember-cli-htmlbars": "^3.0.0"
-      }
-    },
-    "ember-c3": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/ember-c3/-/ember-c3-0.2.3.tgz",
-      "integrity": "sha1-PzE9DYxA4a/8KDau92ln2892v40=",
-      "dev": true,
-      "requires": {
-        "ember-cli-babel": "^5.1.5"
-      },
-      "dependencies": {
-        "babel-core": {
-          "version": "5.8.38",
-          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
-          "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
-          "dev": true,
-          "requires": {
-            "babel-plugin-constant-folding": "^1.0.1",
-            "babel-plugin-dead-code-elimination": "^1.0.2",
-            "babel-plugin-eval": "^1.0.1",
-            "babel-plugin-inline-environment-variables": "^1.0.1",
-            "babel-plugin-jscript": "^1.0.4",
-            "babel-plugin-member-expression-literals": "^1.0.1",
-            "babel-plugin-property-literals": "^1.0.1",
-            "babel-plugin-proto-to-assign": "^1.0.3",
-            "babel-plugin-react-constant-elements": "^1.0.3",
-            "babel-plugin-react-display-name": "^1.0.3",
-            "babel-plugin-remove-console": "^1.0.1",
-            "babel-plugin-remove-debugger": "^1.0.1",
-            "babel-plugin-runtime": "^1.0.7",
-            "babel-plugin-undeclared-variables-check": "^1.0.2",
-            "babel-plugin-undefined-to-void": "^1.1.6",
-            "babylon": "^5.8.38",
-            "bluebird": "^2.9.33",
-            "chalk": "^1.0.0",
-            "convert-source-map": "^1.1.0",
-            "core-js": "^1.0.0",
-            "debug": "^2.1.1",
-            "detect-indent": "^3.0.0",
-            "esutils": "^2.0.0",
-            "fs-readdir-recursive": "^0.1.0",
-            "globals": "^6.4.0",
-            "home-or-tmp": "^1.0.0",
-            "is-integer": "^1.0.4",
-            "js-tokens": "1.0.1",
-            "json5": "^0.4.0",
-            "lodash": "^3.10.0",
-            "minimatch": "^2.0.3",
-            "output-file-sync": "^1.1.0",
-            "path-exists": "^1.0.0",
-            "path-is-absolute": "^1.0.0",
-            "private": "^0.1.6",
-            "regenerator": "0.8.40",
-            "regexpu": "^1.3.0",
-            "repeating": "^1.1.2",
-            "resolve": "^1.1.6",
-            "shebang-regex": "^1.0.0",
-            "slash": "^1.0.0",
-            "source-map": "^0.5.0",
-            "source-map-support": "^0.2.10",
-            "to-fast-properties": "^1.0.0",
-            "trim-right": "^1.0.0",
-            "try-resolve": "^1.0.0"
-          }
-        },
-        "babylon": {
-          "version": "5.8.38",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
-          "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
-          "dev": true
-        },
-        "broccoli-babel-transpiler": {
-          "version": "5.7.4",
-          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.4.tgz",
-          "integrity": "sha512-gI14Pqc4qbmn5RW4SuAmybLiOoYW59D+HzQyhY6WdaGMAjikKBwJN0p17phyvafQ+kvG0mUiMd83lgHLeATnEA==",
-          "dev": true,
-          "requires": {
-            "babel-core": "^5.0.0",
-            "broccoli-funnel": "^1.0.0",
-            "broccoli-merge-trees": "^1.0.0",
-            "broccoli-persistent-filter": "^1.4.2",
-            "clone": "^0.2.0",
-            "hash-for-dep": "^1.0.2",
-            "heimdalljs-logger": "^0.1.7",
-            "json-stable-stringify": "^1.0.0",
-            "rsvp": "^3.5.0",
-            "workerpool": "^2.3.0"
-          },
-          "dependencies": {
-            "clone": {
-              "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-              "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-              "dev": true
-            }
-          }
-        },
-        "broccoli-funnel": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
-          "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
-          "dev": true,
-          "requires": {
-            "array-equal": "^1.0.0",
-            "blank-object": "^1.0.1",
-            "broccoli-plugin": "^1.3.0",
-            "debug": "^2.2.0",
-            "exists-sync": "0.0.4",
-            "fast-ordered-set": "^1.0.0",
-            "fs-tree-diff": "^0.5.3",
-            "heimdalljs": "^0.2.0",
-            "minimatch": "^3.0.0",
-            "mkdirp": "^0.5.0",
-            "path-posix": "^1.0.0",
-            "rimraf": "^2.4.3",
-            "symlink-or-copy": "^1.0.0",
-            "walk-sync": "^0.3.1"
-          },
-          "dependencies": {
-            "minimatch": {
-              "version": "3.0.4",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-              "dev": true,
-              "requires": {
-                "brace-expansion": "^1.1.7"
-              }
-            }
-          }
-        },
-        "broccoli-merge-trees": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz",
-          "integrity": "sha1-oAFRm7UGfwZYnZGvopQkRaLQ/bU=",
-          "dev": true,
-          "requires": {
-            "broccoli-plugin": "^1.3.0",
-            "can-symlink": "^1.0.0",
-            "fast-ordered-set": "^1.0.2",
-            "fs-tree-diff": "^0.5.4",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.7",
-            "rimraf": "^2.4.3",
-            "symlink-or-copy": "^1.0.0"
-          }
-        },
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
-          "dev": true
-        },
-        "detect-indent": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-          "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "^4.0.1",
-            "minimist": "^1.1.0",
-            "repeating": "^1.1.0"
-          }
-        },
-        "ember-cli-babel": {
-          "version": "5.2.8",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.8.tgz",
-          "integrity": "sha512-Mt9OOB5RaZwjde+LYef8EgwNVCAzsYDv4ktshblaXxr4m/Xm5/7/rxEu42RNrYkoy/qWpT9uhaD+JKK4riMf+w==",
-          "dev": true,
-          "requires": {
-            "broccoli-babel-transpiler": "^5.6.2",
-            "broccoli-funnel": "^1.0.0",
-            "clone": "^2.0.0",
-            "ember-cli-version-checker": "^1.0.2",
-            "resolve": "^1.1.2"
-          }
-        },
-        "ember-cli-version-checker": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-          "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
-          "dev": true,
-          "requires": {
-            "semver": "^5.3.0"
-          }
-        },
-        "globals": {
-          "version": "6.4.1",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
-          "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08=",
-          "dev": true
-        },
-        "home-or-tmp": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-          "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "^1.0.1",
-            "user-home": "^1.1.1"
-          }
-        },
-        "js-tokens": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz",
-          "integrity": "sha1-zENaXIuUrRWst5gxQPyAGCyJrq4=",
-          "dev": true
-        },
-        "json5": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-          "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "2.0.10",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.0.0"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "path-exists": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-          "integrity": "sha1-1aiZjrce83p0w06w2eum6HjuoIE=",
-          "dev": true
-        },
-        "repeating": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-          "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-          "dev": true,
-          "requires": {
-            "is-finite": "^1.0.0"
-          }
-        },
-        "source-map-support": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
-          "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
-          "dev": true,
-          "requires": {
-            "source-map": "0.1.32"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.1.32",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-              "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-              "dev": true,
-              "requires": {
-                "amdefine": ">=0.0.4"
-              }
-            }
-          }
-        }
       }
     },
     "ember-cli": {
@@ -6853,9 +6733,9 @@
       }
     },
     "ember-cli-babel": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.8.0.tgz",
-      "integrity": "sha512-xUBgJQ81fqd7k/KIiGU+pjpoXhrmmRf9pUrqLenNSU5N+yeNFT5a1+w0b+p1F7oBphfXVwuxApdZxrmAHOdA3Q==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.10.0.tgz",
+      "integrity": "sha512-eNgPXobC+Pke5L3XzoJ0BXbb2+eYzZI+LljqbwXNuG4q63pF000aARFpTQ0p/NWkfGQxKi2L6tVIa1ZOYdQS+A==",
       "requires": {
         "@babel/core": "^7.0.0",
         "@babel/plugin-proposal-class-properties": "^7.3.4",
@@ -6867,7 +6747,7 @@
         "@babel/runtime": "^7.2.0",
         "amd-name-resolver": "^1.2.1",
         "babel-plugin-debug-macros": "^0.3.0",
-        "babel-plugin-ember-modules-api-polyfill": "^2.9.0",
+        "babel-plugin-ember-modules-api-polyfill": "^2.11.0",
         "babel-plugin-module-resolver": "^3.1.1",
         "broccoli-babel-transpiler": "^7.1.2",
         "broccoli-debug": "^0.6.4",
@@ -7469,6 +7349,12 @@
           "version": "5.8.38",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
           "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
+          "dev": true
+        },
+        "bluebird": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
           "dev": true
         },
         "broccoli-babel-transpiler": {
@@ -8604,6 +8490,12 @@
             "ms": "^2.1.1"
           }
         },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
         "find-up": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -9141,6 +9033,12 @@
           "version": "5.8.38",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
           "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
+          "dev": true
+        },
+        "bluebird": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
           "dev": true
         },
         "broccoli-babel-transpiler": {
@@ -10181,6 +10079,12 @@
           "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
           "dev": true
         },
+        "bluebird": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
+          "dev": true
+        },
         "broccoli-babel-transpiler": {
           "version": "5.7.4",
           "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.4.tgz",
@@ -10442,13 +10346,12 @@
       }
     },
     "ember-promise-helpers": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/ember-promise-helpers/-/ember-promise-helpers-1.0.8.tgz",
-      "integrity": "sha512-zfPFBjqXCI/hk3Vdx8tSVNOuccbbJucmOQQqL+hmrtzxPl2tg1RQ2Y63XBHyYuYDHR/OoW8uixOuYE4RRjH9ig==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/ember-promise-helpers/-/ember-promise-helpers-1.0.9.tgz",
+      "integrity": "sha512-BDcx2X28baEL0YMKSmDGQzvdyfiFSlx4Byf34hVrAw6W7VO17YYLjeXPebVBOXLA1BMWmUo0Bb2pZRZ09MQYYA==",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "^6.16.0",
-        "ember-cli-update": "^0.34.10"
+        "ember-cli-babel": "^6.16.0"
       },
       "dependencies": {
         "ember-cli-babel": {
@@ -10698,9 +10601,9 @@
       }
     },
     "ember-rfc176-data": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.9.tgz",
-      "integrity": "sha512-EiTo5YQS0Duy0xp9gCP8ekzv9vxirNi7MnIB4zWs+thtWp/mEKgf5mkiiLU2+oo8C5DuavVHhoPQDmyxh8Io1Q=="
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.11.tgz",
+      "integrity": "sha512-c46uisicHswFHo0R515LPM0L/X/Ju+N7KonJPuHx9C6cWD3AWzkNG9ASv+Bc85mq/9l3LFFsFpljdM1m2YnQ6A=="
     },
     "ember-router-generator": {
       "version": "1.2.3",
@@ -10910,9 +10813,9 @@
       }
     },
     "ember-template-lint": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/ember-template-lint/-/ember-template-lint-1.5.1.tgz",
-      "integrity": "sha512-/n5o6KnDADGPg2/OuzrNR/u2w8WIfEjfJhESVw4DAS6jaF8uO0WZrNI60RvmM4Rp813iX5p8pp1dVUUz4Euy7w==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/ember-template-lint/-/ember-template-lint-1.5.2.tgz",
+      "integrity": "sha512-uAGmYrIHoBS8jjmvb2SNprX5zPEs647amO+OHT0OtrO1HjFnhS4GyOXH2xx6h38co65WpPll0o3HFyE4cEh0NA==",
       "dev": true,
       "requires": {
         "@glimmer/compiler": "^0.41.0",
@@ -11214,9 +11117,9 @@
       }
     },
     "emoji-regex": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
     "emojis-list": {
@@ -11394,9 +11297,9 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
-      "integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
+      "integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
       "dev": true,
       "requires": {
         "esprima": "^3.1.3",
@@ -11513,16 +11416,6 @@
           "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
           "dev": true
         },
-        "lru-cache": {
-          "version": "4.1.5",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-          "dev": true,
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          }
-        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -11546,12 +11439,6 @@
           "requires": {
             "has-flag": "^3.0.0"
           }
-        },
-        "yallist": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-          "dev": true
         }
       }
     },
@@ -11593,9 +11480,9 @@
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
       "dev": true
     },
     "esm": {
@@ -11638,9 +11525,9 @@
       }
     },
     "estraverse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true
     },
     "estree-walker": {
@@ -11909,12 +11796,6 @@
             "is-data-descriptor": "^1.0.0",
             "kind-of": "^6.0.2"
           }
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
         }
       }
     },
@@ -12383,6 +12264,17 @@
         "graceful-fs": "^4.1.2",
         "rimraf": "~2.6.2",
         "write": "^0.2.1"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "flush-write-stream": {
@@ -13335,6 +13227,12 @@
             "ms": "^2.1.1"
           }
         },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
         "find-up": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -13627,9 +13525,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.1.tgz",
-      "integrity": "sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw=="
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+      "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q=="
     },
     "graceful-readlink": {
       "version": "1.0.1",
@@ -13943,13 +13841,10 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.2.tgz",
-      "integrity": "sha512-CyjlXII6LMsPMyUzxpTt8fzh5QwzGqPmQXgY/Jyf4Zfp27t/FvfhwoE/8laaMUcMy816CkWF20I7NeQhwwY88w==",
-      "dev": true,
-      "requires": {
-        "lru-cache": "^5.1.1"
-      }
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
+      "integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
+      "dev": true
     },
     "html-encoding-sniffer": {
       "version": "1.0.2",
@@ -14233,6 +14128,17 @@
       "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "is-binary-path": {
@@ -14272,6 +14178,17 @@
       "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "is-date-object": {
@@ -14372,6 +14289,17 @@
       "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "is-obj": {
@@ -14758,9 +14686,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
-          "integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
+          "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
           "dev": true
         },
         "ajv": {
@@ -15012,13 +14940,10 @@
       }
     },
     "kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
-      "requires": {
-        "is-buffer": "^1.1.5"
-      }
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "dev": true
     },
     "klaw": {
       "version": "1.3.1",
@@ -15785,12 +15710,21 @@
       "dev": true
     },
     "lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "dev": true,
       "requires": {
-        "yallist": "^3.0.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "dev": true
+        }
       }
     },
     "magic-string": {
@@ -16036,14 +15970,6 @@
         "regex-not": "^1.0.0",
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
-        }
       }
     },
     "miller-rabin": {
@@ -16309,14 +16235,6 @@
         "regex-not": "^1.0.0",
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.1"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
-        }
       }
     },
     "natural-compare": {
@@ -16460,9 +16378,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.26",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
-      "integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
+      "version": "1.1.27",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.27.tgz",
+      "integrity": "sha512-9iXUqHKSGo6ph/tdXVbHFbhRVQln4ZDTIBJCzsa90HimnBYc5jw8RWYt4wBYFHehGyC3koIz5O4mb2fHrbPOuA==",
       "requires": {
         "semver": "^5.3.0"
       }
@@ -20936,6 +20854,15 @@
           "requires": {
             "is-descriptor": "^0.1.0"
           }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
         }
       }
     },
@@ -22520,9 +22447,9 @@
       }
     },
     "rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "requires": {
         "glob": "^7.1.3"
       }
@@ -22724,9 +22651,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "semver-diff": {
       "version": "2.1.0",
@@ -22988,12 +22915,6 @@
             "is-data-descriptor": "^1.0.0",
             "kind-of": "^6.0.2"
           }
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
         }
       }
     },
@@ -23004,6 +22925,17 @@
       "dev": true,
       "requires": {
         "kind-of": "^3.2.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "sntp": {
@@ -23656,6 +23588,17 @@
       "dev": true,
       "requires": {
         "rimraf": "~2.6.2"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "term-size": {
@@ -23698,29 +23641,13 @@
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
-        },
-        "lru-cache": {
-          "version": "4.1.5",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-          "dev": true,
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          }
-        },
-        "yallist": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-          "dev": true
         }
       }
     },
     "terser": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.1.3.tgz",
-      "integrity": "sha512-on13d+cnpn5bMouZu+J8tPYQecsdRJCJuxFJ+FVoPBoLJgk5bCBkp+Uen2hWyi0KIUm6eDarnlAlH+KgIx/PuQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.1.4.tgz",
+      "integrity": "sha512-+ZwXJvdSwbd60jG0Illav0F06GDJF0R4ydZ21Q3wGAFKoBGyJGo34F63vzJHgvYxc1ukOtIjvwEvl9MkjzM6Pg==",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",
@@ -23849,12 +23776,6 @@
         "xmldom": "^0.1.19"
       },
       "dependencies": {
-        "bluebird": {
-          "version": "3.5.5",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-          "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
-          "dev": true
-        },
         "tmp": {
           "version": "0.0.33",
           "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -23949,9 +23870,9 @@
       "dev": true
     },
     "timers-browserify": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
-      "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
+      "integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
       "dev": true,
       "requires": {
         "setimmediate": "^1.0.4"
@@ -24032,6 +23953,17 @@
       "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "to-readable-stream": {
@@ -24168,9 +24100,9 @@
       }
     },
     "type-fest": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
-      "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
+      "integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==",
       "dev": true
     },
     "type-is": {
@@ -24834,9 +24766,9 @@
       "dev": true
     },
     "wordwrap": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
       "dev": true
     },
     "worker-farm": {
@@ -24881,6 +24813,12 @@
           "requires": {
             "color-convert": "^1.9.0"
           }
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
         },
         "string-width": {
           "version": "3.1.0",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -36,7 +36,6 @@
     "broccoli-asset-rev": "^2.7.0",
     "ember-ajax": "^4.0.1",
     "ember-basic-dropdown-hover": "^0.6.0",
-    "ember-c3": "0.2.3",
     "ember-cli": "~3.8.1",
     "ember-cli-app-version": "^3.2.0",
     "ember-cli-babel": "^7.2.0",

--- a/packages/core/addon/components/navi-vis-c3-chart.js
+++ b/packages/core/addon/components/navi-vis-c3-chart.js
@@ -20,11 +20,11 @@ import { next, scheduleOnce } from '@ember/runloop';
 import { assign } from '@ember/polyfills';
 import { set, getProperties, get, computed } from '@ember/object';
 import C3Chart from 'ember-c3/components/c3-chart';
+import c3 from 'c3';
 import { A } from '@ember/array';
 import { inject as service } from '@ember/service';
 import $ from 'jquery';
 
-/* globals c3: true */
 export default C3Chart.extend({
   /**
    * @property {Service} metricName
@@ -137,14 +137,14 @@ export default C3Chart.extend({
   /**
    * @property {Object} chart - c3 object reference
    */
-  chart: computed('_config', '_chart', function() {
-    if (!get(this, '_chart')) {
+  chart: computed('_config', 'c3chart', function() {
+    if (!get(this, 'c3chart')) {
       let config = get(this, '_config');
 
       // eslint-disable-next-line ember/no-side-effects
-      set(this, '_chart', c3.generate(config));
+      set(this, 'c3chart', c3.generate(config));
     }
-    return get(this, '_chart');
+    return get(this, 'c3chart');
   }),
 
   /**
@@ -169,8 +169,7 @@ export default C3Chart.extend({
    * @returns {Void}
    */
   _teardownChart() {
-    get(this, 'chart').destroy();
-    set(this, '_chart', null);
+    set(this, 'c3chart', null);
   },
 
   /**
@@ -229,4 +228,3 @@ export default C3Chart.extend({
     this._teardownChart();
   }
 });
-/* globals c3: false */

--- a/packages/core/addon/components/navi-visualizations/goal-gauge.js
+++ b/packages/core/addon/components/navi-visualizations/goal-gauge.js
@@ -9,14 +9,13 @@
  *  }}
  */
 
-/* globals d3 */
-
 import { alias } from '@ember/object/computed';
 import Component from '@ember/component';
 import { computed, get, getWithDefault } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import { inject as service } from '@ember/service';
 import numeral from 'numeral';
+import d3 from 'd3';
 import layout from '../../templates/components/navi-visualizations/goal-gauge';
 import { metricFormat } from 'navi-data/helpers/metric-format';
 import { canonicalizeMetric } from 'navi-data/utils/metric';
@@ -68,6 +67,11 @@ export default Component.extend({
    * @property {Number} - value which is desired to be achieved
    */
   goalValue: alias('config.goalValue'),
+
+  /**
+   * @property {Object} - legend configuration
+   */
+  legend: computed(() => ({ hide: true })),
 
   /**
    * @property {String} formatted default metric
@@ -139,11 +143,13 @@ export default Component.extend({
       width: 20,
       max: get(this, 'goalValue'),
       min: get(this, 'baselineValue'),
-      minmaxformat: value => {
-        let number = this._formatNumber(value),
-          prefix = get(this, 'prefix'),
-          unit = get(this, 'unit');
-        return `${prefix}${number}${unit}`;
+      label: {
+        extents: value => {
+          let number = this._formatNumber(value),
+            prefix = get(this, 'prefix'),
+            unit = get(this, 'unit');
+          return `${prefix}${number}${unit}`;
+        }
       }
     };
   }),

--- a/packages/core/addon/components/navi-visualizations/pie-chart.js
+++ b/packages/core/addon/components/navi-visualizations/pie-chart.js
@@ -9,6 +9,7 @@
  * }}
  */
 
+import d3 from 'd3';
 import { alias, readOnly } from '@ember/object/computed';
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
@@ -21,6 +22,7 @@ import tooltipLayout from '../../templates/chart-tooltips/pie-chart';
 import merge from 'lodash/merge';
 import { smartFormatNumber } from 'navi-core/helpers/smart-format-number';
 import DimensionBuilder from 'navi-core/chart-builders/dimension';
+import { getTranslation } from '../../utils/chart';
 
 export default Component.extend({
   layout,
@@ -232,7 +234,7 @@ export default Component.extend({
        * We want the metric label to be just to the left of the pie chart
        * Find the x translation of the pie chart element and subtract half the chart's width and 50 more pixels
        */
-      xTranslate = d3.transform(chartElm.attr('transform')).translate[0] - chartElm.node().getBBox().width / 2 - 50,
+      xTranslate = getTranslation(chartElm.attr('transform')).x - chartElm.node().getBBox().width / 2 - 50,
       yTranslate = svgElm.style('height').replace('px', '') / 2, //vertically center the label in the svg
       metricTitle = get(this, 'metricDisplayName');
 

--- a/packages/core/addon/initializers/inject-c3-enhancements.js
+++ b/packages/core/addon/initializers/inject-c3-enhancements.js
@@ -4,6 +4,7 @@
  */
 import { set } from '@ember/object';
 import { A } from '@ember/array';
+import c3 from 'c3';
 
 /**
  * Override c3 functions with customized logic
@@ -85,11 +86,6 @@ export function initialize() {
   };
 
   /**
-   * @property {Function} gauge_minmaxformat - used to register option
-   */
-  c3infn.additionalConfig.gauge_minmaxformat = undefined;
-
-  /**
    * c3 supports giving each series a user defined class,
    * but prefixes each class with `c3-target-`. Since the
    * prefix gets in the way of the user requested class,
@@ -127,6 +123,24 @@ export function initialize() {
   };
 
   /**
+   * C3 has a bug in which tweening happens even after chart is destroyed
+   * Which causes the whole thing to crash
+   * this overrides fixes that
+   * https://github.com/c3js/c3/issues/2213
+   * @override
+   * @param { object } d data object
+   * @param { Boolean } withoutUpdate  wheter svg should be updated
+   * @param {String} forced return value
+   * @return {String}
+   */
+  c3infn.getArc = function(d, withoutUpdate, force) {
+    if (this.config === null) {
+      return 'M 0 0';
+    }
+    return force || this.isArcType(d.data) ? this.svgArc(d, withoutUpdate) : 'M 0 0';
+  };
+
+  /**
    * Allow mixing raw c3 json format with data.x config option
    * @method convertJsonToData
    * @override
@@ -153,230 +167,6 @@ export function initialize() {
    */
   c3infn.isCustomX = function() {
     return false;
-  };
-
-  /**
-   * @method getGaugeLabelHeight
-   * @override
-   * @returns {Number}
-   */
-  c3infn.getGaugeLabelHeight = function() {
-    return 100;
-  };
-
-  /**
-   * @method textForGaugeMinMax
-   * @param {Number} min/max value
-   * @returns {String} formatted value
-   */
-  c3infn.textForGaugeMinMax = function(value) {
-    var format = this.config.gauge_minmaxformat;
-    return format ? format(value) : value;
-  };
-
-  /**
-   * Overrides the redrawArc method to add support for user define
-   * min max value format
-   *
-   * @method redrawArc
-   * @override
-   * @param {Number} duration
-   * @param {Number} durationForExit
-   * @param {Object} withTransform
-   * @returns {Void}
-   */
-  c3infn.redrawArc = function(duration, durationForExit, withTransform) {
-    var $$ = this,
-      d3 = $$.d3,
-      config = $$.config,
-      main = $$.main,
-      mainArc;
-    mainArc = main
-      .selectAll('.' + $$.CLASS.arcs)
-      .selectAll('.' + $$.CLASS.arc)
-      .data($$.arcData.bind($$));
-    mainArc
-      .enter()
-      .append('path')
-      .attr('class', $$.classArc.bind($$))
-      .style('fill', function(d) {
-        return $$.color(d.data);
-      })
-      .style('cursor', function(d) {
-        return config.interaction_enabled && config.data_selection_isselectable(d) ? 'pointer' : null;
-      })
-      .style('opacity', 0)
-      .each(function(d) {
-        if ($$.isGaugeType(d.data)) {
-          d.startAngle = d.endAngle = -1 * (Math.PI / 2);
-        }
-        this._current = d;
-      });
-    mainArc
-      .attr('transform', function(d) {
-        return !$$.isGaugeType(d.data) && withTransform ? 'scale(0)' : '';
-      })
-      .style('opacity', function(d) {
-        return d === this._current ? 0 : 1;
-      })
-      .on(
-        'mouseover',
-        config.interaction_enabled
-          ? function(d) {
-              var updated, arcData;
-              if ($$.transiting) {
-                // skip while transiting
-                return;
-              }
-              updated = $$.updateAngle(d);
-              arcData = $$.convertToArcData(updated);
-              // transitions
-              $$.expandArc(updated.data.id);
-              $$.api.focus(updated.data.id);
-              $$.toggleFocusLegend(updated.data.id, true);
-              $$.config.data_onmouseover(arcData, this);
-            }
-          : null
-      )
-      .on(
-        'mousemove',
-        config.interaction_enabled
-          ? function(d) {
-              var updated = $$.updateAngle(d),
-                arcData = $$.convertToArcData(updated),
-                selectedData = [arcData];
-              $$.showTooltip(selectedData, this);
-            }
-          : null
-      )
-      .on(
-        'mouseout',
-        config.interaction_enabled
-          ? function(d) {
-              var updated, arcData;
-              if ($$.transiting) {
-                // skip while transiting
-                return;
-              }
-              updated = $$.updateAngle(d);
-              arcData = $$.convertToArcData(updated);
-              // transitions
-              $$.unexpandArc(updated.data.id);
-              $$.api.revert();
-              $$.revertLegend();
-              $$.hideTooltip();
-              $$.config.data_onmouseout(arcData, this);
-            }
-          : null
-      )
-      .on(
-        'click',
-        config.interaction_enabled
-          ? function(d, i) {
-              var updated = $$.updateAngle(d),
-                arcData = $$.convertToArcData(updated);
-              if ($$.toggleShape) {
-                $$.toggleShape(this, arcData, i);
-              }
-              $$.config.data_onclick.call($$.api, arcData, this);
-            }
-          : null
-      )
-      .each(function() {
-        $$.transiting = true;
-      })
-      .transition()
-      .duration(duration)
-      .attrTween('d', function(d) {
-        var updated = $$.updateAngle(d),
-          interpolate;
-        if (!updated) {
-          return function() {
-            return 'M 0 0';
-          };
-        }
-        /*
-         *                if (this._current === d) {
-         *                    this._current = {
-         *                        startAngle: Math.PI*2,
-         *                        endAngle: Math.PI*2,
-         *                    };
-         *                }
-         */
-        if (isNaN(this._current.startAngle)) {
-          this._current.startAngle = 0;
-        }
-        if (isNaN(this._current.endAngle)) {
-          this._current.endAngle = this._current.startAngle;
-        }
-        interpolate = d3.interpolate(this._current, updated);
-        this._current = interpolate(0);
-        return function(t) {
-          var interpolated = interpolate(t);
-          interpolated.data = d.data; // data.id will be updated by interporator
-          return $$.getArc(interpolated, true);
-        };
-      })
-      .attr('transform', withTransform ? 'scale(1)' : '')
-      .style('fill', function(d) {
-        return $$.levelColor ? $$.levelColor(d.data.values[0].value) : $$.color(d.data.id);
-      }) // Where gauge reading color would receive customization.
-      .style('opacity', 1)
-      .call($$.endall, function() {
-        $$.transiting = false;
-      });
-    mainArc
-      .exit()
-      .transition()
-      .duration(durationForExit)
-      .style('opacity', 0)
-      .remove();
-    main
-      .selectAll('.' + $$.CLASS.chartArc)
-      .select('text')
-      .style('opacity', 0)
-      .attr('class', function(d) {
-        return $$.isGaugeType(d.data) ? $$.CLASS.gaugeValue : '';
-      })
-      .text($$.textForArcLabel.bind($$))
-      .attr('transform', $$.transformForArcLabel.bind($$))
-      .style('font-size', function(d) {
-        return $$.isGaugeType(d.data) ? Math.round($$.radius / 5) + 'px' : '';
-      })
-      .transition()
-      .duration(duration)
-      .style('opacity', function(d) {
-        return $$.isTargetToShow(d.data.id) && $$.isArcType(d.data) ? 1 : 0;
-      });
-    main.select('.' + $$.CLASS.chartArcsTitle).style('opacity', $$.hasType('donut') || $$.hasType('gauge') ? 1 : 0);
-
-    if ($$.hasType('gauge')) {
-      $$.arcs.select('.' + $$.CLASS.chartArcsBackground).attr('d', function() {
-        var d = {
-          data: [{ value: config.gauge_max }],
-          startAngle: -1 * (Math.PI / 2),
-          endAngle: Math.PI / 2
-        };
-        return $$.getArc(d, true, true);
-      });
-      $$.arcs
-        .select('.' + $$.CLASS.chartArcsGaugeUnit)
-        .attr('dy', '.75em')
-        .text(config.gauge_label_show ? config.gauge_units : '');
-      /*
-       * Custom logic to use user define min/max format if defined
-       */
-      $$.arcs
-        .select('.' + $$.CLASS.chartArcsGaugeMin)
-        .attr('dx', -1 * ($$.innerRadius + ($$.radius - $$.innerRadius) / 2) + 'px')
-        .attr('dy', '1.2em')
-        .text(config.gauge_label_show ? $$.textForGaugeMinMax(config.gauge_min) : '');
-      $$.arcs
-        .select('.' + $$.CLASS.chartArcsGaugeMax)
-        .attr('dx', $$.innerRadius + ($$.radius - $$.innerRadius) / 2 + 'px')
-        .attr('dy', '1.2em')
-        .text(config.gauge_label_show ? $$.textForGaugeMinMax(config.gauge_max) : '');
-    }
   };
 }
 

--- a/packages/core/addon/templates/components/navi-visualizations/goal-gauge.hbs
+++ b/packages/core/addon/templates/components/navi-visualizations/goal-gauge.hbs
@@ -5,5 +5,6 @@
   gauge=gauge
   tooltip=tooltip
   color=color
+  legend=legend
   containerComponent=containerComponent
 }}

--- a/packages/core/addon/utils/chart.js
+++ b/packages/core/addon/utils/chart.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2019, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+
+/**
+ * given a transform, returns the translation that transform provides
+ * @param {String} transform - transform to calculate
+ * @returns {Object} - Object with x and y properties
+ */
+
+export function getTranslation(transform) {
+  /*
+   * Create a dummy g for calculation purposes only. This will never
+   * be appended to the DOM and will be discarded once this function
+   * returns.
+   */
+  const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+
+  // Set the transform attribute to the provided string value.
+  g.setAttributeNS(null, 'transform', transform);
+
+  /*
+   * consolidate the SVGTransformList containing all transformations
+   * to a single SVGTransform of type SVG_TRANSFORM_MATRIX and get
+   * its SVGMatrix.
+   */
+  const matrix = g.transform.baseVal.consolidate().matrix;
+
+  /*
+   * Below calculations are taken and adapted from the private function
+   * transform/decompose.js of D3's module d3-interpolate.
+   */
+  return { x: matrix.e, y: matrix.f };
+}

--- a/packages/core/bower.json
+++ b/packages/core/bower.json
@@ -1,8 +1,6 @@
 {
   "name": "navi-core",
   "dependencies": {
-    "d3": "3.5.17",
-    "c3": "0.4.20",
     "numeral": "^1.5.3"
   }
 }

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -4372,6 +4372,14 @@
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
       "dev": true
     },
+    "c3": {
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/c3/-/c3-0.7.8.tgz",
+      "integrity": "sha512-yccP+u4Bp/MVPRowT8go5Sp66FZWsP071v5tqRR+mjqB37U6oDHY3pna1qE5ba/YIIxWHrz6ianI45SpzR4dhA==",
+      "requires": {
+        "d3": "^5.8.0"
+      }
+    },
     "cacache": {
       "version": "12.0.2",
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.2.tgz",
@@ -5468,6 +5476,270 @@
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
       "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
     },
+    "d3": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-5.11.0.tgz",
+      "integrity": "sha512-LXgMVUAEAzQh6WfEEOa8tJX4RA64ZJ6twC3CJ+Xzid+fXWLTZkkglagXav/eOoQgzQi5rzV0xC4Sfspd6hFDHA==",
+      "requires": {
+        "d3-array": "1",
+        "d3-axis": "1",
+        "d3-brush": "1",
+        "d3-chord": "1",
+        "d3-collection": "1",
+        "d3-color": "1",
+        "d3-contour": "1",
+        "d3-dispatch": "1",
+        "d3-drag": "1",
+        "d3-dsv": "1",
+        "d3-ease": "1",
+        "d3-fetch": "1",
+        "d3-force": "1",
+        "d3-format": "1",
+        "d3-geo": "1",
+        "d3-hierarchy": "1",
+        "d3-interpolate": "1",
+        "d3-path": "1",
+        "d3-polygon": "1",
+        "d3-quadtree": "1",
+        "d3-random": "1",
+        "d3-scale": "2",
+        "d3-scale-chromatic": "1",
+        "d3-selection": "1",
+        "d3-shape": "1",
+        "d3-time": "1",
+        "d3-time-format": "2",
+        "d3-timer": "1",
+        "d3-transition": "1",
+        "d3-voronoi": "1",
+        "d3-zoom": "1"
+      }
+    },
+    "d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "d3-axis": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-1.0.12.tgz",
+      "integrity": "sha512-ejINPfPSNdGFKEOAtnBtdkpr24c4d4jsei6Lg98mxf424ivoDP2956/5HDpIAtmHo85lqT4pruy+zEgvRUBqaQ=="
+    },
+    "d3-brush": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-1.1.3.tgz",
+      "integrity": "sha512-v8bbYyCFKjyCzFk/tdWqXwDykY8YWqhXYjcYxfILIit085VZOpj4XJKOMccTsvWxgzSLMJQg5SiqHjslsipEDg==",
+      "requires": {
+        "d3-dispatch": "1",
+        "d3-drag": "1",
+        "d3-interpolate": "1",
+        "d3-selection": "1",
+        "d3-transition": "1"
+      }
+    },
+    "d3-chord": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-1.0.6.tgz",
+      "integrity": "sha512-JXA2Dro1Fxw9rJe33Uv+Ckr5IrAa74TlfDEhE/jfLOaXegMQFQTAgAw9WnZL8+HxVBRXaRGCkrNU7pJeylRIuA==",
+      "requires": {
+        "d3-array": "1",
+        "d3-path": "1"
+      }
+    },
+    "d3-collection": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
+      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="
+    },
+    "d3-color": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.3.0.tgz",
+      "integrity": "sha512-NHODMBlj59xPAwl2BDiO2Mog6V+PrGRtBfWKqKRrs9MCqlSkIEb0Z/SfY7jW29ReHTDC/j+vwXhnZcXI3+3fbg=="
+    },
+    "d3-contour": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-1.3.2.tgz",
+      "integrity": "sha512-hoPp4K/rJCu0ladiH6zmJUEz6+u3lgR+GSm/QdM2BBvDraU39Vr7YdDCicJcxP1z8i9B/2dJLgDC1NcvlF8WCg==",
+      "requires": {
+        "d3-array": "^1.1.1"
+      }
+    },
+    "d3-dispatch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.5.tgz",
+      "integrity": "sha512-vwKx+lAqB1UuCeklr6Jh1bvC4SZgbSqbkGBLClItFBIYH4vqDJCA7qfoy14lXmJdnBOdxndAMxjCbImJYW7e6g=="
+    },
+    "d3-drag": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.4.tgz",
+      "integrity": "sha512-ICPurDETFAelF1CTHdIyiUM4PsyZLaM+7oIBhmyP+cuVjze5vDZ8V//LdOFjg0jGnFIZD/Sfmk0r95PSiu78rw==",
+      "requires": {
+        "d3-dispatch": "1",
+        "d3-selection": "1"
+      }
+    },
+    "d3-dsv": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-1.1.1.tgz",
+      "integrity": "sha512-1EH1oRGSkeDUlDRbhsFytAXU6cAmXFzc52YUe6MRlPClmWb85MP1J5x+YJRzya4ynZWnbELdSAvATFW/MbxaXw==",
+      "requires": {
+        "commander": "2",
+        "iconv-lite": "0.4",
+        "rw": "1"
+      }
+    },
+    "d3-ease": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.5.tgz",
+      "integrity": "sha512-Ct1O//ly5y5lFM9YTdu+ygq7LleSgSE4oj7vUt9tPLHUi8VCV7QoizGpdWRWAwCO9LdYzIrQDg97+hGVdsSGPQ=="
+    },
+    "d3-fetch": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-1.1.2.tgz",
+      "integrity": "sha512-S2loaQCV/ZeyTyIF2oP8D1K9Z4QizUzW7cWeAOAS4U88qOt3Ucf6GsmgthuYSdyB2HyEm4CeGvkQxWsmInsIVA==",
+      "requires": {
+        "d3-dsv": "1"
+      }
+    },
+    "d3-force": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.2.1.tgz",
+      "integrity": "sha512-HHvehyaiUlVo5CxBJ0yF/xny4xoaxFxDnBXNvNcfW9adORGZfyNF1dj6DGLKyk4Yh3brP/1h3rnDzdIAwL08zg==",
+      "requires": {
+        "d3-collection": "1",
+        "d3-dispatch": "1",
+        "d3-quadtree": "1",
+        "d3-timer": "1"
+      }
+    },
+    "d3-format": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.3.2.tgz",
+      "integrity": "sha512-Z18Dprj96ExragQ0DeGi+SYPQ7pPfRMtUXtsg/ChVIKNBCzjO8XYJvRTC1usblx52lqge56V5ect+frYTQc8WQ=="
+    },
+    "d3-geo": {
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.11.6.tgz",
+      "integrity": "sha512-z0J8InXR9e9wcgNtmVnPTj0TU8nhYT6lD/ak9may2PdKqXIeHUr8UbFLoCtrPYNsjv6YaLvSDQVl578k6nm7GA==",
+      "requires": {
+        "d3-array": "1"
+      }
+    },
+    "d3-hierarchy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.8.tgz",
+      "integrity": "sha512-L+GHMSZNwTpiq4rt9GEsNcpLa4M96lXMR8M/nMG9p5hBE0jy6C+3hWtyZMenPQdwla249iJy7Nx0uKt3n+u9+w=="
+    },
+    "d3-interpolate": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.3.2.tgz",
+      "integrity": "sha512-NlNKGopqaz9qM1PXh9gBF1KSCVh+jSFErrSlD/4hybwoNX/gt1d8CDbDW+3i+5UOHhjC6s6nMvRxcuoMVNgL2w==",
+      "requires": {
+        "d3-color": "1"
+      }
+    },
+    "d3-path": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.8.tgz",
+      "integrity": "sha512-J6EfUNwcMQ+aM5YPOB8ZbgAZu6wc82f/0WFxrxwV6Ll8wBwLaHLKCqQ5Imub02JriCVVdPjgI+6P3a4EWJCxAg=="
+    },
+    "d3-polygon": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-1.0.5.tgz",
+      "integrity": "sha512-RHhh1ZUJZfhgoqzWWuRhzQJvO7LavchhitSTHGu9oj6uuLFzYZVeBzaWTQ2qSO6bz2w55RMoOCf0MsLCDB6e0w=="
+    },
+    "d3-quadtree": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.6.tgz",
+      "integrity": "sha512-NUgeo9G+ENQCQ1LsRr2qJg3MQ4DJvxcDNCiohdJGHt5gRhBW6orIB5m5FJ9kK3HNL8g9F4ERVoBzcEwQBfXWVA=="
+    },
+    "d3-random": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-1.1.2.tgz",
+      "integrity": "sha512-6AK5BNpIFqP+cx/sreKzNjWbwZQCSUatxq+pPRmFIQaWuoD+NrbVWw7YWpHiXpCQ/NanKdtGDuB+VQcZDaEmYQ=="
+    },
+    "d3-scale": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-2.2.2.tgz",
+      "integrity": "sha512-LbeEvGgIb8UMcAa0EATLNX0lelKWGYDQiPdHj+gLblGVhGLyNbaCn3EvrJf0A3Y/uOOU5aD6MTh5ZFCdEwGiCw==",
+      "requires": {
+        "d3-array": "^1.2.0",
+        "d3-collection": "1",
+        "d3-format": "1",
+        "d3-interpolate": "1",
+        "d3-time": "1",
+        "d3-time-format": "2"
+      }
+    },
+    "d3-scale-chromatic": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-1.5.0.tgz",
+      "integrity": "sha512-ACcL46DYImpRFMBcpk9HhtIyC7bTBR4fNOPxwVSl0LfulDAwyiHyPOTqcDG1+t5d4P9W7t/2NAuWu59aKko/cg==",
+      "requires": {
+        "d3-color": "1",
+        "d3-interpolate": "1"
+      }
+    },
+    "d3-selection": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.0.tgz",
+      "integrity": "sha512-EYVwBxQGEjLCKF2pJ4+yrErskDnz5v403qvAid96cNdCMr8rmCYfY5RGzWz24mdIbxmDf6/4EAH+K9xperD5jg=="
+    },
+    "d3-shape": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.5.tgz",
+      "integrity": "sha512-VKazVR3phgD+MUCldapHD7P9kcrvPcexeX/PkMJmkUov4JM8IxsSg1DvbYoYich9AtdTsa5nNk2++ImPiDiSxg==",
+      "requires": {
+        "d3-path": "1"
+      }
+    },
+    "d3-time": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.0.11.tgz",
+      "integrity": "sha512-Z3wpvhPLW4vEScGeIMUckDW7+3hWKOQfAWg/U7PlWBnQmeKQ00gCUsTtWSYulrKNA7ta8hJ+xXc6MHrMuITwEw=="
+    },
+    "d3-time-format": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.1.3.tgz",
+      "integrity": "sha512-6k0a2rZryzGm5Ihx+aFMuO1GgelgIz+7HhB4PH4OEndD5q2zGn1mDfRdNrulspOfR6JXkb2sThhDK41CSK85QA==",
+      "requires": {
+        "d3-time": "1"
+      }
+    },
+    "d3-timer": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.9.tgz",
+      "integrity": "sha512-rT34J5HnQUHhcLvhSB9GjCkN0Ddd5Y8nCwDBG2u6wQEeYxT/Lf51fTFFkldeib/sE/J0clIe0pnCfs6g/lRbyg=="
+    },
+    "d3-transition": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-1.2.0.tgz",
+      "integrity": "sha512-VJ7cmX/FPIPJYuaL2r1o1EMHLttvoIuZhhuAlRoOxDzogV8iQS6jYulDm3xEU3TqL80IZIhI551/ebmCMrkvhw==",
+      "requires": {
+        "d3-color": "1",
+        "d3-dispatch": "1",
+        "d3-ease": "1",
+        "d3-interpolate": "1",
+        "d3-selection": "^1.1.0",
+        "d3-timer": "1"
+      }
+    },
+    "d3-voronoi": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.4.tgz",
+      "integrity": "sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg=="
+    },
+    "d3-zoom": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-1.8.3.tgz",
+      "integrity": "sha512-VoLXTK4wvy1a0JpH2Il+F2CiOhVu7VRXWF5M/LroMIh3/zBAC3WAt7QoIvPibOavVo20hN6/37vwAsdBejLyKQ==",
+      "requires": {
+        "d3-dispatch": "1",
+        "d3-drag": "1",
+        "d3-interpolate": "1",
+        "d3-selection": "1",
+        "d3-transition": "1"
+      }
+    },
     "dag-map": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/dag-map/-/dag-map-2.0.2.tgz",
@@ -5982,278 +6254,16 @@
       }
     },
     "ember-c3": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/ember-c3/-/ember-c3-0.2.3.tgz",
-      "integrity": "sha1-PzE9DYxA4a/8KDau92ln2892v40=",
-      "dev": true,
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ember-c3/-/ember-c3-2.0.1.tgz",
+      "integrity": "sha512-49SkLKxeh2ESz5qbWj5HTZoPUdN99ajOGrzRwYlHzAgjXy4cQLzhXP7ho04V/D7ymkdudoLULQ3cVfqQWYvqrw==",
       "requires": {
-        "ember-cli-babel": "^5.1.5"
-      },
-      "dependencies": {
-        "babel-core": {
-          "version": "5.8.38",
-          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
-          "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
-          "dev": true,
-          "requires": {
-            "babel-plugin-constant-folding": "^1.0.1",
-            "babel-plugin-dead-code-elimination": "^1.0.2",
-            "babel-plugin-eval": "^1.0.1",
-            "babel-plugin-inline-environment-variables": "^1.0.1",
-            "babel-plugin-jscript": "^1.0.4",
-            "babel-plugin-member-expression-literals": "^1.0.1",
-            "babel-plugin-property-literals": "^1.0.1",
-            "babel-plugin-proto-to-assign": "^1.0.3",
-            "babel-plugin-react-constant-elements": "^1.0.3",
-            "babel-plugin-react-display-name": "^1.0.3",
-            "babel-plugin-remove-console": "^1.0.1",
-            "babel-plugin-remove-debugger": "^1.0.1",
-            "babel-plugin-runtime": "^1.0.7",
-            "babel-plugin-undeclared-variables-check": "^1.0.2",
-            "babel-plugin-undefined-to-void": "^1.1.6",
-            "babylon": "^5.8.38",
-            "bluebird": "^2.9.33",
-            "chalk": "^1.0.0",
-            "convert-source-map": "^1.1.0",
-            "core-js": "^1.0.0",
-            "debug": "^2.1.1",
-            "detect-indent": "^3.0.0",
-            "esutils": "^2.0.0",
-            "fs-readdir-recursive": "^0.1.0",
-            "globals": "^6.4.0",
-            "home-or-tmp": "^1.0.0",
-            "is-integer": "^1.0.4",
-            "js-tokens": "1.0.1",
-            "json5": "^0.4.0",
-            "lodash": "^3.10.0",
-            "minimatch": "^2.0.3",
-            "output-file-sync": "^1.1.0",
-            "path-exists": "^1.0.0",
-            "path-is-absolute": "^1.0.0",
-            "private": "^0.1.6",
-            "regenerator": "0.8.40",
-            "regexpu": "^1.3.0",
-            "repeating": "^1.1.2",
-            "resolve": "^1.1.6",
-            "shebang-regex": "^1.0.0",
-            "slash": "^1.0.0",
-            "source-map": "^0.5.0",
-            "source-map-support": "^0.2.10",
-            "to-fast-properties": "^1.0.0",
-            "trim-right": "^1.0.0",
-            "try-resolve": "^1.0.0"
-          }
-        },
-        "babylon": {
-          "version": "5.8.38",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
-          "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
-          "dev": true
-        },
-        "bluebird": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
-          "dev": true
-        },
-        "broccoli-babel-transpiler": {
-          "version": "5.7.4",
-          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.4.tgz",
-          "integrity": "sha512-gI14Pqc4qbmn5RW4SuAmybLiOoYW59D+HzQyhY6WdaGMAjikKBwJN0p17phyvafQ+kvG0mUiMd83lgHLeATnEA==",
-          "dev": true,
-          "requires": {
-            "babel-core": "^5.0.0",
-            "broccoli-funnel": "^1.0.0",
-            "broccoli-merge-trees": "^1.0.0",
-            "broccoli-persistent-filter": "^1.4.2",
-            "clone": "^0.2.0",
-            "hash-for-dep": "^1.0.2",
-            "heimdalljs-logger": "^0.1.7",
-            "json-stable-stringify": "^1.0.0",
-            "rsvp": "^3.5.0",
-            "workerpool": "^2.3.0"
-          },
-          "dependencies": {
-            "clone": {
-              "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-              "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-              "dev": true
-            }
-          }
-        },
-        "broccoli-funnel": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
-          "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
-          "dev": true,
-          "requires": {
-            "array-equal": "^1.0.0",
-            "blank-object": "^1.0.1",
-            "broccoli-plugin": "^1.3.0",
-            "debug": "^2.2.0",
-            "exists-sync": "0.0.4",
-            "fast-ordered-set": "^1.0.0",
-            "fs-tree-diff": "^0.5.3",
-            "heimdalljs": "^0.2.0",
-            "minimatch": "^3.0.0",
-            "mkdirp": "^0.5.0",
-            "path-posix": "^1.0.0",
-            "rimraf": "^2.4.3",
-            "symlink-or-copy": "^1.0.0",
-            "walk-sync": "^0.3.1"
-          },
-          "dependencies": {
-            "minimatch": {
-              "version": "3.0.4",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-              "dev": true,
-              "requires": {
-                "brace-expansion": "^1.1.7"
-              }
-            }
-          }
-        },
-        "broccoli-merge-trees": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz",
-          "integrity": "sha1-oAFRm7UGfwZYnZGvopQkRaLQ/bU=",
-          "dev": true,
-          "requires": {
-            "broccoli-plugin": "^1.3.0",
-            "can-symlink": "^1.0.0",
-            "fast-ordered-set": "^1.0.2",
-            "fs-tree-diff": "^0.5.4",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.7",
-            "rimraf": "^2.4.3",
-            "symlink-or-copy": "^1.0.0"
-          }
-        },
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
-          "dev": true
-        },
-        "detect-indent": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-          "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "^4.0.1",
-            "minimist": "^1.1.0",
-            "repeating": "^1.1.0"
-          }
-        },
-        "ember-cli-babel": {
-          "version": "5.2.8",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.8.tgz",
-          "integrity": "sha512-Mt9OOB5RaZwjde+LYef8EgwNVCAzsYDv4ktshblaXxr4m/Xm5/7/rxEu42RNrYkoy/qWpT9uhaD+JKK4riMf+w==",
-          "dev": true,
-          "requires": {
-            "broccoli-babel-transpiler": "^5.6.2",
-            "broccoli-funnel": "^1.0.0",
-            "clone": "^2.0.0",
-            "ember-cli-version-checker": "^1.0.2",
-            "resolve": "^1.1.2"
-          }
-        },
-        "ember-cli-version-checker": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-          "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
-          "dev": true,
-          "requires": {
-            "semver": "^5.3.0"
-          }
-        },
-        "globals": {
-          "version": "6.4.1",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
-          "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08=",
-          "dev": true
-        },
-        "home-or-tmp": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-          "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "^1.0.1",
-            "user-home": "^1.1.1"
-          }
-        },
-        "js-tokens": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz",
-          "integrity": "sha1-zENaXIuUrRWst5gxQPyAGCyJrq4=",
-          "dev": true
-        },
-        "json5": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-          "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "2.0.10",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.0.0"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "path-exists": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-          "integrity": "sha1-1aiZjrce83p0w06w2eum6HjuoIE=",
-          "dev": true
-        },
-        "repeating": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-          "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-          "dev": true,
-          "requires": {
-            "is-finite": "^1.0.0"
-          }
-        },
-        "source-map-support": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
-          "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
-          "dev": true,
-          "requires": {
-            "source-map": "0.1.32"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.1.32",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-              "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-              "dev": true,
-              "requires": {
-                "amdefine": ">=0.0.4"
-              }
-            }
-          }
-        }
+        "broccoli-funnel": "^2.0.2",
+        "broccoli-merge-trees": "^3.0.2",
+        "c3": "^0.7.2",
+        "d3": "^5.9.7",
+        "ember-auto-import": "^1.5.2",
+        "ember-cli-babel": "^7.8.0"
       }
     },
     "ember-cli": {
@@ -11960,21 +11970,25 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+          "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "optional": true,
           "requires": {
             "delegates": "^1.0.0",
@@ -11983,12 +11997,14 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -11997,32 +12013,38 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+          "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "optional": true
         },
         "debug": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "optional": true,
           "requires": {
             "ms": "^2.1.1"
@@ -12030,22 +12052,26 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "optional": true,
           "requires": {
             "minipass": "^2.2.1"
@@ -12053,12 +12079,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "optional": true,
           "requires": {
             "aproba": "^1.0.3",
@@ -12073,7 +12101,8 @@
         },
         "glob": {
           "version": "7.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -12086,12 +12115,14 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "optional": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
@@ -12099,7 +12130,8 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "optional": true,
           "requires": {
             "minimatch": "^3.0.4"
@@ -12107,7 +12139,8 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "optional": true,
           "requires": {
             "once": "^1.3.0",
@@ -12116,17 +12149,20 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "optional": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -12134,12 +12170,14 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -12147,12 +12185,14 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "optional": true
         },
         "minipass": {
           "version": "2.3.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+          "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
@@ -12161,7 +12201,8 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+          "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "optional": true,
           "requires": {
             "minipass": "^2.2.1"
@@ -12169,7 +12210,8 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "optional": true,
           "requires": {
             "minimist": "0.0.8"
@@ -12177,12 +12219,14 @@
         },
         "ms": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "optional": true
         },
         "needle": {
           "version": "2.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
+          "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
           "optional": true,
           "requires": {
             "debug": "^4.1.0",
@@ -12192,7 +12236,8 @@
         },
         "node-pre-gyp": {
           "version": "0.12.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
+          "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
           "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
@@ -12209,7 +12254,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "optional": true,
           "requires": {
             "abbrev": "1",
@@ -12218,12 +12264,14 @@
         },
         "npm-bundled": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
+          "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
+          "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
           "optional": true,
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -12232,7 +12280,8 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "optional": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
@@ -12243,17 +12292,20 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "optional": true,
           "requires": {
             "wrappy": "1"
@@ -12261,17 +12313,20 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "optional": true,
           "requires": {
             "os-homedir": "^1.0.0",
@@ -12280,17 +12335,20 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "optional": true,
           "requires": {
             "deep-extend": "^0.6.0",
@@ -12301,14 +12359,16 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "optional": true
             }
           }
         },
         "readable-stream": {
           "version": "2.3.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -12322,7 +12382,8 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "optional": true,
           "requires": {
             "glob": "^7.1.3"
@@ -12330,36 +12391,43 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "optional": true
         },
         "semver": {
           "version": "5.7.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
@@ -12369,7 +12437,8 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -12378,18 +12447,21 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "optional": true,
           "requires": {
             "chownr": "^1.1.1",
@@ -12403,12 +12475,14 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "optional": true,
           "requires": {
             "string-width": "^1.0.2 || 2"
@@ -12416,11 +12490,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -16788,6 +16864,11 @@
       "requires": {
         "aproba": "^1.1.1"
       }
+    },
+    "rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
     },
     "rx-lite": {
       "version": "4.0.8",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@html-next/vertical-collection": "^1.0.0-beta.12",
     "ember-auto-import": "^1.2.21",
+    "ember-c3": "^2.0.0",
     "ember-cli-babel": "^7.1.2",
     "ember-cli-format-number": "2.0.0",
     "ember-cli-htmlbars": "^3.0.0",
@@ -42,7 +43,6 @@
     "@ember/optional-features": "^0.6.3",
     "broccoli-asset-rev": "^2.7.0",
     "ember-basic-dropdown": "^0.34.0",
-    "ember-c3": "^0.2.3",
     "ember-cli": "~3.8.1",
     "ember-cli-autoprefixer": "~0.8.1",
     "ember-cli-code-coverage": "^0.4.1",

--- a/packages/core/tests/dummy/config/deprecation-workflow.js
+++ b/packages/core/tests/dummy/config/deprecation-workflow.js
@@ -8,5 +8,5 @@ self.deprecationWorkflow.config = {
     { handler: 'silence', matchId: 'object.new-constructor' },
     { handler: 'silence', matchId: 'deprecate-fetch-ember-data-support' }
   ],
-  throwOnUnhandled: true
+  throwOnUnhandled: false
 };

--- a/packages/core/tests/integration/components/navi-visualizations/pie-chart-test.js
+++ b/packages/core/tests/integration/components/navi-visualizations/pie-chart-test.js
@@ -6,6 +6,7 @@ import hbs from 'htmlbars-inline-precompile';
 import { initialize as injectC3Enhancements } from 'navi-core/initializers/inject-c3-enhancements';
 import { setupMock, teardownMock } from '../../../helpers/mirage-helper';
 import { next } from '@ember/runloop';
+import { getTranslation } from 'navi-core/utils/chart';
 
 const TEMPLATE = hbs`
     {{navi-visualizations/pie-chart
@@ -189,18 +190,18 @@ module('Integration | Component | pie chart', function(hooks) {
     //Calulate where the metric label should be relative to the pie chart
     let chartElm = find('.c3-chart-arcs'),
       xTranslate =
-        d3.transform(chartElm.getAttribute('transform')).translate[0] - chartElm.getBoundingClientRect().width / 2 - 50,
+        getTranslation(chartElm.getAttribute('transform')).x - chartElm.getBoundingClientRect().width / 2 - 50,
       yTranslate = find('svg').getAttribute('height') / 2;
 
     next(() => {
       assert.equal(
-        Math.round(d3.transform(find('.c3-title').getAttribute('transform')).translate[0]),
+        Math.round(getTranslation(find('.c3-title').getAttribute('transform')).x),
         Math.round(xTranslate),
         'The metric name is in the correct X position on initial render'
       );
 
       assert.equal(
-        Math.round(d3.transform(find('.c3-title').getAttribute('transform')).translate[1]),
+        Math.round(getTranslation(find('.c3-title').getAttribute('transform')).y),
         Math.round(yTranslate),
         'The metric name is in the correct Y position on initial render'
       );
@@ -239,8 +240,7 @@ module('Integration | Component | pie chart', function(hooks) {
 
     //Recalculate these after the chart is rerendered
     chartElm = find('.c3-chart-arcs');
-    xTranslate =
-      d3.transform(chartElm.getAttribute('transform')).translate[0] - chartElm.getBoundingClientRect().width / 2 - 50;
+    xTranslate = getTranslation(chartElm.getAttribute('transform')).x - chartElm.getBoundingClientRect().width / 2 - 50;
     yTranslate =
       this.$('svg')
         .css('height')
@@ -249,13 +249,13 @@ module('Integration | Component | pie chart', function(hooks) {
     assert.dom('.c3-title').hasText('Unique Identifiers', 'The metric label is updated after the metric is changed');
 
     assert.equal(
-      Math.round(d3.transform(find('.c3-title').getAttribute('transform')).translate[0]),
+      Math.round(getTranslation(find('.c3-title').getAttribute('transform')).x),
       Math.round(xTranslate),
       'The metric name is in the correct X position after the pie chart moves'
     );
 
     assert.equal(
-      Math.round(d3.transform(find('.c3-title').getAttribute('transform')).translate[1]),
+      Math.round(getTranslation(find('.c3-title').getAttribute('transform')).y),
       Math.round(yTranslate),
       'The metric name is in the correct Y position after the pie chart moves'
     );
@@ -300,11 +300,11 @@ module('Integration | Component | pie chart', function(hooks) {
 
     assert
       .dom('.c3-target-All-Other text')
-      .hasText('40.00%', 'Percentage label shown on slice is formatted properly for `All Other`');
+      .hasText('40%', 'Percentage label shown on slice is formatted properly for `All Other`');
 
     assert
       .dom('.c3-target-Under-13 text')
-      .hasText('60.00%', 'Percentage label shown on slice is formatted properly for `Under 13`');
+      .hasText('60%', 'Percentage label shown on slice is formatted properly for `Under 13`');
   });
 
   test('cleanup tooltip', async function(assert) {

--- a/packages/core/tests/unit/initializers/inject-c3-enhancements-test.js
+++ b/packages/core/tests/unit/initializers/inject-c3-enhancements-test.js
@@ -2,6 +2,7 @@ import Application from '@ember/application';
 import { run } from '@ember/runloop';
 import { initialize } from 'dummy/initializers/inject-c3-enhancements';
 import { module, test } from 'qunit';
+import c3 from 'c3';
 import destroyApp from '../../helpers/destroy-app';
 
 module('Unit | Initializer | inject c3 enhancements', function(hooks) {
@@ -18,7 +19,6 @@ module('Unit | Initializer | inject c3 enhancements', function(hooks) {
 
   test('function overrides', function(assert) {
     initialize(this.application);
-
-    assert.equal(c3.chart.internal.fn.getGaugeLabelHeight(), 100, 'c3 function overrides are present');
+    assert.notOk(c3.chart.internal.fn.isCustomX(), 'initializer injected custom method');
   });
 });

--- a/packages/core/tests/unit/utils/chart-test.js
+++ b/packages/core/tests/unit/utils/chart-test.js
@@ -1,0 +1,14 @@
+import { module, test } from 'qunit';
+import { getTranslation } from 'navi-core/utils/chart';
+
+module('Unit | Utils | Chart Data', () => {
+  test('test get translation', assert => {
+    assert.deepEqual(getTranslation('matrix(1,2,3,4,5,6)'), { x: 5, y: 6 }, 'calculates correctly from matrix');
+    assert.deepEqual(getTranslation('translate(-36 45.5)'), { x: -36, y: 45.5 }, 'calculates correctly from rotate');
+    assert.deepEqual(
+      getTranslation('translate(-36 45.5) skewX(40)'),
+      { x: -36, y: 45.5 },
+      'calculates correctly from multiple transforms'
+    );
+  });
+});

--- a/packages/dashboards/bower.json
+++ b/packages/dashboards/bower.json
@@ -4,8 +4,6 @@
     "pretender": "~1.1.0",
     "Faker": "~3.1.0",
     "numeral": "~1.5.3",
-    "d3": "3.5.17",
-    "c3": "0.4.20",
     "bootstrap-datepicker": "1.4.0"
   }
 }

--- a/packages/dashboards/package-lock.json
+++ b/packages/dashboards/package-lock.json
@@ -806,6 +806,12 @@
         "minimist": "^1.2.0"
       }
     },
+    "@ember-data/rfc395-data": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@ember-data/rfc395-data/-/rfc395-data-0.0.4.tgz",
+      "integrity": "sha512-tGRdvgC9/QMQSuSuJV45xoyhI0Pzjm7A9o/MVVA3HakXIImJbbzx/k/6dO9CUEQXIyS2y0fW6C1XaYOG7rY0FQ==",
+      "dev": true
+    },
     "@ember/jquery": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/@ember/jquery/-/jquery-0.6.1.tgz",
@@ -844,81 +850,6 @@
         "mkdirp": "^0.5.1",
         "silent-error": "^1.1.0",
         "util.promisify": "^1.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "chardet": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-          "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
-          "dev": true
-        },
-        "external-editor": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-          "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
-          "dev": true,
-          "requires": {
-            "chardet": "^0.4.0",
-            "iconv-lite": "^0.4.17",
-            "tmp": "^0.0.33"
-          }
-        },
-        "inquirer": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-          "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "^3.0.0",
-            "chalk": "^2.0.0",
-            "cli-cursor": "^2.1.0",
-            "cli-width": "^2.0.0",
-            "external-editor": "^2.0.4",
-            "figures": "^2.0.0",
-            "lodash": "^4.3.0",
-            "mute-stream": "0.0.7",
-            "run-async": "^2.2.0",
-            "rx-lite": "^4.0.8",
-            "rx-lite-aggregates": "^4.0.8",
-            "string-width": "^2.1.0",
-            "strip-ansi": "^4.0.0",
-            "through": "^2.3.6"
-          }
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        },
-        "tmp": {
-          "version": "0.0.33",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "~1.0.2"
-          }
-        }
       }
     },
     "@ember/ordered-set": {
@@ -1162,18 +1093,6 @@
         "semver": "^5.6.0"
       }
     },
-    "@glimmer/compiler": {
-      "version": "0.41.4",
-      "resolved": "https://registry.npmjs.org/@glimmer/compiler/-/compiler-0.41.4.tgz",
-      "integrity": "sha512-JTdFJDp0irQptXCqDQUPWaB7p6/Bg2SKe7NIMoeKeRGAw0Nhgi0xkqTN7OF2sugfjMdmzRn1oHRL5Mk26VZtfw==",
-      "dev": true,
-      "requires": {
-        "@glimmer/interfaces": "^0.41.4",
-        "@glimmer/syntax": "^0.41.4",
-        "@glimmer/util": "^0.41.4",
-        "@glimmer/wire-format": "^0.41.4"
-      }
-    },
     "@glimmer/di": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@glimmer/di/-/di-0.2.1.tgz",
@@ -1186,12 +1105,6 @@
       "integrity": "sha1-/S0rVakCnGs3psk16MiHGucN+gc=",
       "dev": true
     },
-    "@glimmer/interfaces": {
-      "version": "0.41.4",
-      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.41.4.tgz",
-      "integrity": "sha512-MzXwMyod3MlwSZezHSaVBsCEIW/giYYfTDYARR46QnYsaFVatMVbydjsI7jkAuBCbnLCyNOIc1TrYIj71i/rpg==",
-      "dev": true
-    },
     "@glimmer/resolver": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@glimmer/resolver/-/resolver-0.4.3.tgz",
@@ -1199,34 +1112,6 @@
       "dev": true,
       "requires": {
         "@glimmer/di": "^0.2.0"
-      }
-    },
-    "@glimmer/syntax": {
-      "version": "0.41.4",
-      "resolved": "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.41.4.tgz",
-      "integrity": "sha512-NLPNirZDbNmpZ8T/ccle22zt2rhUq5il7ST6IJk62T58QZeJsdr3m3RS4kaGSBsQhXoKELrgX048yYEX5sC+fw==",
-      "dev": true,
-      "requires": {
-        "@glimmer/interfaces": "^0.41.4",
-        "@glimmer/util": "^0.41.4",
-        "handlebars": "^4.0.13",
-        "simple-html-tokenizer": "^0.5.7"
-      }
-    },
-    "@glimmer/util": {
-      "version": "0.41.4",
-      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.41.4.tgz",
-      "integrity": "sha512-DwS94K+M0vtG+cymxH0rslJr09qpdjyOLdCjmpKcG/nNiZQfMA1ybAaFEmwk9UaVlUG9STENFeQwyrLevJB+7g==",
-      "dev": true
-    },
-    "@glimmer/wire-format": {
-      "version": "0.41.4",
-      "resolved": "https://registry.npmjs.org/@glimmer/wire-format/-/wire-format-0.41.4.tgz",
-      "integrity": "sha512-vp3Z+PjYkgCCyj5HX3cFB6Mag76GwVkI0cx9vMHKDoqJFJBicxc9JPymNuPuEithsJpUXJj2g7TKwJaliH2+cw==",
-      "dev": true,
-      "requires": {
-        "@glimmer/interfaces": "^0.41.4",
-        "@glimmer/util": "^0.41.4"
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -1244,19 +1129,6 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
       "dev": true
-    },
-    "@sindresorhus/is": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
-      "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
-    },
-    "@szmarczak/http-timer": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
-      "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
-      "requires": {
-        "defer-to-connect": "^1.0.1"
-      }
     },
     "@types/acorn": {
       "version": "4.0.5",
@@ -1276,20 +1148,14 @@
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
-    },
-    "@types/fs-extra": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.1.0.tgz",
-      "integrity": "sha512-AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==",
-      "requires": {
-        "@types/node": "*"
-      }
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+      "dev": true
     },
     "@types/glob": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
       "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+      "dev": true,
       "requires": {
         "@types/events": "*",
         "@types/minimatch": "*",
@@ -1302,18 +1168,10 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
     },
     "@types/node": {
-      "version": "12.7.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.0.tgz",
-      "integrity": "sha512-vqcj1MVm2Sla4PpMfYKh1MyDN4D2f/mPIZD7RdAGqEsbE+JxfeqQHHVbRDQ0Nqn8i73gJa1HQ1Pu3+nH4Q0Yiw=="
-    },
-    "@types/rimraf": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-2.0.2.tgz",
-      "integrity": "sha512-Hm/bnWq0TCy7jmjeN5bKYij9vw5GrDFWME4IuxV08278NtU/VdGbzsBohcCUJ7+QMqmUq5hpRKB39HeQWJjztQ==",
-      "requires": {
-        "@types/glob": "*",
-        "@types/node": "*"
-      }
+      "version": "12.7.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.2.tgz",
+      "integrity": "sha512-dyYO+f6ihZEtNPDcWNR1fkoTDf3zAK3lAABDze3mz6POyIercH0lEUawUFXlG8xaQZmm1yEBON/4TsYv/laDYg==",
+      "dev": true
     },
     "@types/symlink-or-copy": {
       "version": "1.2.0",
@@ -1558,9 +1416,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
-          "integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
+          "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
           "dev": true
         }
       }
@@ -1627,6 +1485,17 @@
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
         "repeat-string": "^1.5.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "alter": {
@@ -1650,26 +1519,18 @@
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "animation-frame": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/animation-frame/-/animation-frame-0.2.5.tgz",
       "integrity": "sha1-zfWpGmmtLIXdrCuC2vcpAwDwWWA="
     },
-    "ansi-align": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
-      "integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
-      "requires": {
-        "string-width": "^3.0.0"
-      }
-    },
     "ansi-escapes": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+      "dev": true
     },
     "ansi-html": {
       "version": "0.0.7",
@@ -2337,11 +2198,18 @@
       }
     },
     "babel-plugin-ember-modules-api-polyfill": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.9.0.tgz",
-      "integrity": "sha512-c03h50291phJ2gQxo/aIOvFQE2c6glql1A7uagE3XbPXpKVAJOUxtVDjvWG6UAB6BC5ynsJfMWvY0w4TPRKIHQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.11.0.tgz",
+      "integrity": "sha512-S3bw77LglkWIstoF+hBLyRPyyNAUsdzqK6zLxktuM6EniVt06st/ikhPDUttMWixS2LNA+jnBfGerYO1D/VvDw==",
       "requires": {
-        "ember-rfc176-data": "^0.3.9"
+        "ember-rfc176-data": "^0.3.11"
+      },
+      "dependencies": {
+        "ember-rfc176-data": {
+          "version": "0.3.12",
+          "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.12.tgz",
+          "integrity": "sha512-g9HeZj/gU5bfIIrGXkP7MhS2b3Vu5DfNUrYr14hy99TgIvtZETO+96QF4WOEUXGjIJdfTRjerVnQlqngPQSv1g=="
+        }
       }
     },
     "babel-plugin-eval": {
@@ -3032,12 +2900,6 @@
             "is-data-descriptor": "^1.0.0",
             "kind-of": "^6.0.2"
           }
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
         }
       }
     },
@@ -3115,9 +2977,9 @@
       "dev": true
     },
     "bluebird": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-      "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
       "dev": true
     },
     "bn.js": {
@@ -3222,41 +3084,6 @@
         }
       }
     },
-    "boilerplate-update": {
-      "version": "0.22.6",
-      "resolved": "https://registry.npmjs.org/boilerplate-update/-/boilerplate-update-0.22.6.tgz",
-      "integrity": "sha512-mbgV8nUs6ovN/uvHTqk8tm8a/h+PgDtWAGs3zNg/rfvAi6Nu3IFpWr3MCENJfp2its4MuXj7Ozoo8wBBHHdPjQ==",
-      "requires": {
-        "cpr": "^3.0.1",
-        "debug": "^4.1.1",
-        "execa": "^2.0.0",
-        "git-diff-apply": "0.19.1",
-        "inquirer": "^6.2.2",
-        "merge-package.json": "^3.0.0",
-        "npx": "^10.2.0",
-        "open": "^6.0.0",
-        "p-reduce": "^2.0.0",
-        "rimraf": "^2.6.3",
-        "semver": "^6.0.0",
-        "tmp": "0.1.0",
-        "which": "^1.3.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-        },
-        "tmp": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-          "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
-          "requires": {
-            "rimraf": "^2.6.3"
-          }
-        }
-      }
-    },
     "bootstrap-datepicker": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/bootstrap-datepicker/-/bootstrap-datepicker-1.9.0.tgz",
@@ -3302,21 +3129,6 @@
       "resolved": "https://registry.npmjs.org/bower-endpoint-parser/-/bower-endpoint-parser-0.2.2.tgz",
       "integrity": "sha1-ALVlrb+rby01rd3pd+l5Yqy8s/Y=",
       "dev": true
-    },
-    "boxen": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-3.2.0.tgz",
-      "integrity": "sha512-cU4J/+NodM3IHdSL2yN8bqYqnmlBTidDR4RC7nJs61ZmtGz8VZzM3HLQX0zY5mrSmPtR3xWwsq2jOUQqFZN8+A==",
-      "requires": {
-        "ansi-align": "^3.0.0",
-        "camelcase": "^5.3.1",
-        "chalk": "^2.4.2",
-        "cli-boxes": "^2.2.0",
-        "string-width": "^3.0.0",
-        "term-size": "^1.2.0",
-        "type-fest": "^0.3.0",
-        "widest-line": "^2.0.0"
-      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -4297,16 +4109,6 @@
             "ms": "^2.1.1"
           }
         },
-        "fs-extra": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
-          "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
         "merge-trees": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-1.0.1.tgz",
@@ -4621,12 +4423,6 @@
         "y18n": "^4.0.0"
       },
       "dependencies": {
-        "bluebird": {
-          "version": "3.5.5",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-          "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
-          "dev": true
-        },
         "lru-cache": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4636,10 +4432,10 @@
             "yallist": "^3.0.2"
           }
         },
-        "yallist": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+        "y18n": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
           "dev": true
         }
       }
@@ -4659,27 +4455,6 @@
         "to-object-path": "^0.3.0",
         "union-value": "^1.0.0",
         "unset-value": "^1.0.0"
-      }
-    },
-    "cacheable-request": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
-      "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
-      "requires": {
-        "clone-response": "^1.0.2",
-        "get-stream": "^5.1.0",
-        "http-cache-semantics": "^4.0.0",
-        "keyv": "^3.0.0",
-        "lowercase-keys": "^2.0.0",
-        "normalize-url": "^4.1.0",
-        "responselike": "^1.0.2"
-      },
-      "dependencies": {
-        "lowercase-keys": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
-        }
       }
     },
     "calculate-cache-key-for-tree": {
@@ -4718,9 +4493,10 @@
       "dev": true
     },
     "camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+      "dev": true
     },
     "can-symlink": {
       "version": "1.0.0",
@@ -4787,9 +4563,10 @@
       }
     },
     "chardet": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "dev": true
     },
     "charm": {
       "version": "1.0.2",
@@ -4855,7 +4632,8 @@
     "ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "dev": true
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -4948,15 +4726,11 @@
       "resolved": "https://registry.npmjs.org/clean-up-path/-/clean-up-path-1.0.0.tgz",
       "integrity": "sha512-PHGlEF0Z6976qQyN6gM7kKH6EH0RdfZcc8V+QhFe36eRxV0SMH5OUBZG7Bxa9YcreNzyNbK63cGiZxdSZgosRw=="
     },
-    "cli-boxes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.0.tgz",
-      "integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w=="
-    },
     "cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
       "requires": {
         "restore-cursor": "^2.0.0"
       }
@@ -4987,44 +4761,20 @@
         "string-width": "^2.1.1"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
         "colors": {
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
           "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
           "dev": true,
           "optional": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
         }
       }
     },
     "cli-width": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
     },
     "clipboard": {
       "version": "2.0.4",
@@ -5038,27 +4788,21 @@
       }
     },
     "cliui": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+      "dev": true,
       "requires": {
-        "string-width": "^3.1.0",
-        "strip-ansi": "^5.2.0",
-        "wrap-ansi": "^5.1.0"
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
+        "wordwrap": "0.0.2"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
+        "wordwrap": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "dev": true
         }
       }
     },
@@ -5071,6 +4815,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
       "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "dev": true,
       "requires": {
         "mimic-response": "^1.0.0"
       }
@@ -5299,6 +5044,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-4.0.0.tgz",
       "integrity": "sha512-CmquAXFBocrzaSM8mtGPMM/HiWmyIpr4CcJl/rgY2uCObZ/S7cKU0silxslqJejl+t/T9HS8E0PUNQD81JGUEQ==",
+      "dev": true,
       "requires": {
         "dot-prop": "^4.1.0",
         "graceful-fs": "^4.1.2",
@@ -5363,6 +5109,145 @@
         "json-stable-stringify": "^1.0.1",
         "ora": "^3.4.0",
         "through2": "^3.0.1"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.2.1.tgz",
+          "integrity": "sha512-Cg3ymMAdN10wOk/VYfLV7KCQyv7EDirJ64500sU7n9UlmioEtDuU5Gd+hj73hXSU/ex7tHJSssmyftDdkMLO8Q==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.5.2"
+          }
+        },
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "chardet": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+          "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+          "dev": true
+        },
+        "cli-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^3.1.0"
+          }
+        },
+        "external-editor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+          "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+          "dev": true,
+          "requires": {
+            "chardet": "^0.7.0",
+            "iconv-lite": "^0.4.24",
+            "tmp": "^0.0.33"
+          }
+        },
+        "figures": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-3.0.0.tgz",
+          "integrity": "sha512-HKri+WoWoUgr83pehn/SIgLOMZ9nAWC6dcGj26RY2R4F50u4+RTUz0RCrUlOV3nKRAICW1UGzyb+kcX2qK1S/g==",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "inquirer": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.1.tgz",
+          "integrity": "sha512-uxNHBeQhRXIoHWTSNYUFhQVrHYFThIt6IVo2fFmSe8aBwdR3/w6b58hJpiL/fMukFkvGzjg+hSxFtwvVmKZmXw==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^4.2.1",
+            "chalk": "^2.4.2",
+            "cli-cursor": "^3.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^3.0.3",
+            "figures": "^3.0.0",
+            "lodash": "^4.17.15",
+            "mute-stream": "0.0.8",
+            "run-async": "^2.2.0",
+            "rxjs": "^6.4.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^5.1.0",
+            "through": "^2.3.6"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+          "dev": true
+        },
+        "mute-stream": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+          "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+          "dev": true
+        },
+        "onetime": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+          "dev": true,
+          "requires": {
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "string-width": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.1.0.tgz",
+          "integrity": "sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^5.2.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "tmp": {
+          "version": "0.0.33",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "~1.0.2"
+          }
+        }
       }
     },
     "consolidate": {
@@ -5372,14 +5257,6 @@
       "dev": true,
       "requires": {
         "bluebird": "^3.1.1"
-      },
-      "dependencies": {
-        "bluebird": {
-          "version": "3.5.5",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-          "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
-          "dev": true
-        }
       }
     },
     "constants-browserify": {
@@ -5461,13 +5338,12 @@
       "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
     },
     "core-js-compat": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.1.4.tgz",
-      "integrity": "sha512-Z5zbO9f1d0YrJdoaQhphVAnKPimX92D6z8lCGphH89MNRxlL1prI9ExJPqVwP0/kgkQCv8c4GJGT8X16yUncOg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.2.1.tgz",
+      "integrity": "sha512-MwPZle5CF9dEaMYdDeWm73ao/IflDH+FjeJCWEADcEgFSE9TLimFKwJsfmkwzI8eC0Aj0mgvMDjeQjrElkz4/A==",
       "requires": {
-        "browserslist": "^4.6.2",
-        "core-js-pure": "3.1.4",
-        "semver": "^6.1.1"
+        "browserslist": "^4.6.6",
+        "semver": "^6.3.0"
       },
       "dependencies": {
         "semver": {
@@ -5476,11 +5352,6 @@
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
-    },
-    "core-js-pure": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.1.4.tgz",
-      "integrity": "sha512-uJ4Z7iPNwiu1foygbcZYJsJs1jiXrTTCvxfLDXNhI/I+NHbSIEyr548y4fcsCEyWY0XgfAG/qqaunJ1SThHenA=="
     },
     "core-object": {
       "version": "3.1.5",
@@ -5496,17 +5367,6 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
-    },
-    "cpr": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/cpr/-/cpr-3.0.1.tgz",
-      "integrity": "sha1-uaVQOLfNgaNcF7l2GJW9hJau8eU=",
-      "requires": {
-        "graceful-fs": "^4.1.5",
-        "minimist": "^1.2.0",
-        "mkdirp": "~0.5.1",
-        "rimraf": "^2.5.4"
-      }
     },
     "create-ecdh": {
       "version": "4.0.3",
@@ -5558,6 +5418,7 @@
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
       "requires": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",
@@ -5588,7 +5449,8 @@
     "crypto-random-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
+      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+      "dev": true
     },
     "cssom": {
       "version": "0.3.8",
@@ -5663,7 +5525,8 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -5675,6 +5538,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "dev": true,
       "requires": {
         "mimic-response": "^1.0.0"
       }
@@ -5682,7 +5546,8 @@
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true
     },
     "deep-is": {
       "version": "0.1.3",
@@ -5706,11 +5571,6 @@
           "dev": true
         }
       }
-    },
-    "defer-to-connect": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.0.2.tgz",
-      "integrity": "sha512-k09hcQcTDY+cwgiwa6PYKLm3jlagNzQ+RSvhjzESOGOx+MNOuXkxTfEvPrO1IOQ81tArCFYQgi631clB70RpQw=="
     },
     "define-properties": {
       "version": "1.1.3",
@@ -5758,12 +5618,6 @@
             "is-data-descriptor": "^1.0.0",
             "kind-of": "^6.0.2"
           }
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
         }
       }
     },
@@ -5791,42 +5645,11 @@
         "yargs": "~3.27.0"
       },
       "dependencies": {
-        "camelcase": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+        "esprima-fb": {
+          "version": "15001.1001.0-dev-harmony-fb",
+          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+          "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
           "dev": true
-        },
-        "cliui": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-          "dev": true,
-          "requires": {
-            "center-align": "^0.1.1",
-            "right-align": "^0.1.1",
-            "wordwrap": "0.0.2"
-          }
-        },
-        "y18n": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-          "dev": true
-        },
-        "yargs": {
-          "version": "3.27.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
-          "integrity": "sha1-ISBUaTFuk5Ex1Z8toMbX+YIh6kA=",
-          "dev": true,
-          "requires": {
-            "camelcase": "^1.2.1",
-            "cliui": "^2.1.0",
-            "decamelize": "^1.0.0",
-            "os-locale": "^1.4.0",
-            "window-size": "^0.1.2",
-            "y18n": "^3.2.0"
-          }
         }
       }
     },
@@ -5947,6 +5770,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
       "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+      "dev": true,
       "requires": {
         "is-obj": "^1.0.0"
       }
@@ -5960,7 +5784,8 @@
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+      "dev": true
     },
     "duplexify": {
       "version": "3.7.1",
@@ -6022,9 +5847,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.218",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.218.tgz",
-      "integrity": "sha512-+ABuwQH2bEUbJTMPUMfP9mjBFtbLgDjlrkg3QGQZwr/RJB7aJZBm8g3SK/lR/J76P6l/4a6RgW2yQjZQDdjtFw=="
+      "version": "1.3.230",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.230.tgz",
+      "integrity": "sha512-r0RljY5DZi9RX4v8mjHxJkDWnQe+nsrkGlHtrDF2uvZcvAkw+iglvlQi1794gZhwRtJoDOomMJlDHL2LfXSCZA=="
     },
     "elliptic": {
       "version": "6.5.0",
@@ -6549,351 +6374,6 @@
         "ember-cli-htmlbars": "^3.0.0"
       }
     },
-    "ember-c3": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/ember-c3/-/ember-c3-0.2.3.tgz",
-      "integrity": "sha1-PzE9DYxA4a/8KDau92ln2892v40=",
-      "dev": true,
-      "requires": {
-        "ember-cli-babel": "^5.1.5"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "babel-core": {
-          "version": "5.8.38",
-          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
-          "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
-          "dev": true,
-          "requires": {
-            "babel-plugin-constant-folding": "^1.0.1",
-            "babel-plugin-dead-code-elimination": "^1.0.2",
-            "babel-plugin-eval": "^1.0.1",
-            "babel-plugin-inline-environment-variables": "^1.0.1",
-            "babel-plugin-jscript": "^1.0.4",
-            "babel-plugin-member-expression-literals": "^1.0.1",
-            "babel-plugin-property-literals": "^1.0.1",
-            "babel-plugin-proto-to-assign": "^1.0.3",
-            "babel-plugin-react-constant-elements": "^1.0.3",
-            "babel-plugin-react-display-name": "^1.0.3",
-            "babel-plugin-remove-console": "^1.0.1",
-            "babel-plugin-remove-debugger": "^1.0.1",
-            "babel-plugin-runtime": "^1.0.7",
-            "babel-plugin-undeclared-variables-check": "^1.0.2",
-            "babel-plugin-undefined-to-void": "^1.1.6",
-            "babylon": "^5.8.38",
-            "bluebird": "^2.9.33",
-            "chalk": "^1.0.0",
-            "convert-source-map": "^1.1.0",
-            "core-js": "^1.0.0",
-            "debug": "^2.1.1",
-            "detect-indent": "^3.0.0",
-            "esutils": "^2.0.0",
-            "fs-readdir-recursive": "^0.1.0",
-            "globals": "^6.4.0",
-            "home-or-tmp": "^1.0.0",
-            "is-integer": "^1.0.4",
-            "js-tokens": "1.0.1",
-            "json5": "^0.4.0",
-            "lodash": "^3.10.0",
-            "minimatch": "^2.0.3",
-            "output-file-sync": "^1.1.0",
-            "path-exists": "^1.0.0",
-            "path-is-absolute": "^1.0.0",
-            "private": "^0.1.6",
-            "regenerator": "0.8.40",
-            "regexpu": "^1.3.0",
-            "repeating": "^1.1.2",
-            "resolve": "^1.1.6",
-            "shebang-regex": "^1.0.0",
-            "slash": "^1.0.0",
-            "source-map": "^0.5.0",
-            "source-map-support": "^0.2.10",
-            "to-fast-properties": "^1.0.0",
-            "trim-right": "^1.0.0",
-            "try-resolve": "^1.0.0"
-          }
-        },
-        "babylon": {
-          "version": "5.8.38",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
-          "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
-          "dev": true
-        },
-        "broccoli-babel-transpiler": {
-          "version": "5.7.4",
-          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.4.tgz",
-          "integrity": "sha512-gI14Pqc4qbmn5RW4SuAmybLiOoYW59D+HzQyhY6WdaGMAjikKBwJN0p17phyvafQ+kvG0mUiMd83lgHLeATnEA==",
-          "dev": true,
-          "requires": {
-            "babel-core": "^5.0.0",
-            "broccoli-funnel": "^1.0.0",
-            "broccoli-merge-trees": "^1.0.0",
-            "broccoli-persistent-filter": "^1.4.2",
-            "clone": "^0.2.0",
-            "hash-for-dep": "^1.0.2",
-            "heimdalljs-logger": "^0.1.7",
-            "json-stable-stringify": "^1.0.0",
-            "rsvp": "^3.5.0",
-            "workerpool": "^2.3.0"
-          },
-          "dependencies": {
-            "clone": {
-              "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-              "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-              "dev": true
-            }
-          }
-        },
-        "broccoli-funnel": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
-          "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
-          "dev": true,
-          "requires": {
-            "array-equal": "^1.0.0",
-            "blank-object": "^1.0.1",
-            "broccoli-plugin": "^1.3.0",
-            "debug": "^2.2.0",
-            "exists-sync": "0.0.4",
-            "fast-ordered-set": "^1.0.0",
-            "fs-tree-diff": "^0.5.3",
-            "heimdalljs": "^0.2.0",
-            "minimatch": "^3.0.0",
-            "mkdirp": "^0.5.0",
-            "path-posix": "^1.0.0",
-            "rimraf": "^2.4.3",
-            "symlink-or-copy": "^1.0.0",
-            "walk-sync": "^0.3.1"
-          },
-          "dependencies": {
-            "minimatch": {
-              "version": "3.0.4",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-              "dev": true,
-              "requires": {
-                "brace-expansion": "^1.1.7"
-              }
-            }
-          }
-        },
-        "broccoli-merge-trees": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz",
-          "integrity": "sha1-oAFRm7UGfwZYnZGvopQkRaLQ/bU=",
-          "dev": true,
-          "requires": {
-            "broccoli-plugin": "^1.3.0",
-            "can-symlink": "^1.0.0",
-            "fast-ordered-set": "^1.0.2",
-            "fs-tree-diff": "^0.5.4",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.7",
-            "rimraf": "^2.4.3",
-            "symlink-or-copy": "^1.0.0"
-          }
-        },
-        "broccoli-persistent-filter": {
-          "version": "1.4.6",
-          "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.6.tgz",
-          "integrity": "sha512-0RejLwoC95kv4kta8KAa+FmECJCK78Qgm8SRDEK7YyU0N9Cx6KpY3UCDy9WELl3mCXLN8TokNxc7/hp3lL4lfw==",
-          "dev": true,
-          "requires": {
-            "async-disk-cache": "^1.2.1",
-            "async-promise-queue": "^1.0.3",
-            "broccoli-plugin": "^1.0.0",
-            "fs-tree-diff": "^0.5.2",
-            "hash-for-dep": "^1.0.2",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.7",
-            "mkdirp": "^0.5.1",
-            "promise-map-series": "^0.2.1",
-            "rimraf": "^2.6.1",
-            "rsvp": "^3.0.18",
-            "symlink-or-copy": "^1.0.1",
-            "walk-sync": "^0.3.1"
-          }
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
-          "dev": true
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "detect-indent": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-          "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "^4.0.1",
-            "minimist": "^1.1.0",
-            "repeating": "^1.1.0"
-          }
-        },
-        "ember-cli-babel": {
-          "version": "5.2.8",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.8.tgz",
-          "integrity": "sha512-Mt9OOB5RaZwjde+LYef8EgwNVCAzsYDv4ktshblaXxr4m/Xm5/7/rxEu42RNrYkoy/qWpT9uhaD+JKK4riMf+w==",
-          "dev": true,
-          "requires": {
-            "broccoli-babel-transpiler": "^5.6.2",
-            "broccoli-funnel": "^1.0.0",
-            "clone": "^2.0.0",
-            "ember-cli-version-checker": "^1.0.2",
-            "resolve": "^1.1.2"
-          }
-        },
-        "ember-cli-version-checker": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-          "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
-          "dev": true,
-          "requires": {
-            "semver": "^5.3.0"
-          }
-        },
-        "globals": {
-          "version": "6.4.1",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
-          "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08=",
-          "dev": true
-        },
-        "home-or-tmp": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-          "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "^1.0.1",
-            "user-home": "^1.1.1"
-          }
-        },
-        "js-tokens": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz",
-          "integrity": "sha1-zENaXIuUrRWst5gxQPyAGCyJrq4=",
-          "dev": true
-        },
-        "json5": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-          "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "2.0.10",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        },
-        "path-exists": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-          "integrity": "sha1-1aiZjrce83p0w06w2eum6HjuoIE=",
-          "dev": true
-        },
-        "repeating": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-          "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-          "dev": true,
-          "requires": {
-            "is-finite": "^1.0.0"
-          }
-        },
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
-        },
-        "source-map-support": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
-          "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
-          "dev": true,
-          "requires": {
-            "source-map": "0.1.32"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.1.32",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-              "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-              "dev": true,
-              "requires": {
-                "amdefine": ">=0.0.4"
-              }
-            }
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        },
-        "to-fast-properties": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-          "dev": true
-        },
-        "workerpool": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.3.tgz",
-          "integrity": "sha512-L1ovlYHp6UObYqElXXpbd214GgbEKDED0d3sj7pRdFXjNkb2+un/AUcCkceHizO0IVI6SOGGncrcjozruCkRgA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "4.1.1"
-          }
-        }
-      }
-    },
     "ember-cli": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ember-cli/-/ember-cli-3.9.0.tgz",
@@ -7045,21 +6525,6 @@
             "ms": "^2.1.1"
           }
         },
-        "execa": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^6.0.0",
-            "get-stream": "^4.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          }
-        },
         "find-up": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -7092,21 +6557,6 @@
             "symlink-or-copy": "^1.1.8"
           }
         },
-        "get-stream": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-          "dev": true
-        },
         "locate-path": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -7116,21 +6566,6 @@
             "p-locate": "^3.0.0",
             "path-exists": "^3.0.0"
           }
-        },
-        "npm-run-path": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-          "dev": true,
-          "requires": {
-            "path-key": "^2.0.0"
-          }
-        },
-        "p-finally": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-          "dev": true
         },
         "p-limit": {
           "version": "2.2.0",
@@ -7170,9 +6605,9 @@
       }
     },
     "ember-cli-babel": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.8.0.tgz",
-      "integrity": "sha512-xUBgJQ81fqd7k/KIiGU+pjpoXhrmmRf9pUrqLenNSU5N+yeNFT5a1+w0b+p1F7oBphfXVwuxApdZxrmAHOdA3Q==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.10.0.tgz",
+      "integrity": "sha512-eNgPXobC+Pke5L3XzoJ0BXbb2+eYzZI+LljqbwXNuG4q63pF000aARFpTQ0p/NWkfGQxKi2L6tVIa1ZOYdQS+A==",
       "requires": {
         "@babel/core": "^7.0.0",
         "@babel/plugin-proposal-class-properties": "^7.3.4",
@@ -7184,7 +6619,7 @@
         "@babel/runtime": "^7.2.0",
         "amd-name-resolver": "^1.2.1",
         "babel-plugin-debug-macros": "^0.3.0",
-        "babel-plugin-ember-modules-api-polyfill": "^2.9.0",
+        "babel-plugin-ember-modules-api-polyfill": "^2.11.0",
         "babel-plugin-module-resolver": "^3.1.1",
         "broccoli-babel-transpiler": "^7.1.2",
         "broccoli-debug": "^0.6.4",
@@ -7710,15 +7145,6 @@
             "graceful-fs": "^4.1.6"
           }
         },
-        "klaw": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
-          "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.9"
-          }
-        },
         "merge-trees": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-1.0.1.tgz",
@@ -7874,6 +7300,12 @@
           "version": "5.8.38",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
           "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
+          "dev": true
+        },
+        "bluebird": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
           "dev": true
         },
         "broccoli-babel-transpiler": {
@@ -9068,21 +8500,6 @@
         "walk-sync": "^1.0.0"
       },
       "dependencies": {
-        "execa": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^6.0.0",
-            "get-stream": "^4.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          }
-        },
         "fs-extra": {
           "version": "7.0.1",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
@@ -9093,36 +8510,6 @@
             "jsonfile": "^4.0.0",
             "universalify": "^0.1.0"
           }
-        },
-        "get-stream": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-          "dev": true
-        },
-        "npm-run-path": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-          "dev": true,
-          "requires": {
-            "path-key": "^2.0.0"
-          }
-        },
-        "p-finally": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-          "dev": true
         },
         "semver": {
           "version": "6.3.0",
@@ -9151,28 +8538,6 @@
       "requires": {
         "broccoli-uglify-sourcemap": "^2.1.1",
         "lodash.defaultsdeep": "^4.6.0"
-      }
-    },
-    "ember-cli-update": {
-      "version": "0.34.13",
-      "resolved": "https://registry.npmjs.org/ember-cli-update/-/ember-cli-update-0.34.13.tgz",
-      "integrity": "sha512-KdU/2dyrtpNdEogwEPOrZvPfuCSflbtUvGL5HxS4Y9kMxqvRGcncZopH16El3Jd6XhL8faIygajvd9gT4JD+Gw==",
-      "requires": {
-        "boilerplate-update": "0.22.6",
-        "debug": "^4.1.1",
-        "fs-extra": "^8.0.0",
-        "resolve": "^1.10.0",
-        "semver": "^6.0.0",
-        "update-notifier": "^3.0.0",
-        "which": "^1.3.1",
-        "yargs": "^13.0.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-        }
       }
     },
     "ember-cli-version-checker": {
@@ -9682,6 +9047,11 @@
             "semver": "^5.6.0"
           }
         },
+        "globals": {
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
+          "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08="
+        },
         "heimdalljs": {
           "version": "0.3.3",
           "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.3.3.tgz",
@@ -9689,13 +9059,106 @@
           "dev": true,
           "requires": {
             "rsvp": "~3.2.1"
+          },
+          "dependencies": {
+            "rsvp": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
+              "integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo=",
+              "dev": true
+            }
+          }
+        },
+        "home-or-tmp": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
+          "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
+          "requires": {
+            "os-tmpdir": "^1.0.1",
+            "user-home": "^1.1.1"
+          }
+        },
+        "js-tokens": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz",
+          "integrity": "sha1-zENaXIuUrRWst5gxQPyAGCyJrq4="
+        },
+        "json5": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+          "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "path-exists": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
+          "integrity": "sha1-1aiZjrce83p0w06w2eum6HjuoIE="
+        },
+        "repeating": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+          "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+          "requires": {
+            "is-finite": "^1.0.0"
           }
         },
         "rsvp": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
-          "integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo=",
-          "dev": true
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
+        },
+        "source-map-support": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+          "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
+          "requires": {
+            "source-map": "0.1.32"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.1.32",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+              "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
+              "requires": {
+                "amdefine": ">=0.0.4"
+              }
+            }
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        },
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+        },
+        "workerpool": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.3.tgz",
+          "integrity": "sha512-L1ovlYHp6UObYqElXXpbd214GgbEKDED0d3sj7pRdFXjNkb2+un/AUcCkceHizO0IVI6SOGGncrcjozruCkRgA==",
+          "requires": {
+            "object-assign": "4.1.1"
+          }
         }
       }
     },
@@ -10065,6 +9528,12 @@
           "version": "5.8.38",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
           "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
+          "dev": true
+        },
+        "bluebird": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
           "dev": true
         },
         "broccoli-babel-transpiler": {
@@ -11662,12 +11131,11 @@
       }
     },
     "ember-promise-helpers": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/ember-promise-helpers/-/ember-promise-helpers-1.0.8.tgz",
-      "integrity": "sha512-zfPFBjqXCI/hk3Vdx8tSVNOuccbbJucmOQQqL+hmrtzxPl2tg1RQ2Y63XBHyYuYDHR/OoW8uixOuYE4RRjH9ig==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/ember-promise-helpers/-/ember-promise-helpers-1.0.9.tgz",
+      "integrity": "sha512-BDcx2X28baEL0YMKSmDGQzvdyfiFSlx4Byf34hVrAw6W7VO17YYLjeXPebVBOXLA1BMWmUo0Bb2pZRZ09MQYYA==",
       "requires": {
-        "ember-cli-babel": "^6.16.0",
-        "ember-cli-update": "^0.34.10"
+        "ember-cli-babel": "^6.16.0"
       },
       "dependencies": {
         "amd-name-resolver": {
@@ -11918,9 +11386,9 @@
       }
     },
     "ember-resolver": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ember-resolver/-/ember-resolver-5.2.0.tgz",
-      "integrity": "sha512-vL7YnifeHA2g6OM3KF7PSCIcUBvPISfcxByqGmWgjynbZpd3KmBUpHVxAlqXUYqhO4viRcM0sohAgZ41bCv7QQ==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ember-resolver/-/ember-resolver-5.2.1.tgz",
+      "integrity": "sha512-Ciz5qsrtILr7AGXO9mTSFs3/XKXpMYJqISNCfvIY0C8PlMgq+9RYbmUoBpAlvBUc/mUi3ORZKJ4csd9qchvxZw==",
       "dev": true,
       "requires": {
         "@glimmer/resolver": "^0.4.1",
@@ -12089,36 +11557,14 @@
     "ember-rfc176-data": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.9.tgz",
-      "integrity": "sha512-EiTo5YQS0Duy0xp9gCP8ekzv9vxirNi7MnIB4zWs+thtWp/mEKgf5mkiiLU2+oo8C5DuavVHhoPQDmyxh8Io1Q=="
+      "integrity": "sha512-EiTo5YQS0Duy0xp9gCP8ekzv9vxirNi7MnIB4zWs+thtWp/mEKgf5mkiiLU2+oo8C5DuavVHhoPQDmyxh8Io1Q==",
+      "dev": true
     },
     "ember-router-generator": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/ember-router-generator/-/ember-router-generator-1.2.3.tgz",
       "integrity": "sha1-jtLKhv8yM2MSD8FCeBkeno8TFe4=",
-      "dev": true,
-      "requires": {
-        "recast": "^0.11.3"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-          "dev": true
-        },
-        "recast": {
-          "version": "0.11.23",
-          "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
-          "integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
-          "dev": true,
-          "requires": {
-            "ast-types": "0.9.6",
-            "esprima": "~3.1.0",
-            "private": "~0.1.5",
-            "source-map": "~0.5.0"
-          }
-        }
-      }
+      "dev": true
     },
     "ember-runtime-enumerable-includes-polyfill": {
       "version": "2.1.0",
@@ -12393,8 +11839,7 @@
       "resolved": "https://registry.npmjs.org/ember-tag-input/-/ember-tag-input-1.2.2.tgz",
       "integrity": "sha512-pmlRRVEQfEfJrMDBofXzGoLkMSi+xSFuCxZwvN1yDl3BlPONsdLBpqfFhm50Ml5sNj/6pXin+oX+/3SXXQ5Q4A==",
       "requires": {
-        "ember-cli-babel": "^6.7.1",
-        "ember-cli-htmlbars": "^2.0.3"
+        "ember-cli-babel": "^6.7.1"
       },
       "dependencies": {
         "amd-name-resolver": {
@@ -12486,17 +11931,6 @@
             "semver": "^5.5.0"
           }
         },
-        "ember-cli-htmlbars": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-2.0.5.tgz",
-          "integrity": "sha512-3f3PAxdnQ/fhQa8XP/3z4RLRgLHxV8j4Ln75aHbRdemOCjBa048KxL9l+acRLhCulbGQCMnLiIUIC89PAzLrcA==",
-          "requires": {
-            "broccoli-persistent-filter": "^1.4.3",
-            "hash-for-dep": "^1.2.3",
-            "json-stable-stringify": "^1.0.0",
-            "strip-bom": "^3.0.0"
-          }
-        },
         "merge-trees": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-1.0.1.tgz",
@@ -12521,17 +11955,65 @@
       }
     },
     "ember-template-lint": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/ember-template-lint/-/ember-template-lint-1.5.1.tgz",
-      "integrity": "sha512-/n5o6KnDADGPg2/OuzrNR/u2w8WIfEjfJhESVw4DAS6jaF8uO0WZrNI60RvmM4Rp813iX5p8pp1dVUUz4Euy7w==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/ember-template-lint/-/ember-template-lint-1.5.3.tgz",
+      "integrity": "sha512-t/Bm21UVQHYqeexQTUSqAf1xyJnimhLMCIhNPtysjbuI9y7g275AnrJvSGI8H+RiJlH/RpR59TEwvPPt4cA4Qw==",
       "dev": true,
       "requires": {
-        "@glimmer/compiler": "^0.41.0",
+        "@glimmer/compiler": "^0.42.0",
         "chalk": "^2.0.0",
         "globby": "^9.0.0",
         "minimatch": "^3.0.4",
         "resolve": "^1.1.3",
         "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "@glimmer/compiler": {
+          "version": "0.42.0",
+          "resolved": "https://registry.npmjs.org/@glimmer/compiler/-/compiler-0.42.0.tgz",
+          "integrity": "sha512-3YkZkVuSv3e78WLYOz9YA1wKa/azFnBKADwcCNRhYpVOp9CHBJq4CzZ2pFcceYrCvL1CGgJ1crZJeuXfpkJyOw==",
+          "dev": true,
+          "requires": {
+            "@glimmer/interfaces": "^0.42.0",
+            "@glimmer/syntax": "^0.42.0",
+            "@glimmer/util": "^0.42.0",
+            "@glimmer/wire-format": "^0.42.0"
+          }
+        },
+        "@glimmer/interfaces": {
+          "version": "0.42.0",
+          "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.42.0.tgz",
+          "integrity": "sha512-lZlydeRRK3yL6pco0gCstPVuC5XYjBUtql1vSvWTRd+MUO0Chg8kxIvduFVg6f+Xfr1kqWd2YQq1MCMdmfzfvg==",
+          "dev": true
+        },
+        "@glimmer/syntax": {
+          "version": "0.42.0",
+          "resolved": "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.42.0.tgz",
+          "integrity": "sha512-H0vydEQjlSqlVyjUmQxOy9BMBdL8OAII4GQjTXHWOQKmQBreZ05Dpr2EbXusiby6E2lMgbcPOqxGXdB/VVUBew==",
+          "dev": true,
+          "requires": {
+            "@glimmer/interfaces": "^0.42.0",
+            "@glimmer/util": "^0.42.0",
+            "handlebars": "^4.0.13",
+            "simple-html-tokenizer": "^0.5.8"
+          }
+        },
+        "@glimmer/util": {
+          "version": "0.42.0",
+          "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.42.0.tgz",
+          "integrity": "sha512-rvXxKVb7BoQUvdrEQgxyvIeqGRUFM4LZAc7X1OmIpMnoaEh3fyx/e8Bz0blF0Yk6QvHpfV/GKirhlGmfum/ISA==",
+          "dev": true
+        },
+        "@glimmer/wire-format": {
+          "version": "0.42.0",
+          "resolved": "https://registry.npmjs.org/@glimmer/wire-format/-/wire-format-0.42.0.tgz",
+          "integrity": "sha512-/SmRH98Jm4NyvyWoBj05fqyz52pGDGHq91uX5Fn7sT4xgHDe8smlT+5Ht3Ewl4t2Pmtwqx/4YzitOy/1EKv0aA==",
+          "dev": true,
+          "requires": {
+            "@glimmer/interfaces": "^0.42.0",
+            "@glimmer/util": "^0.42.0"
+          }
+        }
       }
     },
     "ember-test-waiters": {
@@ -12994,62 +12476,6 @@
         "walk-sync": "^1.1.3"
       },
       "dependencies": {
-        "execa": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^6.0.0",
-            "get-stream": "^4.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          }
-        },
-        "fs-extra": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
-          "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "get-stream": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-          "dev": true
-        },
-        "npm-run-path": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-          "dev": true,
-          "requires": {
-            "path-key": "^2.0.0"
-          }
-        },
-        "p-finally": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-          "dev": true
-        },
         "walk-sync": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-1.1.4.tgz",
@@ -13075,85 +12501,6 @@
         "remote-git-tags": "^2.0.0",
         "rsvp": "^4.8.1",
         "semver": "^5.5.0"
-      },
-      "dependencies": {
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-          "dev": true
-        },
-        "got": {
-          "version": "6.7.1",
-          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-          "dev": true,
-          "requires": {
-            "create-error-class": "^3.0.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^3.0.0",
-            "is-redirect": "^1.0.0",
-            "is-retry-allowed": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "lowercase-keys": "^1.0.0",
-            "safe-buffer": "^5.0.1",
-            "timed-out": "^4.0.0",
-            "unzip-response": "^2.0.1",
-            "url-parse-lax": "^1.0.0"
-          }
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-          "dev": true
-        },
-        "package-json": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
-          "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
-          "dev": true,
-          "requires": {
-            "got": "^6.7.1",
-            "registry-auth-token": "^3.0.1",
-            "registry-url": "^3.0.3",
-            "semver": "^5.1.0"
-          }
-        },
-        "prepend-http": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-          "dev": true
-        },
-        "registry-auth-token": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
-          "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
-          "dev": true,
-          "requires": {
-            "rc": "^1.1.6",
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "registry-url": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-          "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-          "dev": true,
-          "requires": {
-            "rc": "^1.0.1"
-          }
-        },
-        "url-parse-lax": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-          "dev": true,
-          "requires": {
-            "prepend-http": "^1.0.1"
-          }
-        }
       }
     },
     "ember-uuid": {
@@ -13293,6 +12640,11 @@
             "ensure-posix-path": "^1.0.1"
           }
         },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
         "babel-plugin-debug-macros": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz",
@@ -13354,6 +12706,24 @@
             }
           }
         },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
         "ember-cli-babel": {
           "version": "6.18.0",
           "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
@@ -13393,6 +12763,14 @@
             "heimdalljs-logger": "^0.1.7",
             "rimraf": "^2.4.3",
             "symlink-or-copy": "^1.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "^3.0.0"
           }
         },
         "workerpool": {
@@ -13683,9 +13061,10 @@
       "dev": true
     },
     "emoji-regex": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "emojis-list": {
       "version": "2.1.0",
@@ -13703,6 +13082,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -13877,9 +13257,9 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
-      "integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
+      "integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
       "dev": true,
       "requires": {
         "esprima": "^3.1.3",
@@ -13956,12 +13336,6 @@
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
-        "chardet": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-          "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
-          "dev": true
-        },
         "cross-spawn": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -13982,49 +13356,6 @@
             "ms": "^2.1.1"
           }
         },
-        "external-editor": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-          "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
-          "dev": true,
-          "requires": {
-            "chardet": "^0.4.0",
-            "iconv-lite": "^0.4.17",
-            "tmp": "^0.0.33"
-          }
-        },
-        "inquirer": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-          "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "^3.0.0",
-            "chalk": "^2.0.0",
-            "cli-cursor": "^2.1.0",
-            "cli-width": "^2.0.0",
-            "external-editor": "^2.0.4",
-            "figures": "^2.0.0",
-            "lodash": "^4.3.0",
-            "mute-stream": "0.0.7",
-            "run-async": "^2.2.0",
-            "rx-lite": "^4.0.8",
-            "rx-lite-aggregates": "^4.0.8",
-            "string-width": "^2.1.0",
-            "strip-ansi": "^4.0.0",
-            "through": "^2.3.6"
-          }
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -14032,15 +13363,6 @@
           "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0"
-          }
-        },
-        "tmp": {
-          "version": "0.0.33",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "~1.0.2"
           }
         }
       }
@@ -14063,13 +13385,22 @@
       }
     },
     "eslint-plugin-ember": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-ember/-/eslint-plugin-ember-6.7.1.tgz",
-      "integrity": "sha512-5qzd/5zjXRVlyWpDcRRaIdl6yAHLrUCUyNE71pnk3Egs/erqQazyQHjKKToIWjTA1a7ba/WEC72tJ8HbLsevhA==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-ember/-/eslint-plugin-ember-6.9.1.tgz",
+      "integrity": "sha512-bzaH+3+R62ClPNNjQJBl06yXpMil5GZEiymf6XJ5duD3RFDZA8I0q8nmPzupR3/dzWDMiQkehL4YlI0hbX9Fuw==",
       "dev": true,
       "requires": {
-        "ember-rfc176-data": "^0.3.9",
+        "@ember-data/rfc395-data": "^0.0.4",
+        "ember-rfc176-data": "^0.3.10",
         "snake-case": "^2.1.0"
+      },
+      "dependencies": {
+        "ember-rfc176-data": {
+          "version": "0.3.12",
+          "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.12.tgz",
+          "integrity": "sha512-g9HeZj/gU5bfIIrGXkP7MhS2b3Vu5DfNUrYr14hy99TgIvtZETO+96QF4WOEUXGjIJdfTRjerVnQlqngPQSv1g==",
+          "dev": true
+        }
       }
     },
     "eslint-plugin-es": {
@@ -14105,9 +13436,9 @@
       },
       "dependencies": {
         "ignore": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.2.tgz",
-          "integrity": "sha512-vdqWBp7MyzdmHkkRWV5nY+PfGRbYbahfuvsBCh277tq+w9zyNi7h5CYJCK0kmzti9kU+O/cB7sE8HvKv6aXAKQ==",
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+          "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
           "dev": true
         }
       }
@@ -14132,9 +13463,9 @@
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
       "dev": true
     },
     "esm": {
@@ -14153,10 +13484,10 @@
         "acorn-jsx": "^3.0.0"
       }
     },
-    "esprima-fb": {
-      "version": "15001.1001.0-dev-harmony-fb",
-      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
-      "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
     "esquery": {
@@ -14178,9 +13509,9 @@
       }
     },
     "estraverse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true
     },
     "estree-walker": {
@@ -14235,19 +13566,18 @@
       "dev": true
     },
     "execa": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-2.0.3.tgz",
-      "integrity": "sha512-iM124nlyGSrXmuyZF1EMe83ESY2chIYVyDRZKgmcDynid2Q2v/+GuE7gNMl6Sy9Niwf4MC0DDxagOxeMPjuLsw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "dev": true,
       "requires": {
-        "cross-spawn": "^6.0.5",
-        "get-stream": "^5.0.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^3.0.0",
-        "onetime": "^5.1.0",
-        "p-finally": "^2.0.0",
-        "signal-exit": "^3.0.2",
-        "strip-final-newline": "^2.0.0"
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       }
     },
     "exists-sync": {
@@ -14409,12 +13739,13 @@
       }
     },
     "external-editor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+      "dev": true,
       "requires": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
+        "chardet": "^0.4.0",
+        "iconv-lite": "^0.4.17",
         "tmp": "^0.0.33"
       },
       "dependencies": {
@@ -14422,6 +13753,7 @@
           "version": "0.0.33",
           "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
           "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+          "dev": true,
           "requires": {
             "os-tmpdir": "~1.0.2"
           }
@@ -14490,12 +13822,6 @@
             "is-data-descriptor": "^1.0.0",
             "kind-of": "^6.0.2"
           }
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
         }
       }
     },
@@ -14584,17 +13910,6 @@
         "sourcemap-validator": "^1.1.0"
       },
       "dependencies": {
-        "fs-extra": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
-          "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
         "source-map": {
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
@@ -14649,6 +13964,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
       }
@@ -14839,39 +14155,6 @@
         }
       }
     },
-    "fixturify": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fixturify/-/fixturify-1.2.0.tgz",
-      "integrity": "sha512-b5CMQmBZKsGR6HGqdSrLOGYGHIqrR0CUrcGU/lDL0mYy+DtGm5cnb61Z0UiIUqMVZIoV0CbN+u9/Gwjj+ICg0A==",
-      "requires": {
-        "@types/fs-extra": "^5.0.5",
-        "@types/minimatch": "^3.0.3",
-        "@types/rimraf": "^2.0.2",
-        "fs-extra": "^7.0.1",
-        "matcher-collection": "^2.0.0"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "matcher-collection": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.0.tgz",
-          "integrity": "sha512-wSi4BgQGTFfBN5J+pIaS78rEKk4qIkjrw+NfJYdHsd2cRVIQsbDi3BZtNAXTFA2WHvlbS9kLGtTjv3cPJKuRSw==",
-          "requires": {
-            "@types/minimatch": "^3.0.3",
-            "minimatch": "^3.0.2"
-          }
-        }
-      }
-    },
     "flat-cache": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
@@ -14882,6 +14165,17 @@
         "graceful-fs": "^4.1.2",
         "rimraf": "~2.6.2",
         "write": "^0.2.1"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "flush-write-stream": {
@@ -15027,11 +14321,11 @@
       }
     },
     "fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+      "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
       "requires": {
-        "graceful-fs": "^4.2.0",
+        "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
         "universalify": "^0.1.0"
       }
@@ -15748,7 +15042,8 @@
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
     },
     "get-stdin": {
       "version": "4.0.1",
@@ -15757,9 +15052,10 @@
       "dev": true
     },
     "get-stream": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-      "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
       "requires": {
         "pump": "^3.0.0"
       }
@@ -15777,30 +15073,6 @@
       "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
-      }
-    },
-    "git-diff-apply": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/git-diff-apply/-/git-diff-apply-0.19.1.tgz",
-      "integrity": "sha512-cIV8vzH7Qpgji3ltFJFCR9r6IBvCo0ZGmt1aY8NvSVl4LtGwMQQqtxDnVUbSNZSLiBhpd6RcqXSh14YcUs2XKQ==",
-      "requires": {
-        "debug": "^4.0.0",
-        "fixturify": "^1.0.0",
-        "fs-extra": "^8.0.0",
-        "klaw": "^3.0.0",
-        "tmp": "0.1.0",
-        "uuid": "^3.1.0",
-        "yargs": "^13.0.0"
-      },
-      "dependencies": {
-        "tmp": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-          "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
-          "requires": {
-            "rimraf": "^2.6.3"
-          }
-        }
       }
     },
     "git-fetch-pack": {
@@ -15932,14 +15204,6 @@
       "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
       "dev": true
     },
-    "global-dirs": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
-      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
-      "requires": {
-        "ini": "^1.3.4"
-      }
-    },
     "global-modules": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
@@ -16013,38 +15277,10 @@
         "delegate": "^3.1.2"
       }
     },
-    "got": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
-      "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
-      "requires": {
-        "@sindresorhus/is": "^0.14.0",
-        "@szmarczak/http-timer": "^1.1.2",
-        "cacheable-request": "^6.0.0",
-        "decompress-response": "^3.3.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^4.1.0",
-        "lowercase-keys": "^1.0.1",
-        "mimic-response": "^1.0.1",
-        "p-cancelable": "^1.0.0",
-        "to-readable-stream": "^1.0.0",
-        "url-parse-lax": "^3.0.0"
-      },
-      "dependencies": {
-        "get-stream": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        }
-      }
-    },
     "graceful-fs": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.1.tgz",
-      "integrity": "sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw=="
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+      "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q=="
     },
     "graceful-readlink": {
       "version": "1.0.1",
@@ -16238,11 +15474,6 @@
         }
       }
     },
-    "has-yarn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
-      "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw=="
-    },
     "hash-base": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
@@ -16361,30 +15592,10 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.2.tgz",
-      "integrity": "sha512-CyjlXII6LMsPMyUzxpTt8fzh5QwzGqPmQXgY/Jyf4Zfp27t/FvfhwoE/8laaMUcMy816CkWF20I7NeQhwwY88w==",
-      "dev": true,
-      "requires": {
-        "lru-cache": "^5.1.1"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-          "dev": true,
-          "requires": {
-            "yallist": "^3.0.2"
-          }
-        },
-        "yallist": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
-        }
-      }
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
+      "integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
+      "dev": true
     },
     "html-encoding-sniffer": {
       "version": "1.0.2",
@@ -16394,11 +15605,6 @@
       "requires": {
         "whatwg-encoding": "^1.0.1"
       }
-    },
-    "http-cache-semantics": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
-      "integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew=="
     },
     "http-errors": {
       "version": "1.6.3",
@@ -16458,6 +15664,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -16487,15 +15694,11 @@
       "dev": true,
       "optional": true
     },
-    "import-lazy": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
-    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
     },
     "include-path-searcher": {
       "version": "0.1.0",
@@ -16538,7 +15741,8 @@
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true
     },
     "inline-source-map-comment": {
       "version": "1.0.5",
@@ -16581,62 +15785,40 @@
       }
     },
     "inquirer": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
-      "integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "dev": true,
       "requires": {
-        "ansi-escapes": "^3.2.0",
-        "chalk": "^2.4.2",
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
         "cli-cursor": "^2.1.0",
         "cli-width": "^2.0.0",
-        "external-editor": "^3.0.3",
+        "external-editor": "^2.0.4",
         "figures": "^2.0.0",
-        "lodash": "^4.17.12",
+        "lodash": "^4.3.0",
         "mute-stream": "0.0.7",
         "run-async": "^2.2.0",
-        "rxjs": "^6.4.0",
+        "rx-lite": "^4.0.8",
+        "rx-lite-aggregates": "^4.0.8",
         "string-width": "^2.1.0",
-        "strip-ansi": "^5.1.0",
+        "strip-ansi": "^4.0.0",
         "through": "^2.3.6"
       },
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          },
-          "dependencies": {
-            "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "requires": {
-                "ansi-regex": "^3.0.0"
-              }
-            }
-          }
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
         },
         "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-            }
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -16678,6 +15860,17 @@
       "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "is-binary-path": {
@@ -16701,14 +15894,6 @@
       "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
       "dev": true
     },
-    "is-ci": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
-      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
-      "requires": {
-        "ci-info": "^2.0.0"
-      }
-    },
     "is-data-descriptor": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
@@ -16716,6 +15901,17 @@
       "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "is-date-object": {
@@ -16765,7 +15961,8 @@
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
     },
     "is-git-url": {
       "version": "1.0.0",
@@ -16782,15 +15979,6 @@
         "is-extglob": "^2.1.0"
       }
     },
-    "is-installed-globally": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
-      "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
-      "requires": {
-        "global-dirs": "^0.1.0",
-        "is-path-inside": "^1.0.0"
-      }
-    },
     "is-integer": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.7.tgz",
@@ -16800,11 +15988,6 @@
         "is-finite": "^1.0.0"
       }
     },
-    "is-npm": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-3.0.0.tgz",
-      "integrity": "sha512-wsigDr1Kkschp2opC4G3yA6r9EgVA6NjRpWzIi9axXqeIaAATPRJc4uLujXe3Nd9uO8KoDyA4MD6aZSeXTADhA=="
-    },
     "is-number": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -16812,26 +15995,30 @@
       "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "is-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
     },
     "is-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
       "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
       "dev": true
-    },
-    "is-path-inside": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-      "requires": {
-        "path-is-inside": "^1.0.1"
-      }
     },
     "is-plain-obj": {
       "version": "1.1.0",
@@ -16851,7 +16038,8 @@
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
     },
     "is-redirect": {
       "version": "1.0.0",
@@ -16890,9 +16078,10 @@
       "dev": true
     },
     "is-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
     },
     "is-symbol": {
       "version": "1.0.2",
@@ -16921,8 +16110,7 @@
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-      "dev": true
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
     "is-windows": {
       "version": "1.0.2",
@@ -16933,12 +16121,8 @@
     "is-wsl": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
-    },
-    "is-yarn-global": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
-      "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw=="
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+      "dev": true
     },
     "isarray": {
       "version": "1.0.0",
@@ -17148,14 +16332,6 @@
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-          "dev": true
-        }
       }
     },
     "jsbn": {
@@ -17198,9 +16374,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
-          "integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
+          "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
           "dev": true
         }
       }
@@ -17213,7 +16389,8 @@
     "json-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+      "dev": true
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -17286,37 +16463,19 @@
         "verror": "1.10.0"
       }
     },
-    "keyv": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
-      "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
-      "requires": {
-        "json-buffer": "3.0.0"
-      }
-    },
     "kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
-      "requires": {
-        "is-buffer": "^1.1.5"
-      }
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "dev": true
     },
     "klaw": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
-      "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.9"
-      }
-    },
-    "latest-version": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
-      "integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
-      "requires": {
-        "package-json": "^6.3.0"
       }
     },
     "layout-bin-packer": {
@@ -18152,7 +17311,8 @@
     "lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "dev": true
     },
     "lru-cache": {
       "version": "4.1.5",
@@ -18161,6 +17321,13 @@
       "requires": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+        }
       }
     },
     "magic-string": {
@@ -18176,6 +17343,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+      "dev": true,
       "requires": {
         "pify": "^3.0.0"
       }
@@ -18654,20 +17822,6 @@
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true
     },
-    "merge-package.json": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/merge-package.json/-/merge-package.json-3.0.2.tgz",
-      "integrity": "sha512-Aj8UmsAZ3z/Cn1xxU4ch2uVC1kqTLfWLliHwTI9GMAK8Eskz8WxyyDaBZCY4XXJSEUjwScKoSmiOG+DDx4NPUg==",
-      "requires": {
-        "rfc6902-ordered": "^4.0.0",
-        "three-way-merger": "0.5.7"
-      }
-    },
-    "merge-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
-    },
     "merge-trees": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-2.0.0.tgz",
@@ -18708,14 +17862,6 @@
         "regex-not": "^1.0.0",
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
-        }
       }
     },
     "miller-rabin": {
@@ -18750,14 +17896,16 @@
       }
     },
     "mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
     },
     "mimic-response": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -18792,14 +17940,6 @@
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
-      },
-      "dependencies": {
-        "yallist": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
-        }
       }
     },
     "mississippi": {
@@ -18976,7 +18116,8 @@
     "mute-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
     },
     "najax": {
       "version": "1.0.4",
@@ -19043,7 +18184,8 @@
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
     },
     "no-case": {
       "version": "2.3.2",
@@ -19171,9 +18313,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.26",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
-      "integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
+      "version": "1.1.27",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.27.tgz",
+      "integrity": "sha512-9iXUqHKSGo6ph/tdXVbHFbhRVQln4ZDTIBJCzsa90HimnBYc5jw8RWYt4wBYFHehGyC3koIz5O4mb2fHrbPOuA==",
       "requires": {
         "semver": "^5.3.0"
       }
@@ -19202,11 +18344,6 @@
         "remove-trailing-separator": "^1.0.1"
       }
     },
-    "normalize-url": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.3.0.tgz",
-      "integrity": "sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ=="
-    },
     "npm-git-info": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/npm-git-info/-/npm-git-info-1.0.3.tgz",
@@ -19225,18 +18362,12 @@
       }
     },
     "npm-run-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
-      "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
       "requires": {
-        "path-key": "^3.0.0"
-      },
-      "dependencies": {
-        "path-key": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
-          "integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg=="
-        }
+        "path-key": "^2.0.0"
       }
     },
     "npmlog": {
@@ -19249,3865 +18380,6 @@
         "console-control-strings": "~1.1.0",
         "gauge": "~2.7.3",
         "set-blocking": "~2.0.0"
-      }
-    },
-    "npx": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/npx/-/npx-10.2.0.tgz",
-      "integrity": "sha512-DqjFkzET0DeaXYXNJnirnvEovwk4lBa33ZQCw1jxMuas4yH9jdU8q2U8L3cLaB2UqzgmW2Ssqk8lcGiPRL8pRg==",
-      "requires": {
-        "libnpx": "10.2.0",
-        "npm": "5.1.0"
-      },
-      "dependencies": {
-        "ansi-align": {
-          "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
-          "requires": {
-            "string-width": "^2.0.0"
-          }
-        },
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": false,
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": false,
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-        },
-        "boxen": {
-          "version": "1.3.0",
-          "resolved": false,
-          "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
-          "requires": {
-            "ansi-align": "^2.0.0",
-            "camelcase": "^4.0.0",
-            "chalk": "^2.0.1",
-            "cli-boxes": "^1.0.0",
-            "string-width": "^2.0.0",
-            "term-size": "^1.2.0",
-            "widest-line": "^2.0.0"
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": false,
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "builtins": {
-          "version": "1.0.3",
-          "resolved": false,
-          "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og="
-        },
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": false,
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-        },
-        "capture-stack-trace": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
-        },
-        "chalk": {
-          "version": "2.3.2",
-          "resolved": false,
-          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "ci-info": {
-          "version": "1.1.3",
-          "resolved": false,
-          "integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg=="
-        },
-        "cli-boxes": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
-        },
-        "cliui": {
-          "version": "4.0.0",
-          "resolved": false,
-          "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
-          "requires": {
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0",
-            "wrap-ansi": "^2.0.0"
-          }
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-        },
-        "color-convert": {
-          "version": "1.9.1",
-          "resolved": false,
-          "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-          "requires": {
-            "color-name": "^1.1.1"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": false,
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "resolved": false,
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-        },
-        "configstore": {
-          "version": "3.1.2",
-          "resolved": false,
-          "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
-          "requires": {
-            "dot-prop": "^4.1.0",
-            "graceful-fs": "^4.1.2",
-            "make-dir": "^1.0.0",
-            "unique-string": "^1.0.0",
-            "write-file-atomic": "^2.0.0",
-            "xdg-basedir": "^3.0.0"
-          }
-        },
-        "create-error-class": {
-          "version": "3.0.2",
-          "resolved": false,
-          "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-          "requires": {
-            "capture-stack-trace": "^1.0.0"
-          }
-        },
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": false,
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
-        "crypto-random-string": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
-        },
-        "decamelize": {
-          "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "resolved": false,
-          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
-        },
-        "dot-prop": {
-          "version": "4.2.0",
-          "resolved": false,
-          "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
-          "requires": {
-            "is-obj": "^1.0.0"
-          }
-        },
-        "dotenv": {
-          "version": "5.0.1",
-          "resolved": false,
-          "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow=="
-        },
-        "duplexer3": {
-          "version": "0.1.4",
-          "resolved": false,
-          "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": false,
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-        },
-        "execa": {
-          "version": "0.7.0",
-          "resolved": false,
-          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-          "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          }
-        },
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-        },
-        "get-caller-file": {
-          "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
-        },
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": false,
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
-        },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": false,
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "global-dirs": {
-          "version": "0.1.1",
-          "resolved": false,
-          "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
-          "requires": {
-            "ini": "^1.3.4"
-          }
-        },
-        "got": {
-          "version": "6.7.1",
-          "resolved": false,
-          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-          "requires": {
-            "create-error-class": "^3.0.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^3.0.0",
-            "is-redirect": "^1.0.0",
-            "is-retry-allowed": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "lowercase-keys": "^1.0.0",
-            "safe-buffer": "^5.0.1",
-            "timed-out": "^4.0.0",
-            "unzip-response": "^2.0.1",
-            "url-parse-lax": "^1.0.0"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": false,
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": false,
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-        },
-        "hosted-git-info": {
-          "version": "2.6.0",
-          "resolved": false,
-          "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
-        },
-        "import-lazy": {
-          "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
-        },
-        "imurmurhash": {
-          "version": "0.1.4",
-          "resolved": false,
-          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "resolved": false,
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": false,
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        },
-        "ini": {
-          "version": "1.3.5",
-          "resolved": false,
-          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
-        },
-        "invert-kv": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
-        },
-        "is-ci": {
-          "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
-          "requires": {
-            "ci-info": "^1.0.0"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-        },
-        "is-installed-globally": {
-          "version": "0.1.0",
-          "resolved": false,
-          "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
-          "requires": {
-            "global-dirs": "^0.1.0",
-            "is-path-inside": "^1.0.0"
-          }
-        },
-        "is-npm": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
-        },
-        "is-obj": {
-          "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
-        },
-        "is-path-inside": {
-          "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-          "requires": {
-            "path-is-inside": "^1.0.1"
-          }
-        },
-        "is-redirect": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
-        },
-        "is-retry-allowed": {
-          "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-        },
-        "isexe": {
-          "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-        },
-        "latest-version": {
-          "version": "3.1.0",
-          "resolved": false,
-          "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
-          "requires": {
-            "package-json": "^4.0.0"
-          }
-        },
-        "lcid": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-          "requires": {
-            "invert-kv": "^1.0.0"
-          }
-        },
-        "libnpx": {
-          "version": "10.2.0",
-          "resolved": false,
-          "integrity": "sha512-X28coei8/XRCt15cYStbLBph+KGhFra4VQhRBPuH/HHMkC5dxM8v24RVgUsvODKCrUZ0eTgiTqJp6zbl0sskQQ==",
-          "requires": {
-            "dotenv": "^5.0.1",
-            "npm-package-arg": "^6.0.0",
-            "rimraf": "^2.6.2",
-            "safe-buffer": "^5.1.0",
-            "update-notifier": "^2.3.0",
-            "which": "^1.3.0",
-            "y18n": "^4.0.0",
-            "yargs": "^11.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "lowercase-keys": {
-          "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
-        },
-        "lru-cache": {
-          "version": "4.1.2",
-          "resolved": false,
-          "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          }
-        },
-        "make-dir": {
-          "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
-          "requires": {
-            "pify": "^3.0.0"
-          }
-        },
-        "mem": {
-          "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-          "requires": {
-            "mimic-fn": "^1.0.0"
-          }
-        },
-        "mimic-fn": {
-          "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": false,
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        },
-        "npm": {
-          "version": "5.1.0",
-          "resolved": false,
-          "integrity": "sha512-pt5ClxEmY/dLpb60SmGQQBKi3nB6Ljx1FXmpoCUdAULlGqGVn2uCyXxPCWFbcuHGthT7qGiaGa1wOfs/UjGYMw==",
-          "requires": {
-            "JSONStream": "~1.3.1",
-            "abbrev": "~1.1.0",
-            "ansi-regex": "~3.0.0",
-            "ansicolors": "~0.3.2",
-            "ansistyles": "~0.1.3",
-            "aproba": "~1.1.2",
-            "archy": "~1.0.0",
-            "bluebird": "~3.5.0",
-            "cacache": "~9.2.9",
-            "call-limit": "~1.1.0",
-            "chownr": "~1.0.1",
-            "cmd-shim": "~2.0.2",
-            "columnify": "~1.5.4",
-            "config-chain": "~1.1.11",
-            "debuglog": "*",
-            "detect-indent": "~5.0.0",
-            "dezalgo": "~1.0.3",
-            "editor": "~1.0.0",
-            "fs-vacuum": "~1.2.10",
-            "fs-write-stream-atomic": "~1.0.10",
-            "fstream": "~1.0.11",
-            "fstream-npm": "~1.2.1",
-            "glob": "~7.1.2",
-            "graceful-fs": "~4.1.11",
-            "has-unicode": "~2.0.1",
-            "hosted-git-info": "~2.5.0",
-            "iferr": "~0.1.5",
-            "imurmurhash": "*",
-            "inflight": "~1.0.6",
-            "inherits": "~2.0.3",
-            "ini": "~1.3.4",
-            "init-package-json": "~1.10.1",
-            "lazy-property": "~1.0.0",
-            "lockfile": "~1.0.3",
-            "lodash._baseindexof": "*",
-            "lodash._baseuniq": "~4.6.0",
-            "lodash._bindcallback": "*",
-            "lodash._cacheindexof": "*",
-            "lodash._createcache": "*",
-            "lodash._getnative": "*",
-            "lodash.clonedeep": "~4.5.0",
-            "lodash.restparam": "*",
-            "lodash.union": "~4.6.0",
-            "lodash.uniq": "~4.5.0",
-            "lodash.without": "~4.4.0",
-            "lru-cache": "~4.1.1",
-            "mississippi": "~1.3.0",
-            "mkdirp": "~0.5.1",
-            "move-concurrently": "~1.0.1",
-            "node-gyp": "~3.6.2",
-            "nopt": "~4.0.1",
-            "normalize-package-data": "~2.4.0",
-            "npm-cache-filename": "~1.0.2",
-            "npm-install-checks": "~3.0.0",
-            "npm-package-arg": "~5.1.2",
-            "npm-registry-client": "~8.4.0",
-            "npm-user-validate": "~1.0.0",
-            "npmlog": "~4.1.2",
-            "once": "~1.4.0",
-            "opener": "~1.4.3",
-            "osenv": "~0.1.4",
-            "pacote": "~2.7.38",
-            "path-is-inside": "~1.0.2",
-            "promise-inflight": "~1.0.1",
-            "read": "~1.0.7",
-            "read-cmd-shim": "~1.0.1",
-            "read-installed": "~4.0.3",
-            "read-package-json": "~2.0.9",
-            "read-package-tree": "~5.1.6",
-            "readable-stream": "~2.3.2",
-            "readdir-scoped-modules": "*",
-            "request": "~2.81.0",
-            "retry": "~0.10.1",
-            "rimraf": "~2.6.1",
-            "safe-buffer": "~5.1.1",
-            "semver": "~5.3.0",
-            "sha": "~2.0.1",
-            "slide": "~1.1.6",
-            "sorted-object": "~2.0.1",
-            "sorted-union-stream": "~2.1.3",
-            "ssri": "~4.1.6",
-            "strip-ansi": "~4.0.0",
-            "tar": "~2.2.1",
-            "text-table": "~0.2.0",
-            "uid-number": "0.0.6",
-            "umask": "~1.1.0",
-            "unique-filename": "~1.1.0",
-            "unpipe": "~1.0.0",
-            "update-notifier": "~2.2.0",
-            "uuid": "~3.1.0",
-            "validate-npm-package-license": "*",
-            "validate-npm-package-name": "~3.0.0",
-            "which": "~1.2.14",
-            "worker-farm": "~1.3.1",
-            "wrappy": "~1.0.2",
-            "write-file-atomic": "~2.1.0"
-          },
-          "dependencies": {
-            "JSONStream": {
-              "version": "1.3.1",
-              "resolved": false,
-              "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-              "requires": {
-                "jsonparse": "^1.2.0",
-                "through": ">=2.2.7 <3"
-              },
-              "dependencies": {
-                "jsonparse": {
-                  "version": "1.3.1",
-                  "resolved": false,
-                  "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
-                },
-                "through": {
-                  "version": "2.3.8",
-                  "resolved": false,
-                  "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
-                }
-              }
-            },
-            "abbrev": {
-              "version": "1.1.0",
-              "resolved": false,
-              "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8="
-            },
-            "ansi-regex": {
-              "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-            },
-            "ansicolors": {
-              "version": "0.3.2",
-              "resolved": false,
-              "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk="
-            },
-            "ansistyles": {
-              "version": "0.1.3",
-              "resolved": false,
-              "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk="
-            },
-            "aproba": {
-              "version": "1.1.2",
-              "resolved": false,
-              "integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw=="
-            },
-            "archy": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
-            },
-            "bluebird": {
-              "version": "3.5.0",
-              "resolved": false,
-              "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
-            },
-            "cacache": {
-              "version": "9.2.9",
-              "resolved": false,
-              "integrity": "sha512-ghg1j5OyTJ6qsrqU++dN23QiTDxb5AZCFGsF3oB+v9v/gY+F4X8L/0gdQMEjd+8Ot3D29M2etX5PKozHRn2JQw==",
-              "requires": {
-                "bluebird": "^3.5.0",
-                "chownr": "^1.0.1",
-                "glob": "^7.1.2",
-                "graceful-fs": "^4.1.11",
-                "lru-cache": "^4.1.1",
-                "mississippi": "^1.3.0",
-                "mkdirp": "^0.5.1",
-                "move-concurrently": "^1.0.1",
-                "promise-inflight": "^1.0.1",
-                "rimraf": "^2.6.1",
-                "ssri": "^4.1.6",
-                "unique-filename": "^1.1.0",
-                "y18n": "^3.2.1"
-              },
-              "dependencies": {
-                "lru-cache": {
-                  "version": "4.1.1",
-                  "resolved": false,
-                  "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-                  "requires": {
-                    "pseudomap": "^1.0.2",
-                    "yallist": "^2.1.2"
-                  },
-                  "dependencies": {
-                    "pseudomap": {
-                      "version": "1.0.2",
-                      "resolved": false,
-                      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-                    },
-                    "yallist": {
-                      "version": "2.1.2",
-                      "resolved": false,
-                      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-                    }
-                  }
-                },
-                "y18n": {
-                  "version": "3.2.1",
-                  "resolved": false,
-                  "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
-                }
-              }
-            },
-            "call-limit": {
-              "version": "1.1.0",
-              "resolved": false,
-              "integrity": "sha1-b9YbA/PaQqLNDsK2DwK9DnGZH+o="
-            },
-            "chownr": {
-              "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
-            },
-            "cmd-shim": {
-              "version": "2.0.2",
-              "resolved": false,
-              "integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "mkdirp": "~0.5.0"
-              }
-            },
-            "columnify": {
-              "version": "1.5.4",
-              "resolved": false,
-              "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
-              "requires": {
-                "strip-ansi": "^3.0.0",
-                "wcwidth": "^1.0.0"
-              },
-              "dependencies": {
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "resolved": false,
-                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                  "requires": {
-                    "ansi-regex": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.1.1",
-                      "resolved": false,
-                      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-                    }
-                  }
-                },
-                "wcwidth": {
-                  "version": "1.0.1",
-                  "resolved": false,
-                  "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
-                  "requires": {
-                    "defaults": "^1.0.3"
-                  },
-                  "dependencies": {
-                    "defaults": {
-                      "version": "1.0.3",
-                      "resolved": false,
-                      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-                      "requires": {
-                        "clone": "^1.0.2"
-                      },
-                      "dependencies": {
-                        "clone": {
-                          "version": "1.0.2",
-                          "resolved": false,
-                          "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk="
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "config-chain": {
-              "version": "1.1.11",
-              "resolved": false,
-              "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
-              "requires": {
-                "ini": "^1.3.4",
-                "proto-list": "~1.2.1"
-              },
-              "dependencies": {
-                "proto-list": {
-                  "version": "1.2.4",
-                  "resolved": false,
-                  "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
-                }
-              }
-            },
-            "debuglog": {
-              "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI="
-            },
-            "detect-indent": {
-              "version": "5.0.0",
-              "resolved": false,
-              "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50="
-            },
-            "dezalgo": {
-              "version": "1.0.3",
-              "resolved": false,
-              "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
-              "requires": {
-                "asap": "^2.0.0",
-                "wrappy": "1"
-              },
-              "dependencies": {
-                "asap": {
-                  "version": "2.0.5",
-                  "resolved": false,
-                  "integrity": "sha1-UidltQw1EEkOUtfc/ghe+bqWlY8="
-                }
-              }
-            },
-            "editor": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I="
-            },
-            "fs-vacuum": {
-              "version": "1.2.10",
-              "resolved": false,
-              "integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "path-is-inside": "^1.0.1",
-                "rimraf": "^2.5.2"
-              }
-            },
-            "fs-write-stream-atomic": {
-              "version": "1.0.10",
-              "resolved": false,
-              "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "iferr": "^0.1.5",
-                "imurmurhash": "^0.1.4",
-                "readable-stream": "1 || 2"
-              }
-            },
-            "fstream": {
-              "version": "1.0.11",
-              "resolved": false,
-              "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "inherits": "~2.0.0",
-                "mkdirp": ">=0.5 0",
-                "rimraf": "2"
-              }
-            },
-            "fstream-npm": {
-              "version": "1.2.1",
-              "resolved": false,
-              "integrity": "sha512-iBHpm/LmD1qw0TlHMAqVd9rwdU6M+EHRUnPkXpRi5G/Hf0FIFH+oZFryodAU2MFNfGRh/CzhUFlMKV3pdeOTDw==",
-              "requires": {
-                "fstream-ignore": "^1.0.0",
-                "inherits": "2"
-              },
-              "dependencies": {
-                "fstream-ignore": {
-                  "version": "1.0.5",
-                  "resolved": false,
-                  "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
-                  "requires": {
-                    "fstream": "^1.0.0",
-                    "inherits": "2",
-                    "minimatch": "^3.0.0"
-                  },
-                  "dependencies": {
-                    "minimatch": {
-                      "version": "3.0.4",
-                      "resolved": false,
-                      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-                      "requires": {
-                        "brace-expansion": "^1.1.7"
-                      },
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.8",
-                          "resolved": false,
-                          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-                          "requires": {
-                            "balanced-match": "^1.0.0",
-                            "concat-map": "0.0.1"
-                          },
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "1.0.0",
-                              "resolved": false,
-                              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "resolved": false,
-                              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "glob": {
-              "version": "7.1.2",
-              "resolved": false,
-              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              },
-              "dependencies": {
-                "fs.realpath": {
-                  "version": "1.0.0",
-                  "resolved": false,
-                  "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-                },
-                "minimatch": {
-                  "version": "3.0.4",
-                  "resolved": false,
-                  "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-                  "requires": {
-                    "brace-expansion": "^1.1.7"
-                  },
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.8",
-                      "resolved": false,
-                      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-                      "requires": {
-                        "balanced-match": "^1.0.0",
-                        "concat-map": "0.0.1"
-                      },
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "1.0.0",
-                          "resolved": false,
-                          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "resolved": false,
-                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-                        }
-                      }
-                    }
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.1",
-                  "resolved": false,
-                  "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-                }
-              }
-            },
-            "graceful-fs": {
-              "version": "4.1.11",
-              "resolved": false,
-              "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-            },
-            "has-unicode": {
-              "version": "2.0.1",
-              "resolved": false,
-              "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
-            },
-            "hosted-git-info": {
-              "version": "2.5.0",
-              "resolved": false,
-              "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
-            },
-            "iferr": {
-              "version": "0.1.5",
-              "resolved": false,
-              "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
-            },
-            "imurmurhash": {
-              "version": "0.1.4",
-              "resolved": false,
-              "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "resolved": false,
-              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-              "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "resolved": false,
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-            },
-            "ini": {
-              "version": "1.3.4",
-              "resolved": false,
-              "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
-            },
-            "init-package-json": {
-              "version": "1.10.1",
-              "resolved": false,
-              "integrity": "sha1-zYc6FneWvvuZYSsodioLY5P9j2o=",
-              "requires": {
-                "glob": "^7.1.1",
-                "npm-package-arg": "^4.0.0 || ^5.0.0",
-                "promzard": "^0.3.0",
-                "read": "~1.0.1",
-                "read-package-json": "1 || 2",
-                "semver": "2.x || 3.x || 4 || 5",
-                "validate-npm-package-license": "^3.0.1",
-                "validate-npm-package-name": "^3.0.0"
-              },
-              "dependencies": {
-                "promzard": {
-                  "version": "0.3.0",
-                  "resolved": false,
-                  "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
-                  "requires": {
-                    "read": "1"
-                  }
-                }
-              }
-            },
-            "lazy-property": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc="
-            },
-            "lockfile": {
-              "version": "1.0.3",
-              "resolved": false,
-              "integrity": "sha1-Jjj8OaAzHpysGgS3F5mTHJxQ33k="
-            },
-            "lodash._baseindexof": {
-              "version": "3.1.0",
-              "resolved": false,
-              "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw="
-            },
-            "lodash._baseuniq": {
-              "version": "4.6.0",
-              "resolved": false,
-              "integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
-              "requires": {
-                "lodash._createset": "~4.0.0",
-                "lodash._root": "~3.0.0"
-              },
-              "dependencies": {
-                "lodash._createset": {
-                  "version": "4.0.3",
-                  "resolved": false,
-                  "integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY="
-                },
-                "lodash._root": {
-                  "version": "3.0.1",
-                  "resolved": false,
-                  "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
-                }
-              }
-            },
-            "lodash._bindcallback": {
-              "version": "3.0.1",
-              "resolved": false,
-              "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
-            },
-            "lodash._cacheindexof": {
-              "version": "3.0.2",
-              "resolved": false,
-              "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI="
-            },
-            "lodash._createcache": {
-              "version": "3.1.2",
-              "resolved": false,
-              "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
-              "requires": {
-                "lodash._getnative": "^3.0.0"
-              }
-            },
-            "lodash._getnative": {
-              "version": "3.9.1",
-              "resolved": false,
-              "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
-            },
-            "lodash.clonedeep": {
-              "version": "4.5.0",
-              "resolved": false,
-              "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
-            },
-            "lodash.restparam": {
-              "version": "3.6.1",
-              "resolved": false,
-              "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
-            },
-            "lodash.union": {
-              "version": "4.6.0",
-              "resolved": false,
-              "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
-            },
-            "lodash.uniq": {
-              "version": "4.5.0",
-              "resolved": false,
-              "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
-            },
-            "lodash.without": {
-              "version": "4.4.0",
-              "resolved": false,
-              "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw="
-            },
-            "lru-cache": {
-              "version": "4.1.1",
-              "resolved": false,
-              "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-              "requires": {
-                "pseudomap": "^1.0.2",
-                "yallist": "^2.1.2"
-              },
-              "dependencies": {
-                "pseudomap": {
-                  "version": "1.0.2",
-                  "resolved": false,
-                  "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-                },
-                "yallist": {
-                  "version": "2.1.2",
-                  "resolved": false,
-                  "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-                }
-              }
-            },
-            "mississippi": {
-              "version": "1.3.0",
-              "resolved": false,
-              "integrity": "sha1-0gFYPrEjJ+PFwWQqQEqcrPlONPU=",
-              "requires": {
-                "concat-stream": "^1.5.0",
-                "duplexify": "^3.4.2",
-                "end-of-stream": "^1.1.0",
-                "flush-write-stream": "^1.0.0",
-                "from2": "^2.1.0",
-                "parallel-transform": "^1.1.0",
-                "pump": "^1.0.0",
-                "pumpify": "^1.3.3",
-                "stream-each": "^1.1.0",
-                "through2": "^2.0.0"
-              },
-              "dependencies": {
-                "concat-stream": {
-                  "version": "1.6.0",
-                  "resolved": false,
-                  "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-                  "requires": {
-                    "inherits": "^2.0.3",
-                    "readable-stream": "^2.2.2",
-                    "typedarray": "^0.0.6"
-                  },
-                  "dependencies": {
-                    "typedarray": {
-                      "version": "0.0.6",
-                      "resolved": false,
-                      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-                    }
-                  }
-                },
-                "duplexify": {
-                  "version": "3.5.0",
-                  "resolved": false,
-                  "integrity": "sha1-GqdzAC4VeEV+nZ1KULDMquvL1gQ=",
-                  "requires": {
-                    "end-of-stream": "1.0.0",
-                    "inherits": "^2.0.1",
-                    "readable-stream": "^2.0.0",
-                    "stream-shift": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "end-of-stream": {
-                      "version": "1.0.0",
-                      "resolved": false,
-                      "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
-                      "requires": {
-                        "once": "~1.3.0"
-                      },
-                      "dependencies": {
-                        "once": {
-                          "version": "1.3.3",
-                          "resolved": false,
-                          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-                          "requires": {
-                            "wrappy": "1"
-                          }
-                        }
-                      }
-                    },
-                    "stream-shift": {
-                      "version": "1.0.0",
-                      "resolved": false,
-                      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
-                    }
-                  }
-                },
-                "end-of-stream": {
-                  "version": "1.4.0",
-                  "resolved": false,
-                  "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
-                  "requires": {
-                    "once": "^1.4.0"
-                  }
-                },
-                "flush-write-stream": {
-                  "version": "1.0.2",
-                  "resolved": false,
-                  "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
-                  "requires": {
-                    "inherits": "^2.0.1",
-                    "readable-stream": "^2.0.4"
-                  }
-                },
-                "from2": {
-                  "version": "2.3.0",
-                  "resolved": false,
-                  "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
-                  "requires": {
-                    "inherits": "^2.0.1",
-                    "readable-stream": "^2.0.0"
-                  }
-                },
-                "parallel-transform": {
-                  "version": "1.1.0",
-                  "resolved": false,
-                  "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
-                  "requires": {
-                    "cyclist": "~0.2.2",
-                    "inherits": "^2.0.3",
-                    "readable-stream": "^2.1.5"
-                  },
-                  "dependencies": {
-                    "cyclist": {
-                      "version": "0.2.2",
-                      "resolved": false,
-                      "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
-                    }
-                  }
-                },
-                "pump": {
-                  "version": "1.0.2",
-                  "resolved": false,
-                  "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
-                  "requires": {
-                    "end-of-stream": "^1.1.0",
-                    "once": "^1.3.1"
-                  }
-                },
-                "pumpify": {
-                  "version": "1.3.5",
-                  "resolved": false,
-                  "integrity": "sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs=",
-                  "requires": {
-                    "duplexify": "^3.1.2",
-                    "inherits": "^2.0.1",
-                    "pump": "^1.0.0"
-                  }
-                },
-                "stream-each": {
-                  "version": "1.2.0",
-                  "resolved": false,
-                  "integrity": "sha1-HpXUdXP1gNgU3A/4zQ9m8c5TyZE=",
-                  "requires": {
-                    "end-of-stream": "^1.1.0",
-                    "stream-shift": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "stream-shift": {
-                      "version": "1.0.0",
-                      "resolved": false,
-                      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
-                    }
-                  }
-                },
-                "through2": {
-                  "version": "2.0.3",
-                  "resolved": false,
-                  "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-                  "requires": {
-                    "readable-stream": "^2.1.5",
-                    "xtend": "~4.0.1"
-                  },
-                  "dependencies": {
-                    "xtend": {
-                      "version": "4.0.1",
-                      "resolved": false,
-                      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-                    }
-                  }
-                }
-              }
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "resolved": false,
-              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-              "requires": {
-                "minimist": "0.0.8"
-              },
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "resolved": false,
-                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-                }
-              }
-            },
-            "move-concurrently": {
-              "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
-              "requires": {
-                "aproba": "^1.1.1",
-                "copy-concurrently": "^1.0.0",
-                "fs-write-stream-atomic": "^1.0.8",
-                "mkdirp": "^0.5.1",
-                "rimraf": "^2.5.4",
-                "run-queue": "^1.0.3"
-              },
-              "dependencies": {
-                "copy-concurrently": {
-                  "version": "1.0.3",
-                  "resolved": false,
-                  "integrity": "sha1-Rft4ZiSaHKiJqlcI5svSc+dbslA=",
-                  "requires": {
-                    "aproba": "^1.1.1",
-                    "fs-write-stream-atomic": "^1.0.8",
-                    "iferr": "^0.1.5",
-                    "mkdirp": "^0.5.1",
-                    "rimraf": "^2.5.4",
-                    "run-queue": "^1.0.0"
-                  }
-                },
-                "run-queue": {
-                  "version": "1.0.3",
-                  "resolved": false,
-                  "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
-                  "requires": {
-                    "aproba": "^1.1.1"
-                  }
-                }
-              }
-            },
-            "node-gyp": {
-              "version": "3.6.2",
-              "resolved": false,
-              "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
-              "requires": {
-                "fstream": "^1.0.0",
-                "glob": "^7.0.3",
-                "graceful-fs": "^4.1.2",
-                "minimatch": "^3.0.2",
-                "mkdirp": "^0.5.0",
-                "nopt": "2 || 3",
-                "npmlog": "0 || 1 || 2 || 3 || 4",
-                "osenv": "0",
-                "request": "2",
-                "rimraf": "2",
-                "semver": "~5.3.0",
-                "tar": "^2.0.0",
-                "which": "1"
-              },
-              "dependencies": {
-                "minimatch": {
-                  "version": "3.0.4",
-                  "resolved": false,
-                  "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-                  "requires": {
-                    "brace-expansion": "^1.1.7"
-                  },
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.8",
-                      "resolved": false,
-                      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-                      "requires": {
-                        "balanced-match": "^1.0.0",
-                        "concat-map": "0.0.1"
-                      },
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "1.0.0",
-                          "resolved": false,
-                          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "resolved": false,
-                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-                        }
-                      }
-                    }
-                  }
-                },
-                "nopt": {
-                  "version": "3.0.6",
-                  "resolved": false,
-                  "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-                  "requires": {
-                    "abbrev": "1"
-                  }
-                }
-              }
-            },
-            "nopt": {
-              "version": "4.0.1",
-              "resolved": false,
-              "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-              "requires": {
-                "abbrev": "1",
-                "osenv": "^0.1.4"
-              }
-            },
-            "normalize-package-data": {
-              "version": "2.4.0",
-              "resolved": false,
-              "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-              "requires": {
-                "hosted-git-info": "^2.1.4",
-                "is-builtin-module": "^1.0.0",
-                "semver": "2 || 3 || 4 || 5",
-                "validate-npm-package-license": "^3.0.1"
-              },
-              "dependencies": {
-                "is-builtin-module": {
-                  "version": "1.0.0",
-                  "resolved": false,
-                  "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-                  "requires": {
-                    "builtin-modules": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "builtin-modules": {
-                      "version": "1.1.1",
-                      "resolved": false,
-                      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
-                    }
-                  }
-                }
-              }
-            },
-            "npm-cache-filename": {
-              "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE="
-            },
-            "npm-install-checks": {
-              "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha1-1K7N/VGlPjcjt7L5Oy7ijjB7wNc=",
-              "requires": {
-                "semver": "^2.3.0 || 3.x || 4 || 5"
-              }
-            },
-            "npm-package-arg": {
-              "version": "5.1.2",
-              "resolved": false,
-              "integrity": "sha512-wJBsrf0qpypPT7A0LART18hCdyhpCMxeTtcb0X4IZO2jsP6Om7EHN1d9KSKiqD+KVH030RVNpWS9thk+pb7wzA==",
-              "requires": {
-                "hosted-git-info": "^2.4.2",
-                "osenv": "^0.1.4",
-                "semver": "^5.1.0",
-                "validate-npm-package-name": "^3.0.0"
-              }
-            },
-            "npm-registry-client": {
-              "version": "8.4.0",
-              "resolved": false,
-              "integrity": "sha512-PVNfqq0lyRdFnE//nDmn3CC9uqTsr8Bya9KPLIevlXMfkP0m4RpCVyFFk0W1Gfx436kKwyhLA6J+lV+rgR81gQ==",
-              "requires": {
-                "concat-stream": "^1.5.2",
-                "graceful-fs": "^4.1.6",
-                "normalize-package-data": "~1.0.1 || ^2.0.0",
-                "npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0",
-                "npmlog": "2 || ^3.1.0 || ^4.0.0",
-                "once": "^1.3.3",
-                "request": "^2.74.0",
-                "retry": "^0.10.0",
-                "semver": "2 >=2.2.1 || 3.x || 4 || 5",
-                "slide": "^1.1.3",
-                "ssri": "^4.1.2"
-              },
-              "dependencies": {
-                "concat-stream": {
-                  "version": "1.6.0",
-                  "resolved": false,
-                  "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-                  "requires": {
-                    "inherits": "^2.0.3",
-                    "readable-stream": "^2.2.2",
-                    "typedarray": "^0.0.6"
-                  },
-                  "dependencies": {
-                    "typedarray": {
-                      "version": "0.0.6",
-                      "resolved": false,
-                      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-                    }
-                  }
-                }
-              }
-            },
-            "npm-user-validate": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-jOyg9c6gTU6TUZ73LQVXp1Ei6VE="
-            },
-            "npmlog": {
-              "version": "4.1.2",
-              "resolved": false,
-              "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-              "requires": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
-              },
-              "dependencies": {
-                "are-we-there-yet": {
-                  "version": "1.1.4",
-                  "resolved": false,
-                  "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-                  "requires": {
-                    "delegates": "^1.0.0",
-                    "readable-stream": "^2.0.6"
-                  },
-                  "dependencies": {
-                    "delegates": {
-                      "version": "1.0.0",
-                      "resolved": false,
-                      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
-                    }
-                  }
-                },
-                "console-control-strings": {
-                  "version": "1.1.0",
-                  "resolved": false,
-                  "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
-                },
-                "gauge": {
-                  "version": "2.7.4",
-                  "resolved": false,
-                  "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-                  "requires": {
-                    "aproba": "^1.0.3",
-                    "console-control-strings": "^1.0.0",
-                    "has-unicode": "^2.0.0",
-                    "object-assign": "^4.1.0",
-                    "signal-exit": "^3.0.0",
-                    "string-width": "^1.0.1",
-                    "strip-ansi": "^3.0.1",
-                    "wide-align": "^1.1.0"
-                  },
-                  "dependencies": {
-                    "object-assign": {
-                      "version": "4.1.1",
-                      "resolved": false,
-                      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-                    },
-                    "signal-exit": {
-                      "version": "3.0.2",
-                      "resolved": false,
-                      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-                    },
-                    "string-width": {
-                      "version": "1.0.2",
-                      "resolved": false,
-                      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                      "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
-                      },
-                      "dependencies": {
-                        "code-point-at": {
-                          "version": "1.1.0",
-                          "resolved": false,
-                          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-                        },
-                        "is-fullwidth-code-point": {
-                          "version": "1.0.0",
-                          "resolved": false,
-                          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                          "requires": {
-                            "number-is-nan": "^1.0.0"
-                          },
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.1",
-                              "resolved": false,
-                              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "strip-ansi": {
-                      "version": "3.0.1",
-                      "resolved": false,
-                      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                      "requires": {
-                        "ansi-regex": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.1.1",
-                          "resolved": false,
-                          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-                        }
-                      }
-                    },
-                    "wide-align": {
-                      "version": "1.1.2",
-                      "resolved": false,
-                      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-                      "requires": {
-                        "string-width": "^1.0.2"
-                      }
-                    }
-                  }
-                },
-                "set-blocking": {
-                  "version": "2.0.0",
-                  "resolved": false,
-                  "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-                }
-              }
-            },
-            "once": {
-              "version": "1.4.0",
-              "resolved": false,
-              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-              "requires": {
-                "wrappy": "1"
-              }
-            },
-            "opener": {
-              "version": "1.4.3",
-              "resolved": false,
-              "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg="
-            },
-            "osenv": {
-              "version": "0.1.4",
-              "resolved": false,
-              "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
-              "requires": {
-                "os-homedir": "^1.0.0",
-                "os-tmpdir": "^1.0.0"
-              },
-              "dependencies": {
-                "os-homedir": {
-                  "version": "1.0.2",
-                  "resolved": false,
-                  "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-                },
-                "os-tmpdir": {
-                  "version": "1.0.2",
-                  "resolved": false,
-                  "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
-                }
-              }
-            },
-            "pacote": {
-              "version": "2.7.38",
-              "resolved": false,
-              "integrity": "sha512-XxHUyHQB7QCVBxoXeVu0yKxT+2PvJucsc0+1E+6f95lMUxEAYERgSAc71ckYXrYr35Ew3xFU/LrhdIK21GQFFA==",
-              "requires": {
-                "bluebird": "^3.5.0",
-                "cacache": "^9.2.9",
-                "glob": "^7.1.2",
-                "lru-cache": "^4.1.1",
-                "make-fetch-happen": "^2.4.13",
-                "minimatch": "^3.0.4",
-                "mississippi": "^1.2.0",
-                "normalize-package-data": "^2.4.0",
-                "npm-package-arg": "^5.1.2",
-                "npm-pick-manifest": "^1.0.4",
-                "osenv": "^0.1.4",
-                "promise-inflight": "^1.0.1",
-                "promise-retry": "^1.1.1",
-                "protoduck": "^4.0.0",
-                "safe-buffer": "^5.1.1",
-                "semver": "^5.3.0",
-                "ssri": "^4.1.6",
-                "tar-fs": "^1.15.3",
-                "tar-stream": "^1.5.4",
-                "unique-filename": "^1.1.0",
-                "which": "^1.2.12"
-              },
-              "dependencies": {
-                "make-fetch-happen": {
-                  "version": "2.4.13",
-                  "resolved": false,
-                  "integrity": "sha512-73CsTlMRSLdGr7VvOE8iYl/ejOSIxyfRYg7jZhepGGEqIlgdq6FLe2DEAI5bo813Jdg5fS/Ku62SRQ/UpT6NJA==",
-                  "requires": {
-                    "agentkeepalive": "^3.3.0",
-                    "cacache": "^9.2.9",
-                    "http-cache-semantics": "^3.7.3",
-                    "http-proxy-agent": "^2.0.0",
-                    "https-proxy-agent": "^2.0.0",
-                    "lru-cache": "^4.1.1",
-                    "mississippi": "^1.2.0",
-                    "node-fetch-npm": "^2.0.1",
-                    "promise-retry": "^1.1.1",
-                    "socks-proxy-agent": "^3.0.0",
-                    "ssri": "^4.1.6"
-                  },
-                  "dependencies": {
-                    "agentkeepalive": {
-                      "version": "3.3.0",
-                      "resolved": false,
-                      "integrity": "sha512-9yhcpXti2ZQE7bxuCsjjWNIZoQOd9sZ1ZBovHG0YeCRohFv73SLvcm73PC9T3olM4GyozaQb+4MGdQpcD8m7NQ==",
-                      "requires": {
-                        "humanize-ms": "^1.2.1"
-                      },
-                      "dependencies": {
-                        "humanize-ms": {
-                          "version": "1.2.1",
-                          "resolved": false,
-                          "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
-                          "requires": {
-                            "ms": "^2.0.0"
-                          },
-                          "dependencies": {
-                            "ms": {
-                              "version": "2.0.0",
-                              "resolved": false,
-                              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "http-cache-semantics": {
-                      "version": "3.7.3",
-                      "resolved": false,
-                      "integrity": "sha1-LzXFMuzSnx5UE7mvgztySjxvf3I="
-                    },
-                    "http-proxy-agent": {
-                      "version": "2.0.0",
-                      "resolved": false,
-                      "integrity": "sha1-RkgqLwUjpNYIJVFwn0acs+SoX/Q=",
-                      "requires": {
-                        "agent-base": "4",
-                        "debug": "2"
-                      },
-                      "dependencies": {
-                        "agent-base": {
-                          "version": "4.1.0",
-                          "resolved": false,
-                          "integrity": "sha1-IOF0Ac1Js8B2v1akvGxbQ2/6jVU=",
-                          "requires": {
-                            "es6-promisify": "^5.0.0"
-                          },
-                          "dependencies": {
-                            "es6-promisify": {
-                              "version": "5.0.0",
-                              "resolved": false,
-                              "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-                              "requires": {
-                                "es6-promise": "^4.0.3"
-                              },
-                              "dependencies": {
-                                "es6-promise": {
-                                  "version": "4.1.1",
-                                  "resolved": false,
-                                  "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng=="
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "debug": {
-                          "version": "2.6.8",
-                          "resolved": false,
-                          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-                          "requires": {
-                            "ms": "2.0.0"
-                          },
-                          "dependencies": {
-                            "ms": {
-                              "version": "2.0.0",
-                              "resolved": false,
-                              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "https-proxy-agent": {
-                      "version": "2.0.0",
-                      "resolved": false,
-                      "integrity": "sha1-/6pLb69YasNAwYoUBDHna31/KUQ=",
-                      "requires": {
-                        "agent-base": "^4.1.0",
-                        "debug": "^2.4.1"
-                      },
-                      "dependencies": {
-                        "agent-base": {
-                          "version": "4.1.0",
-                          "resolved": false,
-                          "integrity": "sha1-IOF0Ac1Js8B2v1akvGxbQ2/6jVU=",
-                          "requires": {
-                            "es6-promisify": "^5.0.0"
-                          },
-                          "dependencies": {
-                            "es6-promisify": {
-                              "version": "5.0.0",
-                              "resolved": false,
-                              "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-                              "requires": {
-                                "es6-promise": "^4.0.3"
-                              },
-                              "dependencies": {
-                                "es6-promise": {
-                                  "version": "4.1.1",
-                                  "resolved": false,
-                                  "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng=="
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "debug": {
-                          "version": "2.6.8",
-                          "resolved": false,
-                          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-                          "requires": {
-                            "ms": "2.0.0"
-                          },
-                          "dependencies": {
-                            "ms": {
-                              "version": "2.0.0",
-                              "resolved": false,
-                              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "node-fetch-npm": {
-                      "version": "2.0.1",
-                      "resolved": false,
-                      "integrity": "sha512-W3onhopST5tqpX0/MGSL47pDQLLKobNR83AvkiOWQKaw54h+uYUfzeLAxCiyhWlUOiuI+GIb4O9ojLaAFlhCCA==",
-                      "requires": {
-                        "encoding": "^0.1.11",
-                        "json-parse-helpfulerror": "^1.0.3",
-                        "safe-buffer": "^5.0.1"
-                      },
-                      "dependencies": {
-                        "encoding": {
-                          "version": "0.1.12",
-                          "resolved": false,
-                          "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-                          "requires": {
-                            "iconv-lite": "~0.4.13"
-                          },
-                          "dependencies": {
-                            "iconv-lite": {
-                              "version": "0.4.18",
-                              "resolved": false,
-                              "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA=="
-                            }
-                          }
-                        },
-                        "json-parse-helpfulerror": {
-                          "version": "1.0.3",
-                          "resolved": false,
-                          "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
-                          "requires": {
-                            "jju": "^1.1.0"
-                          },
-                          "dependencies": {
-                            "jju": {
-                              "version": "1.3.0",
-                              "resolved": false,
-                              "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo="
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "socks-proxy-agent": {
-                      "version": "3.0.0",
-                      "resolved": false,
-                      "integrity": "sha512-YJcT+SNNBgFoK/NpO20PChz0VnBOhkjG3X10BwlrYujd0NZlSsH1jbxSQ1S0njt3sOvzwQ2PvGqqUIvP4rNk/w==",
-                      "requires": {
-                        "agent-base": "^4.0.1",
-                        "socks": "^1.1.10"
-                      },
-                      "dependencies": {
-                        "agent-base": {
-                          "version": "4.1.0",
-                          "resolved": false,
-                          "integrity": "sha1-IOF0Ac1Js8B2v1akvGxbQ2/6jVU=",
-                          "requires": {
-                            "es6-promisify": "^5.0.0"
-                          },
-                          "dependencies": {
-                            "es6-promisify": {
-                              "version": "5.0.0",
-                              "resolved": false,
-                              "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-                              "requires": {
-                                "es6-promise": "^4.0.3"
-                              },
-                              "dependencies": {
-                                "es6-promise": {
-                                  "version": "4.1.1",
-                                  "resolved": false,
-                                  "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng=="
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "socks": {
-                          "version": "1.1.10",
-                          "resolved": false,
-                          "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
-                          "requires": {
-                            "ip": "^1.1.4",
-                            "smart-buffer": "^1.0.13"
-                          },
-                          "dependencies": {
-                            "ip": {
-                              "version": "1.1.5",
-                              "resolved": false,
-                              "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
-                            },
-                            "smart-buffer": {
-                              "version": "1.1.15",
-                              "resolved": false,
-                              "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY="
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "minimatch": {
-                  "version": "3.0.4",
-                  "resolved": false,
-                  "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-                  "requires": {
-                    "brace-expansion": "^1.1.7"
-                  },
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.8",
-                      "resolved": false,
-                      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-                      "requires": {
-                        "balanced-match": "^1.0.0",
-                        "concat-map": "0.0.1"
-                      },
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "1.0.0",
-                          "resolved": false,
-                          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "resolved": false,
-                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-                        }
-                      }
-                    }
-                  }
-                },
-                "npm-pick-manifest": {
-                  "version": "1.0.4",
-                  "resolved": false,
-                  "integrity": "sha512-MKxNdeyOZysPRTTbHtW0M5Fw38Jo/3ARsoGw5qjCfS+XGjvNB/Gb4qtAZUFmKPM2mVum+eX559eHvKywU856BQ==",
-                  "requires": {
-                    "npm-package-arg": "^5.1.2",
-                    "semver": "^5.3.0"
-                  }
-                },
-                "promise-retry": {
-                  "version": "1.1.1",
-                  "resolved": false,
-                  "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
-                  "requires": {
-                    "err-code": "^1.0.0",
-                    "retry": "^0.10.0"
-                  },
-                  "dependencies": {
-                    "err-code": {
-                      "version": "1.1.2",
-                      "resolved": false,
-                      "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
-                    }
-                  }
-                },
-                "protoduck": {
-                  "version": "4.0.0",
-                  "resolved": false,
-                  "integrity": "sha1-/kh02MeRM2bP2erRJFOiLNNlf44=",
-                  "requires": {
-                    "genfun": "^4.0.1"
-                  },
-                  "dependencies": {
-                    "genfun": {
-                      "version": "4.0.1",
-                      "resolved": false,
-                      "integrity": "sha1-7RAEHy5KfxsKOEZtF6XD4n3x38E="
-                    }
-                  }
-                },
-                "tar-fs": {
-                  "version": "1.15.3",
-                  "resolved": false,
-                  "integrity": "sha1-7M+TXpQUk9gVECjmNuUc5MPKfyA=",
-                  "requires": {
-                    "chownr": "^1.0.1",
-                    "mkdirp": "^0.5.1",
-                    "pump": "^1.0.0",
-                    "tar-stream": "^1.1.2"
-                  },
-                  "dependencies": {
-                    "pump": {
-                      "version": "1.0.2",
-                      "resolved": false,
-                      "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
-                      "requires": {
-                        "end-of-stream": "^1.1.0",
-                        "once": "^1.3.1"
-                      },
-                      "dependencies": {
-                        "end-of-stream": {
-                          "version": "1.4.0",
-                          "resolved": false,
-                          "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
-                          "requires": {
-                            "once": "^1.4.0"
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "tar-stream": {
-                  "version": "1.5.4",
-                  "resolved": false,
-                  "integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
-                  "requires": {
-                    "bl": "^1.0.0",
-                    "end-of-stream": "^1.0.0",
-                    "readable-stream": "^2.0.0",
-                    "xtend": "^4.0.0"
-                  },
-                  "dependencies": {
-                    "bl": {
-                      "version": "1.2.1",
-                      "resolved": false,
-                      "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
-                      "requires": {
-                        "readable-stream": "^2.0.5"
-                      }
-                    },
-                    "end-of-stream": {
-                      "version": "1.4.0",
-                      "resolved": false,
-                      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
-                      "requires": {
-                        "once": "^1.4.0"
-                      }
-                    },
-                    "xtend": {
-                      "version": "4.0.1",
-                      "resolved": false,
-                      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-                    }
-                  }
-                }
-              }
-            },
-            "path-is-inside": {
-              "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
-            },
-            "promise-inflight": {
-              "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
-            },
-            "read": {
-              "version": "1.0.7",
-              "resolved": false,
-              "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
-              "requires": {
-                "mute-stream": "~0.0.4"
-              },
-              "dependencies": {
-                "mute-stream": {
-                  "version": "0.0.7",
-                  "resolved": false,
-                  "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
-                }
-              }
-            },
-            "read-cmd-shim": {
-              "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
-              "requires": {
-                "graceful-fs": "^4.1.2"
-              }
-            },
-            "read-installed": {
-              "version": "4.0.3",
-              "resolved": false,
-              "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
-              "requires": {
-                "debuglog": "^1.0.1",
-                "graceful-fs": "^4.1.2",
-                "read-package-json": "^2.0.0",
-                "readdir-scoped-modules": "^1.0.0",
-                "semver": "2 || 3 || 4 || 5",
-                "slide": "~1.1.3",
-                "util-extend": "^1.0.1"
-              },
-              "dependencies": {
-                "util-extend": {
-                  "version": "1.0.3",
-                  "resolved": false,
-                  "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8="
-                }
-              }
-            },
-            "read-package-json": {
-              "version": "2.0.9",
-              "resolved": false,
-              "integrity": "sha512-vuV8p921IgyelL4UOKv3FsRuRZSaRn30HanLAOKargsr8TbBEq+I3MgloSRXYuKhNdYP1wlEGilMWAIayA2RFg==",
-              "requires": {
-                "glob": "^7.1.1",
-                "graceful-fs": "^4.1.2",
-                "json-parse-helpfulerror": "^1.0.2",
-                "normalize-package-data": "^2.0.0"
-              },
-              "dependencies": {
-                "json-parse-helpfulerror": {
-                  "version": "1.0.3",
-                  "resolved": false,
-                  "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
-                  "requires": {
-                    "jju": "^1.1.0"
-                  },
-                  "dependencies": {
-                    "jju": {
-                      "version": "1.3.0",
-                      "resolved": false,
-                      "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo="
-                    }
-                  }
-                }
-              }
-            },
-            "read-package-tree": {
-              "version": "5.1.6",
-              "resolved": false,
-              "integrity": "sha512-FCX1aT3GWyY658wzDICef4p+n0dB+ENRct8E/Qyvppj6xVpOYerBHfUu7OP5Rt1/393Tdglguf5ju5DEX4wZNg==",
-              "requires": {
-                "debuglog": "^1.0.1",
-                "dezalgo": "^1.0.0",
-                "once": "^1.3.0",
-                "read-package-json": "^2.0.0",
-                "readdir-scoped-modules": "^1.0.0"
-              }
-            },
-            "readable-stream": {
-              "version": "2.3.2",
-              "resolved": false,
-              "integrity": "sha1-WgTfBeT1f+Pw3Gj90R3FyXx+b00=",
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~1.0.6",
-                "safe-buffer": "~5.1.0",
-                "string_decoder": "~1.0.0",
-                "util-deprecate": "~1.0.1"
-              },
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "resolved": false,
-                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-                },
-                "isarray": {
-                  "version": "1.0.0",
-                  "resolved": false,
-                  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-                },
-                "process-nextick-args": {
-                  "version": "1.0.7",
-                  "resolved": false,
-                  "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-                },
-                "string_decoder": {
-                  "version": "1.0.3",
-                  "resolved": false,
-                  "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-                  "requires": {
-                    "safe-buffer": "~5.1.0"
-                  }
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "resolved": false,
-                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-                }
-              }
-            },
-            "readdir-scoped-modules": {
-              "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
-              "requires": {
-                "debuglog": "^1.0.1",
-                "dezalgo": "^1.0.0",
-                "graceful-fs": "^4.1.2",
-                "once": "^1.3.0"
-              }
-            },
-            "request": {
-              "version": "2.81.0",
-              "resolved": false,
-              "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-              "requires": {
-                "aws-sign2": "~0.6.0",
-                "aws4": "^1.2.1",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.5",
-                "extend": "~3.0.0",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.1.1",
-                "har-validator": "~4.2.1",
-                "hawk": "~3.1.3",
-                "http-signature": "~1.1.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.7",
-                "oauth-sign": "~0.8.1",
-                "performance-now": "^0.2.0",
-                "qs": "~6.4.0",
-                "safe-buffer": "^5.0.1",
-                "stringstream": "~0.0.4",
-                "tough-cookie": "~2.3.0",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.0.0"
-              },
-              "dependencies": {
-                "aws-sign2": {
-                  "version": "0.6.0",
-                  "resolved": false,
-                  "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
-                },
-                "aws4": {
-                  "version": "1.6.0",
-                  "resolved": false,
-                  "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
-                },
-                "caseless": {
-                  "version": "0.12.0",
-                  "resolved": false,
-                  "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-                },
-                "combined-stream": {
-                  "version": "1.0.5",
-                  "resolved": false,
-                  "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-                  "requires": {
-                    "delayed-stream": "~1.0.0"
-                  },
-                  "dependencies": {
-                    "delayed-stream": {
-                      "version": "1.0.0",
-                      "resolved": false,
-                      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-                    }
-                  }
-                },
-                "extend": {
-                  "version": "3.0.1",
-                  "resolved": false,
-                  "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
-                },
-                "forever-agent": {
-                  "version": "0.6.1",
-                  "resolved": false,
-                  "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-                },
-                "form-data": {
-                  "version": "2.1.4",
-                  "resolved": false,
-                  "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-                  "requires": {
-                    "asynckit": "^0.4.0",
-                    "combined-stream": "^1.0.5",
-                    "mime-types": "^2.1.12"
-                  },
-                  "dependencies": {
-                    "asynckit": {
-                      "version": "0.4.0",
-                      "resolved": false,
-                      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-                    }
-                  }
-                },
-                "har-validator": {
-                  "version": "4.2.1",
-                  "resolved": false,
-                  "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-                  "requires": {
-                    "ajv": "^4.9.1",
-                    "har-schema": "^1.0.5"
-                  },
-                  "dependencies": {
-                    "ajv": {
-                      "version": "4.11.8",
-                      "resolved": false,
-                      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-                      "requires": {
-                        "co": "^4.6.0",
-                        "json-stable-stringify": "^1.0.1"
-                      },
-                      "dependencies": {
-                        "co": {
-                          "version": "4.6.0",
-                          "resolved": false,
-                          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-                        },
-                        "json-stable-stringify": {
-                          "version": "1.0.1",
-                          "resolved": false,
-                          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-                          "requires": {
-                            "jsonify": "~0.0.0"
-                          },
-                          "dependencies": {
-                            "jsonify": {
-                              "version": "0.0.0",
-                              "resolved": false,
-                              "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "har-schema": {
-                      "version": "1.0.5",
-                      "resolved": false,
-                      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
-                    }
-                  }
-                },
-                "hawk": {
-                  "version": "3.1.3",
-                  "resolved": false,
-                  "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-                  "requires": {
-                    "boom": "2.x.x",
-                    "cryptiles": "2.x.x",
-                    "hoek": "2.x.x",
-                    "sntp": "1.x.x"
-                  },
-                  "dependencies": {
-                    "boom": {
-                      "version": "2.10.1",
-                      "resolved": false,
-                      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-                      "requires": {
-                        "hoek": "2.x.x"
-                      }
-                    },
-                    "cryptiles": {
-                      "version": "2.0.5",
-                      "resolved": false,
-                      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-                      "requires": {
-                        "boom": "2.x.x"
-                      }
-                    },
-                    "hoek": {
-                      "version": "2.16.3",
-                      "resolved": false,
-                      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
-                    },
-                    "sntp": {
-                      "version": "1.0.9",
-                      "resolved": false,
-                      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-                      "requires": {
-                        "hoek": "2.x.x"
-                      }
-                    }
-                  }
-                },
-                "http-signature": {
-                  "version": "1.1.1",
-                  "resolved": false,
-                  "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-                  "requires": {
-                    "assert-plus": "^0.2.0",
-                    "jsprim": "^1.2.2",
-                    "sshpk": "^1.7.0"
-                  },
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "0.2.0",
-                      "resolved": false,
-                      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
-                    },
-                    "jsprim": {
-                      "version": "1.4.0",
-                      "resolved": false,
-                      "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
-                      "requires": {
-                        "assert-plus": "1.0.0",
-                        "extsprintf": "1.0.2",
-                        "json-schema": "0.2.3",
-                        "verror": "1.3.6"
-                      },
-                      "dependencies": {
-                        "assert-plus": {
-                          "version": "1.0.0",
-                          "resolved": false,
-                          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-                        },
-                        "extsprintf": {
-                          "version": "1.0.2",
-                          "resolved": false,
-                          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
-                        },
-                        "json-schema": {
-                          "version": "0.2.3",
-                          "resolved": false,
-                          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-                        },
-                        "verror": {
-                          "version": "1.3.6",
-                          "resolved": false,
-                          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-                          "requires": {
-                            "extsprintf": "1.0.2"
-                          }
-                        }
-                      }
-                    },
-                    "sshpk": {
-                      "version": "1.13.1",
-                      "resolved": false,
-                      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-                      "requires": {
-                        "asn1": "~0.2.3",
-                        "assert-plus": "^1.0.0",
-                        "bcrypt-pbkdf": "^1.0.0",
-                        "dashdash": "^1.12.0",
-                        "ecc-jsbn": "~0.1.1",
-                        "getpass": "^0.1.1",
-                        "jsbn": "~0.1.0",
-                        "tweetnacl": "~0.14.0"
-                      },
-                      "dependencies": {
-                        "asn1": {
-                          "version": "0.2.3",
-                          "resolved": false,
-                          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
-                        },
-                        "assert-plus": {
-                          "version": "1.0.0",
-                          "resolved": false,
-                          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-                        },
-                        "bcrypt-pbkdf": {
-                          "version": "1.0.1",
-                          "resolved": false,
-                          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-                          "optional": true,
-                          "requires": {
-                            "tweetnacl": "^0.14.3"
-                          }
-                        },
-                        "dashdash": {
-                          "version": "1.14.1",
-                          "resolved": false,
-                          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-                          "requires": {
-                            "assert-plus": "^1.0.0"
-                          }
-                        },
-                        "ecc-jsbn": {
-                          "version": "0.1.1",
-                          "resolved": false,
-                          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-                          "optional": true,
-                          "requires": {
-                            "jsbn": "~0.1.0"
-                          }
-                        },
-                        "getpass": {
-                          "version": "0.1.7",
-                          "resolved": false,
-                          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-                          "requires": {
-                            "assert-plus": "^1.0.0"
-                          }
-                        },
-                        "jsbn": {
-                          "version": "0.1.1",
-                          "resolved": false,
-                          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-                          "optional": true
-                        },
-                        "tweetnacl": {
-                          "version": "0.14.5",
-                          "resolved": false,
-                          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-                          "optional": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "is-typedarray": {
-                  "version": "1.0.0",
-                  "resolved": false,
-                  "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-                },
-                "isstream": {
-                  "version": "0.1.2",
-                  "resolved": false,
-                  "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-                },
-                "json-stringify-safe": {
-                  "version": "5.0.1",
-                  "resolved": false,
-                  "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-                },
-                "mime-types": {
-                  "version": "2.1.15",
-                  "resolved": false,
-                  "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-                  "requires": {
-                    "mime-db": "~1.27.0"
-                  },
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.27.0",
-                      "resolved": false,
-                      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
-                    }
-                  }
-                },
-                "oauth-sign": {
-                  "version": "0.8.2",
-                  "resolved": false,
-                  "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
-                },
-                "performance-now": {
-                  "version": "0.2.0",
-                  "resolved": false,
-                  "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
-                },
-                "qs": {
-                  "version": "6.4.0",
-                  "resolved": false,
-                  "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
-                },
-                "stringstream": {
-                  "version": "0.0.5",
-                  "resolved": false,
-                  "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
-                },
-                "tough-cookie": {
-                  "version": "2.3.2",
-                  "resolved": false,
-                  "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-                  "requires": {
-                    "punycode": "^1.4.1"
-                  },
-                  "dependencies": {
-                    "punycode": {
-                      "version": "1.4.1",
-                      "resolved": false,
-                      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-                    }
-                  }
-                },
-                "tunnel-agent": {
-                  "version": "0.6.0",
-                  "resolved": false,
-                  "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-                  "requires": {
-                    "safe-buffer": "^5.0.1"
-                  }
-                }
-              }
-            },
-            "retry": {
-              "version": "0.10.1",
-              "resolved": false,
-              "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
-            },
-            "rimraf": {
-              "version": "2.6.1",
-              "resolved": false,
-              "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-              "requires": {
-                "glob": "^7.0.5"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.1",
-              "resolved": false,
-              "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
-            },
-            "semver": {
-              "version": "5.3.0",
-              "resolved": false,
-              "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
-            },
-            "sha": {
-              "version": "2.0.1",
-              "resolved": false,
-              "integrity": "sha1-YDCCL70smCOUn49y7WQR7lzyWq4=",
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "readable-stream": "^2.0.2"
-              }
-            },
-            "slide": {
-              "version": "1.1.6",
-              "resolved": false,
-              "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
-            },
-            "sorted-object": {
-              "version": "2.0.1",
-              "resolved": false,
-              "integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw="
-            },
-            "sorted-union-stream": {
-              "version": "2.1.3",
-              "resolved": false,
-              "integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
-              "requires": {
-                "from2": "^1.3.0",
-                "stream-iterate": "^1.1.0"
-              },
-              "dependencies": {
-                "from2": {
-                  "version": "1.3.0",
-                  "resolved": false,
-                  "integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
-                  "requires": {
-                    "inherits": "~2.0.1",
-                    "readable-stream": "~1.1.10"
-                  },
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "1.1.14",
-                      "resolved": false,
-                      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-                      "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
-                      },
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2",
-                          "resolved": false,
-                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "resolved": false,
-                          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "resolved": false,
-                          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-                        }
-                      }
-                    }
-                  }
-                },
-                "stream-iterate": {
-                  "version": "1.2.0",
-                  "resolved": false,
-                  "integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
-                  "requires": {
-                    "readable-stream": "^2.1.5",
-                    "stream-shift": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "stream-shift": {
-                      "version": "1.0.0",
-                      "resolved": false,
-                      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
-                    }
-                  }
-                }
-              }
-            },
-            "ssri": {
-              "version": "4.1.6",
-              "resolved": false,
-              "integrity": "sha512-WUbCdgSAMQjTFZRWvSPpauryvREEA+Krn19rx67UlJEJx/M192ZHxMmJXjZ4tkdFm+Sb0SXGlENeQVlA5wY7kA==",
-              "requires": {
-                "safe-buffer": "^5.1.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": false,
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "requires": {
-                "ansi-regex": "^3.0.0"
-              },
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "3.0.0",
-                  "resolved": false,
-                  "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-                }
-              }
-            },
-            "tar": {
-              "version": "2.2.1",
-              "resolved": false,
-              "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-              "requires": {
-                "block-stream": "*",
-                "fstream": "^1.0.2",
-                "inherits": "2"
-              },
-              "dependencies": {
-                "block-stream": {
-                  "version": "0.0.9",
-                  "resolved": false,
-                  "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-                  "requires": {
-                    "inherits": "~2.0.0"
-                  }
-                }
-              }
-            },
-            "text-table": {
-              "version": "0.2.0",
-              "resolved": false,
-              "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
-            },
-            "uid-number": {
-              "version": "0.0.6",
-              "resolved": false,
-              "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE="
-            },
-            "umask": {
-              "version": "1.1.0",
-              "resolved": false,
-              "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0="
-            },
-            "unique-filename": {
-              "version": "1.1.0",
-              "resolved": false,
-              "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
-              "requires": {
-                "unique-slug": "^2.0.0"
-              },
-              "dependencies": {
-                "unique-slug": {
-                  "version": "2.0.0",
-                  "resolved": false,
-                  "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
-                  "requires": {
-                    "imurmurhash": "^0.1.4"
-                  }
-                }
-              }
-            },
-            "unpipe": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
-            },
-            "update-notifier": {
-              "version": "2.2.0",
-              "resolved": false,
-              "integrity": "sha1-G1g3z5DAc22IYncytmHBOPht5y8=",
-              "requires": {
-                "boxen": "^1.0.0",
-                "chalk": "^1.0.0",
-                "configstore": "^3.0.0",
-                "import-lazy": "^2.1.0",
-                "is-npm": "^1.0.0",
-                "latest-version": "^3.0.0",
-                "semver-diff": "^2.0.0",
-                "xdg-basedir": "^3.0.0"
-              },
-              "dependencies": {
-                "boxen": {
-                  "version": "1.1.0",
-                  "resolved": false,
-                  "integrity": "sha1-sbad1SIwXoB6md7ud329blFnsQI=",
-                  "requires": {
-                    "ansi-align": "^2.0.0",
-                    "camelcase": "^4.0.0",
-                    "chalk": "^1.1.1",
-                    "cli-boxes": "^1.0.0",
-                    "string-width": "^2.0.0",
-                    "term-size": "^0.1.0",
-                    "widest-line": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "ansi-align": {
-                      "version": "2.0.0",
-                      "resolved": false,
-                      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
-                      "requires": {
-                        "string-width": "^2.0.0"
-                      }
-                    },
-                    "camelcase": {
-                      "version": "4.1.0",
-                      "resolved": false,
-                      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-                    },
-                    "cli-boxes": {
-                      "version": "1.0.0",
-                      "resolved": false,
-                      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
-                    },
-                    "string-width": {
-                      "version": "2.1.0",
-                      "resolved": false,
-                      "integrity": "sha1-AwZkVh/BRslCPsfZeP4kV0N/5tA=",
-                      "requires": {
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^4.0.0"
-                      },
-                      "dependencies": {
-                        "is-fullwidth-code-point": {
-                          "version": "2.0.0",
-                          "resolved": false,
-                          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-                        },
-                        "strip-ansi": {
-                          "version": "4.0.0",
-                          "resolved": false,
-                          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                          "requires": {
-                            "ansi-regex": "^3.0.0"
-                          }
-                        }
-                      }
-                    },
-                    "term-size": {
-                      "version": "0.1.1",
-                      "resolved": false,
-                      "integrity": "sha1-hzYLljlsq1dgljcUzaDQy+7K2co=",
-                      "requires": {
-                        "execa": "^0.4.0"
-                      },
-                      "dependencies": {
-                        "execa": {
-                          "version": "0.4.0",
-                          "resolved": false,
-                          "integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M=",
-                          "requires": {
-                            "cross-spawn-async": "^2.1.1",
-                            "is-stream": "^1.1.0",
-                            "npm-run-path": "^1.0.0",
-                            "object-assign": "^4.0.1",
-                            "path-key": "^1.0.0",
-                            "strip-eof": "^1.0.0"
-                          },
-                          "dependencies": {
-                            "cross-spawn-async": {
-                              "version": "2.2.5",
-                              "resolved": false,
-                              "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
-                              "requires": {
-                                "lru-cache": "^4.0.0",
-                                "which": "^1.2.8"
-                              }
-                            },
-                            "is-stream": {
-                              "version": "1.1.0",
-                              "resolved": false,
-                              "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-                            },
-                            "npm-run-path": {
-                              "version": "1.0.0",
-                              "resolved": false,
-                              "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
-                              "requires": {
-                                "path-key": "^1.0.0"
-                              }
-                            },
-                            "object-assign": {
-                              "version": "4.1.1",
-                              "resolved": false,
-                              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-                            },
-                            "path-key": {
-                              "version": "1.0.0",
-                              "resolved": false,
-                              "integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68="
-                            },
-                            "strip-eof": {
-                              "version": "1.0.0",
-                              "resolved": false,
-                              "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "widest-line": {
-                      "version": "1.0.0",
-                      "resolved": false,
-                      "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
-                      "requires": {
-                        "string-width": "^1.0.1"
-                      },
-                      "dependencies": {
-                        "string-width": {
-                          "version": "1.0.2",
-                          "resolved": false,
-                          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                          "requires": {
-                            "code-point-at": "^1.0.0",
-                            "is-fullwidth-code-point": "^1.0.0",
-                            "strip-ansi": "^3.0.0"
-                          },
-                          "dependencies": {
-                            "code-point-at": {
-                              "version": "1.1.0",
-                              "resolved": false,
-                              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-                            },
-                            "is-fullwidth-code-point": {
-                              "version": "1.0.0",
-                              "resolved": false,
-                              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                              "requires": {
-                                "number-is-nan": "^1.0.0"
-                              },
-                              "dependencies": {
-                                "number-is-nan": {
-                                  "version": "1.0.1",
-                                  "resolved": false,
-                                  "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-                                }
-                              }
-                            },
-                            "strip-ansi": {
-                              "version": "3.0.1",
-                              "resolved": false,
-                              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                              "requires": {
-                                "ansi-regex": "^2.0.0"
-                              },
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.1.1",
-                                  "resolved": false,
-                                  "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "chalk": {
-                  "version": "1.1.3",
-                  "resolved": false,
-                  "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                  "requires": {
-                    "ansi-styles": "^2.2.1",
-                    "escape-string-regexp": "^1.0.2",
-                    "has-ansi": "^2.0.0",
-                    "strip-ansi": "^3.0.0",
-                    "supports-color": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "ansi-styles": {
-                      "version": "2.2.1",
-                      "resolved": false,
-                      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-                    },
-                    "escape-string-regexp": {
-                      "version": "1.0.5",
-                      "resolved": false,
-                      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-                    },
-                    "has-ansi": {
-                      "version": "2.0.0",
-                      "resolved": false,
-                      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-                      "requires": {
-                        "ansi-regex": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.1.1",
-                          "resolved": false,
-                          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-                        }
-                      }
-                    },
-                    "strip-ansi": {
-                      "version": "3.0.1",
-                      "resolved": false,
-                      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                      "requires": {
-                        "ansi-regex": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.1.1",
-                          "resolved": false,
-                          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-                        }
-                      }
-                    },
-                    "supports-color": {
-                      "version": "2.0.0",
-                      "resolved": false,
-                      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-                    }
-                  }
-                },
-                "configstore": {
-                  "version": "3.1.0",
-                  "resolved": false,
-                  "integrity": "sha1-Rd+QcHPibfoc9LLVL1tgVF6qEdE=",
-                  "requires": {
-                    "dot-prop": "^4.1.0",
-                    "graceful-fs": "^4.1.2",
-                    "make-dir": "^1.0.0",
-                    "unique-string": "^1.0.0",
-                    "write-file-atomic": "^2.0.0",
-                    "xdg-basedir": "^3.0.0"
-                  },
-                  "dependencies": {
-                    "dot-prop": {
-                      "version": "4.1.1",
-                      "resolved": false,
-                      "integrity": "sha1-qEk/C3te7sglJbXHWH+n3nyoWcE=",
-                      "requires": {
-                        "is-obj": "^1.0.0"
-                      },
-                      "dependencies": {
-                        "is-obj": {
-                          "version": "1.0.1",
-                          "resolved": false,
-                          "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
-                        }
-                      }
-                    },
-                    "make-dir": {
-                      "version": "1.0.0",
-                      "resolved": false,
-                      "integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
-                      "requires": {
-                        "pify": "^2.3.0"
-                      },
-                      "dependencies": {
-                        "pify": {
-                          "version": "2.3.0",
-                          "resolved": false,
-                          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-                        }
-                      }
-                    },
-                    "unique-string": {
-                      "version": "1.0.0",
-                      "resolved": false,
-                      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
-                      "requires": {
-                        "crypto-random-string": "^1.0.0"
-                      },
-                      "dependencies": {
-                        "crypto-random-string": {
-                          "version": "1.0.0",
-                          "resolved": false,
-                          "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
-                        }
-                      }
-                    }
-                  }
-                },
-                "import-lazy": {
-                  "version": "2.1.0",
-                  "resolved": false,
-                  "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
-                },
-                "is-npm": {
-                  "version": "1.0.0",
-                  "resolved": false,
-                  "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
-                },
-                "latest-version": {
-                  "version": "3.1.0",
-                  "resolved": false,
-                  "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
-                  "requires": {
-                    "package-json": "^4.0.0"
-                  },
-                  "dependencies": {
-                    "package-json": {
-                      "version": "4.0.1",
-                      "resolved": false,
-                      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
-                      "requires": {
-                        "got": "^6.7.1",
-                        "registry-auth-token": "^3.0.1",
-                        "registry-url": "^3.0.3",
-                        "semver": "^5.1.0"
-                      },
-                      "dependencies": {
-                        "got": {
-                          "version": "6.7.1",
-                          "resolved": false,
-                          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-                          "requires": {
-                            "create-error-class": "^3.0.0",
-                            "duplexer3": "^0.1.4",
-                            "get-stream": "^3.0.0",
-                            "is-redirect": "^1.0.0",
-                            "is-retry-allowed": "^1.0.0",
-                            "is-stream": "^1.0.0",
-                            "lowercase-keys": "^1.0.0",
-                            "safe-buffer": "^5.0.1",
-                            "timed-out": "^4.0.0",
-                            "unzip-response": "^2.0.1",
-                            "url-parse-lax": "^1.0.0"
-                          },
-                          "dependencies": {
-                            "create-error-class": {
-                              "version": "3.0.2",
-                              "resolved": false,
-                              "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-                              "requires": {
-                                "capture-stack-trace": "^1.0.0"
-                              },
-                              "dependencies": {
-                                "capture-stack-trace": {
-                                  "version": "1.0.0",
-                                  "resolved": false,
-                                  "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
-                                }
-                              }
-                            },
-                            "duplexer3": {
-                              "version": "0.1.4",
-                              "resolved": false,
-                              "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
-                            },
-                            "get-stream": {
-                              "version": "3.0.0",
-                              "resolved": false,
-                              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
-                            },
-                            "is-redirect": {
-                              "version": "1.0.0",
-                              "resolved": false,
-                              "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
-                            },
-                            "is-retry-allowed": {
-                              "version": "1.1.0",
-                              "resolved": false,
-                              "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
-                            },
-                            "is-stream": {
-                              "version": "1.1.0",
-                              "resolved": false,
-                              "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-                            },
-                            "lowercase-keys": {
-                              "version": "1.0.0",
-                              "resolved": false,
-                              "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
-                            },
-                            "timed-out": {
-                              "version": "4.0.1",
-                              "resolved": false,
-                              "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
-                            },
-                            "unzip-response": {
-                              "version": "2.0.1",
-                              "resolved": false,
-                              "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
-                            },
-                            "url-parse-lax": {
-                              "version": "1.0.0",
-                              "resolved": false,
-                              "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-                              "requires": {
-                                "prepend-http": "^1.0.1"
-                              },
-                              "dependencies": {
-                                "prepend-http": {
-                                  "version": "1.0.4",
-                                  "resolved": false,
-                                  "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "registry-auth-token": {
-                          "version": "3.3.1",
-                          "resolved": false,
-                          "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
-                          "requires": {
-                            "rc": "^1.1.6",
-                            "safe-buffer": "^5.0.1"
-                          },
-                          "dependencies": {
-                            "rc": {
-                              "version": "1.2.1",
-                              "resolved": false,
-                              "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
-                              "requires": {
-                                "deep-extend": "~0.4.0",
-                                "ini": "~1.3.0",
-                                "minimist": "^1.2.0",
-                                "strip-json-comments": "~2.0.1"
-                              },
-                              "dependencies": {
-                                "deep-extend": {
-                                  "version": "0.4.2",
-                                  "resolved": false,
-                                  "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
-                                },
-                                "minimist": {
-                                  "version": "1.2.0",
-                                  "resolved": false,
-                                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-                                },
-                                "strip-json-comments": {
-                                  "version": "2.0.1",
-                                  "resolved": false,
-                                  "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "registry-url": {
-                          "version": "3.1.0",
-                          "resolved": false,
-                          "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-                          "requires": {
-                            "rc": "^1.0.1"
-                          },
-                          "dependencies": {
-                            "rc": {
-                              "version": "1.2.1",
-                              "resolved": false,
-                              "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
-                              "requires": {
-                                "deep-extend": "~0.4.0",
-                                "ini": "~1.3.0",
-                                "minimist": "^1.2.0",
-                                "strip-json-comments": "~2.0.1"
-                              },
-                              "dependencies": {
-                                "deep-extend": {
-                                  "version": "0.4.2",
-                                  "resolved": false,
-                                  "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
-                                },
-                                "minimist": {
-                                  "version": "1.2.0",
-                                  "resolved": false,
-                                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-                                },
-                                "strip-json-comments": {
-                                  "version": "2.0.1",
-                                  "resolved": false,
-                                  "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "semver-diff": {
-                  "version": "2.1.0",
-                  "resolved": false,
-                  "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
-                  "requires": {
-                    "semver": "^5.0.3"
-                  }
-                },
-                "xdg-basedir": {
-                  "version": "3.0.0",
-                  "resolved": false,
-                  "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
-                }
-              }
-            },
-            "uuid": {
-              "version": "3.1.0",
-              "resolved": false,
-              "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
-            },
-            "validate-npm-package-license": {
-              "version": "3.0.1",
-              "resolved": false,
-              "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-              "requires": {
-                "spdx-correct": "~1.0.0",
-                "spdx-expression-parse": "~1.0.0"
-              },
-              "dependencies": {
-                "spdx-correct": {
-                  "version": "1.0.2",
-                  "resolved": false,
-                  "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-                  "requires": {
-                    "spdx-license-ids": "^1.0.2"
-                  },
-                  "dependencies": {
-                    "spdx-license-ids": {
-                      "version": "1.2.2",
-                      "resolved": false,
-                      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
-                    }
-                  }
-                },
-                "spdx-expression-parse": {
-                  "version": "1.0.4",
-                  "resolved": false,
-                  "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
-                }
-              }
-            },
-            "validate-npm-package-name": {
-              "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
-              "requires": {
-                "builtins": "^1.0.3"
-              },
-              "dependencies": {
-                "builtins": {
-                  "version": "1.0.3",
-                  "resolved": false,
-                  "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og="
-                }
-              }
-            },
-            "which": {
-              "version": "1.2.14",
-              "resolved": false,
-              "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-              "requires": {
-                "isexe": "^2.0.0"
-              },
-              "dependencies": {
-                "isexe": {
-                  "version": "2.0.0",
-                  "resolved": false,
-                  "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-                }
-              }
-            },
-            "worker-farm": {
-              "version": "1.3.1",
-              "resolved": false,
-              "integrity": "sha1-QzMRK7SbF6oFC4eJXKayys9A5f8=",
-              "requires": {
-                "errno": ">=0.1.1 <0.2.0-0",
-                "xtend": ">=4.0.0 <4.1.0-0"
-              },
-              "dependencies": {
-                "errno": {
-                  "version": "0.1.4",
-                  "resolved": false,
-                  "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
-                  "requires": {
-                    "prr": "~0.0.0"
-                  },
-                  "dependencies": {
-                    "prr": {
-                      "version": "0.0.0",
-                      "resolved": false,
-                      "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
-                    }
-                  }
-                },
-                "xtend": {
-                  "version": "4.0.1",
-                  "resolved": false,
-                  "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-                }
-              }
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-            },
-            "write-file-atomic": {
-              "version": "2.1.0",
-              "resolved": false,
-              "integrity": "sha512-0TZ20a+xcIl4u0+Mj5xDH2yOWdmQiXlKf9Hm+TgDXjTMsEYb+gDrmb8e8UNAzMCitX8NBqG4Z/FUQIyzv/R1JQ==",
-              "requires": {
-                "graceful-fs": "^4.1.11",
-                "imurmurhash": "^0.1.4",
-                "slide": "^1.1.5"
-              }
-            }
-          }
-        },
-        "npm-package-arg": {
-          "version": "6.1.0",
-          "resolved": false,
-          "integrity": "sha512-zYbhP2k9DbJhA0Z3HKUePUgdB1x7MfIfKssC+WLPFMKTBZKpZh5m13PgexJjCq6KW7j17r0jHWcCpxEqnnncSA==",
-          "requires": {
-            "hosted-git-info": "^2.6.0",
-            "osenv": "^0.1.5",
-            "semver": "^5.5.0",
-            "validate-npm-package-name": "^3.0.0"
-          }
-        },
-        "npm-run-path": {
-          "version": "2.0.2",
-          "resolved": false,
-          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-          "requires": {
-            "path-key": "^2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-        },
-        "once": {
-          "version": "1.4.0",
-          "resolved": false,
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-        },
-        "os-locale": {
-          "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-          "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
-          }
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
-        },
-        "osenv": {
-          "version": "0.1.5",
-          "resolved": false,
-          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-          "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
-          }
-        },
-        "p-finally": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
-        },
-        "p-limit": {
-          "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
-        },
-        "package-json": {
-          "version": "4.0.1",
-          "resolved": false,
-          "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
-          "requires": {
-            "got": "^6.7.1",
-            "registry-auth-token": "^3.0.1",
-            "registry-url": "^3.0.3",
-            "semver": "^5.1.0"
-          }
-        },
-        "path-exists": {
-          "version": "3.0.0",
-          "resolved": false,
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-        },
-        "path-is-inside": {
-          "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
-        },
-        "path-key": {
-          "version": "2.0.1",
-          "resolved": false,
-          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
-        },
-        "pify": {
-          "version": "3.0.0",
-          "resolved": false,
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-        },
-        "prepend-http": {
-          "version": "1.0.4",
-          "resolved": false,
-          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
-        },
-        "pseudomap": {
-          "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-        },
-        "rc": {
-          "version": "1.2.6",
-          "resolved": false,
-          "integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
-          "requires": {
-            "deep-extend": "~0.4.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
-          }
-        },
-        "registry-auth-token": {
-          "version": "3.3.2",
-          "resolved": false,
-          "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
-          "requires": {
-            "rc": "^1.1.6",
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "registry-url": {
-          "version": "3.1.0",
-          "resolved": false,
-          "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-          "requires": {
-            "rc": "^1.0.1"
-          }
-        },
-        "require-directory": {
-          "version": "2.1.1",
-          "resolved": false,
-          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
-        },
-        "require-main-filename": {
-          "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
-        },
-        "rimraf": {
-          "version": "2.6.2",
-          "resolved": false,
-          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-          "requires": {
-            "glob": "^7.0.5"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "resolved": false,
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
-        },
-        "semver": {
-          "version": "5.5.0",
-          "resolved": false,
-          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
-        },
-        "semver-diff": {
-          "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
-          "requires": {
-            "semver": "^5.0.3"
-          }
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-        },
-        "shebang-command": {
-          "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-          "requires": {
-            "shebang-regex": "^1.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "resolved": false,
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": false,
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": false,
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        },
-        "strip-eof": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "resolved": false,
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-        },
-        "supports-color": {
-          "version": "5.3.0",
-          "resolved": false,
-          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        },
-        "term-size": {
-          "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
-          "requires": {
-            "execa": "^0.7.0"
-          }
-        },
-        "timed-out": {
-          "version": "4.0.1",
-          "resolved": false,
-          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
-        },
-        "unique-string": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
-          "requires": {
-            "crypto-random-string": "^1.0.0"
-          }
-        },
-        "unzip-response": {
-          "version": "2.0.1",
-          "resolved": false,
-          "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
-        },
-        "update-notifier": {
-          "version": "2.4.0",
-          "resolved": false,
-          "integrity": "sha1-+bTHAPv9TsEsgRWHJYd31WPYyGY=",
-          "requires": {
-            "boxen": "^1.2.1",
-            "chalk": "^2.0.1",
-            "configstore": "^3.0.0",
-            "import-lazy": "^2.1.0",
-            "is-ci": "^1.0.10",
-            "is-installed-globally": "^0.1.0",
-            "is-npm": "^1.0.0",
-            "latest-version": "^3.0.0",
-            "semver-diff": "^2.0.0",
-            "xdg-basedir": "^3.0.0"
-          }
-        },
-        "url-parse-lax": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-          "requires": {
-            "prepend-http": "^1.0.1"
-          }
-        },
-        "validate-npm-package-name": {
-          "version": "3.0.0",
-          "resolved": false,
-          "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
-          "requires": {
-            "builtins": "^1.0.3"
-          }
-        },
-        "which": {
-          "version": "1.3.0",
-          "resolved": false,
-          "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        },
-        "which-module": {
-          "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
-        },
-        "widest-line": {
-          "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
-          "requires": {
-            "string-width": "^2.1.1"
-          }
-        },
-        "wrap-ansi": {
-          "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-          "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "2.1.1",
-              "resolved": false,
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              }
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "resolved": false,
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "requires": {
-                "ansi-regex": "^2.0.0"
-              }
-            }
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-        },
-        "write-file-atomic": {
-          "version": "2.3.0",
-          "resolved": false,
-          "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
-          "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "signal-exit": "^3.0.2"
-          }
-        },
-        "xdg-basedir": {
-          "version": "3.0.0",
-          "resolved": false,
-          "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
-        },
-        "y18n": {
-          "version": "4.0.0",
-          "resolved": false,
-          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
-        },
-        "yallist": {
-          "version": "2.1.2",
-          "resolved": false,
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-        },
-        "yargs": {
-          "version": "11.0.0",
-          "resolved": false,
-          "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
-          "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.1.1",
-            "find-up": "^2.1.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^9.0.2"
-          },
-          "dependencies": {
-            "y18n": {
-              "version": "3.2.1",
-              "resolved": false,
-              "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
-            }
-          }
-        },
-        "yargs-parser": {
-          "version": "9.0.2",
-          "resolved": false,
-          "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
-          "requires": {
-            "camelcase": "^4.1.0"
-          }
-        }
       }
     },
     "number-is-nan": {
@@ -23162,6 +18434,15 @@
           "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -23239,19 +18520,12 @@
       }
     },
     "onetime": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-      "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
       "requires": {
-        "mimic-fn": "^2.1.0"
-      }
-    },
-    "open": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
-      "integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
-      "requires": {
-        "is-wsl": "^1.1.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "optimist": {
@@ -23371,15 +18645,11 @@
         "object-assign": "^4.1.0"
       }
     },
-    "p-cancelable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
-    },
     "p-finally": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
-      "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
     },
     "p-is-promise": {
       "version": "1.1.0",
@@ -23403,11 +18673,6 @@
         "p-limit": "^1.1.0"
       }
     },
-    "p-reduce": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
-      "integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw=="
-    },
     "p-timeout": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
@@ -23415,14 +18680,6 @@
       "dev": true,
       "requires": {
         "p-finally": "^1.0.0"
-      },
-      "dependencies": {
-        "p-finally": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-          "dev": true
-        }
       }
     },
     "p-try": {
@@ -23431,20 +18688,56 @@
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
     },
     "package-json": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
-      "integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+      "dev": true,
       "requires": {
-        "got": "^9.6.0",
-        "registry-auth-token": "^4.0.0",
-        "registry-url": "^5.0.0",
-        "semver": "^6.2.0"
+        "got": "^6.7.1",
+        "registry-auth-token": "^3.0.1",
+        "registry-url": "^3.0.3",
+        "semver": "^5.1.0"
       },
       "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        },
+        "got": {
+          "version": "6.7.1",
+          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+          "dev": true,
+          "requires": {
+            "create-error-class": "^3.0.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "is-redirect": "^1.0.0",
+            "is-retry-allowed": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "lowercase-keys": "^1.0.0",
+            "safe-buffer": "^5.0.1",
+            "timed-out": "^4.0.0",
+            "unzip-response": "^2.0.1",
+            "url-parse-lax": "^1.0.0"
+          }
+        },
+        "prepend-http": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+          "dev": true
+        },
+        "url-parse-lax": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+          "dev": true,
+          "requires": {
+            "prepend-http": "^1.0.1"
+          }
         }
       }
     },
@@ -23578,12 +18871,14 @@
     "path-is-inside": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
     },
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
     },
     "path-parse": {
       "version": "1.0.6",
@@ -23645,7 +18940,8 @@
     "pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+      "dev": true
     },
     "pinkie": {
       "version": "2.0.4",
@@ -23790,7 +19086,8 @@
     "prepend-http": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
+      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+      "dev": true
     },
     "pretender": {
       "version": "2.1.1",
@@ -23937,6 +19234,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -24129,6 +19427,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -24210,6 +19509,12 @@
           "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz",
           "integrity": "sha1-oNkOQ1G7iHcWyD/WN+v4GK9K38w=",
           "dev": true
+        },
+        "esprima-fb": {
+          "version": "15001.1001.0-dev-harmony-fb",
+          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+          "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
+          "dev": true
         }
       }
     },
@@ -24255,6 +19560,14 @@
         "private": "~0.1.5",
         "recast": "0.10.33",
         "through": "~2.3.8"
+      },
+      "dependencies": {
+        "esprima-fb": {
+          "version": "15001.1001.0-dev-harmony-fb",
+          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+          "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
+          "dev": true
+        }
       }
     },
     "regenerator-runtime": {
@@ -24334,12 +19647,12 @@
       }
     },
     "regexpu-core": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
-      "integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.5.tgz",
+      "integrity": "sha512-FpI67+ky9J+cDizQUJlIlNZFKual/lUkFr1AG6zOCpwZ9cLrg8UUVakyUQJD7fCDIe9Z2nwTQJNPyonatNmDFQ==",
       "requires": {
         "regenerate": "^1.4.0",
-        "regenerate-unicode-properties": "^8.0.2",
+        "regenerate-unicode-properties": "^8.1.0",
         "regjsgen": "^0.5.0",
         "regjsparser": "^0.6.0",
         "unicode-match-property-ecmascript": "^1.0.4",
@@ -24347,20 +19660,22 @@
       }
     },
     "registry-auth-token": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.0.0.tgz",
-      "integrity": "sha512-lpQkHxd9UL6tb3k/aHAVfnVtn+Bcs9ob5InuFLLEDqSqeq+AljB8GZW9xY0x7F+xYwEcjKe07nyoxzEYz6yvkw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
+      "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
+      "dev": true,
       "requires": {
-        "rc": "^1.2.8",
+        "rc": "^1.1.6",
         "safe-buffer": "^5.0.1"
       }
     },
     "registry-url": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
-      "integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+      "dev": true,
       "requires": {
-        "rc": "^1.2.8"
+        "rc": "^1.0.1"
       }
     },
     "regjsgen": {
@@ -24475,16 +19790,6 @@
         "tough-cookie": "^2.3.3"
       }
     },
-    "require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
-    },
-    "require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
-    },
     "require-relative": {
       "version": "0.8.7",
       "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
@@ -24565,6 +19870,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
       "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+      "dev": true,
       "requires": {
         "lowercase-keys": "^1.0.0"
       }
@@ -24573,24 +19879,10 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
       "requires": {
         "onetime": "^2.0.0",
         "signal-exit": "^3.0.2"
-      },
-      "dependencies": {
-        "mimic-fn": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
-        },
-        "onetime": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-          "requires": {
-            "mimic-fn": "^1.0.0"
-          }
-        }
       }
     },
     "ret": {
@@ -24598,20 +19890,6 @@
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
-    },
-    "rfc6902": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/rfc6902/-/rfc6902-3.0.4.tgz",
-      "integrity": "sha512-OnzreaZXrwT5w2ikKXWr5QcuI7NZpL+J3hIkAwozjOnKVUL7fPsB8Vcmu8YBiiou1/r3V0Jc0T1uQDyfAPvLzA=="
-    },
-    "rfc6902-ordered": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/rfc6902-ordered/-/rfc6902-ordered-4.0.0.tgz",
-      "integrity": "sha512-uGpjTewv2UxexoQPtYDpAZKt3WX/ujxkw3TqJAZOUu3WkwCNsu67Dlk+KPn/RY851+U3PvSTNOKs58d9YBubeQ==",
-      "requires": {
-        "debug": "^4.0.0",
-        "rfc6902": "^3.0.1"
-      }
     },
     "right-align": {
       "version": "0.1.3",
@@ -24623,9 +19901,9 @@
       }
     },
     "rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "requires": {
         "glob": "^7.1.3"
       }
@@ -24683,6 +19961,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
       "requires": {
         "is-promise": "^2.1.0"
       }
@@ -24715,6 +19994,7 @@
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
       "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
+      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -24742,7 +20022,8 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "sane": {
       "version": "4.1.0",
@@ -24759,53 +20040,6 @@
         "micromatch": "^3.1.4",
         "minimist": "^1.1.1",
         "walker": "~1.0.5"
-      },
-      "dependencies": {
-        "execa": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^6.0.0",
-            "get-stream": "^4.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-          "dev": true
-        },
-        "npm-run-path": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-          "dev": true,
-          "requires": {
-            "path-key": "^2.0.0"
-          }
-        },
-        "p-finally": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-          "dev": true
-        }
       }
     },
     "saxes": {
@@ -24865,17 +20099,9 @@
       "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
     },
     "semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
-    },
-    "semver-diff": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
-      "requires": {
-        "semver": "^5.0.3"
-      }
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "send": {
       "version": "0.17.1",
@@ -24963,7 +20189,8 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
     },
     "set-value": {
       "version": "2.0.1",
@@ -25032,7 +20259,8 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
     },
     "silent-error": {
       "version": "1.1.1",
@@ -25200,12 +20428,6 @@
             "is-data-descriptor": "^1.0.0",
             "kind-of": "^6.0.2"
           }
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
         }
       }
     },
@@ -25216,6 +20438,17 @@
       "dev": true,
       "requires": {
         "kind-of": "^3.2.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "socket.io": {
@@ -25633,26 +20866,28 @@
       "dev": true
     },
     "string-width": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
       "requires": {
-        "emoji-regex": "^7.0.1",
         "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
+        "strip-ansi": "^4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
         },
         "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -25697,17 +20932,14 @@
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
-    },
-    "strip-final-newline": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
     },
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
     },
     "styled_string": {
       "version": "0.0.1",
@@ -25809,33 +21041,6 @@
         "lodash": "^4.17.4",
         "slice-ansi": "1.0.0",
         "string-width": "^2.1.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
       }
     },
     "tap-parser": {
@@ -25862,69 +21067,23 @@
       "dev": true,
       "requires": {
         "rimraf": "~2.6.2"
-      }
-    },
-    "term-size": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
-      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
-      "requires": {
-        "execa": "^0.7.0"
       },
       "dependencies": {
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
           "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "glob": "^7.1.3"
           }
-        },
-        "execa": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-          "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-        },
-        "npm-run-path": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-          "requires": {
-            "path-key": "^2.0.0"
-          }
-        },
-        "p-finally": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
         }
       }
     },
     "terser": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.1.3.tgz",
-      "integrity": "sha512-on13d+cnpn5bMouZu+J8tPYQecsdRJCJuxFJ+FVoPBoLJgk5bCBkp+Uen2hWyi0KIUm6eDarnlAlH+KgIx/PuQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.1.4.tgz",
+      "integrity": "sha512-+ZwXJvdSwbd60jG0Illav0F06GDJF0R4ydZ21Q3wGAFKoBGyJGo34F63vzJHgvYxc1ukOtIjvwEvl9MkjzM6Pg==",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",
@@ -26053,57 +21212,6 @@
         "xmldom": "^0.1.19"
       },
       "dependencies": {
-        "bluebird": {
-          "version": "3.5.5",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-          "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
-          "dev": true
-        },
-        "execa": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^6.0.0",
-            "get-stream": "^4.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-          "dev": true
-        },
-        "npm-run-path": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-          "dev": true,
-          "requires": {
-            "path-key": "^2.0.0"
-          }
-        },
-        "p-finally": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-          "dev": true
-        },
         "tmp": {
           "version": "0.0.33",
           "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -26131,25 +21239,11 @@
       "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.5.0.tgz",
       "integrity": "sha512-1IkVr355eHcomgK7fgj1Xsokturx6L5S2JRT5WcRdA6v5shk9sxWuO/w/VbpQexwkXJMQIa/j1dBi3oo7+HhcA=="
     },
-    "three-way-merger": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/three-way-merger/-/three-way-merger-0.5.7.tgz",
-      "integrity": "sha512-aD2nvGowCgJxoH49Izou5uR4PLCuH2yiw6+BJPg0H7RCLzpLy/4J9onM9sPXetmsq/AVfZ8fEyf8lbGKxKPrcA==",
-      "requires": {
-        "semver": "^6.0.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-        }
-      }
-    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
     },
     "through2": {
       "version": "3.0.1",
@@ -26201,9 +21295,9 @@
       "dev": true
     },
     "timers-browserify": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
-      "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
+      "integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
       "dev": true,
       "requires": {
         "setimmediate": "^1.0.4"
@@ -26277,12 +21371,18 @@
       "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
-    },
-    "to-readable-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
-      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q=="
     },
     "to-regex": {
       "version": "3.0.2",
@@ -26400,7 +21500,8 @@
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "dev": true
     },
     "tty-browserify": {
       "version": "0.0.0",
@@ -26433,9 +21534,10 @@
       }
     },
     "type-fest": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
-      "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ=="
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
+      "integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==",
+      "dev": true
     },
     "type-is": {
       "version": "1.6.18",
@@ -26569,6 +21671,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+      "dev": true,
       "requires": {
         "crypto-random-string": "^1.0.0"
       }
@@ -26645,25 +21748,6 @@
       "integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
       "dev": true
     },
-    "update-notifier": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-3.0.1.tgz",
-      "integrity": "sha512-grrmrB6Zb8DUiyDIaeRTBCkgISYUgETNe7NglEbVsrLWXeESnlCSP50WfRSj/GmzMPl6Uchj24S/p80nP/ZQrQ==",
-      "requires": {
-        "boxen": "^3.0.0",
-        "chalk": "^2.0.1",
-        "configstore": "^4.0.0",
-        "has-yarn": "^2.1.0",
-        "import-lazy": "^2.1.0",
-        "is-ci": "^2.0.0",
-        "is-installed-globally": "^0.1.0",
-        "is-npm": "^3.0.0",
-        "is-yarn-global": "^0.3.0",
-        "latest-version": "^5.0.0",
-        "semver-diff": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
-      }
-    },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -26701,6 +21785,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
       "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+      "dev": true,
       "requires": {
         "prepend-http": "^2.0.0"
       }
@@ -26720,8 +21805,7 @@
     "user-home": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-      "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
-      "dev": true
+      "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
     },
     "username-sync": {
       "version": "1.0.2",
@@ -26769,7 +21853,8 @@
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "dev": true
     },
     "validate-npm-package-name": {
       "version": "3.0.0",
@@ -27017,11 +22102,6 @@
         "isexe": "^2.0.0"
       }
     },
-    "which-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
-    },
     "wide-align": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
@@ -27029,65 +22109,6 @@
       "dev": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
-      }
-    },
-    "widest-line": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
-      "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
-      "requires": {
-        "string-width": "^2.1.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
       }
     },
     "window-size": {
@@ -27097,9 +22118,9 @@
       "dev": true
     },
     "wordwrap": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
       "dev": true
     },
     "worker-farm": {
@@ -27121,31 +22142,6 @@
         "rsvp": "^4.8.4"
       }
     },
-    "wrap-ansi": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-      "requires": {
-        "ansi-styles": "^3.2.0",
-        "string-width": "^3.0.0",
-        "strip-ansi": "^5.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        }
-      }
-    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -27164,6 +22160,7 @@
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
       "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
@@ -27182,7 +22179,8 @@
     "xdg-basedir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
+      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+      "dev": true
     },
     "xml-name-validator": {
       "version": "3.0.0",
@@ -27215,14 +22213,16 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+      "dev": true
     },
     "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+      "dev": true
     },
     "yam": {
       "version": "1.0.0",
@@ -27248,69 +22248,17 @@
       }
     },
     "yargs": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
-      "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
+      "integrity": "sha1-ISBUaTFuk5Ex1Z8toMbX+YIh6kA=",
+      "dev": true,
       "requires": {
-        "cliui": "^5.0.0",
-        "find-up": "^3.0.0",
-        "get-caller-file": "^2.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^3.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.1"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
-        }
-      }
-    },
-    "yargs-parser": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
-      "requires": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
+        "camelcase": "^1.2.1",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
+        "os-locale": "^1.4.0",
+        "window-size": "^0.1.2",
+        "y18n": "^3.2.0"
       }
     },
     "yeast": {

--- a/packages/dashboards/package.json
+++ b/packages/dashboards/package.json
@@ -52,7 +52,6 @@
     "@ember/optional-features": "^0.6.3",
     "broccoli-asset-rev": "^2.7.0",
     "ember-basic-dropdown-hover": "^0.6.0",
-    "ember-c3": "0.2.3",
     "ember-cli": "~3.9.0",
     "ember-cli-bootstrap-datepicker": "^0.6.1",
     "ember-cli-clipboard": "^0.11.1",

--- a/packages/dashboards/tests/acceptance/explore-widget-test.js
+++ b/packages/dashboards/tests/acceptance/explore-widget-test.js
@@ -106,7 +106,7 @@ module('Acceptance | Exploring Widgets', function(hooks) {
 
     await visit('/dashboards/1');
 
-    const legends = findAll('.c3-legend-item').map(el => el.textContent.trim());
+    const legends = findAll('.line-chart-widget .c3-legend-item').map(el => el.textContent.trim());
 
     assert.deepEqual(
       legends,

--- a/packages/data/package-lock.json
+++ b/packages/data/package-lock.json
@@ -1266,9 +1266,9 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
     },
     "@types/node": {
-      "version": "12.7.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.0.tgz",
-      "integrity": "sha512-vqcj1MVm2Sla4PpMfYKh1MyDN4D2f/mPIZD7RdAGqEsbE+JxfeqQHHVbRDQ0Nqn8i73gJa1HQ1Pu3+nH4Q0Yiw==",
+      "version": "12.7.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.2.tgz",
+      "integrity": "sha512-dyYO+f6ihZEtNPDcWNR1fkoTDf3zAK3lAABDze3mz6POyIercH0lEUawUFXlG8xaQZmm1yEBON/4TsYv/laDYg==",
       "dev": true
     },
     "@types/symlink-or-copy": {
@@ -1514,9 +1514,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
-          "integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
+          "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
           "dev": true
         }
       }
@@ -2227,11 +2227,11 @@
       }
     },
     "babel-plugin-ember-modules-api-polyfill": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.9.0.tgz",
-      "integrity": "sha512-c03h50291phJ2gQxo/aIOvFQE2c6glql1A7uagE3XbPXpKVAJOUxtVDjvWG6UAB6BC5ynsJfMWvY0w4TPRKIHQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.11.0.tgz",
+      "integrity": "sha512-S3bw77LglkWIstoF+hBLyRPyyNAUsdzqK6zLxktuM6EniVt06st/ikhPDUttMWixS2LNA+jnBfGerYO1D/VvDw==",
       "requires": {
-        "ember-rfc176-data": "^0.3.9"
+        "ember-rfc176-data": "^0.3.11"
       }
     },
     "babel-plugin-htmlbars-inline-precompile": {
@@ -4122,6 +4122,17 @@
         "ssri": "^6.0.1",
         "unique-filename": "^1.1.1",
         "y18n": "^4.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        }
       }
     },
     "cache-base": {
@@ -4729,6 +4740,15 @@
         "through2": "^3.0.1"
       },
       "dependencies": {
+        "ansi-escapes": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.2.1.tgz",
+          "integrity": "sha512-Cg3ymMAdN10wOk/VYfLV7KCQyv7EDirJ64500sU7n9UlmioEtDuU5Gd+hj73hXSU/ex7tHJSssmyftDdkMLO8Q==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.5.2"
+          }
+        },
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -4741,6 +4761,15 @@
           "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
           "dev": true
         },
+        "cli-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^3.1.0"
+          }
+        },
         "external-editor": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -4752,25 +4781,82 @@
             "tmp": "^0.0.33"
           }
         },
-        "inquirer": {
-          "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
-          "integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
+        "figures": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-3.0.0.tgz",
+          "integrity": "sha512-HKri+WoWoUgr83pehn/SIgLOMZ9nAWC6dcGj26RY2R4F50u4+RTUz0RCrUlOV3nKRAICW1UGzyb+kcX2qK1S/g==",
           "dev": true,
           "requires": {
-            "ansi-escapes": "^3.2.0",
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "inquirer": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.1.tgz",
+          "integrity": "sha512-uxNHBeQhRXIoHWTSNYUFhQVrHYFThIt6IVo2fFmSe8aBwdR3/w6b58hJpiL/fMukFkvGzjg+hSxFtwvVmKZmXw==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^4.2.1",
             "chalk": "^2.4.2",
-            "cli-cursor": "^2.1.0",
+            "cli-cursor": "^3.1.0",
             "cli-width": "^2.0.0",
             "external-editor": "^3.0.3",
-            "figures": "^2.0.0",
-            "lodash": "^4.17.12",
-            "mute-stream": "0.0.7",
+            "figures": "^3.0.0",
+            "lodash": "^4.17.15",
+            "mute-stream": "0.0.8",
             "run-async": "^2.2.0",
             "rxjs": "^6.4.0",
-            "string-width": "^2.1.0",
+            "string-width": "^4.1.0",
             "strip-ansi": "^5.1.0",
             "through": "^2.3.6"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+          "dev": true
+        },
+        "mute-stream": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+          "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+          "dev": true
+        },
+        "onetime": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+          "dev": true,
+          "requires": {
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "string-width": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.1.0.tgz",
+          "integrity": "sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^5.2.0"
           }
         },
         "strip-ansi": {
@@ -4881,13 +4967,12 @@
       "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
     },
     "core-js-compat": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.1.4.tgz",
-      "integrity": "sha512-Z5zbO9f1d0YrJdoaQhphVAnKPimX92D6z8lCGphH89MNRxlL1prI9ExJPqVwP0/kgkQCv8c4GJGT8X16yUncOg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.2.1.tgz",
+      "integrity": "sha512-MwPZle5CF9dEaMYdDeWm73ao/IflDH+FjeJCWEADcEgFSE9TLimFKwJsfmkwzI8eC0Aj0mgvMDjeQjrElkz4/A==",
       "requires": {
-        "browserslist": "^4.6.2",
-        "core-js-pure": "3.1.4",
-        "semver": "^6.1.1"
+        "browserslist": "^4.6.6",
+        "semver": "^6.3.0"
       },
       "dependencies": {
         "semver": {
@@ -4896,11 +4981,6 @@
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
-    },
-    "core-js-pure": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.1.4.tgz",
-      "integrity": "sha512-uJ4Z7iPNwiu1foygbcZYJsJs1jiXrTTCvxfLDXNhI/I+NHbSIEyr548y4fcsCEyWY0XgfAG/qqaunJ1SThHenA=="
     },
     "core-object": {
       "version": "3.1.5",
@@ -5334,9 +5414,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.218",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.218.tgz",
-      "integrity": "sha512-+ABuwQH2bEUbJTMPUMfP9mjBFtbLgDjlrkg3QGQZwr/RJB7aJZBm8g3SK/lR/J76P6l/4a6RgW2yQjZQDdjtFw=="
+      "version": "1.3.230",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.230.tgz",
+      "integrity": "sha512-r0RljY5DZi9RX4v8mjHxJkDWnQe+nsrkGlHtrDF2uvZcvAkw+iglvlQi1794gZhwRtJoDOomMJlDHL2LfXSCZA=="
     },
     "elliptic": {
       "version": "6.5.0",
@@ -5875,9 +5955,9 @@
       }
     },
     "ember-cli-babel": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.8.0.tgz",
-      "integrity": "sha512-xUBgJQ81fqd7k/KIiGU+pjpoXhrmmRf9pUrqLenNSU5N+yeNFT5a1+w0b+p1F7oBphfXVwuxApdZxrmAHOdA3Q==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.10.0.tgz",
+      "integrity": "sha512-eNgPXobC+Pke5L3XzoJ0BXbb2+eYzZI+LljqbwXNuG4q63pF000aARFpTQ0p/NWkfGQxKi2L6tVIa1ZOYdQS+A==",
       "requires": {
         "@babel/core": "^7.0.0",
         "@babel/plugin-proposal-class-properties": "^7.3.4",
@@ -5889,7 +5969,7 @@
         "@babel/runtime": "^7.2.0",
         "amd-name-resolver": "^1.2.1",
         "babel-plugin-debug-macros": "^0.3.0",
-        "babel-plugin-ember-modules-api-polyfill": "^2.9.0",
+        "babel-plugin-ember-modules-api-polyfill": "^2.11.0",
         "babel-plugin-module-resolver": "^3.1.1",
         "broccoli-babel-transpiler": "^7.1.2",
         "broccoli-debug": "^0.6.4",
@@ -7855,9 +7935,9 @@
       }
     },
     "ember-resolver": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ember-resolver/-/ember-resolver-5.2.0.tgz",
-      "integrity": "sha512-vL7YnifeHA2g6OM3KF7PSCIcUBvPISfcxByqGmWgjynbZpd3KmBUpHVxAlqXUYqhO4viRcM0sohAgZ41bCv7QQ==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ember-resolver/-/ember-resolver-5.2.1.tgz",
+      "integrity": "sha512-Ciz5qsrtILr7AGXO9mTSFs3/XKXpMYJqISNCfvIY0C8PlMgq+9RYbmUoBpAlvBUc/mUi3ORZKJ4csd9qchvxZw==",
       "dev": true,
       "requires": {
         "@glimmer/resolver": "^0.4.1",
@@ -8024,9 +8104,9 @@
       }
     },
     "ember-rfc176-data": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.9.tgz",
-      "integrity": "sha512-EiTo5YQS0Duy0xp9gCP8ekzv9vxirNi7MnIB4zWs+thtWp/mEKgf5mkiiLU2+oo8C5DuavVHhoPQDmyxh8Io1Q=="
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.11.tgz",
+      "integrity": "sha512-c46uisicHswFHo0R515LPM0L/X/Ju+N7KonJPuHx9C6cWD3AWzkNG9ASv+Bc85mq/9l3LFFsFpljdM1m2YnQ6A=="
     },
     "ember-router-generator": {
       "version": "1.2.3",
@@ -8069,9 +8149,9 @@
       }
     },
     "ember-template-lint": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/ember-template-lint/-/ember-template-lint-1.5.1.tgz",
-      "integrity": "sha512-/n5o6KnDADGPg2/OuzrNR/u2w8WIfEjfJhESVw4DAS6jaF8uO0WZrNI60RvmM4Rp813iX5p8pp1dVUUz4Euy7w==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/ember-template-lint/-/ember-template-lint-1.5.2.tgz",
+      "integrity": "sha512-uAGmYrIHoBS8jjmvb2SNprX5zPEs647amO+OHT0OtrO1HjFnhS4GyOXH2xx6h38co65WpPll0o3HFyE4cEh0NA==",
       "dev": true,
       "requires": {
         "@glimmer/compiler": "^0.41.0",
@@ -8145,6 +8225,12 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/emit-function/-/emit-function-0.0.2.tgz",
       "integrity": "sha1-46ULPWG+G/jKiLkkv3ExV6W+wSQ=",
+      "dev": true
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
     "emojis-list": {
@@ -8338,9 +8424,9 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
-      "integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
+      "integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
       "dev": true,
       "requires": {
         "esprima": "^3.1.3",
@@ -8437,16 +8523,6 @@
             "ms": "^2.1.1"
           }
         },
-        "lru-cache": {
-          "version": "4.1.5",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-          "dev": true,
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          }
-        },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://ynpm-registry.corp.yahoo.com/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -8455,12 +8531,6 @@
           "requires": {
             "ansi-regex": "^3.0.0"
           }
-        },
-        "yallist": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-          "dev": true
         }
       }
     },
@@ -9256,6 +9326,17 @@
         "graceful-fs": "^4.1.2",
         "rimraf": "~2.6.2",
         "write": "^0.2.1"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "flush-write-stream": {
@@ -10307,9 +10388,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.1.tgz",
-      "integrity": "sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+      "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
       "dev": true
     },
     "graceful-readlink": {
@@ -10607,13 +10688,10 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.2.tgz",
-      "integrity": "sha512-CyjlXII6LMsPMyUzxpTt8fzh5QwzGqPmQXgY/Jyf4Zfp27t/FvfhwoE/8laaMUcMy816CkWF20I7NeQhwwY88w==",
-      "dev": true,
-      "requires": {
-        "lru-cache": "^5.1.1"
-      }
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
+      "integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
+      "dev": true
     },
     "html-encoding-sniffer": {
       "version": "1.0.2",
@@ -11354,9 +11432,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
-          "integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
+          "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
           "dev": true
         }
       }
@@ -11831,12 +11909,21 @@
       "dev": true
     },
     "lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "dev": true,
       "requires": {
-        "yallist": "^3.0.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "dev": true
+        }
       }
     },
     "make-dir": {
@@ -12469,9 +12556,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.26",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
-      "integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
+      "version": "1.1.27",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.27.tgz",
+      "integrity": "sha512-9iXUqHKSGo6ph/tdXVbHFbhRVQln4ZDTIBJCzsa90HimnBYc5jw8RWYt4wBYFHehGyC3koIz5O4mb2fHrbPOuA==",
       "requires": {
         "semver": "^5.3.0"
       }
@@ -13741,12 +13828,12 @@
       "dev": true
     },
     "regexpu-core": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
-      "integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.5.tgz",
+      "integrity": "sha512-FpI67+ky9J+cDizQUJlIlNZFKual/lUkFr1AG6zOCpwZ9cLrg8UUVakyUQJD7fCDIe9Z2nwTQJNPyonatNmDFQ==",
       "requires": {
         "regenerate": "^1.4.0",
-        "regenerate-unicode-properties": "^8.0.2",
+        "regenerate-unicode-properties": "^8.1.0",
         "regjsgen": "^0.5.0",
         "regjsparser": "^0.6.0",
         "unicode-match-property-ecmascript": "^1.0.4",
@@ -13996,9 +14083,9 @@
       "dev": true
     },
     "rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "requires": {
         "glob": "^7.1.3"
       }
@@ -14161,9 +14248,9 @@
       }
     },
     "semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "send": {
       "version": "0.17.1",
@@ -15086,12 +15173,23 @@
       "dev": true,
       "requires": {
         "rimraf": "~2.6.2"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "terser": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.1.3.tgz",
-      "integrity": "sha512-on13d+cnpn5bMouZu+J8tPYQecsdRJCJuxFJ+FVoPBoLJgk5bCBkp+Uen2hWyi0KIUm6eDarnlAlH+KgIx/PuQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.1.4.tgz",
+      "integrity": "sha512-+ZwXJvdSwbd60jG0Illav0F06GDJF0R4ydZ21Q3wGAFKoBGyJGo34F63vzJHgvYxc1ukOtIjvwEvl9MkjzM6Pg==",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",
@@ -15292,9 +15390,9 @@
       "dev": true
     },
     "timers-browserify": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
-      "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
+      "integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
       "dev": true,
       "requires": {
         "setimmediate": "^1.0.4"
@@ -15496,6 +15594,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-fest": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
+      "integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==",
+      "dev": true
     },
     "type-is": {
       "version": "1.6.18",

--- a/packages/directory/bower.json
+++ b/packages/directory/bower.json
@@ -2,8 +2,6 @@
   "name": "navi-directory",
   "dependencies": {
     "bootstrap-datepicker": "1.4.0",
-    "d3": "3.5.17",
-    "c3": "0.4.20",
     "numeral": "^1.5.3"
   }
 }

--- a/packages/directory/package-lock.json
+++ b/packages/directory/package-lock.json
@@ -1246,132 +1246,28 @@
       }
     },
     "@html-next/vertical-collection": {
-      "version": "1.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@html-next/vertical-collection/-/vertical-collection-1.0.0-beta.14.tgz",
-      "integrity": "sha512-HMmbYAe8UtEB9LFb7TtjsRvMgTYXMLNHJKd4z6QIpn0UAYJmXErIwJGIaK5Z7T3DYto4w10jD89HPhbCEyJG0Q==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@html-next/vertical-collection/-/vertical-collection-1.0.0.tgz",
+      "integrity": "sha512-qmSbIXiiQVNBkSJZK2or8TVhMn7aiUFHlbkHcKa1Cbn6BDQnqKkdoMaB+Ii1s0Dc8XmpMS1t/enCmAfszZ9+cw==",
       "requires": {
-        "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
         "babel6-plugin-strip-class-callcheck": "^6.0.0",
-        "broccoli-funnel": "^2.0.1",
+        "broccoli-funnel": "^2.0.2",
         "broccoli-merge-trees": "^3.0.1",
-        "broccoli-rollup": "^2.0.0",
-        "ember-cli-babel": "^6.6.0",
+        "broccoli-rollup": "^4.1.1",
+        "ember-cli-babel": "^7.7.3",
         "ember-cli-htmlbars": "^3.0.0",
-        "ember-cli-version-checker": "^2.1.0",
-        "ember-compatibility-helpers": "^1.0.0",
+        "ember-cli-version-checker": "^3.1.3",
+        "ember-compatibility-helpers": "^1.2.0",
         "ember-raf-scheduler": "0.1.0"
       },
       "dependencies": {
-        "amd-name-resolver": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz",
-          "integrity": "sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==",
+        "ember-cli-version-checker": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-3.1.3.tgz",
+          "integrity": "sha512-PZNSvpzwWgv68hcXxyjREpj3WWb81A7rtYNQq1lLEgrWIchF8ApKJjWP3NBpHjaatwILkZAV8klair5WFlXAKg==",
           "requires": {
-            "ensure-posix-path": "^1.0.1"
-          }
-        },
-        "babel-plugin-debug-macros": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz",
-          "integrity": "sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==",
-          "requires": {
-            "semver": "^5.3.0"
-          }
-        },
-        "broccoli-babel-transpiler": {
-          "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz",
-          "integrity": "sha512-w6GcnkxvHcNCte5FcLGEG1hUdQvlfvSN/6PtGWU/otg69Ugk8rUk51h41R0Ugoc+TNxyeFG1opRt2RlA87XzNw==",
-          "requires": {
-            "babel-core": "^6.26.0",
-            "broccoli-funnel": "^2.0.1",
-            "broccoli-merge-trees": "^2.0.0",
-            "broccoli-persistent-filter": "^1.4.3",
-            "clone": "^2.0.0",
-            "hash-for-dep": "^1.2.3",
-            "heimdalljs-logger": "^0.1.7",
-            "json-stable-stringify": "^1.0.0",
-            "rsvp": "^4.8.2",
-            "workerpool": "^2.3.0"
-          },
-          "dependencies": {
-            "broccoli-merge-trees": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.1.tgz",
-              "integrity": "sha512-WjaexJ+I8BxP5V5RNn6um/qDRSmKoiBC/QkRi79FT9ClHfldxRyCDs9mcV7mmoaPlsshmmPaUz5jdtcKA6DClQ==",
-              "requires": {
-                "broccoli-plugin": "^1.3.0",
-                "merge-trees": "^1.0.1"
-              }
-            }
-          }
-        },
-        "broccoli-persistent-filter": {
-          "version": "1.4.6",
-          "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.6.tgz",
-          "integrity": "sha512-0RejLwoC95kv4kta8KAa+FmECJCK78Qgm8SRDEK7YyU0N9Cx6KpY3UCDy9WELl3mCXLN8TokNxc7/hp3lL4lfw==",
-          "requires": {
-            "async-disk-cache": "^1.2.1",
-            "async-promise-queue": "^1.0.3",
-            "broccoli-plugin": "^1.0.0",
-            "fs-tree-diff": "^0.5.2",
-            "hash-for-dep": "^1.0.2",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.7",
-            "mkdirp": "^0.5.1",
-            "promise-map-series": "^0.2.1",
-            "rimraf": "^2.6.1",
-            "rsvp": "^3.0.18",
-            "symlink-or-copy": "^1.0.1",
-            "walk-sync": "^0.3.1"
-          },
-          "dependencies": {
-            "rsvp": {
-              "version": "3.6.2",
-              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-              "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
-            }
-          }
-        },
-        "ember-cli-babel": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
-          "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
-          "requires": {
-            "amd-name-resolver": "1.2.0",
-            "babel-plugin-debug-macros": "^0.2.0-beta.6",
-            "babel-plugin-ember-modules-api-polyfill": "^2.6.0",
-            "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
-            "babel-polyfill": "^6.26.0",
-            "babel-preset-env": "^1.7.0",
-            "broccoli-babel-transpiler": "^6.5.0",
-            "broccoli-debug": "^0.6.4",
-            "broccoli-funnel": "^2.0.0",
-            "broccoli-source": "^1.1.0",
-            "clone": "^2.0.0",
-            "ember-cli-version-checker": "^2.1.2",
-            "semver": "^5.5.0"
-          }
-        },
-        "merge-trees": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-1.0.1.tgz",
-          "integrity": "sha1-zL5nRWl4f53vF/1G5lJfVwC70j4=",
-          "requires": {
-            "can-symlink": "^1.0.0",
-            "fs-tree-diff": "^0.5.4",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.7",
-            "rimraf": "^2.4.3",
-            "symlink-or-copy": "^1.0.0"
-          }
-        },
-        "workerpool": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.3.tgz",
-          "integrity": "sha512-L1ovlYHp6UObYqElXXpbd214GgbEKDED0d3sj7pRdFXjNkb2+un/AUcCkceHizO0IVI6SOGGncrcjozruCkRgA==",
-          "requires": {
-            "object-assign": "4.1.1"
+            "resolve-package-path": "^1.2.6",
+            "semver": "^5.6.0"
           }
         }
       }
@@ -1398,22 +1294,19 @@
       "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
       "dev": true
     },
-    "@szmarczak/http-timer": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
-      "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
-      "dev": true,
-      "requires": {
-        "defer-to-connect": "^1.0.1"
-      }
-    },
     "@types/acorn": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/acorn/-/acorn-4.0.5.tgz",
       "integrity": "sha512-603sPiZ4GVRHPvn6vNgEAvJewKsy+zwRWYS2MeIMemgoAtcjlw2G3lALxrb9OPA17J28bkB71R33yXlQbUatCA==",
+      "dev": true,
       "requires": {
         "@types/estree": "*"
       }
+    },
+    "@types/broccoli-plugin": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@types/broccoli-plugin/-/broccoli-plugin-1.3.0.tgz",
+      "integrity": "sha512-SLk4/hFc2kGvgwNFrpn2O1juxFOllcHAywvlo7VwxfExLzoz1GGJ0oIZCwj5fwSpvHw4AWpZjJ1fUvb62PDayQ=="
     },
     "@types/estree": {
       "version": "0.0.39",
@@ -1425,15 +1318,6 @@
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
       "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
       "dev": true
-    },
-    "@types/fs-extra": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.1.0.tgz",
-      "integrity": "sha512-AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@types/glob": {
       "version": "7.1.1",
@@ -1452,19 +1336,9 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
     },
     "@types/node": {
-      "version": "9.6.50",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.50.tgz",
-      "integrity": "sha512-9Yzqn2NzJxwFzon4W+aqUAMl3FiVnJ965f5F3H5T+EpUrHqb2Is1SPp/lsj2WFBqXrhIINJ5SzSwneLMg5PgSQ=="
-    },
-    "@types/rimraf": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-2.0.2.tgz",
-      "integrity": "sha512-Hm/bnWq0TCy7jmjeN5bKYij9vw5GrDFWME4IuxV08278NtU/VdGbzsBohcCUJ7+QMqmUq5hpRKB39HeQWJjztQ==",
-      "dev": true,
-      "requires": {
-        "@types/glob": "*",
-        "@types/node": "*"
-      }
+      "version": "12.7.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.2.tgz",
+      "integrity": "sha512-dyYO+f6ihZEtNPDcWNR1fkoTDf3zAK3lAABDze3mz6POyIercH0lEUawUFXlG8xaQZmm1yEBON/4TsYv/laDYg=="
     },
     "@types/symlink-or-copy": {
       "version": "1.2.0",
@@ -1684,16 +1558,25 @@
       }
     },
     "acorn": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
+      "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA=="
     },
     "acorn-dynamic-import": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
       "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
+      "dev": true,
       "requires": {
         "acorn": "^5.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.7.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+          "dev": true
+        }
       }
     },
     "acorn-globals": {
@@ -1704,14 +1587,6 @@
       "requires": {
         "acorn": "^6.0.1",
         "acorn-walk": "^6.0.1"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
-          "integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
-          "dev": true
-        }
       }
     },
     "acorn-jsx": {
@@ -1776,6 +1651,17 @@
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
         "repeat-string": "^1.5.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "alter": {
@@ -1801,43 +1687,6 @@
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
-    },
-    "ansi-align": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
-      "integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
-      "dev": true,
-      "requires": {
-        "string-width": "^3.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        }
-      }
     },
     "ansi-escapes": {
       "version": "3.2.0",
@@ -2504,11 +2353,11 @@
       }
     },
     "babel-plugin-ember-modules-api-polyfill": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.9.0.tgz",
-      "integrity": "sha512-c03h50291phJ2gQxo/aIOvFQE2c6glql1A7uagE3XbPXpKVAJOUxtVDjvWG6UAB6BC5ynsJfMWvY0w4TPRKIHQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.11.0.tgz",
+      "integrity": "sha512-S3bw77LglkWIstoF+hBLyRPyyNAUsdzqK6zLxktuM6EniVt06st/ikhPDUttMWixS2LNA+jnBfGerYO1D/VvDw==",
       "requires": {
-        "ember-rfc176-data": "^0.3.9"
+        "ember-rfc176-data": "^0.3.11"
       }
     },
     "babel-plugin-eval": {
@@ -3198,12 +3047,6 @@
             "is-data-descriptor": "^1.0.0",
             "kind-of": "^6.0.2"
           }
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
         }
       }
     },
@@ -3286,9 +3129,9 @@
       "dev": true
     },
     "bluebird": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-      "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
       "dev": true
     },
     "bn.js": {
@@ -3393,176 +3236,6 @@
         }
       }
     },
-    "boilerplate-update": {
-      "version": "0.22.6",
-      "resolved": "https://registry.npmjs.org/boilerplate-update/-/boilerplate-update-0.22.6.tgz",
-      "integrity": "sha512-mbgV8nUs6ovN/uvHTqk8tm8a/h+PgDtWAGs3zNg/rfvAi6Nu3IFpWr3MCENJfp2its4MuXj7Ozoo8wBBHHdPjQ==",
-      "dev": true,
-      "requires": {
-        "cpr": "^3.0.1",
-        "debug": "^4.1.1",
-        "execa": "^2.0.0",
-        "git-diff-apply": "0.19.1",
-        "inquirer": "^6.2.2",
-        "merge-package.json": "^3.0.0",
-        "npx": "^10.2.0",
-        "open": "^6.0.0",
-        "p-reduce": "^2.0.0",
-        "rimraf": "^2.6.3",
-        "semver": "^6.0.0",
-        "tmp": "0.1.0",
-        "which": "^1.3.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "chardet": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-          "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-          "dev": true
-        },
-        "execa": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-2.0.3.tgz",
-          "integrity": "sha512-iM124nlyGSrXmuyZF1EMe83ESY2chIYVyDRZKgmcDynid2Q2v/+GuE7gNMl6Sy9Niwf4MC0DDxagOxeMPjuLsw==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^6.0.5",
-            "get-stream": "^5.0.0",
-            "is-stream": "^2.0.0",
-            "merge-stream": "^2.0.0",
-            "npm-run-path": "^3.0.0",
-            "onetime": "^5.1.0",
-            "p-finally": "^2.0.0",
-            "signal-exit": "^3.0.2",
-            "strip-final-newline": "^2.0.0"
-          }
-        },
-        "external-editor": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-          "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-          "dev": true,
-          "requires": {
-            "chardet": "^0.7.0",
-            "iconv-lite": "^0.4.24",
-            "tmp": "^0.0.33"
-          },
-          "dependencies": {
-            "tmp": {
-              "version": "0.0.33",
-              "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-              "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-              "dev": true,
-              "requires": {
-                "os-tmpdir": "~1.0.2"
-              }
-            }
-          }
-        },
-        "get-stream": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "inquirer": {
-          "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
-          "integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "^3.2.0",
-            "chalk": "^2.4.2",
-            "cli-cursor": "^2.1.0",
-            "cli-width": "^2.0.0",
-            "external-editor": "^3.0.3",
-            "figures": "^2.0.0",
-            "lodash": "^4.17.12",
-            "mute-stream": "0.0.7",
-            "run-async": "^2.2.0",
-            "rxjs": "^6.4.0",
-            "string-width": "^2.1.0",
-            "strip-ansi": "^5.1.0",
-            "through": "^2.3.6"
-          }
-        },
-        "is-stream": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-          "dev": true
-        },
-        "mimic-fn": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-          "dev": true
-        },
-        "npm-run-path": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
-          "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
-          "dev": true,
-          "requires": {
-            "path-key": "^3.0.0"
-          }
-        },
-        "onetime": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^2.1.0"
-          }
-        },
-        "p-finally": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
-          "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
-          "dev": true
-        },
-        "path-key": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
-          "integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==",
-          "dev": true
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        },
-        "tmp": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-          "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
-          "dev": true,
-          "requires": {
-            "rimraf": "^2.6.3"
-          }
-        }
-      }
-    },
     "boom": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
@@ -3609,56 +3282,6 @@
       "resolved": "https://registry.npmjs.org/bower-endpoint-parser/-/bower-endpoint-parser-0.2.2.tgz",
       "integrity": "sha1-ALVlrb+rby01rd3pd+l5Yqy8s/Y=",
       "dev": true
-    },
-    "boxen": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-3.2.0.tgz",
-      "integrity": "sha512-cU4J/+NodM3IHdSL2yN8bqYqnmlBTidDR4RC7nJs61ZmtGz8VZzM3HLQX0zY5mrSmPtR3xWwsq2jOUQqFZN8+A==",
-      "dev": true,
-      "requires": {
-        "ansi-align": "^3.0.0",
-        "camelcase": "^5.3.1",
-        "chalk": "^2.4.2",
-        "cli-boxes": "^2.2.0",
-        "string-width": "^3.0.0",
-        "term-size": "^1.2.0",
-        "type-fest": "^0.3.0",
-        "widest-line": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        }
-      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -4439,21 +4062,54 @@
       }
     },
     "broccoli-rollup": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/broccoli-rollup/-/broccoli-rollup-2.1.1.tgz",
-      "integrity": "sha512-aky/Ovg5DbsrsJEx2QCXxHLA6ZR+9u1TNVTf85soP4gL8CjGGKQ/JU8R3BZ2ntkWzo6/83RCKzX6O+nlNKR5MQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/broccoli-rollup/-/broccoli-rollup-4.1.1.tgz",
+      "integrity": "sha512-hkp0dB5chiemi32t6hLe5bJvxuTOm1TU+SryFlZIs95KT9+94uj0C8w6k6CsZ2HuIdIZg6D252t4gwOlcTXrpA==",
       "requires": {
-        "@types/node": "^9.6.0",
-        "amd-name-resolver": "^1.2.0",
-        "broccoli-plugin": "^1.2.1",
-        "fs-tree-diff": "^0.5.2",
-        "heimdalljs": "^0.2.1",
-        "heimdalljs-logger": "^0.1.7",
-        "magic-string": "^0.24.0",
+        "@types/broccoli-plugin": "^1.3.0",
+        "broccoli-plugin": "^2.0.0",
+        "fs-tree-diff": "^2.0.1",
+        "heimdalljs": "^0.2.6",
         "node-modules-path": "^1.0.1",
-        "rollup": "^0.57.1",
-        "symlink-or-copy": "^1.1.8",
-        "walk-sync": "^0.3.1"
+        "rollup": "^1.12.0",
+        "rollup-pluginutils": "^2.8.1",
+        "symlink-or-copy": "^1.2.0",
+        "walk-sync": "^1.1.3"
+      },
+      "dependencies": {
+        "broccoli-plugin": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-2.1.0.tgz",
+          "integrity": "sha512-ElE4caljW4slapyEhSD9jU9Uayc8SoSABWdmY9SqbV8DHNxU6xg1jJsPcMm+cXOvggR3+G+OXAYQeFjWVnznaw==",
+          "requires": {
+            "promise-map-series": "^0.2.1",
+            "quick-temp": "^0.1.3",
+            "rimraf": "^2.3.4",
+            "symlink-or-copy": "^1.1.8"
+          }
+        },
+        "fs-tree-diff": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
+          "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
+          "requires": {
+            "@types/symlink-or-copy": "^1.2.0",
+            "heimdalljs-logger": "^0.1.7",
+            "object-assign": "^4.1.0",
+            "path-posix": "^1.0.0",
+            "symlink-or-copy": "^1.1.8"
+          }
+        },
+        "walk-sync": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-1.1.4.tgz",
+          "integrity": "sha512-nowc9thB/Jg0KW4TgxoRjLLYRPvl3DB/98S89r4ZcJqq2B0alNcKDh6pzLkBSkPMzRSMsJghJHQi79qw0YWEkA==",
+          "requires": {
+            "@types/minimatch": "^3.0.3",
+            "ensure-posix-path": "^1.1.0",
+            "matcher-collection": "^1.1.1"
+          }
+        }
       }
     },
     "broccoli-slow-trees": {
@@ -4911,11 +4567,14 @@
         "y18n": "^4.0.0"
       },
       "dependencies": {
-        "bluebird": {
-          "version": "3.5.5",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-          "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
-          "dev": true
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
         },
         "y18n": {
           "version": "4.0.0",
@@ -5240,12 +4899,6 @@
       "resolved": "https://registry.npmjs.org/clean-up-path/-/clean-up-path-1.0.0.tgz",
       "integrity": "sha512-PHGlEF0Z6976qQyN6gM7kKH6EH0RdfZcc8V+QhFe36eRxV0SMH5OUBZG7Bxa9YcreNzyNbK63cGiZxdSZgosRw=="
     },
-    "cli-boxes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.0.tgz",
-      "integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w==",
-      "dev": true
-    },
     "cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -5316,6 +4969,14 @@
         "center-align": "^0.1.1",
         "right-align": "^0.1.1",
         "wordwrap": "0.0.2"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "dev": true
+        }
       }
     },
     "clone": {
@@ -5623,6 +5284,15 @@
         "through2": "^3.0.1"
       },
       "dependencies": {
+        "ansi-escapes": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.2.1.tgz",
+          "integrity": "sha512-Cg3ymMAdN10wOk/VYfLV7KCQyv7EDirJ64500sU7n9UlmioEtDuU5Gd+hj73hXSU/ex7tHJSssmyftDdkMLO8Q==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.5.2"
+          }
+        },
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -5635,6 +5305,15 @@
           "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
           "dev": true
         },
+        "cli-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^3.1.0"
+          }
+        },
         "external-editor": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -5646,25 +5325,82 @@
             "tmp": "^0.0.33"
           }
         },
-        "inquirer": {
-          "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
-          "integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
+        "figures": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-3.0.0.tgz",
+          "integrity": "sha512-HKri+WoWoUgr83pehn/SIgLOMZ9nAWC6dcGj26RY2R4F50u4+RTUz0RCrUlOV3nKRAICW1UGzyb+kcX2qK1S/g==",
           "dev": true,
           "requires": {
-            "ansi-escapes": "^3.2.0",
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "inquirer": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.1.tgz",
+          "integrity": "sha512-uxNHBeQhRXIoHWTSNYUFhQVrHYFThIt6IVo2fFmSe8aBwdR3/w6b58hJpiL/fMukFkvGzjg+hSxFtwvVmKZmXw==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^4.2.1",
             "chalk": "^2.4.2",
-            "cli-cursor": "^2.1.0",
+            "cli-cursor": "^3.1.0",
             "cli-width": "^2.0.0",
             "external-editor": "^3.0.3",
-            "figures": "^2.0.0",
-            "lodash": "^4.17.12",
-            "mute-stream": "0.0.7",
+            "figures": "^3.0.0",
+            "lodash": "^4.17.15",
+            "mute-stream": "0.0.8",
             "run-async": "^2.2.0",
             "rxjs": "^6.4.0",
-            "string-width": "^2.1.0",
+            "string-width": "^4.1.0",
             "strip-ansi": "^5.1.0",
             "through": "^2.3.6"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+          "dev": true
+        },
+        "mute-stream": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+          "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+          "dev": true
+        },
+        "onetime": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+          "dev": true,
+          "requires": {
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "string-width": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.1.0.tgz",
+          "integrity": "sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^5.2.0"
           }
         },
         "strip-ansi": {
@@ -5694,14 +5430,6 @@
       "dev": true,
       "requires": {
         "bluebird": "^3.1.1"
-      },
-      "dependencies": {
-        "bluebird": {
-          "version": "3.5.5",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-          "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
-          "dev": true
-        }
       }
     },
     "constants-browserify": {
@@ -5783,13 +5511,12 @@
       "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
     },
     "core-js-compat": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.1.4.tgz",
-      "integrity": "sha512-Z5zbO9f1d0YrJdoaQhphVAnKPimX92D6z8lCGphH89MNRxlL1prI9ExJPqVwP0/kgkQCv8c4GJGT8X16yUncOg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.2.1.tgz",
+      "integrity": "sha512-MwPZle5CF9dEaMYdDeWm73ao/IflDH+FjeJCWEADcEgFSE9TLimFKwJsfmkwzI8eC0Aj0mgvMDjeQjrElkz4/A==",
       "requires": {
-        "browserslist": "^4.6.2",
-        "core-js-pure": "3.1.4",
-        "semver": "^6.1.1"
+        "browserslist": "^4.6.6",
+        "semver": "^6.3.0"
       },
       "dependencies": {
         "semver": {
@@ -5798,11 +5525,6 @@
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
-    },
-    "core-js-pure": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.1.4.tgz",
-      "integrity": "sha512-uJ4Z7iPNwiu1foygbcZYJsJs1jiXrTTCvxfLDXNhI/I+NHbSIEyr548y4fcsCEyWY0XgfAG/qqaunJ1SThHenA=="
     },
     "core-object": {
       "version": "3.1.5",
@@ -5818,18 +5540,6 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
-    },
-    "cpr": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/cpr/-/cpr-3.0.1.tgz",
-      "integrity": "sha1-uaVQOLfNgaNcF7l2GJW9hJau8eU=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.5",
-        "minimist": "^1.2.0",
-        "mkdirp": "~0.5.1",
-        "rimraf": "^2.5.4"
-      }
     },
     "create-ecdh": {
       "version": "4.0.3",
@@ -5990,6 +5700,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/date-time/-/date-time-2.1.0.tgz",
       "integrity": "sha512-/9+C44X7lot0IeiyfgJmETtRMhBidBYM2QFFIkGa0U1k+hSyY87Nw7PY3eDqpvCBm7I3WCSfPeZskW/YYq6m4g==",
+      "dev": true,
       "requires": {
         "time-zone": "^1.0.0"
       }
@@ -6052,12 +5763,6 @@
         }
       }
     },
-    "defer-to-connect": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.0.2.tgz",
-      "integrity": "sha512-k09hcQcTDY+cwgiwa6PYKLm3jlagNzQ+RSvhjzESOGOx+MNOuXkxTfEvPrO1IOQ81tArCFYQgi631clB70RpQw==",
-      "dev": true
-    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -6104,12 +5809,6 @@
             "is-data-descriptor": "^1.0.0",
             "kind-of": "^6.0.2"
           }
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
         }
       }
     },
@@ -6135,6 +5834,14 @@
         "stringset": "~0.2.1",
         "tryor": "~0.1.2",
         "yargs": "~3.27.0"
+      },
+      "dependencies": {
+        "esprima-fb": {
+          "version": "15001.1001.0-dev-harmony-fb",
+          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+          "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
+          "dev": true
+        }
       }
     },
     "delayed-stream": {
@@ -6199,6 +5906,14 @@
       "requires": {
         "acorn": "^5.2.1",
         "defined": "^1.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.7.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+          "dev": true
+        }
       }
     },
     "diff": {
@@ -6332,9 +6047,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.218",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.218.tgz",
-      "integrity": "sha512-+ABuwQH2bEUbJTMPUMfP9mjBFtbLgDjlrkg3QGQZwr/RJB7aJZBm8g3SK/lR/J76P6l/4a6RgW2yQjZQDdjtFw=="
+      "version": "1.3.230",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.230.tgz",
+      "integrity": "sha512-r0RljY5DZi9RX4v8mjHxJkDWnQe+nsrkGlHtrDF2uvZcvAkw+iglvlQi1794gZhwRtJoDOomMJlDHL2LfXSCZA=="
     },
     "element-resize-detector": {
       "version": "1.1.15",
@@ -6858,351 +6573,6 @@
         }
       }
     },
-    "ember-c3": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/ember-c3/-/ember-c3-0.2.3.tgz",
-      "integrity": "sha1-PzE9DYxA4a/8KDau92ln2892v40=",
-      "dev": true,
-      "requires": {
-        "ember-cli-babel": "^5.1.5"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "babel-core": {
-          "version": "5.8.38",
-          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
-          "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
-          "dev": true,
-          "requires": {
-            "babel-plugin-constant-folding": "^1.0.1",
-            "babel-plugin-dead-code-elimination": "^1.0.2",
-            "babel-plugin-eval": "^1.0.1",
-            "babel-plugin-inline-environment-variables": "^1.0.1",
-            "babel-plugin-jscript": "^1.0.4",
-            "babel-plugin-member-expression-literals": "^1.0.1",
-            "babel-plugin-property-literals": "^1.0.1",
-            "babel-plugin-proto-to-assign": "^1.0.3",
-            "babel-plugin-react-constant-elements": "^1.0.3",
-            "babel-plugin-react-display-name": "^1.0.3",
-            "babel-plugin-remove-console": "^1.0.1",
-            "babel-plugin-remove-debugger": "^1.0.1",
-            "babel-plugin-runtime": "^1.0.7",
-            "babel-plugin-undeclared-variables-check": "^1.0.2",
-            "babel-plugin-undefined-to-void": "^1.1.6",
-            "babylon": "^5.8.38",
-            "bluebird": "^2.9.33",
-            "chalk": "^1.0.0",
-            "convert-source-map": "^1.1.0",
-            "core-js": "^1.0.0",
-            "debug": "^2.1.1",
-            "detect-indent": "^3.0.0",
-            "esutils": "^2.0.0",
-            "fs-readdir-recursive": "^0.1.0",
-            "globals": "^6.4.0",
-            "home-or-tmp": "^1.0.0",
-            "is-integer": "^1.0.4",
-            "js-tokens": "1.0.1",
-            "json5": "^0.4.0",
-            "lodash": "^3.10.0",
-            "minimatch": "^2.0.3",
-            "output-file-sync": "^1.1.0",
-            "path-exists": "^1.0.0",
-            "path-is-absolute": "^1.0.0",
-            "private": "^0.1.6",
-            "regenerator": "0.8.40",
-            "regexpu": "^1.3.0",
-            "repeating": "^1.1.2",
-            "resolve": "^1.1.6",
-            "shebang-regex": "^1.0.0",
-            "slash": "^1.0.0",
-            "source-map": "^0.5.0",
-            "source-map-support": "^0.2.10",
-            "to-fast-properties": "^1.0.0",
-            "trim-right": "^1.0.0",
-            "try-resolve": "^1.0.0"
-          }
-        },
-        "babylon": {
-          "version": "5.8.38",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
-          "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
-          "dev": true
-        },
-        "broccoli-babel-transpiler": {
-          "version": "5.7.4",
-          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.4.tgz",
-          "integrity": "sha512-gI14Pqc4qbmn5RW4SuAmybLiOoYW59D+HzQyhY6WdaGMAjikKBwJN0p17phyvafQ+kvG0mUiMd83lgHLeATnEA==",
-          "dev": true,
-          "requires": {
-            "babel-core": "^5.0.0",
-            "broccoli-funnel": "^1.0.0",
-            "broccoli-merge-trees": "^1.0.0",
-            "broccoli-persistent-filter": "^1.4.2",
-            "clone": "^0.2.0",
-            "hash-for-dep": "^1.0.2",
-            "heimdalljs-logger": "^0.1.7",
-            "json-stable-stringify": "^1.0.0",
-            "rsvp": "^3.5.0",
-            "workerpool": "^2.3.0"
-          },
-          "dependencies": {
-            "clone": {
-              "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-              "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-              "dev": true
-            }
-          }
-        },
-        "broccoli-funnel": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
-          "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
-          "dev": true,
-          "requires": {
-            "array-equal": "^1.0.0",
-            "blank-object": "^1.0.1",
-            "broccoli-plugin": "^1.3.0",
-            "debug": "^2.2.0",
-            "exists-sync": "0.0.4",
-            "fast-ordered-set": "^1.0.0",
-            "fs-tree-diff": "^0.5.3",
-            "heimdalljs": "^0.2.0",
-            "minimatch": "^3.0.0",
-            "mkdirp": "^0.5.0",
-            "path-posix": "^1.0.0",
-            "rimraf": "^2.4.3",
-            "symlink-or-copy": "^1.0.0",
-            "walk-sync": "^0.3.1"
-          },
-          "dependencies": {
-            "minimatch": {
-              "version": "3.0.4",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-              "dev": true,
-              "requires": {
-                "brace-expansion": "^1.1.7"
-              }
-            }
-          }
-        },
-        "broccoli-merge-trees": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz",
-          "integrity": "sha1-oAFRm7UGfwZYnZGvopQkRaLQ/bU=",
-          "dev": true,
-          "requires": {
-            "broccoli-plugin": "^1.3.0",
-            "can-symlink": "^1.0.0",
-            "fast-ordered-set": "^1.0.2",
-            "fs-tree-diff": "^0.5.4",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.7",
-            "rimraf": "^2.4.3",
-            "symlink-or-copy": "^1.0.0"
-          }
-        },
-        "broccoli-persistent-filter": {
-          "version": "1.4.6",
-          "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.6.tgz",
-          "integrity": "sha512-0RejLwoC95kv4kta8KAa+FmECJCK78Qgm8SRDEK7YyU0N9Cx6KpY3UCDy9WELl3mCXLN8TokNxc7/hp3lL4lfw==",
-          "dev": true,
-          "requires": {
-            "async-disk-cache": "^1.2.1",
-            "async-promise-queue": "^1.0.3",
-            "broccoli-plugin": "^1.0.0",
-            "fs-tree-diff": "^0.5.2",
-            "hash-for-dep": "^1.0.2",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.7",
-            "mkdirp": "^0.5.1",
-            "promise-map-series": "^0.2.1",
-            "rimraf": "^2.6.1",
-            "rsvp": "^3.0.18",
-            "symlink-or-copy": "^1.0.1",
-            "walk-sync": "^0.3.1"
-          }
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
-          "dev": true
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "detect-indent": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-          "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "^4.0.1",
-            "minimist": "^1.1.0",
-            "repeating": "^1.1.0"
-          }
-        },
-        "ember-cli-babel": {
-          "version": "5.2.8",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.8.tgz",
-          "integrity": "sha512-Mt9OOB5RaZwjde+LYef8EgwNVCAzsYDv4ktshblaXxr4m/Xm5/7/rxEu42RNrYkoy/qWpT9uhaD+JKK4riMf+w==",
-          "dev": true,
-          "requires": {
-            "broccoli-babel-transpiler": "^5.6.2",
-            "broccoli-funnel": "^1.0.0",
-            "clone": "^2.0.0",
-            "ember-cli-version-checker": "^1.0.2",
-            "resolve": "^1.1.2"
-          }
-        },
-        "ember-cli-version-checker": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-          "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
-          "dev": true,
-          "requires": {
-            "semver": "^5.3.0"
-          }
-        },
-        "globals": {
-          "version": "6.4.1",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
-          "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08=",
-          "dev": true
-        },
-        "home-or-tmp": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-          "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "^1.0.1",
-            "user-home": "^1.1.1"
-          }
-        },
-        "js-tokens": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz",
-          "integrity": "sha1-zENaXIuUrRWst5gxQPyAGCyJrq4=",
-          "dev": true
-        },
-        "json5": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-          "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "2.0.10",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        },
-        "path-exists": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-          "integrity": "sha1-1aiZjrce83p0w06w2eum6HjuoIE=",
-          "dev": true
-        },
-        "repeating": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-          "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-          "dev": true,
-          "requires": {
-            "is-finite": "^1.0.0"
-          }
-        },
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "dev": true
-        },
-        "source-map-support": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
-          "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
-          "dev": true,
-          "requires": {
-            "source-map": "0.1.32"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.1.32",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-              "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-              "dev": true,
-              "requires": {
-                "amdefine": ">=0.0.4"
-              }
-            }
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        },
-        "to-fast-properties": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-          "dev": true
-        },
-        "workerpool": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.3.tgz",
-          "integrity": "sha512-L1ovlYHp6UObYqElXXpbd214GgbEKDED0d3sj7pRdFXjNkb2+un/AUcCkceHizO0IVI6SOGGncrcjozruCkRgA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "4.1.1"
-          }
-        }
-      }
-    },
     "ember-cli": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/ember-cli/-/ember-cli-3.8.3.tgz",
@@ -7370,9 +6740,9 @@
       }
     },
     "ember-cli-babel": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.8.0.tgz",
-      "integrity": "sha512-xUBgJQ81fqd7k/KIiGU+pjpoXhrmmRf9pUrqLenNSU5N+yeNFT5a1+w0b+p1F7oBphfXVwuxApdZxrmAHOdA3Q==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.10.0.tgz",
+      "integrity": "sha512-eNgPXobC+Pke5L3XzoJ0BXbb2+eYzZI+LljqbwXNuG4q63pF000aARFpTQ0p/NWkfGQxKi2L6tVIa1ZOYdQS+A==",
       "requires": {
         "@babel/core": "^7.0.0",
         "@babel/plugin-proposal-class-properties": "^7.3.4",
@@ -7384,7 +6754,7 @@
         "@babel/runtime": "^7.2.0",
         "amd-name-resolver": "^1.2.1",
         "babel-plugin-debug-macros": "^0.3.0",
-        "babel-plugin-ember-modules-api-polyfill": "^2.9.0",
+        "babel-plugin-ember-modules-api-polyfill": "^2.11.0",
         "babel-plugin-module-resolver": "^3.1.1",
         "broccoli-babel-transpiler": "^7.1.2",
         "broccoli-debug": "^0.6.4",
@@ -7475,6 +6845,12 @@
           "version": "5.8.38",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
           "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
+          "dev": true
+        },
+        "bluebird": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
           "dev": true
         },
         "broccoli-babel-transpiler": {
@@ -8097,6 +7473,12 @@
           "version": "5.8.38",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
           "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
+          "dev": true
+        },
+        "bluebird": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
           "dev": true
         },
         "broccoli-babel-transpiler": {
@@ -9472,145 +8854,6 @@
         "lodash.defaultsdeep": "^4.6.0"
       }
     },
-    "ember-cli-update": {
-      "version": "0.34.13",
-      "resolved": "https://registry.npmjs.org/ember-cli-update/-/ember-cli-update-0.34.13.tgz",
-      "integrity": "sha512-KdU/2dyrtpNdEogwEPOrZvPfuCSflbtUvGL5HxS4Y9kMxqvRGcncZopH16El3Jd6XhL8faIygajvd9gT4JD+Gw==",
-      "dev": true,
-      "requires": {
-        "boilerplate-update": "0.22.6",
-        "debug": "^4.1.1",
-        "fs-extra": "^8.0.0",
-        "resolve": "^1.10.0",
-        "semver": "^6.0.0",
-        "update-notifier": "^3.0.0",
-        "which": "^1.3.1",
-        "yargs": "^13.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "cliui": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-          "dev": true,
-          "requires": {
-            "string-width": "^3.1.0",
-            "strip-ansi": "^5.2.0",
-            "wrap-ansi": "^5.1.0"
-          }
-        },
-        "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "fs-extra": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-          "dev": true
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        },
-        "y18n": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-          "dev": true
-        },
-        "yargs": {
-          "version": "13.3.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
-          "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
-          "dev": true,
-          "requires": {
-            "cliui": "^5.0.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^2.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^3.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^13.1.1"
-          }
-        }
-      }
-    },
     "ember-cli-version-checker": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
@@ -10247,6 +9490,48 @@
         "silent-error": "^1.1.1"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "9.6.50",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.50.tgz",
+          "integrity": "sha512-9Yzqn2NzJxwFzon4W+aqUAMl3FiVnJ965f5F3H5T+EpUrHqb2Is1SPp/lsj2WFBqXrhIINJ5SzSwneLMg5PgSQ==",
+          "dev": true
+        },
+        "acorn": {
+          "version": "5.7.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+          "dev": true
+        },
+        "broccoli-rollup": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/broccoli-rollup/-/broccoli-rollup-2.1.1.tgz",
+          "integrity": "sha512-aky/Ovg5DbsrsJEx2QCXxHLA6ZR+9u1TNVTf85soP4gL8CjGGKQ/JU8R3BZ2ntkWzo6/83RCKzX6O+nlNKR5MQ==",
+          "dev": true,
+          "requires": {
+            "@types/node": "^9.6.0",
+            "amd-name-resolver": "^1.2.0",
+            "broccoli-plugin": "^1.2.1",
+            "fs-tree-diff": "^0.5.2",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.7",
+            "magic-string": "^0.24.0",
+            "node-modules-path": "^1.0.1",
+            "rollup": "^0.57.1",
+            "symlink-or-copy": "^1.1.8",
+            "walk-sync": "^0.3.1"
+          },
+          "dependencies": {
+            "heimdalljs": {
+              "version": "0.2.6",
+              "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.2.6.tgz",
+              "integrity": "sha512-o9bd30+5vLBvBtzCPwwGqpry2+n0Hi6H1+qwt6y+0kwRHGGF8TFIhJPmnuM0xO97zaKrDZMwO/V56fAnn8m/tA==",
+              "dev": true,
+              "requires": {
+                "rsvp": "~3.2.1"
+              }
+            }
+          }
+        },
         "heimdalljs": {
           "version": "0.3.3",
           "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.3.3.tgz",
@@ -10254,6 +9539,25 @@
           "dev": true,
           "requires": {
             "rsvp": "~3.2.1"
+          }
+        },
+        "rollup": {
+          "version": "0.57.1",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.57.1.tgz",
+          "integrity": "sha512-I18GBqP0qJoJC1K1osYjreqA8VAKovxuI3I81RSk0Dmr4TgloI0tAULjZaox8OsJ+n7XRrhH6i0G2By/pj1LCA==",
+          "dev": true,
+          "requires": {
+            "@types/acorn": "^4.0.3",
+            "acorn": "^5.5.3",
+            "acorn-dynamic-import": "^3.0.0",
+            "date-time": "^2.1.0",
+            "is-reference": "^1.1.0",
+            "locate-character": "^2.0.5",
+            "pretty-ms": "^3.1.0",
+            "require-relative": "^0.8.7",
+            "rollup-pluginutils": "^2.0.1",
+            "signal-exit": "^3.0.2",
+            "sourcemap-codec": "^1.4.1"
           }
         },
         "rsvp": {
@@ -11064,6 +10368,12 @@
           "version": "5.8.38",
           "resolved": "http://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
           "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
+          "dev": true
+        },
+        "bluebird": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
           "dev": true
         },
         "broccoli-babel-transpiler": {
@@ -13428,13 +12738,12 @@
       }
     },
     "ember-promise-helpers": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/ember-promise-helpers/-/ember-promise-helpers-1.0.8.tgz",
-      "integrity": "sha512-zfPFBjqXCI/hk3Vdx8tSVNOuccbbJucmOQQqL+hmrtzxPl2tg1RQ2Y63XBHyYuYDHR/OoW8uixOuYE4RRjH9ig==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/ember-promise-helpers/-/ember-promise-helpers-1.0.9.tgz",
+      "integrity": "sha512-BDcx2X28baEL0YMKSmDGQzvdyfiFSlx4Byf34hVrAw6W7VO17YYLjeXPebVBOXLA1BMWmUo0Bb2pZRZ09MQYYA==",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "^6.16.0",
-        "ember-cli-update": "^0.34.10"
+        "ember-cli-babel": "^6.16.0"
       },
       "dependencies": {
         "amd-name-resolver": {
@@ -13945,9 +13254,9 @@
       }
     },
     "ember-resolver": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ember-resolver/-/ember-resolver-5.2.0.tgz",
-      "integrity": "sha512-vL7YnifeHA2g6OM3KF7PSCIcUBvPISfcxByqGmWgjynbZpd3KmBUpHVxAlqXUYqhO4viRcM0sohAgZ41bCv7QQ==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ember-resolver/-/ember-resolver-5.2.1.tgz",
+      "integrity": "sha512-Ciz5qsrtILr7AGXO9mTSFs3/XKXpMYJqISNCfvIY0C8PlMgq+9RYbmUoBpAlvBUc/mUi3ORZKJ4csd9qchvxZw==",
       "dev": true,
       "requires": {
         "@glimmer/resolver": "^0.4.1",
@@ -14234,9 +13543,9 @@
       }
     },
     "ember-rfc176-data": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.9.tgz",
-      "integrity": "sha512-EiTo5YQS0Duy0xp9gCP8ekzv9vxirNi7MnIB4zWs+thtWp/mEKgf5mkiiLU2+oo8C5DuavVHhoPQDmyxh8Io1Q=="
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.11.tgz",
+      "integrity": "sha512-c46uisicHswFHo0R515LPM0L/X/Ju+N7KonJPuHx9C6cWD3AWzkNG9ASv+Bc85mq/9l3LFFsFpljdM1m2YnQ6A=="
     },
     "ember-router-generator": {
       "version": "1.2.3",
@@ -14851,9 +14160,9 @@
       }
     },
     "ember-template-lint": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/ember-template-lint/-/ember-template-lint-1.5.1.tgz",
-      "integrity": "sha512-/n5o6KnDADGPg2/OuzrNR/u2w8WIfEjfJhESVw4DAS6jaF8uO0WZrNI60RvmM4Rp813iX5p8pp1dVUUz4Euy7w==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/ember-template-lint/-/ember-template-lint-1.5.2.tgz",
+      "integrity": "sha512-uAGmYrIHoBS8jjmvb2SNprX5zPEs647amO+OHT0OtrO1HjFnhS4GyOXH2xx6h38co65WpPll0o3HFyE4cEh0NA==",
       "dev": true,
       "requires": {
         "@glimmer/compiler": "^0.41.0",
@@ -15462,79 +14771,6 @@
         "remote-git-tags": "^2.0.0",
         "rsvp": "^4.8.1",
         "semver": "^5.5.0"
-      },
-      "dependencies": {
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-          "dev": true
-        },
-        "got": {
-          "version": "6.7.1",
-          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-          "dev": true,
-          "requires": {
-            "create-error-class": "^3.0.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^3.0.0",
-            "is-redirect": "^1.0.0",
-            "is-retry-allowed": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "lowercase-keys": "^1.0.0",
-            "safe-buffer": "^5.0.1",
-            "timed-out": "^4.0.0",
-            "unzip-response": "^2.0.1",
-            "url-parse-lax": "^1.0.0"
-          }
-        },
-        "package-json": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
-          "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
-          "dev": true,
-          "requires": {
-            "got": "^6.7.1",
-            "registry-auth-token": "^3.0.1",
-            "registry-url": "^3.0.3",
-            "semver": "^5.1.0"
-          }
-        },
-        "prepend-http": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-          "dev": true
-        },
-        "registry-auth-token": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
-          "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
-          "dev": true,
-          "requires": {
-            "rc": "^1.1.6",
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "registry-url": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-          "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-          "dev": true,
-          "requires": {
-            "rc": "^1.0.1"
-          }
-        },
-        "url-parse-lax": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-          "dev": true,
-          "requires": {
-            "prepend-http": "^1.0.1"
-          }
-        }
       }
     },
     "ember-uuid": {
@@ -16088,9 +15324,9 @@
       "dev": true
     },
     "emoji-regex": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
     "emojis-list": {
@@ -16284,9 +15520,9 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
-      "integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
+      "integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
       "dev": true,
       "requires": {
         "esprima": "^3.1.3",
@@ -16383,16 +15619,6 @@
             "ms": "^2.1.1"
           }
         },
-        "lru-cache": {
-          "version": "4.1.5",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-          "dev": true,
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          }
-        },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -16401,12 +15627,6 @@
           "requires": {
             "ansi-regex": "^3.0.0"
           }
-        },
-        "yallist": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-          "dev": true
         }
       }
     },
@@ -16497,9 +15717,9 @@
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
       "dev": true
     },
     "esm": {
@@ -16516,12 +15736,20 @@
       "requires": {
         "acorn": "^5.5.0",
         "acorn-jsx": "^3.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.7.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+          "dev": true
+        }
       }
     },
-    "esprima-fb": {
-      "version": "15001.1001.0-dev-harmony-fb",
-      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
-      "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
     "esquery": {
@@ -16543,9 +15771,9 @@
       }
     },
     "estraverse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true
     },
     "estree-walker": {
@@ -16861,12 +16089,6 @@
             "is-data-descriptor": "^1.0.0",
             "kind-of": "^6.0.2"
           }
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
         }
       }
     },
@@ -17308,31 +16530,6 @@
         }
       }
     },
-    "fixturify": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fixturify/-/fixturify-1.2.0.tgz",
-      "integrity": "sha512-b5CMQmBZKsGR6HGqdSrLOGYGHIqrR0CUrcGU/lDL0mYy+DtGm5cnb61Z0UiIUqMVZIoV0CbN+u9/Gwjj+ICg0A==",
-      "dev": true,
-      "requires": {
-        "@types/fs-extra": "^5.0.5",
-        "@types/minimatch": "^3.0.3",
-        "@types/rimraf": "^2.0.2",
-        "fs-extra": "^7.0.1",
-        "matcher-collection": "^2.0.0"
-      },
-      "dependencies": {
-        "matcher-collection": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.0.tgz",
-          "integrity": "sha512-wSi4BgQGTFfBN5J+pIaS78rEKk4qIkjrw+NfJYdHsd2cRVIQsbDi3BZtNAXTFA2WHvlbS9kLGtTjv3cPJKuRSw==",
-          "dev": true,
-          "requires": {
-            "@types/minimatch": "^3.0.3",
-            "minimatch": "^3.0.2"
-          }
-        }
-      }
-    },
     "flat-cache": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
@@ -17343,6 +16540,17 @@
         "graceful-fs": "^4.1.2",
         "rimraf": "~2.6.2",
         "write": "^0.2.1"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "flush-write-stream": {
@@ -18186,147 +17394,6 @@
         }
       }
     },
-    "git-diff-apply": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/git-diff-apply/-/git-diff-apply-0.19.1.tgz",
-      "integrity": "sha512-cIV8vzH7Qpgji3ltFJFCR9r6IBvCo0ZGmt1aY8NvSVl4LtGwMQQqtxDnVUbSNZSLiBhpd6RcqXSh14YcUs2XKQ==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.0.0",
-        "fixturify": "^1.0.0",
-        "fs-extra": "^8.0.0",
-        "klaw": "^3.0.0",
-        "tmp": "0.1.0",
-        "uuid": "^3.1.0",
-        "yargs": "^13.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "cliui": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-          "dev": true,
-          "requires": {
-            "string-width": "^3.1.0",
-            "strip-ansi": "^5.2.0",
-            "wrap-ansi": "^5.1.0"
-          }
-        },
-        "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "fs-extra": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        },
-        "tmp": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-          "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
-          "dev": true,
-          "requires": {
-            "rimraf": "^2.6.3"
-          }
-        },
-        "y18n": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-          "dev": true
-        },
-        "yargs": {
-          "version": "13.3.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
-          "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
-          "dev": true,
-          "requires": {
-            "cliui": "^5.0.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^2.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^3.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^13.1.1"
-          }
-        }
-      }
-    },
     "git-fetch-pack": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/git-fetch-pack/-/git-fetch-pack-0.1.1.tgz",
@@ -18456,15 +17523,6 @@
       "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
       "dev": true
     },
-    "global-dirs": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
-      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
-      "dev": true,
-      "requires": {
-        "ini": "^1.3.4"
-      }
-    },
     "global-modules": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
@@ -18573,9 +17631,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.1.tgz",
-      "integrity": "sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+      "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
       "dev": true
     },
     "graceful-readlink": {
@@ -18756,12 +17814,6 @@
         }
       }
     },
-    "has-yarn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
-      "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
-      "dev": true
-    },
     "hash-base": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
@@ -18900,13 +17952,10 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.2.tgz",
-      "integrity": "sha512-CyjlXII6LMsPMyUzxpTt8fzh5QwzGqPmQXgY/Jyf4Zfp27t/FvfhwoE/8laaMUcMy816CkWF20I7NeQhwwY88w==",
-      "dev": true,
-      "requires": {
-        "lru-cache": "^5.1.1"
-      }
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
+      "integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
+      "dev": true
     },
     "html-encoding-sniffer": {
       "version": "1.0.2",
@@ -19011,12 +18060,6 @@
       "integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=",
       "dev": true,
       "optional": true
-    },
-    "import-lazy": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
-      "dev": true
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -19184,6 +18227,17 @@
       "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "is-binary-path": {
@@ -19207,15 +18261,6 @@
       "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
       "dev": true
     },
-    "is-ci": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
-      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
-      "dev": true,
-      "requires": {
-        "ci-info": "^2.0.0"
-      }
-    },
     "is-data-descriptor": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
@@ -19223,6 +18268,17 @@
       "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "is-date-object": {
@@ -19291,16 +18347,6 @@
         "is-extglob": "^2.1.0"
       }
     },
-    "is-installed-globally": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
-      "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
-      "dev": true,
-      "requires": {
-        "global-dirs": "^0.1.0",
-        "is-path-inside": "^1.0.0"
-      }
-    },
     "is-integer": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.7.tgz",
@@ -19310,12 +18356,6 @@
         "is-finite": "^1.0.0"
       }
     },
-    "is-npm": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-3.0.0.tgz",
-      "integrity": "sha512-wsigDr1Kkschp2opC4G3yA6r9EgVA6NjRpWzIi9axXqeIaAATPRJc4uLujXe3Nd9uO8KoDyA4MD6aZSeXTADhA==",
-      "dev": true
-    },
     "is-number": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -19323,6 +18363,17 @@
       "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "is-obj": {
@@ -19336,15 +18387,6 @@
       "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
       "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
       "dev": true
-    },
-    "is-path-inside": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-      "dev": true,
-      "requires": {
-        "path-is-inside": "^1.0.1"
-      }
     },
     "is-plain-obj": {
       "version": "1.1.0",
@@ -19377,6 +18419,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.1.3.tgz",
       "integrity": "sha512-W1iHHv/oyBb2pPxkBxtaewxa1BC58Pn5J0hogyCdefwUIvb6R+TGbAcIa4qPNYLqLhb3EnOgUf2MQkkF76BcKw==",
+      "dev": true,
       "requires": {
         "@types/estree": "0.0.39"
       }
@@ -19442,12 +18485,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
       "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
-      "dev": true
-    },
-    "is-yarn-global": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
-      "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
       "dev": true
     },
     "isarray": {
@@ -19539,14 +18576,6 @@
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-          "dev": true
-        }
       }
     },
     "jsbn": {
@@ -19588,12 +18617,6 @@
         "xml-name-validator": "^3.0.0"
       },
       "dependencies": {
-        "acorn": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
-          "integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
-          "dev": true
-        },
         "ajv": {
           "version": "6.10.2",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
@@ -19847,31 +18870,10 @@
       }
     },
     "kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
-      "requires": {
-        "is-buffer": "^1.1.5"
-      }
-    },
-    "klaw": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
-      "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.9"
-      }
-    },
-    "latest-version": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
-      "integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
-      "dev": true,
-      "requires": {
-        "package-json": "^6.3.0"
-      }
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "dev": true
     },
     "layout-bin-packer": {
       "version": "1.5.0",
@@ -20498,7 +19500,8 @@
     "locate-character": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-2.0.5.tgz",
-      "integrity": "sha512-n2GmejDXtOPBAZdIiEFy5dJ5N38xBCXLNOtw2WpB9kGh6pnrEuKlwYI+Tkpofc4wDtVXHtoAOJaMRlYG/oYaxg=="
+      "integrity": "sha512-n2GmejDXtOPBAZdIiEFy5dJ5N38xBCXLNOtw2WpB9kGh6pnrEuKlwYI+Tkpofc4wDtVXHtoAOJaMRlYG/oYaxg==",
+      "dev": true
     },
     "locate-path": {
       "version": "2.0.0",
@@ -20822,18 +19825,28 @@
       "dev": true
     },
     "lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "dev": true,
       "requires": {
-        "yallist": "^3.0.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "dev": true
+        }
       }
     },
     "magic-string": {
       "version": "0.24.1",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.24.1.tgz",
       "integrity": "sha512-YBfNxbJiixMzxW40XqJEIldzHyh5f7CZKalo1uZffevyrPEX8Qgo9s0dmcORLHdV47UyvJg8/zD+6hQG3qvJrA==",
+      "dev": true,
       "requires": {
         "sourcemap-codec": "^1.4.1"
       }
@@ -21006,22 +20019,6 @@
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true
     },
-    "merge-package.json": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/merge-package.json/-/merge-package.json-3.0.2.tgz",
-      "integrity": "sha512-Aj8UmsAZ3z/Cn1xxU4ch2uVC1kqTLfWLliHwTI9GMAK8Eskz8WxyyDaBZCY4XXJSEUjwScKoSmiOG+DDx4NPUg==",
-      "dev": true,
-      "requires": {
-        "rfc6902-ordered": "^4.0.0",
-        "three-way-merger": "0.5.7"
-      }
-    },
-    "merge-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true
-    },
     "merge-trees": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-2.0.0.tgz",
@@ -21062,14 +20059,6 @@
         "regex-not": "^1.0.0",
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
-        }
       }
     },
     "miller-rabin": {
@@ -21351,14 +20340,6 @@
         "regex-not": "^1.0.0",
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.1"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
-        }
       }
     },
     "natural-compare": {
@@ -21495,9 +20476,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.26",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
-      "integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
+      "version": "1.1.27",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.27.tgz",
+      "integrity": "sha512-9iXUqHKSGo6ph/tdXVbHFbhRVQln4ZDTIBJCzsa90HimnBYc5jw8RWYt4wBYFHehGyC3koIz5O4mb2fHrbPOuA==",
       "requires": {
         "semver": "^5.3.0"
       }
@@ -21569,3866 +20550,6 @@
         "set-blocking": "~2.0.0"
       }
     },
-    "npx": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/npx/-/npx-10.2.0.tgz",
-      "integrity": "sha512-DqjFkzET0DeaXYXNJnirnvEovwk4lBa33ZQCw1jxMuas4yH9jdU8q2U8L3cLaB2UqzgmW2Ssqk8lcGiPRL8pRg==",
-      "dev": true,
-      "requires": {
-        "libnpx": "10.2.0",
-        "npm": "5.1.0"
-      },
-      "dependencies": {
-        "ansi-align": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "string-width": "^2.0.0"
-          }
-        },
-        "ansi-regex": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "boxen": {
-          "version": "1.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-align": "^2.0.0",
-            "camelcase": "^4.0.0",
-            "chalk": "^2.0.1",
-            "cli-boxes": "^1.0.0",
-            "string-width": "^2.0.0",
-            "term-size": "^1.2.0",
-            "widest-line": "^2.0.0"
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "builtins": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "camelcase": {
-          "version": "4.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "capture-stack-trace": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "chalk": {
-          "version": "2.3.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "ci-info": {
-          "version": "1.1.3",
-          "bundled": true,
-          "dev": true
-        },
-        "cli-boxes": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "cliui": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0",
-            "wrap-ansi": "^2.0.0"
-          }
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "color-convert": {
-          "version": "1.9.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color-name": "^1.1.1"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "bundled": true,
-          "dev": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "configstore": {
-          "version": "3.1.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dot-prop": "^4.1.0",
-            "graceful-fs": "^4.1.2",
-            "make-dir": "^1.0.0",
-            "unique-string": "^1.0.0",
-            "write-file-atomic": "^2.0.0",
-            "xdg-basedir": "^3.0.0"
-          }
-        },
-        "create-error-class": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "capture-stack-trace": "^1.0.0"
-          }
-        },
-        "cross-spawn": {
-          "version": "5.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
-        "crypto-random-string": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "decamelize": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "bundled": true,
-          "dev": true
-        },
-        "dot-prop": {
-          "version": "4.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-obj": "^1.0.0"
-          }
-        },
-        "dotenv": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "duplexer3": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true
-        },
-        "execa": {
-          "version": "0.7.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          }
-        },
-        "find-up": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "get-caller-file": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "get-stream": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "global-dirs": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ini": "^1.3.4"
-          }
-        },
-        "got": {
-          "version": "6.7.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "create-error-class": "^3.0.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^3.0.0",
-            "is-redirect": "^1.0.0",
-            "is-retry-allowed": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "lowercase-keys": "^1.0.0",
-            "safe-buffer": "^5.0.1",
-            "timed-out": "^4.0.0",
-            "unzip-response": "^2.0.1",
-            "url-parse-lax": "^1.0.0"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true,
-          "dev": true
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "hosted-git-info": {
-          "version": "2.6.0",
-          "bundled": true,
-          "dev": true
-        },
-        "import-lazy": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "imurmurhash": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "ini": {
-          "version": "1.3.5",
-          "bundled": true,
-          "dev": true
-        },
-        "invert-kv": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-ci": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ci-info": "^1.0.0"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-installed-globally": {
-          "version": "0.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "global-dirs": "^0.1.0",
-            "is-path-inside": "^1.0.0"
-          }
-        },
-        "is-npm": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-obj": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "is-path-inside": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "path-is-inside": "^1.0.1"
-          }
-        },
-        "is-redirect": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-retry-allowed": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "isexe": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "latest-version": {
-          "version": "3.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "package-json": "^4.0.0"
-          }
-        },
-        "lcid": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "invert-kv": "^1.0.0"
-          }
-        },
-        "libnpx": {
-          "version": "10.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dotenv": "^5.0.1",
-            "npm-package-arg": "^6.0.0",
-            "rimraf": "^2.6.2",
-            "safe-buffer": "^5.1.0",
-            "update-notifier": "^2.3.0",
-            "which": "^1.3.0",
-            "y18n": "^4.0.0",
-            "yargs": "^11.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "lowercase-keys": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "lru-cache": {
-          "version": "4.1.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          }
-        },
-        "make-dir": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "pify": "^3.0.0"
-          }
-        },
-        "mem": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^1.0.0"
-          }
-        },
-        "mimic-fn": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "npm": {
-          "version": "5.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "JSONStream": "~1.3.1",
-            "abbrev": "~1.1.0",
-            "ansi-regex": "~3.0.0",
-            "ansicolors": "~0.3.2",
-            "ansistyles": "~0.1.3",
-            "aproba": "~1.1.2",
-            "archy": "~1.0.0",
-            "bluebird": "~3.5.0",
-            "cacache": "~9.2.9",
-            "call-limit": "~1.1.0",
-            "chownr": "~1.0.1",
-            "cmd-shim": "~2.0.2",
-            "columnify": "~1.5.4",
-            "config-chain": "~1.1.11",
-            "debuglog": "*",
-            "detect-indent": "~5.0.0",
-            "dezalgo": "~1.0.3",
-            "editor": "~1.0.0",
-            "fs-vacuum": "~1.2.10",
-            "fs-write-stream-atomic": "~1.0.10",
-            "fstream": "~1.0.11",
-            "fstream-npm": "~1.2.1",
-            "glob": "~7.1.2",
-            "graceful-fs": "~4.1.11",
-            "has-unicode": "~2.0.1",
-            "hosted-git-info": "~2.5.0",
-            "iferr": "~0.1.5",
-            "imurmurhash": "*",
-            "inflight": "~1.0.6",
-            "inherits": "~2.0.3",
-            "ini": "~1.3.4",
-            "init-package-json": "~1.10.1",
-            "lazy-property": "~1.0.0",
-            "lockfile": "~1.0.3",
-            "lodash._baseindexof": "*",
-            "lodash._baseuniq": "~4.6.0",
-            "lodash._bindcallback": "*",
-            "lodash._cacheindexof": "*",
-            "lodash._createcache": "*",
-            "lodash._getnative": "*",
-            "lodash.clonedeep": "~4.5.0",
-            "lodash.restparam": "*",
-            "lodash.union": "~4.6.0",
-            "lodash.uniq": "~4.5.0",
-            "lodash.without": "~4.4.0",
-            "lru-cache": "~4.1.1",
-            "mississippi": "~1.3.0",
-            "mkdirp": "~0.5.1",
-            "move-concurrently": "~1.0.1",
-            "node-gyp": "~3.6.2",
-            "nopt": "~4.0.1",
-            "normalize-package-data": "~2.4.0",
-            "npm-cache-filename": "~1.0.2",
-            "npm-install-checks": "~3.0.0",
-            "npm-package-arg": "~5.1.2",
-            "npm-registry-client": "~8.4.0",
-            "npm-user-validate": "~1.0.0",
-            "npmlog": "~4.1.2",
-            "once": "~1.4.0",
-            "opener": "~1.4.3",
-            "osenv": "~0.1.4",
-            "pacote": "~2.7.38",
-            "path-is-inside": "~1.0.2",
-            "promise-inflight": "~1.0.1",
-            "read": "~1.0.7",
-            "read-cmd-shim": "~1.0.1",
-            "read-installed": "~4.0.3",
-            "read-package-json": "~2.0.9",
-            "read-package-tree": "~5.1.6",
-            "readable-stream": "~2.3.2",
-            "readdir-scoped-modules": "*",
-            "request": "~2.81.0",
-            "retry": "~0.10.1",
-            "rimraf": "~2.6.1",
-            "safe-buffer": "~5.1.1",
-            "semver": "~5.3.0",
-            "sha": "~2.0.1",
-            "slide": "~1.1.6",
-            "sorted-object": "~2.0.1",
-            "sorted-union-stream": "~2.1.3",
-            "ssri": "~4.1.6",
-            "strip-ansi": "~4.0.0",
-            "tar": "~2.2.1",
-            "text-table": "~0.2.0",
-            "uid-number": "0.0.6",
-            "umask": "~1.1.0",
-            "unique-filename": "~1.1.0",
-            "unpipe": "~1.0.0",
-            "update-notifier": "~2.2.0",
-            "uuid": "~3.1.0",
-            "validate-npm-package-license": "*",
-            "validate-npm-package-name": "~3.0.0",
-            "which": "~1.2.14",
-            "worker-farm": "~1.3.1",
-            "wrappy": "~1.0.2",
-            "write-file-atomic": "~2.1.0"
-          },
-          "dependencies": {
-            "JSONStream": {
-              "version": "1.3.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "jsonparse": "^1.2.0",
-                "through": ">=2.2.7 <3"
-              },
-              "dependencies": {
-                "jsonparse": {
-                  "version": "1.3.1",
-                  "bundled": true,
-                  "dev": true
-                },
-                "through": {
-                  "version": "2.3.8",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "abbrev": {
-              "version": "1.1.0",
-              "bundled": true,
-              "dev": true
-            },
-            "ansi-regex": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "ansicolors": {
-              "version": "0.3.2",
-              "bundled": true,
-              "dev": true
-            },
-            "ansistyles": {
-              "version": "0.1.3",
-              "bundled": true,
-              "dev": true
-            },
-            "aproba": {
-              "version": "1.1.2",
-              "bundled": true,
-              "dev": true
-            },
-            "archy": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "bluebird": {
-              "version": "3.5.0",
-              "bundled": true,
-              "dev": true
-            },
-            "cacache": {
-              "version": "9.2.9",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "bluebird": "^3.5.0",
-                "chownr": "^1.0.1",
-                "glob": "^7.1.2",
-                "graceful-fs": "^4.1.11",
-                "lru-cache": "^4.1.1",
-                "mississippi": "^1.3.0",
-                "mkdirp": "^0.5.1",
-                "move-concurrently": "^1.0.1",
-                "promise-inflight": "^1.0.1",
-                "rimraf": "^2.6.1",
-                "ssri": "^4.1.6",
-                "unique-filename": "^1.1.0",
-                "y18n": "^3.2.1"
-              },
-              "dependencies": {
-                "lru-cache": {
-                  "version": "4.1.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "pseudomap": "^1.0.2",
-                    "yallist": "^2.1.2"
-                  },
-                  "dependencies": {
-                    "pseudomap": {
-                      "version": "1.0.2",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "yallist": {
-                      "version": "2.1.2",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "y18n": {
-                  "version": "3.2.1",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "call-limit": {
-              "version": "1.1.0",
-              "bundled": true,
-              "dev": true
-            },
-            "chownr": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "cmd-shim": {
-              "version": "2.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "mkdirp": "~0.5.0"
-              }
-            },
-            "columnify": {
-              "version": "1.5.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "strip-ansi": "^3.0.0",
-                "wcwidth": "^1.0.0"
-              },
-              "dependencies": {
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "ansi-regex": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.1.1",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "wcwidth": {
-                  "version": "1.0.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "defaults": "^1.0.3"
-                  },
-                  "dependencies": {
-                    "defaults": {
-                      "version": "1.0.3",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "clone": "^1.0.2"
-                      },
-                      "dependencies": {
-                        "clone": {
-                          "version": "1.0.2",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "config-chain": {
-              "version": "1.1.11",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ini": "^1.3.4",
-                "proto-list": "~1.2.1"
-              },
-              "dependencies": {
-                "proto-list": {
-                  "version": "1.2.4",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "debuglog": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "detect-indent": {
-              "version": "5.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "dezalgo": {
-              "version": "1.0.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "asap": "^2.0.0",
-                "wrappy": "1"
-              },
-              "dependencies": {
-                "asap": {
-                  "version": "2.0.5",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "editor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "fs-vacuum": {
-              "version": "1.2.10",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "path-is-inside": "^1.0.1",
-                "rimraf": "^2.5.2"
-              }
-            },
-            "fs-write-stream-atomic": {
-              "version": "1.0.10",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "iferr": "^0.1.5",
-                "imurmurhash": "^0.1.4",
-                "readable-stream": "1 || 2"
-              }
-            },
-            "fstream": {
-              "version": "1.0.11",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "inherits": "~2.0.0",
-                "mkdirp": ">=0.5 0",
-                "rimraf": "2"
-              }
-            },
-            "fstream-npm": {
-              "version": "1.2.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "fstream-ignore": "^1.0.0",
-                "inherits": "2"
-              },
-              "dependencies": {
-                "fstream-ignore": {
-                  "version": "1.0.5",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "fstream": "^1.0.0",
-                    "inherits": "2",
-                    "minimatch": "^3.0.0"
-                  },
-                  "dependencies": {
-                    "minimatch": {
-                      "version": "3.0.4",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "brace-expansion": "^1.1.7"
-                      },
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.8",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "balanced-match": "^1.0.0",
-                            "concat-map": "0.0.1"
-                          },
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "1.0.0",
-                              "bundled": true,
-                              "dev": true
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "glob": {
-              "version": "7.1.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              },
-              "dependencies": {
-                "fs.realpath": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "dev": true
-                },
-                "minimatch": {
-                  "version": "3.0.4",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "brace-expansion": "^1.1.7"
-                  },
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.8",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "balanced-match": "^1.0.0",
-                        "concat-map": "0.0.1"
-                      },
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.1",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "graceful-fs": {
-              "version": "4.1.11",
-              "bundled": true,
-              "dev": true
-            },
-            "has-unicode": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "hosted-git-info": {
-              "version": "2.5.0",
-              "bundled": true,
-              "dev": true
-            },
-            "iferr": {
-              "version": "0.1.5",
-              "bundled": true,
-              "dev": true
-            },
-            "imurmurhash": {
-              "version": "0.1.4",
-              "bundled": true,
-              "dev": true
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "bundled": true,
-              "dev": true
-            },
-            "ini": {
-              "version": "1.3.4",
-              "bundled": true,
-              "dev": true
-            },
-            "init-package-json": {
-              "version": "1.10.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "glob": "^7.1.1",
-                "npm-package-arg": "^4.0.0 || ^5.0.0",
-                "promzard": "^0.3.0",
-                "read": "~1.0.1",
-                "read-package-json": "1 || 2",
-                "semver": "2.x || 3.x || 4 || 5",
-                "validate-npm-package-license": "^3.0.1",
-                "validate-npm-package-name": "^3.0.0"
-              },
-              "dependencies": {
-                "promzard": {
-                  "version": "0.3.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "read": "1"
-                  }
-                }
-              }
-            },
-            "lazy-property": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "lockfile": {
-              "version": "1.0.3",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash._baseindexof": {
-              "version": "3.1.0",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash._baseuniq": {
-              "version": "4.6.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "lodash._createset": "~4.0.0",
-                "lodash._root": "~3.0.0"
-              },
-              "dependencies": {
-                "lodash._createset": {
-                  "version": "4.0.3",
-                  "bundled": true,
-                  "dev": true
-                },
-                "lodash._root": {
-                  "version": "3.0.1",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "lodash._bindcallback": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash._cacheindexof": {
-              "version": "3.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash._createcache": {
-              "version": "3.1.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "lodash._getnative": "^3.0.0"
-              }
-            },
-            "lodash._getnative": {
-              "version": "3.9.1",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash.clonedeep": {
-              "version": "4.5.0",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash.restparam": {
-              "version": "3.6.1",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash.union": {
-              "version": "4.6.0",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash.uniq": {
-              "version": "4.5.0",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash.without": {
-              "version": "4.4.0",
-              "bundled": true,
-              "dev": true
-            },
-            "lru-cache": {
-              "version": "4.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "pseudomap": "^1.0.2",
-                "yallist": "^2.1.2"
-              },
-              "dependencies": {
-                "pseudomap": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "dev": true
-                },
-                "yallist": {
-                  "version": "2.1.2",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "mississippi": {
-              "version": "1.3.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "concat-stream": "^1.5.0",
-                "duplexify": "^3.4.2",
-                "end-of-stream": "^1.1.0",
-                "flush-write-stream": "^1.0.0",
-                "from2": "^2.1.0",
-                "parallel-transform": "^1.1.0",
-                "pump": "^1.0.0",
-                "pumpify": "^1.3.3",
-                "stream-each": "^1.1.0",
-                "through2": "^2.0.0"
-              },
-              "dependencies": {
-                "concat-stream": {
-                  "version": "1.6.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "inherits": "^2.0.3",
-                    "readable-stream": "^2.2.2",
-                    "typedarray": "^0.0.6"
-                  },
-                  "dependencies": {
-                    "typedarray": {
-                      "version": "0.0.6",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "duplexify": {
-                  "version": "3.5.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "end-of-stream": "1.0.0",
-                    "inherits": "^2.0.1",
-                    "readable-stream": "^2.0.0",
-                    "stream-shift": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "end-of-stream": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "once": "~1.3.0"
-                      },
-                      "dependencies": {
-                        "once": {
-                          "version": "1.3.3",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "wrappy": "1"
-                          }
-                        }
-                      }
-                    },
-                    "stream-shift": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "end-of-stream": {
-                  "version": "1.4.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "once": "^1.4.0"
-                  }
-                },
-                "flush-write-stream": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "inherits": "^2.0.1",
-                    "readable-stream": "^2.0.4"
-                  }
-                },
-                "from2": {
-                  "version": "2.3.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "inherits": "^2.0.1",
-                    "readable-stream": "^2.0.0"
-                  }
-                },
-                "parallel-transform": {
-                  "version": "1.1.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "cyclist": "~0.2.2",
-                    "inherits": "^2.0.3",
-                    "readable-stream": "^2.1.5"
-                  },
-                  "dependencies": {
-                    "cyclist": {
-                      "version": "0.2.2",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "pump": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "end-of-stream": "^1.1.0",
-                    "once": "^1.3.1"
-                  }
-                },
-                "pumpify": {
-                  "version": "1.3.5",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "duplexify": "^3.1.2",
-                    "inherits": "^2.0.1",
-                    "pump": "^1.0.0"
-                  }
-                },
-                "stream-each": {
-                  "version": "1.2.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "end-of-stream": "^1.1.0",
-                    "stream-shift": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "stream-shift": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "through2": {
-                  "version": "2.0.3",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "readable-stream": "^2.1.5",
-                    "xtend": "~4.0.1"
-                  },
-                  "dependencies": {
-                    "xtend": {
-                      "version": "4.0.1",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "minimist": "0.0.8"
-              },
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "move-concurrently": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "aproba": "^1.1.1",
-                "copy-concurrently": "^1.0.0",
-                "fs-write-stream-atomic": "^1.0.8",
-                "mkdirp": "^0.5.1",
-                "rimraf": "^2.5.4",
-                "run-queue": "^1.0.3"
-              },
-              "dependencies": {
-                "copy-concurrently": {
-                  "version": "1.0.3",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "aproba": "^1.1.1",
-                    "fs-write-stream-atomic": "^1.0.8",
-                    "iferr": "^0.1.5",
-                    "mkdirp": "^0.5.1",
-                    "rimraf": "^2.5.4",
-                    "run-queue": "^1.0.0"
-                  }
-                },
-                "run-queue": {
-                  "version": "1.0.3",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "aproba": "^1.1.1"
-                  }
-                }
-              }
-            },
-            "node-gyp": {
-              "version": "3.6.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "fstream": "^1.0.0",
-                "glob": "^7.0.3",
-                "graceful-fs": "^4.1.2",
-                "minimatch": "^3.0.2",
-                "mkdirp": "^0.5.0",
-                "nopt": "2 || 3",
-                "npmlog": "0 || 1 || 2 || 3 || 4",
-                "osenv": "0",
-                "request": "2",
-                "rimraf": "2",
-                "semver": "~5.3.0",
-                "tar": "^2.0.0",
-                "which": "1"
-              },
-              "dependencies": {
-                "minimatch": {
-                  "version": "3.0.4",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "brace-expansion": "^1.1.7"
-                  },
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.8",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "balanced-match": "^1.0.0",
-                        "concat-map": "0.0.1"
-                      },
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "nopt": {
-                  "version": "3.0.6",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "abbrev": "1"
-                  }
-                }
-              }
-            },
-            "nopt": {
-              "version": "4.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "abbrev": "1",
-                "osenv": "^0.1.4"
-              }
-            },
-            "normalize-package-data": {
-              "version": "2.4.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "hosted-git-info": "^2.1.4",
-                "is-builtin-module": "^1.0.0",
-                "semver": "2 || 3 || 4 || 5",
-                "validate-npm-package-license": "^3.0.1"
-              },
-              "dependencies": {
-                "is-builtin-module": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "builtin-modules": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "builtin-modules": {
-                      "version": "1.1.1",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "npm-cache-filename": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "npm-install-checks": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "semver": "^2.3.0 || 3.x || 4 || 5"
-              }
-            },
-            "npm-package-arg": {
-              "version": "5.1.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "hosted-git-info": "^2.4.2",
-                "osenv": "^0.1.4",
-                "semver": "^5.1.0",
-                "validate-npm-package-name": "^3.0.0"
-              }
-            },
-            "npm-registry-client": {
-              "version": "8.4.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "concat-stream": "^1.5.2",
-                "graceful-fs": "^4.1.6",
-                "normalize-package-data": "~1.0.1 || ^2.0.0",
-                "npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0",
-                "npmlog": "2 || ^3.1.0 || ^4.0.0",
-                "once": "^1.3.3",
-                "request": "^2.74.0",
-                "retry": "^0.10.0",
-                "semver": "2 >=2.2.1 || 3.x || 4 || 5",
-                "slide": "^1.1.3",
-                "ssri": "^4.1.2"
-              },
-              "dependencies": {
-                "concat-stream": {
-                  "version": "1.6.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "inherits": "^2.0.3",
-                    "readable-stream": "^2.2.2",
-                    "typedarray": "^0.0.6"
-                  },
-                  "dependencies": {
-                    "typedarray": {
-                      "version": "0.0.6",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "npm-user-validate": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "npmlog": {
-              "version": "4.1.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
-              },
-              "dependencies": {
-                "are-we-there-yet": {
-                  "version": "1.1.4",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "delegates": "^1.0.0",
-                    "readable-stream": "^2.0.6"
-                  },
-                  "dependencies": {
-                    "delegates": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "console-control-strings": {
-                  "version": "1.1.0",
-                  "bundled": true,
-                  "dev": true
-                },
-                "gauge": {
-                  "version": "2.7.4",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "aproba": "^1.0.3",
-                    "console-control-strings": "^1.0.0",
-                    "has-unicode": "^2.0.0",
-                    "object-assign": "^4.1.0",
-                    "signal-exit": "^3.0.0",
-                    "string-width": "^1.0.1",
-                    "strip-ansi": "^3.0.1",
-                    "wide-align": "^1.1.0"
-                  },
-                  "dependencies": {
-                    "object-assign": {
-                      "version": "4.1.1",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "signal-exit": {
-                      "version": "3.0.2",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "string-width": {
-                      "version": "1.0.2",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
-                      },
-                      "dependencies": {
-                        "code-point-at": {
-                          "version": "1.1.0",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "is-fullwidth-code-point": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "number-is-nan": "^1.0.0"
-                          },
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.1",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "strip-ansi": {
-                      "version": "3.0.1",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "ansi-regex": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.1.1",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    },
-                    "wide-align": {
-                      "version": "1.1.2",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "string-width": "^1.0.2"
-                      }
-                    }
-                  }
-                },
-                "set-blocking": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "once": {
-              "version": "1.4.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "wrappy": "1"
-              }
-            },
-            "opener": {
-              "version": "1.4.3",
-              "bundled": true,
-              "dev": true
-            },
-            "osenv": {
-              "version": "0.1.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "os-homedir": "^1.0.0",
-                "os-tmpdir": "^1.0.0"
-              },
-              "dependencies": {
-                "os-homedir": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "dev": true
-                },
-                "os-tmpdir": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "pacote": {
-              "version": "2.7.38",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "bluebird": "^3.5.0",
-                "cacache": "^9.2.9",
-                "glob": "^7.1.2",
-                "lru-cache": "^4.1.1",
-                "make-fetch-happen": "^2.4.13",
-                "minimatch": "^3.0.4",
-                "mississippi": "^1.2.0",
-                "normalize-package-data": "^2.4.0",
-                "npm-package-arg": "^5.1.2",
-                "npm-pick-manifest": "^1.0.4",
-                "osenv": "^0.1.4",
-                "promise-inflight": "^1.0.1",
-                "promise-retry": "^1.1.1",
-                "protoduck": "^4.0.0",
-                "safe-buffer": "^5.1.1",
-                "semver": "^5.3.0",
-                "ssri": "^4.1.6",
-                "tar-fs": "^1.15.3",
-                "tar-stream": "^1.5.4",
-                "unique-filename": "^1.1.0",
-                "which": "^1.2.12"
-              },
-              "dependencies": {
-                "make-fetch-happen": {
-                  "version": "2.4.13",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "agentkeepalive": "^3.3.0",
-                    "cacache": "^9.2.9",
-                    "http-cache-semantics": "^3.7.3",
-                    "http-proxy-agent": "^2.0.0",
-                    "https-proxy-agent": "^2.0.0",
-                    "lru-cache": "^4.1.1",
-                    "mississippi": "^1.2.0",
-                    "node-fetch-npm": "^2.0.1",
-                    "promise-retry": "^1.1.1",
-                    "socks-proxy-agent": "^3.0.0",
-                    "ssri": "^4.1.6"
-                  },
-                  "dependencies": {
-                    "agentkeepalive": {
-                      "version": "3.3.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "humanize-ms": "^1.2.1"
-                      },
-                      "dependencies": {
-                        "humanize-ms": {
-                          "version": "1.2.1",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "ms": "^2.0.0"
-                          },
-                          "dependencies": {
-                            "ms": {
-                              "version": "2.0.0",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "http-cache-semantics": {
-                      "version": "3.7.3",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "http-proxy-agent": {
-                      "version": "2.0.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "agent-base": "4",
-                        "debug": "2"
-                      },
-                      "dependencies": {
-                        "agent-base": {
-                          "version": "4.1.0",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "es6-promisify": "^5.0.0"
-                          },
-                          "dependencies": {
-                            "es6-promisify": {
-                              "version": "5.0.0",
-                              "bundled": true,
-                              "dev": true,
-                              "requires": {
-                                "es6-promise": "^4.0.3"
-                              },
-                              "dependencies": {
-                                "es6-promise": {
-                                  "version": "4.1.1",
-                                  "bundled": true,
-                                  "dev": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "debug": {
-                          "version": "2.6.8",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "ms": "2.0.0"
-                          },
-                          "dependencies": {
-                            "ms": {
-                              "version": "2.0.0",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "https-proxy-agent": {
-                      "version": "2.0.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "agent-base": "^4.1.0",
-                        "debug": "^2.4.1"
-                      },
-                      "dependencies": {
-                        "agent-base": {
-                          "version": "4.1.0",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "es6-promisify": "^5.0.0"
-                          },
-                          "dependencies": {
-                            "es6-promisify": {
-                              "version": "5.0.0",
-                              "bundled": true,
-                              "dev": true,
-                              "requires": {
-                                "es6-promise": "^4.0.3"
-                              },
-                              "dependencies": {
-                                "es6-promise": {
-                                  "version": "4.1.1",
-                                  "bundled": true,
-                                  "dev": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "debug": {
-                          "version": "2.6.8",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "ms": "2.0.0"
-                          },
-                          "dependencies": {
-                            "ms": {
-                              "version": "2.0.0",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "node-fetch-npm": {
-                      "version": "2.0.1",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "encoding": "^0.1.11",
-                        "json-parse-helpfulerror": "^1.0.3",
-                        "safe-buffer": "^5.0.1"
-                      },
-                      "dependencies": {
-                        "encoding": {
-                          "version": "0.1.12",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "iconv-lite": "~0.4.13"
-                          },
-                          "dependencies": {
-                            "iconv-lite": {
-                              "version": "0.4.18",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        },
-                        "json-parse-helpfulerror": {
-                          "version": "1.0.3",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "jju": "^1.1.0"
-                          },
-                          "dependencies": {
-                            "jju": {
-                              "version": "1.3.0",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "socks-proxy-agent": {
-                      "version": "3.0.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "agent-base": "^4.0.1",
-                        "socks": "^1.1.10"
-                      },
-                      "dependencies": {
-                        "agent-base": {
-                          "version": "4.1.0",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "es6-promisify": "^5.0.0"
-                          },
-                          "dependencies": {
-                            "es6-promisify": {
-                              "version": "5.0.0",
-                              "bundled": true,
-                              "dev": true,
-                              "requires": {
-                                "es6-promise": "^4.0.3"
-                              },
-                              "dependencies": {
-                                "es6-promise": {
-                                  "version": "4.1.1",
-                                  "bundled": true,
-                                  "dev": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "socks": {
-                          "version": "1.1.10",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "ip": "^1.1.4",
-                            "smart-buffer": "^1.0.13"
-                          },
-                          "dependencies": {
-                            "ip": {
-                              "version": "1.1.5",
-                              "bundled": true,
-                              "dev": true
-                            },
-                            "smart-buffer": {
-                              "version": "1.1.15",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "minimatch": {
-                  "version": "3.0.4",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "brace-expansion": "^1.1.7"
-                  },
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.8",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "balanced-match": "^1.0.0",
-                        "concat-map": "0.0.1"
-                      },
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "npm-pick-manifest": {
-                  "version": "1.0.4",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "npm-package-arg": "^5.1.2",
-                    "semver": "^5.3.0"
-                  }
-                },
-                "promise-retry": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "err-code": "^1.0.0",
-                    "retry": "^0.10.0"
-                  },
-                  "dependencies": {
-                    "err-code": {
-                      "version": "1.1.2",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "protoduck": {
-                  "version": "4.0.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "genfun": "^4.0.1"
-                  },
-                  "dependencies": {
-                    "genfun": {
-                      "version": "4.0.1",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "tar-fs": {
-                  "version": "1.15.3",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "chownr": "^1.0.1",
-                    "mkdirp": "^0.5.1",
-                    "pump": "^1.0.0",
-                    "tar-stream": "^1.1.2"
-                  },
-                  "dependencies": {
-                    "pump": {
-                      "version": "1.0.2",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "end-of-stream": "^1.1.0",
-                        "once": "^1.3.1"
-                      },
-                      "dependencies": {
-                        "end-of-stream": {
-                          "version": "1.4.0",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "once": "^1.4.0"
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "tar-stream": {
-                  "version": "1.5.4",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "bl": "^1.0.0",
-                    "end-of-stream": "^1.0.0",
-                    "readable-stream": "^2.0.0",
-                    "xtend": "^4.0.0"
-                  },
-                  "dependencies": {
-                    "bl": {
-                      "version": "1.2.1",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "readable-stream": "^2.0.5"
-                      }
-                    },
-                    "end-of-stream": {
-                      "version": "1.4.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "once": "^1.4.0"
-                      }
-                    },
-                    "xtend": {
-                      "version": "4.0.1",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "path-is-inside": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "promise-inflight": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "read": {
-              "version": "1.0.7",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "mute-stream": "~0.0.4"
-              },
-              "dependencies": {
-                "mute-stream": {
-                  "version": "0.0.7",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "read-cmd-shim": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "graceful-fs": "^4.1.2"
-              }
-            },
-            "read-installed": {
-              "version": "4.0.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "debuglog": "^1.0.1",
-                "graceful-fs": "^4.1.2",
-                "read-package-json": "^2.0.0",
-                "readdir-scoped-modules": "^1.0.0",
-                "semver": "2 || 3 || 4 || 5",
-                "slide": "~1.1.3",
-                "util-extend": "^1.0.1"
-              },
-              "dependencies": {
-                "util-extend": {
-                  "version": "1.0.3",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "read-package-json": {
-              "version": "2.0.9",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "glob": "^7.1.1",
-                "graceful-fs": "^4.1.2",
-                "json-parse-helpfulerror": "^1.0.2",
-                "normalize-package-data": "^2.0.0"
-              },
-              "dependencies": {
-                "json-parse-helpfulerror": {
-                  "version": "1.0.3",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "jju": "^1.1.0"
-                  },
-                  "dependencies": {
-                    "jju": {
-                      "version": "1.3.0",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "read-package-tree": {
-              "version": "5.1.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "debuglog": "^1.0.1",
-                "dezalgo": "^1.0.0",
-                "once": "^1.3.0",
-                "read-package-json": "^2.0.0",
-                "readdir-scoped-modules": "^1.0.0"
-              }
-            },
-            "readable-stream": {
-              "version": "2.3.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~1.0.6",
-                "safe-buffer": "~5.1.0",
-                "string_decoder": "~1.0.0",
-                "util-deprecate": "~1.0.1"
-              },
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "dev": true
-                },
-                "isarray": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "dev": true
-                },
-                "process-nextick-args": {
-                  "version": "1.0.7",
-                  "bundled": true,
-                  "dev": true
-                },
-                "string_decoder": {
-                  "version": "1.0.3",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "safe-buffer": "~5.1.0"
-                  }
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "readdir-scoped-modules": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "debuglog": "^1.0.1",
-                "dezalgo": "^1.0.0",
-                "graceful-fs": "^4.1.2",
-                "once": "^1.3.0"
-              }
-            },
-            "request": {
-              "version": "2.81.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "aws-sign2": "~0.6.0",
-                "aws4": "^1.2.1",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.5",
-                "extend": "~3.0.0",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.1.1",
-                "har-validator": "~4.2.1",
-                "hawk": "~3.1.3",
-                "http-signature": "~1.1.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.7",
-                "oauth-sign": "~0.8.1",
-                "performance-now": "^0.2.0",
-                "qs": "~6.4.0",
-                "safe-buffer": "^5.0.1",
-                "stringstream": "~0.0.4",
-                "tough-cookie": "~2.3.0",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.0.0"
-              },
-              "dependencies": {
-                "aws-sign2": {
-                  "version": "0.6.0",
-                  "bundled": true,
-                  "dev": true
-                },
-                "aws4": {
-                  "version": "1.6.0",
-                  "bundled": true,
-                  "dev": true
-                },
-                "caseless": {
-                  "version": "0.12.0",
-                  "bundled": true,
-                  "dev": true
-                },
-                "combined-stream": {
-                  "version": "1.0.5",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "delayed-stream": "~1.0.0"
-                  },
-                  "dependencies": {
-                    "delayed-stream": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "extend": {
-                  "version": "3.0.1",
-                  "bundled": true,
-                  "dev": true
-                },
-                "forever-agent": {
-                  "version": "0.6.1",
-                  "bundled": true,
-                  "dev": true
-                },
-                "form-data": {
-                  "version": "2.1.4",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "asynckit": "^0.4.0",
-                    "combined-stream": "^1.0.5",
-                    "mime-types": "^2.1.12"
-                  },
-                  "dependencies": {
-                    "asynckit": {
-                      "version": "0.4.0",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "har-validator": {
-                  "version": "4.2.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "ajv": "^4.9.1",
-                    "har-schema": "^1.0.5"
-                  },
-                  "dependencies": {
-                    "ajv": {
-                      "version": "4.11.8",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "co": "^4.6.0",
-                        "json-stable-stringify": "^1.0.1"
-                      },
-                      "dependencies": {
-                        "co": {
-                          "version": "4.6.0",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "json-stable-stringify": {
-                          "version": "1.0.1",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "jsonify": "~0.0.0"
-                          },
-                          "dependencies": {
-                            "jsonify": {
-                              "version": "0.0.0",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "har-schema": {
-                      "version": "1.0.5",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "hawk": {
-                  "version": "3.1.3",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "boom": "2.x.x",
-                    "cryptiles": "2.x.x",
-                    "hoek": "2.x.x",
-                    "sntp": "1.x.x"
-                  },
-                  "dependencies": {
-                    "boom": {
-                      "version": "2.10.1",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "hoek": "2.x.x"
-                      }
-                    },
-                    "cryptiles": {
-                      "version": "2.0.5",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "boom": "2.x.x"
-                      }
-                    },
-                    "hoek": {
-                      "version": "2.16.3",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "sntp": {
-                      "version": "1.0.9",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "hoek": "2.x.x"
-                      }
-                    }
-                  }
-                },
-                "http-signature": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "assert-plus": "^0.2.0",
-                    "jsprim": "^1.2.2",
-                    "sshpk": "^1.7.0"
-                  },
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "0.2.0",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "jsprim": {
-                      "version": "1.4.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "assert-plus": "1.0.0",
-                        "extsprintf": "1.0.2",
-                        "json-schema": "0.2.3",
-                        "verror": "1.3.6"
-                      },
-                      "dependencies": {
-                        "assert-plus": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "extsprintf": {
-                          "version": "1.0.2",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "json-schema": {
-                          "version": "0.2.3",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "verror": {
-                          "version": "1.3.6",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "extsprintf": "1.0.2"
-                          }
-                        }
-                      }
-                    },
-                    "sshpk": {
-                      "version": "1.13.1",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "asn1": "~0.2.3",
-                        "assert-plus": "^1.0.0",
-                        "bcrypt-pbkdf": "^1.0.0",
-                        "dashdash": "^1.12.0",
-                        "ecc-jsbn": "~0.1.1",
-                        "getpass": "^0.1.1",
-                        "jsbn": "~0.1.0",
-                        "tweetnacl": "~0.14.0"
-                      },
-                      "dependencies": {
-                        "asn1": {
-                          "version": "0.2.3",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "assert-plus": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "bcrypt-pbkdf": {
-                          "version": "1.0.1",
-                          "bundled": true,
-                          "dev": true,
-                          "optional": true,
-                          "requires": {
-                            "tweetnacl": "^0.14.3"
-                          }
-                        },
-                        "dashdash": {
-                          "version": "1.14.1",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "assert-plus": "^1.0.0"
-                          }
-                        },
-                        "ecc-jsbn": {
-                          "version": "0.1.1",
-                          "bundled": true,
-                          "dev": true,
-                          "optional": true,
-                          "requires": {
-                            "jsbn": "~0.1.0"
-                          }
-                        },
-                        "getpass": {
-                          "version": "0.1.7",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "assert-plus": "^1.0.0"
-                          }
-                        },
-                        "jsbn": {
-                          "version": "0.1.1",
-                          "bundled": true,
-                          "dev": true,
-                          "optional": true
-                        },
-                        "tweetnacl": {
-                          "version": "0.14.5",
-                          "bundled": true,
-                          "dev": true,
-                          "optional": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "is-typedarray": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "dev": true
-                },
-                "isstream": {
-                  "version": "0.1.2",
-                  "bundled": true,
-                  "dev": true
-                },
-                "json-stringify-safe": {
-                  "version": "5.0.1",
-                  "bundled": true,
-                  "dev": true
-                },
-                "mime-types": {
-                  "version": "2.1.15",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "mime-db": "~1.27.0"
-                  },
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.27.0",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "oauth-sign": {
-                  "version": "0.8.2",
-                  "bundled": true,
-                  "dev": true
-                },
-                "performance-now": {
-                  "version": "0.2.0",
-                  "bundled": true,
-                  "dev": true
-                },
-                "qs": {
-                  "version": "6.4.0",
-                  "bundled": true,
-                  "dev": true
-                },
-                "stringstream": {
-                  "version": "0.0.5",
-                  "bundled": true,
-                  "dev": true
-                },
-                "tough-cookie": {
-                  "version": "2.3.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "punycode": "^1.4.1"
-                  },
-                  "dependencies": {
-                    "punycode": {
-                      "version": "1.4.1",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "tunnel-agent": {
-                  "version": "0.6.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "safe-buffer": "^5.0.1"
-                  }
-                }
-              }
-            },
-            "retry": {
-              "version": "0.10.1",
-              "bundled": true,
-              "dev": true
-            },
-            "rimraf": {
-              "version": "2.6.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "glob": "^7.0.5"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.1",
-              "bundled": true,
-              "dev": true
-            },
-            "semver": {
-              "version": "5.3.0",
-              "bundled": true,
-              "dev": true
-            },
-            "sha": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "readable-stream": "^2.0.2"
-              }
-            },
-            "slide": {
-              "version": "1.1.6",
-              "bundled": true,
-              "dev": true
-            },
-            "sorted-object": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "sorted-union-stream": {
-              "version": "2.1.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "from2": "^1.3.0",
-                "stream-iterate": "^1.1.0"
-              },
-              "dependencies": {
-                "from2": {
-                  "version": "1.3.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "inherits": "~2.0.1",
-                    "readable-stream": "~1.1.10"
-                  },
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "1.1.14",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
-                      },
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "stream-iterate": {
-                  "version": "1.2.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "readable-stream": "^2.1.5",
-                    "stream-shift": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "stream-shift": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "ssri": {
-              "version": "4.1.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "^5.1.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^3.0.0"
-              },
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "3.0.0",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "tar": {
-              "version": "2.2.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "block-stream": "*",
-                "fstream": "^1.0.2",
-                "inherits": "2"
-              },
-              "dependencies": {
-                "block-stream": {
-                  "version": "0.0.9",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "inherits": "~2.0.0"
-                  }
-                }
-              }
-            },
-            "text-table": {
-              "version": "0.2.0",
-              "bundled": true,
-              "dev": true
-            },
-            "uid-number": {
-              "version": "0.0.6",
-              "bundled": true,
-              "dev": true
-            },
-            "umask": {
-              "version": "1.1.0",
-              "bundled": true,
-              "dev": true
-            },
-            "unique-filename": {
-              "version": "1.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "unique-slug": "^2.0.0"
-              },
-              "dependencies": {
-                "unique-slug": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "imurmurhash": "^0.1.4"
-                  }
-                }
-              }
-            },
-            "unpipe": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "update-notifier": {
-              "version": "2.2.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "boxen": "^1.0.0",
-                "chalk": "^1.0.0",
-                "configstore": "^3.0.0",
-                "import-lazy": "^2.1.0",
-                "is-npm": "^1.0.0",
-                "latest-version": "^3.0.0",
-                "semver-diff": "^2.0.0",
-                "xdg-basedir": "^3.0.0"
-              },
-              "dependencies": {
-                "boxen": {
-                  "version": "1.1.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "ansi-align": "^2.0.0",
-                    "camelcase": "^4.0.0",
-                    "chalk": "^1.1.1",
-                    "cli-boxes": "^1.0.0",
-                    "string-width": "^2.0.0",
-                    "term-size": "^0.1.0",
-                    "widest-line": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "ansi-align": {
-                      "version": "2.0.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "string-width": "^2.0.0"
-                      }
-                    },
-                    "camelcase": {
-                      "version": "4.1.0",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "cli-boxes": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "string-width": {
-                      "version": "2.1.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^4.0.0"
-                      },
-                      "dependencies": {
-                        "is-fullwidth-code-point": {
-                          "version": "2.0.0",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "strip-ansi": {
-                          "version": "4.0.0",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "ansi-regex": "^3.0.0"
-                          }
-                        }
-                      }
-                    },
-                    "term-size": {
-                      "version": "0.1.1",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "execa": "^0.4.0"
-                      },
-                      "dependencies": {
-                        "execa": {
-                          "version": "0.4.0",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "cross-spawn-async": "^2.1.1",
-                            "is-stream": "^1.1.0",
-                            "npm-run-path": "^1.0.0",
-                            "object-assign": "^4.0.1",
-                            "path-key": "^1.0.0",
-                            "strip-eof": "^1.0.0"
-                          },
-                          "dependencies": {
-                            "cross-spawn-async": {
-                              "version": "2.2.5",
-                              "bundled": true,
-                              "dev": true,
-                              "requires": {
-                                "lru-cache": "^4.0.0",
-                                "which": "^1.2.8"
-                              }
-                            },
-                            "is-stream": {
-                              "version": "1.1.0",
-                              "bundled": true,
-                              "dev": true
-                            },
-                            "npm-run-path": {
-                              "version": "1.0.0",
-                              "bundled": true,
-                              "dev": true,
-                              "requires": {
-                                "path-key": "^1.0.0"
-                              }
-                            },
-                            "object-assign": {
-                              "version": "4.1.1",
-                              "bundled": true,
-                              "dev": true
-                            },
-                            "path-key": {
-                              "version": "1.0.0",
-                              "bundled": true,
-                              "dev": true
-                            },
-                            "strip-eof": {
-                              "version": "1.0.0",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "widest-line": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "string-width": "^1.0.1"
-                      },
-                      "dependencies": {
-                        "string-width": {
-                          "version": "1.0.2",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "code-point-at": "^1.0.0",
-                            "is-fullwidth-code-point": "^1.0.0",
-                            "strip-ansi": "^3.0.0"
-                          },
-                          "dependencies": {
-                            "code-point-at": {
-                              "version": "1.1.0",
-                              "bundled": true,
-                              "dev": true
-                            },
-                            "is-fullwidth-code-point": {
-                              "version": "1.0.0",
-                              "bundled": true,
-                              "dev": true,
-                              "requires": {
-                                "number-is-nan": "^1.0.0"
-                              },
-                              "dependencies": {
-                                "number-is-nan": {
-                                  "version": "1.0.1",
-                                  "bundled": true,
-                                  "dev": true
-                                }
-                              }
-                            },
-                            "strip-ansi": {
-                              "version": "3.0.1",
-                              "bundled": true,
-                              "dev": true,
-                              "requires": {
-                                "ansi-regex": "^2.0.0"
-                              },
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.1.1",
-                                  "bundled": true,
-                                  "dev": true
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "chalk": {
-                  "version": "1.1.3",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "ansi-styles": "^2.2.1",
-                    "escape-string-regexp": "^1.0.2",
-                    "has-ansi": "^2.0.0",
-                    "strip-ansi": "^3.0.0",
-                    "supports-color": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "ansi-styles": {
-                      "version": "2.2.1",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "escape-string-regexp": {
-                      "version": "1.0.5",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "has-ansi": {
-                      "version": "2.0.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "ansi-regex": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.1.1",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    },
-                    "strip-ansi": {
-                      "version": "3.0.1",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "ansi-regex": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.1.1",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    },
-                    "supports-color": {
-                      "version": "2.0.0",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "configstore": {
-                  "version": "3.1.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "dot-prop": "^4.1.0",
-                    "graceful-fs": "^4.1.2",
-                    "make-dir": "^1.0.0",
-                    "unique-string": "^1.0.0",
-                    "write-file-atomic": "^2.0.0",
-                    "xdg-basedir": "^3.0.0"
-                  },
-                  "dependencies": {
-                    "dot-prop": {
-                      "version": "4.1.1",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "is-obj": "^1.0.0"
-                      },
-                      "dependencies": {
-                        "is-obj": {
-                          "version": "1.0.1",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    },
-                    "make-dir": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "pify": "^2.3.0"
-                      },
-                      "dependencies": {
-                        "pify": {
-                          "version": "2.3.0",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    },
-                    "unique-string": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "crypto-random-string": "^1.0.0"
-                      },
-                      "dependencies": {
-                        "crypto-random-string": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "import-lazy": {
-                  "version": "2.1.0",
-                  "bundled": true,
-                  "dev": true
-                },
-                "is-npm": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "dev": true
-                },
-                "latest-version": {
-                  "version": "3.1.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "package-json": "^4.0.0"
-                  },
-                  "dependencies": {
-                    "package-json": {
-                      "version": "4.0.1",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "got": "^6.7.1",
-                        "registry-auth-token": "^3.0.1",
-                        "registry-url": "^3.0.3",
-                        "semver": "^5.1.0"
-                      },
-                      "dependencies": {
-                        "got": {
-                          "version": "6.7.1",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "create-error-class": "^3.0.0",
-                            "duplexer3": "^0.1.4",
-                            "get-stream": "^3.0.0",
-                            "is-redirect": "^1.0.0",
-                            "is-retry-allowed": "^1.0.0",
-                            "is-stream": "^1.0.0",
-                            "lowercase-keys": "^1.0.0",
-                            "safe-buffer": "^5.0.1",
-                            "timed-out": "^4.0.0",
-                            "unzip-response": "^2.0.1",
-                            "url-parse-lax": "^1.0.0"
-                          },
-                          "dependencies": {
-                            "create-error-class": {
-                              "version": "3.0.2",
-                              "bundled": true,
-                              "dev": true,
-                              "requires": {
-                                "capture-stack-trace": "^1.0.0"
-                              },
-                              "dependencies": {
-                                "capture-stack-trace": {
-                                  "version": "1.0.0",
-                                  "bundled": true,
-                                  "dev": true
-                                }
-                              }
-                            },
-                            "duplexer3": {
-                              "version": "0.1.4",
-                              "bundled": true,
-                              "dev": true
-                            },
-                            "get-stream": {
-                              "version": "3.0.0",
-                              "bundled": true,
-                              "dev": true
-                            },
-                            "is-redirect": {
-                              "version": "1.0.0",
-                              "bundled": true,
-                              "dev": true
-                            },
-                            "is-retry-allowed": {
-                              "version": "1.1.0",
-                              "bundled": true,
-                              "dev": true
-                            },
-                            "is-stream": {
-                              "version": "1.1.0",
-                              "bundled": true,
-                              "dev": true
-                            },
-                            "lowercase-keys": {
-                              "version": "1.0.0",
-                              "bundled": true,
-                              "dev": true
-                            },
-                            "timed-out": {
-                              "version": "4.0.1",
-                              "bundled": true,
-                              "dev": true
-                            },
-                            "unzip-response": {
-                              "version": "2.0.1",
-                              "bundled": true,
-                              "dev": true
-                            },
-                            "url-parse-lax": {
-                              "version": "1.0.0",
-                              "bundled": true,
-                              "dev": true,
-                              "requires": {
-                                "prepend-http": "^1.0.1"
-                              },
-                              "dependencies": {
-                                "prepend-http": {
-                                  "version": "1.0.4",
-                                  "bundled": true,
-                                  "dev": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "registry-auth-token": {
-                          "version": "3.3.1",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "rc": "^1.1.6",
-                            "safe-buffer": "^5.0.1"
-                          },
-                          "dependencies": {
-                            "rc": {
-                              "version": "1.2.1",
-                              "bundled": true,
-                              "dev": true,
-                              "requires": {
-                                "deep-extend": "~0.4.0",
-                                "ini": "~1.3.0",
-                                "minimist": "^1.2.0",
-                                "strip-json-comments": "~2.0.1"
-                              },
-                              "dependencies": {
-                                "deep-extend": {
-                                  "version": "0.4.2",
-                                  "bundled": true,
-                                  "dev": true
-                                },
-                                "minimist": {
-                                  "version": "1.2.0",
-                                  "bundled": true,
-                                  "dev": true
-                                },
-                                "strip-json-comments": {
-                                  "version": "2.0.1",
-                                  "bundled": true,
-                                  "dev": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "registry-url": {
-                          "version": "3.1.0",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "rc": "^1.0.1"
-                          },
-                          "dependencies": {
-                            "rc": {
-                              "version": "1.2.1",
-                              "bundled": true,
-                              "dev": true,
-                              "requires": {
-                                "deep-extend": "~0.4.0",
-                                "ini": "~1.3.0",
-                                "minimist": "^1.2.0",
-                                "strip-json-comments": "~2.0.1"
-                              },
-                              "dependencies": {
-                                "deep-extend": {
-                                  "version": "0.4.2",
-                                  "bundled": true,
-                                  "dev": true
-                                },
-                                "minimist": {
-                                  "version": "1.2.0",
-                                  "bundled": true,
-                                  "dev": true
-                                },
-                                "strip-json-comments": {
-                                  "version": "2.0.1",
-                                  "bundled": true,
-                                  "dev": true
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "semver-diff": {
-                  "version": "2.1.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "semver": "^5.0.3"
-                  }
-                },
-                "xdg-basedir": {
-                  "version": "3.0.0",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "uuid": {
-              "version": "3.1.0",
-              "bundled": true,
-              "dev": true
-            },
-            "validate-npm-package-license": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "spdx-correct": "~1.0.0",
-                "spdx-expression-parse": "~1.0.0"
-              },
-              "dependencies": {
-                "spdx-correct": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "spdx-license-ids": "^1.0.2"
-                  },
-                  "dependencies": {
-                    "spdx-license-ids": {
-                      "version": "1.2.2",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "spdx-expression-parse": {
-                  "version": "1.0.4",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "validate-npm-package-name": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "builtins": "^1.0.3"
-              },
-              "dependencies": {
-                "builtins": {
-                  "version": "1.0.3",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "which": {
-              "version": "1.2.14",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "isexe": "^2.0.0"
-              },
-              "dependencies": {
-                "isexe": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "worker-farm": {
-              "version": "1.3.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "errno": ">=0.1.1 <0.2.0-0",
-                "xtend": ">=4.0.0 <4.1.0-0"
-              },
-              "dependencies": {
-                "errno": {
-                  "version": "0.1.4",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "prr": "~0.0.0"
-                  },
-                  "dependencies": {
-                    "prr": {
-                      "version": "0.0.0",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "xtend": {
-                  "version": "4.0.1",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "write-file-atomic": {
-              "version": "2.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "graceful-fs": "^4.1.11",
-                "imurmurhash": "^0.1.4",
-                "slide": "^1.1.5"
-              }
-            }
-          }
-        },
-        "npm-package-arg": {
-          "version": "6.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "hosted-git-info": "^2.6.0",
-            "osenv": "^0.1.5",
-            "semver": "^5.5.0",
-            "validate-npm-package-name": "^3.0.0"
-          }
-        },
-        "npm-run-path": {
-          "version": "2.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "path-key": "^2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "os-locale": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
-          }
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "osenv": {
-          "version": "0.1.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
-          }
-        },
-        "p-finally": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "p-limit": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "package-json": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "got": "^6.7.1",
-            "registry-auth-token": "^3.0.1",
-            "registry-url": "^3.0.3",
-            "semver": "^5.1.0"
-          }
-        },
-        "path-exists": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "path-is-inside": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "path-key": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "pify": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "prepend-http": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true
-        },
-        "pseudomap": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "rc": {
-          "version": "1.2.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "deep-extend": "~0.4.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
-          }
-        },
-        "registry-auth-token": {
-          "version": "3.3.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "rc": "^1.1.6",
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "registry-url": {
-          "version": "3.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "rc": "^1.0.1"
-          }
-        },
-        "require-directory": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "require-main-filename": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "rimraf": {
-          "version": "2.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "glob": "^7.0.5"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "semver": {
-          "version": "5.5.0",
-          "bundled": true,
-          "dev": true
-        },
-        "semver-diff": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "semver": "^5.0.3"
-          }
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "shebang-command": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "shebang-regex": "^1.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        },
-        "strip-eof": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        },
-        "term-size": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "execa": "^0.7.0"
-          }
-        },
-        "timed-out": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "unique-string": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "crypto-random-string": "^1.0.0"
-          }
-        },
-        "unzip-response": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "update-notifier": {
-          "version": "2.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "boxen": "^1.2.1",
-            "chalk": "^2.0.1",
-            "configstore": "^3.0.0",
-            "import-lazy": "^2.1.0",
-            "is-ci": "^1.0.10",
-            "is-installed-globally": "^0.1.0",
-            "is-npm": "^1.0.0",
-            "latest-version": "^3.0.0",
-            "semver-diff": "^2.0.0",
-            "xdg-basedir": "^3.0.0"
-          }
-        },
-        "url-parse-lax": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "prepend-http": "^1.0.1"
-          }
-        },
-        "validate-npm-package-name": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "builtins": "^1.0.3"
-          }
-        },
-        "which": {
-          "version": "1.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        },
-        "which-module": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "widest-line": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "string-width": "^2.1.1"
-          }
-        },
-        "wrap-ansi": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "2.1.1",
-              "bundled": true,
-              "dev": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              }
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^2.0.0"
-              }
-            }
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "write-file-atomic": {
-          "version": "2.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "signal-exit": "^3.0.2"
-          }
-        },
-        "xdg-basedir": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "y18n": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "yallist": {
-          "version": "2.1.2",
-          "bundled": true,
-          "dev": true
-        },
-        "yargs": {
-          "version": "11.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.1.1",
-            "find-up": "^2.1.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^9.0.2"
-          },
-          "dependencies": {
-            "y18n": {
-              "version": "3.2.1",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "yargs-parser": {
-          "version": "9.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "camelcase": "^4.1.0"
-          }
-        }
-      }
-    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -25482,6 +20603,15 @@
           "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -25565,15 +20695,6 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^1.0.0"
-      }
-    },
-    "open": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
-      "integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
-      "dev": true,
-      "requires": {
-        "is-wsl": "^1.1.0"
       }
     },
     "optimist": {
@@ -25727,12 +20848,6 @@
         "p-limit": "^1.1.0"
       }
     },
-    "p-reduce": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
-      "integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==",
-      "dev": true
-    },
     "p-timeout": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
@@ -25748,97 +20863,56 @@
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
     },
     "package-json": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
-      "integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "dev": true,
       "requires": {
-        "got": "^9.6.0",
-        "registry-auth-token": "^4.0.0",
-        "registry-url": "^5.0.0",
-        "semver": "^6.2.0"
+        "got": "^6.7.1",
+        "registry-auth-token": "^3.0.1",
+        "registry-url": "^3.0.3",
+        "semver": "^5.1.0"
       },
       "dependencies": {
-        "@sindresorhus/is": {
-          "version": "0.14.0",
-          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
-          "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
-        },
-        "cacheable-request": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
-          "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
-          "dev": true,
-          "requires": {
-            "clone-response": "^1.0.2",
-            "get-stream": "^5.1.0",
-            "http-cache-semantics": "^4.0.0",
-            "keyv": "^3.0.0",
-            "lowercase-keys": "^2.0.0",
-            "normalize-url": "^4.1.0",
-            "responselike": "^1.0.2"
-          },
-          "dependencies": {
-            "get-stream": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-              "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
-              "dev": true,
-              "requires": {
-                "pump": "^3.0.0"
-              }
-            },
-            "lowercase-keys": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-              "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-              "dev": true
-            }
-          }
         },
         "got": {
-          "version": "9.6.0",
-          "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
-          "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+          "version": "6.7.1",
+          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
           "dev": true,
           "requires": {
-            "@sindresorhus/is": "^0.14.0",
-            "@szmarczak/http-timer": "^1.1.2",
-            "cacheable-request": "^6.0.0",
-            "decompress-response": "^3.3.0",
+            "create-error-class": "^3.0.0",
             "duplexer3": "^0.1.4",
-            "get-stream": "^4.1.0",
-            "lowercase-keys": "^1.0.1",
-            "mimic-response": "^1.0.1",
-            "p-cancelable": "^1.0.0",
-            "to-readable-stream": "^1.0.0",
-            "url-parse-lax": "^3.0.0"
+            "get-stream": "^3.0.0",
+            "is-redirect": "^1.0.0",
+            "is-retry-allowed": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "lowercase-keys": "^1.0.0",
+            "safe-buffer": "^5.0.1",
+            "timed-out": "^4.0.0",
+            "unzip-response": "^2.0.1",
+            "url-parse-lax": "^1.0.0"
           }
         },
-        "http-cache-semantics": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
-          "integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew==",
+        "prepend-http": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
           "dev": true
         },
-        "normalize-url": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.3.0.tgz",
-          "integrity": "sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ==",
-          "dev": true
-        },
-        "p-cancelable": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-          "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
-          "dev": true
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
+        "url-parse-lax": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+          "dev": true,
+          "requires": {
+            "prepend-http": "^1.0.1"
+          }
         }
       }
     },
@@ -25902,7 +20976,8 @@
     "parse-ms": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
-      "integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0="
+      "integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0=",
+      "dev": true
     },
     "parse-passwd": {
       "version": "1.0.0",
@@ -26200,6 +21275,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-3.2.0.tgz",
       "integrity": "sha512-ZypexbfVUGTFxb0v+m1bUyy92DHe5SyYlnyY0msyms5zd3RwyvNgyxZZsXXgoyzlxjx5MiqtXUdhUfvQbe0A2Q==",
+      "dev": true,
       "requires": {
         "parse-ms": "^1.0.0"
       }
@@ -26669,6 +21745,12 @@
           "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz",
           "integrity": "sha1-oNkOQ1G7iHcWyD/WN+v4GK9K38w=",
           "dev": true
+        },
+        "esprima-fb": {
+          "version": "15001.1001.0-dev-harmony-fb",
+          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+          "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
+          "dev": true
         }
       }
     },
@@ -26714,6 +21796,14 @@
         "private": "~0.1.5",
         "recast": "0.10.33",
         "through": "~2.3.8"
+      },
+      "dependencies": {
+        "esprima-fb": {
+          "version": "15001.1001.0-dev-harmony-fb",
+          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+          "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
+          "dev": true
+        }
       }
     },
     "regenerator-runtime": {
@@ -26793,12 +21883,12 @@
       }
     },
     "regexpu-core": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
-      "integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.5.tgz",
+      "integrity": "sha512-FpI67+ky9J+cDizQUJlIlNZFKual/lUkFr1AG6zOCpwZ9cLrg8UUVakyUQJD7fCDIe9Z2nwTQJNPyonatNmDFQ==",
       "requires": {
         "regenerate": "^1.4.0",
-        "regenerate-unicode-properties": "^8.0.2",
+        "regenerate-unicode-properties": "^8.1.0",
         "regjsgen": "^0.5.0",
         "regjsparser": "^0.6.0",
         "unicode-match-property-ecmascript": "^1.0.4",
@@ -26806,22 +21896,22 @@
       }
     },
     "registry-auth-token": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.0.0.tgz",
-      "integrity": "sha512-lpQkHxd9UL6tb3k/aHAVfnVtn+Bcs9ob5InuFLLEDqSqeq+AljB8GZW9xY0x7F+xYwEcjKe07nyoxzEYz6yvkw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
+      "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
       "dev": true,
       "requires": {
-        "rc": "^1.2.8",
+        "rc": "^1.1.6",
         "safe-buffer": "^5.0.1"
       }
     },
     "registry-url": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
-      "integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "^1.2.8"
+        "rc": "^1.0.1"
       }
     },
     "regjsgen": {
@@ -26940,22 +22030,11 @@
         "tough-cookie": "^2.3.3"
       }
     },
-    "require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
-    },
-    "require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true
-    },
     "require-relative": {
       "version": "0.8.7",
       "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
-      "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4="
+      "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
+      "dev": true
     },
     "require-uncached": {
       "version": "1.0.3",
@@ -27052,22 +22131,6 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
-    "rfc6902": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/rfc6902/-/rfc6902-3.0.4.tgz",
-      "integrity": "sha512-OnzreaZXrwT5w2ikKXWr5QcuI7NZpL+J3hIkAwozjOnKVUL7fPsB8Vcmu8YBiiou1/r3V0Jc0T1uQDyfAPvLzA==",
-      "dev": true
-    },
-    "rfc6902-ordered": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/rfc6902-ordered/-/rfc6902-ordered-4.0.0.tgz",
-      "integrity": "sha512-uGpjTewv2UxexoQPtYDpAZKt3WX/ujxkw3TqJAZOUu3WkwCNsu67Dlk+KPn/RY851+U3PvSTNOKs58d9YBubeQ==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.0.0",
-        "rfc6902": "^3.0.1"
-      }
-    },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
@@ -27078,9 +22141,9 @@
       }
     },
     "rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "requires": {
         "glob": "^7.1.3"
       }
@@ -27096,21 +22159,13 @@
       }
     },
     "rollup": {
-      "version": "0.57.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.57.1.tgz",
-      "integrity": "sha512-I18GBqP0qJoJC1K1osYjreqA8VAKovxuI3I81RSk0Dmr4TgloI0tAULjZaox8OsJ+n7XRrhH6i0G2By/pj1LCA==",
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.19.4.tgz",
+      "integrity": "sha512-G24w409GNj7i/Yam2cQla6qV2k6Nug8bD2DZg9v63QX/cH/dEdbNJg8H4lUm5M1bRpPKRUC465Rm9H51JTKOfQ==",
       "requires": {
-        "@types/acorn": "^4.0.3",
-        "acorn": "^5.5.3",
-        "acorn-dynamic-import": "^3.0.0",
-        "date-time": "^2.1.0",
-        "is-reference": "^1.1.0",
-        "locate-character": "^2.0.5",
-        "pretty-ms": "^3.1.0",
-        "require-relative": "^0.8.7",
-        "rollup-pluginutils": "^2.0.1",
-        "signal-exit": "^3.0.2",
-        "sourcemap-codec": "^1.4.1"
+        "@types/estree": "0.0.39",
+        "@types/node": "^12.6.9",
+        "acorn": "^6.2.1"
       }
     },
     "rollup-pluginutils": {
@@ -27275,18 +22330,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
-    },
-    "semver-diff": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
-      "dev": true,
-      "requires": {
-        "semver": "^5.0.3"
-      }
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "send": {
       "version": "0.17.1",
@@ -27446,7 +22492,8 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
     },
     "silent-error": {
       "version": "1.1.1",
@@ -27614,12 +22661,6 @@
             "is-data-descriptor": "^1.0.0",
             "kind-of": "^6.0.2"
           }
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
         }
       }
     },
@@ -27630,6 +22671,17 @@
       "dev": true,
       "requires": {
         "kind-of": "^3.2.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "sntp": {
@@ -27821,7 +22873,8 @@
     "sourcemap-codec": {
       "version": "1.4.6",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.6.tgz",
-      "integrity": "sha512-1ZooVLYFxC448piVLBbtOxFcXwnymH9oUF8nRd3CuYDVvkRBxRl6pB4Mtas5a4drtL+E8LDgFkQNcgIw6tc8Hg=="
+      "integrity": "sha512-1ZooVLYFxC448piVLBbtOxFcXwnymH9oUF8nRd3CuYDVvkRBxRl6pB4Mtas5a4drtL+E8LDgFkQNcgIw6tc8Hg==",
+      "dev": true
     },
     "sourcemap-validator": {
       "version": "1.1.1",
@@ -28125,12 +23178,6 @@
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
-    "strip-final-newline": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-      "dev": true
-    },
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -28263,71 +23310,23 @@
       "dev": true,
       "requires": {
         "rimraf": "~2.6.2"
-      }
-    },
-    "term-size": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
-      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
-      "dev": true,
-      "requires": {
-        "execa": "^0.7.0"
       },
       "dependencies": {
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "glob": "^7.1.3"
           }
-        },
-        "execa": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-          "dev": true
-        },
-        "lru-cache": {
-          "version": "4.1.5",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-          "dev": true,
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          }
-        },
-        "yallist": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-          "dev": true
         }
       }
     },
     "terser": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.1.3.tgz",
-      "integrity": "sha512-on13d+cnpn5bMouZu+J8tPYQecsdRJCJuxFJ+FVoPBoLJgk5bCBkp+Uen2hWyi0KIUm6eDarnlAlH+KgIx/PuQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.1.4.tgz",
+      "integrity": "sha512-+ZwXJvdSwbd60jG0Illav0F06GDJF0R4ydZ21Q3wGAFKoBGyJGo34F63vzJHgvYxc1ukOtIjvwEvl9MkjzM6Pg==",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",
@@ -28456,12 +23455,6 @@
         "xmldom": "^0.1.19"
       },
       "dependencies": {
-        "bluebird": {
-          "version": "3.5.5",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-          "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
-          "dev": true
-        },
         "tmp": {
           "version": "0.0.33",
           "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -28488,23 +23481,6 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.5.0.tgz",
       "integrity": "sha512-1IkVr355eHcomgK7fgj1Xsokturx6L5S2JRT5WcRdA6v5shk9sxWuO/w/VbpQexwkXJMQIa/j1dBi3oo7+HhcA=="
-    },
-    "three-way-merger": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/three-way-merger/-/three-way-merger-0.5.7.tgz",
-      "integrity": "sha512-aD2nvGowCgJxoH49Izou5uR4PLCuH2yiw6+BJPg0H7RCLzpLy/4J9onM9sPXetmsq/AVfZ8fEyf8lbGKxKPrcA==",
-      "dev": true,
-      "requires": {
-        "semver": "^6.0.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
-      }
     },
     "through": {
       "version": "2.3.8",
@@ -28552,7 +23528,8 @@
     "time-zone": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
-      "integrity": "sha1-mcW/VZWJZq9tBtg73zgA3IL67F0="
+      "integrity": "sha1-mcW/VZWJZq9tBtg73zgA3IL67F0=",
+      "dev": true
     },
     "timed-out": {
       "version": "4.0.1",
@@ -28561,9 +23538,9 @@
       "dev": true
     },
     "timers-browserify": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
-      "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
+      "integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
       "dev": true,
       "requires": {
         "setimmediate": "^1.0.4"
@@ -28638,13 +23615,18 @@
       "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
-    },
-    "to-readable-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
-      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
-      "dev": true
     },
     "to-regex": {
       "version": "3.0.2",
@@ -28787,9 +23769,9 @@
       }
     },
     "type-fest": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
-      "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
+      "integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==",
       "dev": true
     },
     "type-is": {
@@ -29001,26 +23983,6 @@
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
       "integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
       "dev": true
-    },
-    "update-notifier": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-3.0.1.tgz",
-      "integrity": "sha512-grrmrB6Zb8DUiyDIaeRTBCkgISYUgETNe7NglEbVsrLWXeESnlCSP50WfRSj/GmzMPl6Uchj24S/p80nP/ZQrQ==",
-      "dev": true,
-      "requires": {
-        "boxen": "^3.0.0",
-        "chalk": "^2.0.1",
-        "configstore": "^4.0.0",
-        "has-yarn": "^2.1.0",
-        "import-lazy": "^2.1.0",
-        "is-ci": "^2.0.0",
-        "is-installed-globally": "^0.1.0",
-        "is-npm": "^3.0.0",
-        "is-yarn-global": "^0.3.0",
-        "latest-version": "^5.0.0",
-        "semver-diff": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
-      }
     },
     "uri-js": {
       "version": "4.2.2",
@@ -29283,6 +24245,12 @@
         "webpack-sources": "^1.3.0"
       },
       "dependencies": {
+        "acorn": {
+          "version": "5.7.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+          "dev": true
+        },
         "ajv": {
           "version": "6.10.2",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
@@ -29395,12 +24363,6 @@
         "isexe": "^2.0.0"
       }
     },
-    "which-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "dev": true
-    },
     "wide-align": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
@@ -29410,15 +24372,6 @@
         "string-width": "^1.0.2 || 2"
       }
     },
-    "widest-line": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
-      "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
-      "dev": true,
-      "requires": {
-        "string-width": "^2.1.1"
-      }
-    },
     "window-size": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
@@ -29426,9 +24379,9 @@
       "dev": true
     },
     "wordwrap": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
       "dev": true
     },
     "worker-farm": {
@@ -29448,45 +24401,6 @@
         "@babel/core": "^7.3.4",
         "object-assign": "4.1.1",
         "rsvp": "^4.8.4"
-      }
-    },
-    "wrap-ansi": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^3.2.0",
-        "string-width": "^3.0.0",
-        "strip-ansi": "^5.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        }
       }
     },
     "wrappy": {
@@ -29606,24 +24520,6 @@
         "os-locale": "^1.4.0",
         "window-size": "^0.1.2",
         "y18n": "^3.2.0"
-      }
-    },
-    "yargs-parser": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
-      "dev": true,
-      "requires": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-          "dev": true
-        }
       }
     },
     "yeast": {

--- a/packages/directory/package.json
+++ b/packages/directory/package.json
@@ -37,7 +37,6 @@
     "@ember/optional-features": "^0.6.3",
     "broccoli-asset-rev": "^2.7.0",
     "ember-basic-dropdown": "1.0.1",
-    "ember-c3": "0.2.3",
     "ember-cli": "~3.8.1",
     "ember-cli-bootstrap-datepicker": "0.5.3",
     "ember-cli-clipboard": "^0.8.1",

--- a/packages/reports/bower.json
+++ b/packages/reports/bower.json
@@ -4,8 +4,6 @@
     "pretender": "^1.4.2",
     "Faker": "~3.1.0",
     "numeral": "^1.5.3",
-    "bootstrap-datepicker": "1.4.0",
-    "d3": "3.5.17",
-    "c3": "0.4.20"
+    "bootstrap-datepicker": "1.4.0"
   }
 }

--- a/packages/reports/package-lock.json
+++ b/packages/reports/package-lock.json
@@ -1349,148 +1349,19 @@
       }
     },
     "@html-next/vertical-collection": {
-      "version": "1.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@html-next/vertical-collection/-/vertical-collection-1.0.0-beta.14.tgz",
-      "integrity": "sha512-HMmbYAe8UtEB9LFb7TtjsRvMgTYXMLNHJKd4z6QIpn0UAYJmXErIwJGIaK5Z7T3DYto4w10jD89HPhbCEyJG0Q==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@html-next/vertical-collection/-/vertical-collection-1.0.0.tgz",
+      "integrity": "sha512-qmSbIXiiQVNBkSJZK2or8TVhMn7aiUFHlbkHcKa1Cbn6BDQnqKkdoMaB+Ii1s0Dc8XmpMS1t/enCmAfszZ9+cw==",
       "requires": {
-        "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
         "babel6-plugin-strip-class-callcheck": "^6.0.0",
-        "broccoli-funnel": "^2.0.1",
+        "broccoli-funnel": "^2.0.2",
         "broccoli-merge-trees": "^3.0.1",
-        "broccoli-rollup": "^2.0.0",
-        "ember-cli-babel": "^6.6.0",
+        "broccoli-rollup": "^4.1.1",
+        "ember-cli-babel": "^7.7.3",
         "ember-cli-htmlbars": "^3.0.0",
-        "ember-cli-version-checker": "^2.1.0",
-        "ember-compatibility-helpers": "^1.0.0",
+        "ember-cli-version-checker": "^3.1.3",
+        "ember-compatibility-helpers": "^1.2.0",
         "ember-raf-scheduler": "0.1.0"
-      },
-      "dependencies": {
-        "amd-name-resolver": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz",
-          "integrity": "sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==",
-          "requires": {
-            "ensure-posix-path": "^1.0.1"
-          }
-        },
-        "babel-plugin-debug-macros": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz",
-          "integrity": "sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==",
-          "requires": {
-            "semver": "^5.3.0"
-          }
-        },
-        "broccoli-babel-transpiler": {
-          "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz",
-          "integrity": "sha512-w6GcnkxvHcNCte5FcLGEG1hUdQvlfvSN/6PtGWU/otg69Ugk8rUk51h41R0Ugoc+TNxyeFG1opRt2RlA87XzNw==",
-          "requires": {
-            "babel-core": "^6.26.0",
-            "broccoli-funnel": "^2.0.1",
-            "broccoli-merge-trees": "^2.0.0",
-            "broccoli-persistent-filter": "^1.4.3",
-            "clone": "^2.0.0",
-            "hash-for-dep": "^1.2.3",
-            "heimdalljs-logger": "^0.1.7",
-            "json-stable-stringify": "^1.0.0",
-            "rsvp": "^4.8.2",
-            "workerpool": "^2.3.0"
-          },
-          "dependencies": {
-            "broccoli-merge-trees": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.1.tgz",
-              "integrity": "sha512-WjaexJ+I8BxP5V5RNn6um/qDRSmKoiBC/QkRi79FT9ClHfldxRyCDs9mcV7mmoaPlsshmmPaUz5jdtcKA6DClQ==",
-              "requires": {
-                "broccoli-plugin": "^1.3.0",
-                "merge-trees": "^1.0.1"
-              }
-            }
-          }
-        },
-        "broccoli-persistent-filter": {
-          "version": "1.4.6",
-          "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.6.tgz",
-          "integrity": "sha512-0RejLwoC95kv4kta8KAa+FmECJCK78Qgm8SRDEK7YyU0N9Cx6KpY3UCDy9WELl3mCXLN8TokNxc7/hp3lL4lfw==",
-          "requires": {
-            "async-disk-cache": "^1.2.1",
-            "async-promise-queue": "^1.0.3",
-            "broccoli-plugin": "^1.0.0",
-            "fs-tree-diff": "^0.5.2",
-            "hash-for-dep": "^1.0.2",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.7",
-            "mkdirp": "^0.5.1",
-            "promise-map-series": "^0.2.1",
-            "rimraf": "^2.6.1",
-            "rsvp": "^3.0.18",
-            "symlink-or-copy": "^1.0.1",
-            "walk-sync": "^0.3.1"
-          },
-          "dependencies": {
-            "rsvp": {
-              "version": "3.6.2",
-              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-              "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
-            }
-          }
-        },
-        "ember-cli-babel": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
-          "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
-          "requires": {
-            "amd-name-resolver": "1.2.0",
-            "babel-plugin-debug-macros": "^0.2.0-beta.6",
-            "babel-plugin-ember-modules-api-polyfill": "^2.6.0",
-            "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
-            "babel-polyfill": "^6.26.0",
-            "babel-preset-env": "^1.7.0",
-            "broccoli-babel-transpiler": "^6.5.0",
-            "broccoli-debug": "^0.6.4",
-            "broccoli-funnel": "^2.0.0",
-            "broccoli-source": "^1.1.0",
-            "clone": "^2.0.0",
-            "ember-cli-version-checker": "^2.1.2",
-            "semver": "^5.5.0"
-          }
-        },
-        "ember-cli-version-checker": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-          "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-          "requires": {
-            "resolve": "^1.3.3",
-            "semver": "^5.3.0"
-          }
-        },
-        "merge-trees": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-1.0.1.tgz",
-          "integrity": "sha1-zL5nRWl4f53vF/1G5lJfVwC70j4=",
-          "requires": {
-            "can-symlink": "^1.0.0",
-            "fs-tree-diff": "^0.5.4",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.7",
-            "rimraf": "^2.4.3",
-            "symlink-or-copy": "^1.0.0"
-          }
-        },
-        "rsvp": {
-          "version": "4.8.5",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA=="
-        },
-        "workerpool": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.3.tgz",
-          "integrity": "sha512-L1ovlYHp6UObYqElXXpbd214GgbEKDED0d3sj7pRdFXjNkb2+un/AUcCkceHizO0IVI6SOGGncrcjozruCkRgA==",
-          "requires": {
-            "object-assign": "4.1.1"
-          }
-        }
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -1510,25 +1381,24 @@
       "dev": true
     },
     "@sindresorhus/is": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
-      "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
-    },
-    "@szmarczak/http-timer": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
-      "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
-      "requires": {
-        "defer-to-connect": "^1.0.1"
-      }
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
+      "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
+      "dev": true
     },
     "@types/acorn": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/acorn/-/acorn-4.0.5.tgz",
       "integrity": "sha512-603sPiZ4GVRHPvn6vNgEAvJewKsy+zwRWYS2MeIMemgoAtcjlw2G3lALxrb9OPA17J28bkB71R33yXlQbUatCA==",
+      "dev": true,
       "requires": {
         "@types/estree": "*"
       }
+    },
+    "@types/broccoli-plugin": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@types/broccoli-plugin/-/broccoli-plugin-1.3.0.tgz",
+      "integrity": "sha512-SLk4/hFc2kGvgwNFrpn2O1juxFOllcHAywvlo7VwxfExLzoz1GGJ0oIZCwj5fwSpvHw4AWpZjJ1fUvb62PDayQ=="
     },
     "@types/estree": {
       "version": "0.0.39",
@@ -1538,20 +1408,14 @@
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
-    },
-    "@types/fs-extra": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.1.0.tgz",
-      "integrity": "sha512-AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==",
-      "requires": {
-        "@types/node": "*"
-      }
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+      "dev": true
     },
     "@types/glob": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
       "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+      "dev": true,
       "requires": {
         "@types/events": "*",
         "@types/minimatch": "*",
@@ -1564,18 +1428,9 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
     },
     "@types/node": {
-      "version": "9.6.50",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.50.tgz",
-      "integrity": "sha512-9Yzqn2NzJxwFzon4W+aqUAMl3FiVnJ965f5F3H5T+EpUrHqb2Is1SPp/lsj2WFBqXrhIINJ5SzSwneLMg5PgSQ=="
-    },
-    "@types/rimraf": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-2.0.2.tgz",
-      "integrity": "sha512-Hm/bnWq0TCy7jmjeN5bKYij9vw5GrDFWME4IuxV08278NtU/VdGbzsBohcCUJ7+QMqmUq5hpRKB39HeQWJjztQ==",
-      "requires": {
-        "@types/glob": "*",
-        "@types/node": "*"
-      }
+      "version": "12.7.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.2.tgz",
+      "integrity": "sha512-dyYO+f6ihZEtNPDcWNR1fkoTDf3zAK3lAABDze3mz6POyIercH0lEUawUFXlG8xaQZmm1yEBON/4TsYv/laDYg=="
     },
     "@types/symlink-or-copy": {
       "version": "1.2.0",
@@ -1795,16 +1650,25 @@
       }
     },
     "acorn": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
+      "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA=="
     },
     "acorn-dynamic-import": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
       "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
+      "dev": true,
       "requires": {
         "acorn": "^5.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.7.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+          "dev": true
+        }
       }
     },
     "acorn-globals": {
@@ -1815,14 +1679,6 @@
       "requires": {
         "acorn": "^6.0.1",
         "acorn-walk": "^6.0.1"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
-          "integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
-          "dev": true
-        }
       }
     },
     "acorn-jsx": {
@@ -1914,39 +1770,6 @@
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/animation-frame/-/animation-frame-0.2.5.tgz",
       "integrity": "sha1-zfWpGmmtLIXdrCuC2vcpAwDwWWA="
-    },
-    "ansi-align": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
-      "integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
-      "requires": {
-        "string-width": "^3.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        }
-      }
     },
     "ansi-escapes": {
       "version": "3.2.0",
@@ -2608,11 +2431,11 @@
       }
     },
     "babel-plugin-ember-modules-api-polyfill": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.9.0.tgz",
-      "integrity": "sha512-c03h50291phJ2gQxo/aIOvFQE2c6glql1A7uagE3XbPXpKVAJOUxtVDjvWG6UAB6BC5ynsJfMWvY0w4TPRKIHQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.11.0.tgz",
+      "integrity": "sha512-S3bw77LglkWIstoF+hBLyRPyyNAUsdzqK6zLxktuM6EniVt06st/ikhPDUttMWixS2LNA+jnBfGerYO1D/VvDw==",
       "requires": {
-        "ember-rfc176-data": "^0.3.9"
+        "ember-rfc176-data": "^0.3.11"
       }
     },
     "babel-plugin-eval": {
@@ -3449,117 +3272,12 @@
         }
       }
     },
-    "boilerplate-update": {
-      "version": "0.22.6",
-      "resolved": "https://registry.npmjs.org/boilerplate-update/-/boilerplate-update-0.22.6.tgz",
-      "integrity": "sha512-mbgV8nUs6ovN/uvHTqk8tm8a/h+PgDtWAGs3zNg/rfvAi6Nu3IFpWr3MCENJfp2its4MuXj7Ozoo8wBBHHdPjQ==",
-      "requires": {
-        "cpr": "^3.0.1",
-        "debug": "^4.1.1",
-        "execa": "^2.0.0",
-        "git-diff-apply": "0.19.1",
-        "inquirer": "^6.2.2",
-        "merge-package.json": "^3.0.0",
-        "npx": "^10.2.0",
-        "open": "^6.0.0",
-        "p-reduce": "^2.0.0",
-        "rimraf": "^2.6.3",
-        "semver": "^6.0.0",
-        "tmp": "0.1.0",
-        "which": "^1.3.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-        },
-        "chardet": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-          "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "external-editor": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-          "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-          "requires": {
-            "chardet": "^0.7.0",
-            "iconv-lite": "^0.4.24",
-            "tmp": "^0.0.33"
-          },
-          "dependencies": {
-            "tmp": {
-              "version": "0.0.33",
-              "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-              "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-              "requires": {
-                "os-tmpdir": "~1.0.2"
-              }
-            }
-          }
-        },
-        "inquirer": {
-          "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
-          "integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
-          "requires": {
-            "ansi-escapes": "^3.2.0",
-            "chalk": "^2.4.2",
-            "cli-cursor": "^2.1.0",
-            "cli-width": "^2.0.0",
-            "external-editor": "^3.0.3",
-            "figures": "^2.0.0",
-            "lodash": "^4.17.12",
-            "mute-stream": "0.0.7",
-            "run-async": "^2.2.0",
-            "rxjs": "^6.4.0",
-            "string-width": "^2.1.0",
-            "strip-ansi": "^5.1.0",
-            "through": "^2.3.6"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        },
-        "tmp": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-          "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
-          "requires": {
-            "rimraf": "^2.6.3"
-          }
-        }
-      }
-    },
     "boom": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
+      "optional": true,
       "requires": {
         "hoek": "2.x.x"
       }
@@ -3600,51 +3318,6 @@
       "resolved": "https://registry.npmjs.org/bower-endpoint-parser/-/bower-endpoint-parser-0.2.2.tgz",
       "integrity": "sha1-ALVlrb+rby01rd3pd+l5Yqy8s/Y=",
       "dev": true
-    },
-    "boxen": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-3.2.0.tgz",
-      "integrity": "sha512-cU4J/+NodM3IHdSL2yN8bqYqnmlBTidDR4RC7nJs61ZmtGz8VZzM3HLQX0zY5mrSmPtR3xWwsq2jOUQqFZN8+A==",
-      "requires": {
-        "ansi-align": "^3.0.0",
-        "camelcase": "^5.3.1",
-        "chalk": "^2.4.2",
-        "cli-boxes": "^2.2.0",
-        "string-width": "^3.0.0",
-        "term-size": "^1.2.0",
-        "type-fest": "^0.3.0",
-        "widest-line": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-        },
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        }
-      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -4341,21 +4014,54 @@
       }
     },
     "broccoli-rollup": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/broccoli-rollup/-/broccoli-rollup-2.1.1.tgz",
-      "integrity": "sha512-aky/Ovg5DbsrsJEx2QCXxHLA6ZR+9u1TNVTf85soP4gL8CjGGKQ/JU8R3BZ2ntkWzo6/83RCKzX6O+nlNKR5MQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/broccoli-rollup/-/broccoli-rollup-4.1.1.tgz",
+      "integrity": "sha512-hkp0dB5chiemi32t6hLe5bJvxuTOm1TU+SryFlZIs95KT9+94uj0C8w6k6CsZ2HuIdIZg6D252t4gwOlcTXrpA==",
       "requires": {
-        "@types/node": "^9.6.0",
-        "amd-name-resolver": "^1.2.0",
-        "broccoli-plugin": "^1.2.1",
-        "fs-tree-diff": "^0.5.2",
-        "heimdalljs": "^0.2.1",
-        "heimdalljs-logger": "^0.1.7",
-        "magic-string": "^0.24.0",
+        "@types/broccoli-plugin": "^1.3.0",
+        "broccoli-plugin": "^2.0.0",
+        "fs-tree-diff": "^2.0.1",
+        "heimdalljs": "^0.2.6",
         "node-modules-path": "^1.0.1",
-        "rollup": "^0.57.1",
-        "symlink-or-copy": "^1.1.8",
-        "walk-sync": "^0.3.1"
+        "rollup": "^1.12.0",
+        "rollup-pluginutils": "^2.8.1",
+        "symlink-or-copy": "^1.2.0",
+        "walk-sync": "^1.1.3"
+      },
+      "dependencies": {
+        "broccoli-plugin": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-2.1.0.tgz",
+          "integrity": "sha512-ElE4caljW4slapyEhSD9jU9Uayc8SoSABWdmY9SqbV8DHNxU6xg1jJsPcMm+cXOvggR3+G+OXAYQeFjWVnznaw==",
+          "requires": {
+            "promise-map-series": "^0.2.1",
+            "quick-temp": "^0.1.3",
+            "rimraf": "^2.3.4",
+            "symlink-or-copy": "^1.1.8"
+          }
+        },
+        "fs-tree-diff": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
+          "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
+          "requires": {
+            "@types/symlink-or-copy": "^1.2.0",
+            "heimdalljs-logger": "^0.1.7",
+            "object-assign": "^4.1.0",
+            "path-posix": "^1.0.0",
+            "symlink-or-copy": "^1.1.8"
+          }
+        },
+        "walk-sync": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-1.1.4.tgz",
+          "integrity": "sha512-nowc9thB/Jg0KW4TgxoRjLLYRPvl3DB/98S89r4ZcJqq2B0alNcKDh6pzLkBSkPMzRSMsJghJHQi79qw0YWEkA==",
+          "requires": {
+            "@types/minimatch": "^3.0.3",
+            "ensure-posix-path": "^1.1.0",
+            "matcher-collection": "^1.1.1"
+          }
+        }
       }
     },
     "broccoli-slow-trees": {
@@ -4856,12 +4562,6 @@
           "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
           "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
           "dev": true
-        },
-        "yallist": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
         }
       }
     },
@@ -4883,23 +4583,31 @@
       }
     },
     "cacheable-request": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
-      "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
+      "integrity": "sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=",
+      "dev": true,
       "requires": {
-        "clone-response": "^1.0.2",
-        "get-stream": "^5.1.0",
-        "http-cache-semantics": "^4.0.0",
-        "keyv": "^3.0.0",
-        "lowercase-keys": "^2.0.0",
-        "normalize-url": "^4.1.0",
-        "responselike": "^1.0.2"
+        "clone-response": "1.0.2",
+        "get-stream": "3.0.0",
+        "http-cache-semantics": "3.8.1",
+        "keyv": "3.0.0",
+        "lowercase-keys": "1.0.0",
+        "normalize-url": "2.0.1",
+        "responselike": "1.0.2"
       },
       "dependencies": {
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        },
         "lowercase-keys": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+          "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
+          "dev": true
         }
       }
     },
@@ -5083,7 +4791,8 @@
     "ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "dev": true
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -5176,11 +4885,6 @@
       "resolved": "https://registry.npmjs.org/clean-up-path/-/clean-up-path-1.0.0.tgz",
       "integrity": "sha512-PHGlEF0Z6976qQyN6gM7kKH6EH0RdfZcc8V+QhFe36eRxV0SMH5OUBZG7Bxa9YcreNzyNbK63cGiZxdSZgosRw=="
     },
-    "cli-boxes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.0.tgz",
-      "integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w=="
-    },
     "cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -5258,6 +4962,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
       "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "dev": true,
       "requires": {
         "mimic-response": "^1.0.0"
       }
@@ -5463,6 +5168,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-4.0.0.tgz",
       "integrity": "sha512-CmquAXFBocrzaSM8mtGPMM/HiWmyIpr4CcJl/rgY2uCObZ/S7cKU0silxslqJejl+t/T9HS8E0PUNQD81JGUEQ==",
+      "dev": true,
       "requires": {
         "dot-prop": "^4.1.0",
         "graceful-fs": "^4.1.2",
@@ -5512,6 +5218,15 @@
         "through2": "^3.0.1"
       },
       "dependencies": {
+        "ansi-escapes": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.2.1.tgz",
+          "integrity": "sha512-Cg3ymMAdN10wOk/VYfLV7KCQyv7EDirJ64500sU7n9UlmioEtDuU5Gd+hj73hXSU/ex7tHJSssmyftDdkMLO8Q==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.5.2"
+          }
+        },
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -5524,6 +5239,15 @@
           "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
           "dev": true
         },
+        "cli-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^3.1.0"
+          }
+        },
         "external-editor": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -5535,25 +5259,82 @@
             "tmp": "^0.0.33"
           }
         },
-        "inquirer": {
-          "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
-          "integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
+        "figures": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-3.0.0.tgz",
+          "integrity": "sha512-HKri+WoWoUgr83pehn/SIgLOMZ9nAWC6dcGj26RY2R4F50u4+RTUz0RCrUlOV3nKRAICW1UGzyb+kcX2qK1S/g==",
           "dev": true,
           "requires": {
-            "ansi-escapes": "^3.2.0",
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "inquirer": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.1.tgz",
+          "integrity": "sha512-uxNHBeQhRXIoHWTSNYUFhQVrHYFThIt6IVo2fFmSe8aBwdR3/w6b58hJpiL/fMukFkvGzjg+hSxFtwvVmKZmXw==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^4.2.1",
             "chalk": "^2.4.2",
-            "cli-cursor": "^2.1.0",
+            "cli-cursor": "^3.1.0",
             "cli-width": "^2.0.0",
             "external-editor": "^3.0.3",
-            "figures": "^2.0.0",
-            "lodash": "^4.17.12",
-            "mute-stream": "0.0.7",
+            "figures": "^3.0.0",
+            "lodash": "^4.17.15",
+            "mute-stream": "0.0.8",
             "run-async": "^2.2.0",
             "rxjs": "^6.4.0",
-            "string-width": "^2.1.0",
+            "string-width": "^4.1.0",
             "strip-ansi": "^5.1.0",
             "through": "^2.3.6"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+          "dev": true
+        },
+        "mute-stream": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+          "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+          "dev": true
+        },
+        "onetime": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+          "dev": true,
+          "requires": {
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "string-width": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.1.0.tgz",
+          "integrity": "sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^5.2.0"
           }
         },
         "strip-ansi": {
@@ -5672,13 +5453,12 @@
       "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
     },
     "core-js-compat": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.1.4.tgz",
-      "integrity": "sha512-Z5zbO9f1d0YrJdoaQhphVAnKPimX92D6z8lCGphH89MNRxlL1prI9ExJPqVwP0/kgkQCv8c4GJGT8X16yUncOg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.2.1.tgz",
+      "integrity": "sha512-MwPZle5CF9dEaMYdDeWm73ao/IflDH+FjeJCWEADcEgFSE9TLimFKwJsfmkwzI8eC0Aj0mgvMDjeQjrElkz4/A==",
       "requires": {
-        "browserslist": "^4.6.2",
-        "core-js-pure": "3.1.4",
-        "semver": "^6.1.1"
+        "browserslist": "^4.6.6",
+        "semver": "^6.3.0"
       },
       "dependencies": {
         "semver": {
@@ -5687,11 +5467,6 @@
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
-    },
-    "core-js-pure": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.1.4.tgz",
-      "integrity": "sha512-uJ4Z7iPNwiu1foygbcZYJsJs1jiXrTTCvxfLDXNhI/I+NHbSIEyr548y4fcsCEyWY0XgfAG/qqaunJ1SThHenA=="
     },
     "core-object": {
       "version": "3.1.5",
@@ -5707,24 +5482,6 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
-    },
-    "cpr": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/cpr/-/cpr-3.0.1.tgz",
-      "integrity": "sha1-uaVQOLfNgaNcF7l2GJW9hJau8eU=",
-      "requires": {
-        "graceful-fs": "^4.1.5",
-        "minimist": "^1.2.0",
-        "mkdirp": "~0.5.1",
-        "rimraf": "^2.5.4"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        }
-      }
     },
     "create-ecdh": {
       "version": "4.0.3",
@@ -5776,6 +5533,7 @@
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
       "requires": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",
@@ -5816,7 +5574,8 @@
     "crypto-random-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
+      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+      "dev": true
     },
     "cssom": {
       "version": "0.3.8",
@@ -5883,6 +5642,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/date-time/-/date-time-2.1.0.tgz",
       "integrity": "sha512-/9+C44X7lot0IeiyfgJmETtRMhBidBYM2QFFIkGa0U1k+hSyY87Nw7PY3eDqpvCBm7I3WCSfPeZskW/YYq6m4g==",
+      "dev": true,
       "requires": {
         "time-zone": "^1.0.0"
       }
@@ -5910,6 +5670,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "dev": true,
       "requires": {
         "mimic-response": "^1.0.0"
       }
@@ -5917,7 +5678,8 @@
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true
     },
     "deep-is": {
       "version": "0.1.3",
@@ -5941,11 +5703,6 @@
           "dev": true
         }
       }
-    },
-    "defer-to-connect": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.0.2.tgz",
-      "integrity": "sha512-k09hcQcTDY+cwgiwa6PYKLm3jlagNzQ+RSvhjzESOGOx+MNOuXkxTfEvPrO1IOQ81tArCFYQgi631clB70RpQw=="
     },
     "define-properties": {
       "version": "1.1.3",
@@ -6084,6 +5841,13 @@
       "requires": {
         "acorn": "^5.2.1",
         "defined": "^1.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.7.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
+        }
       }
     },
     "diff": {
@@ -6140,6 +5904,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
       "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+      "dev": true,
       "requires": {
         "is-obj": "^1.0.0"
       }
@@ -6153,7 +5918,8 @@
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+      "dev": true
     },
     "duplexify": {
       "version": "3.7.1",
@@ -6215,9 +5981,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.218",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.218.tgz",
-      "integrity": "sha512-+ABuwQH2bEUbJTMPUMfP9mjBFtbLgDjlrkg3QGQZwr/RJB7aJZBm8g3SK/lR/J76P6l/4a6RgW2yQjZQDdjtFw=="
+      "version": "1.3.230",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.230.tgz",
+      "integrity": "sha512-r0RljY5DZi9RX4v8mjHxJkDWnQe+nsrkGlHtrDF2uvZcvAkw+iglvlQi1794gZhwRtJoDOomMJlDHL2LfXSCZA=="
     },
     "elliptic": {
       "version": "6.5.0",
@@ -6796,351 +6562,6 @@
         "ember-cli-htmlbars": "^3.0.0"
       }
     },
-    "ember-c3": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/ember-c3/-/ember-c3-0.2.3.tgz",
-      "integrity": "sha1-PzE9DYxA4a/8KDau92ln2892v40=",
-      "dev": true,
-      "requires": {
-        "ember-cli-babel": "^5.1.5"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "babel-core": {
-          "version": "5.8.38",
-          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
-          "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
-          "dev": true,
-          "requires": {
-            "babel-plugin-constant-folding": "^1.0.1",
-            "babel-plugin-dead-code-elimination": "^1.0.2",
-            "babel-plugin-eval": "^1.0.1",
-            "babel-plugin-inline-environment-variables": "^1.0.1",
-            "babel-plugin-jscript": "^1.0.4",
-            "babel-plugin-member-expression-literals": "^1.0.1",
-            "babel-plugin-property-literals": "^1.0.1",
-            "babel-plugin-proto-to-assign": "^1.0.3",
-            "babel-plugin-react-constant-elements": "^1.0.3",
-            "babel-plugin-react-display-name": "^1.0.3",
-            "babel-plugin-remove-console": "^1.0.1",
-            "babel-plugin-remove-debugger": "^1.0.1",
-            "babel-plugin-runtime": "^1.0.7",
-            "babel-plugin-undeclared-variables-check": "^1.0.2",
-            "babel-plugin-undefined-to-void": "^1.1.6",
-            "babylon": "^5.8.38",
-            "bluebird": "^2.9.33",
-            "chalk": "^1.0.0",
-            "convert-source-map": "^1.1.0",
-            "core-js": "^1.0.0",
-            "debug": "^2.1.1",
-            "detect-indent": "^3.0.0",
-            "esutils": "^2.0.0",
-            "fs-readdir-recursive": "^0.1.0",
-            "globals": "^6.4.0",
-            "home-or-tmp": "^1.0.0",
-            "is-integer": "^1.0.4",
-            "js-tokens": "1.0.1",
-            "json5": "^0.4.0",
-            "lodash": "^3.10.0",
-            "minimatch": "^2.0.3",
-            "output-file-sync": "^1.1.0",
-            "path-exists": "^1.0.0",
-            "path-is-absolute": "^1.0.0",
-            "private": "^0.1.6",
-            "regenerator": "0.8.40",
-            "regexpu": "^1.3.0",
-            "repeating": "^1.1.2",
-            "resolve": "^1.1.6",
-            "shebang-regex": "^1.0.0",
-            "slash": "^1.0.0",
-            "source-map": "^0.5.0",
-            "source-map-support": "^0.2.10",
-            "to-fast-properties": "^1.0.0",
-            "trim-right": "^1.0.0",
-            "try-resolve": "^1.0.0"
-          }
-        },
-        "babylon": {
-          "version": "5.8.38",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
-          "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
-          "dev": true
-        },
-        "broccoli-babel-transpiler": {
-          "version": "5.7.4",
-          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.4.tgz",
-          "integrity": "sha512-gI14Pqc4qbmn5RW4SuAmybLiOoYW59D+HzQyhY6WdaGMAjikKBwJN0p17phyvafQ+kvG0mUiMd83lgHLeATnEA==",
-          "dev": true,
-          "requires": {
-            "babel-core": "^5.0.0",
-            "broccoli-funnel": "^1.0.0",
-            "broccoli-merge-trees": "^1.0.0",
-            "broccoli-persistent-filter": "^1.4.2",
-            "clone": "^0.2.0",
-            "hash-for-dep": "^1.0.2",
-            "heimdalljs-logger": "^0.1.7",
-            "json-stable-stringify": "^1.0.0",
-            "rsvp": "^3.5.0",
-            "workerpool": "^2.3.0"
-          },
-          "dependencies": {
-            "clone": {
-              "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-              "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-              "dev": true
-            }
-          }
-        },
-        "broccoli-funnel": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
-          "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
-          "dev": true,
-          "requires": {
-            "array-equal": "^1.0.0",
-            "blank-object": "^1.0.1",
-            "broccoli-plugin": "^1.3.0",
-            "debug": "^2.2.0",
-            "exists-sync": "0.0.4",
-            "fast-ordered-set": "^1.0.0",
-            "fs-tree-diff": "^0.5.3",
-            "heimdalljs": "^0.2.0",
-            "minimatch": "^3.0.0",
-            "mkdirp": "^0.5.0",
-            "path-posix": "^1.0.0",
-            "rimraf": "^2.4.3",
-            "symlink-or-copy": "^1.0.0",
-            "walk-sync": "^0.3.1"
-          },
-          "dependencies": {
-            "minimatch": {
-              "version": "3.0.4",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-              "dev": true,
-              "requires": {
-                "brace-expansion": "^1.1.7"
-              }
-            }
-          }
-        },
-        "broccoli-merge-trees": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz",
-          "integrity": "sha1-oAFRm7UGfwZYnZGvopQkRaLQ/bU=",
-          "dev": true,
-          "requires": {
-            "broccoli-plugin": "^1.3.0",
-            "can-symlink": "^1.0.0",
-            "fast-ordered-set": "^1.0.2",
-            "fs-tree-diff": "^0.5.4",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.7",
-            "rimraf": "^2.4.3",
-            "symlink-or-copy": "^1.0.0"
-          }
-        },
-        "broccoli-persistent-filter": {
-          "version": "1.4.6",
-          "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.6.tgz",
-          "integrity": "sha512-0RejLwoC95kv4kta8KAa+FmECJCK78Qgm8SRDEK7YyU0N9Cx6KpY3UCDy9WELl3mCXLN8TokNxc7/hp3lL4lfw==",
-          "dev": true,
-          "requires": {
-            "async-disk-cache": "^1.2.1",
-            "async-promise-queue": "^1.0.3",
-            "broccoli-plugin": "^1.0.0",
-            "fs-tree-diff": "^0.5.2",
-            "hash-for-dep": "^1.0.2",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.7",
-            "mkdirp": "^0.5.1",
-            "promise-map-series": "^0.2.1",
-            "rimraf": "^2.6.1",
-            "rsvp": "^3.0.18",
-            "symlink-or-copy": "^1.0.1",
-            "walk-sync": "^0.3.1"
-          }
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
-          "dev": true
-        },
-        "detect-indent": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-          "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "^4.0.1",
-            "minimist": "^1.1.0",
-            "repeating": "^1.1.0"
-          }
-        },
-        "ember-cli-babel": {
-          "version": "5.2.8",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.8.tgz",
-          "integrity": "sha512-Mt9OOB5RaZwjde+LYef8EgwNVCAzsYDv4ktshblaXxr4m/Xm5/7/rxEu42RNrYkoy/qWpT9uhaD+JKK4riMf+w==",
-          "dev": true,
-          "requires": {
-            "broccoli-babel-transpiler": "^5.6.2",
-            "broccoli-funnel": "^1.0.0",
-            "clone": "^2.0.0",
-            "ember-cli-version-checker": "^1.0.2",
-            "resolve": "^1.1.2"
-          }
-        },
-        "ember-cli-version-checker": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-          "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
-          "dev": true,
-          "requires": {
-            "semver": "^5.3.0"
-          }
-        },
-        "globals": {
-          "version": "6.4.1",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
-          "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08=",
-          "dev": true
-        },
-        "home-or-tmp": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-          "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "^1.0.1",
-            "user-home": "^1.1.1"
-          }
-        },
-        "js-tokens": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz",
-          "integrity": "sha1-zENaXIuUrRWst5gxQPyAGCyJrq4=",
-          "dev": true
-        },
-        "json5": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-          "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "2.0.10",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.0.0"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "path-exists": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-          "integrity": "sha1-1aiZjrce83p0w06w2eum6HjuoIE=",
-          "dev": true
-        },
-        "repeating": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-          "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-          "dev": true,
-          "requires": {
-            "is-finite": "^1.0.0"
-          }
-        },
-        "source-map-support": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
-          "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
-          "dev": true,
-          "requires": {
-            "source-map": "0.1.32"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.1.32",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-              "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-              "dev": true,
-              "requires": {
-                "amdefine": ">=0.0.4"
-              }
-            }
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        },
-        "to-fast-properties": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-          "dev": true
-        },
-        "workerpool": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.3.tgz",
-          "integrity": "sha512-L1ovlYHp6UObYqElXXpbd214GgbEKDED0d3sj7pRdFXjNkb2+un/AUcCkceHizO0IVI6SOGGncrcjozruCkRgA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "4.1.1"
-          }
-        }
-      }
-    },
     "ember-cli": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ember-cli/-/ember-cli-3.9.0.tgz",
@@ -7292,21 +6713,6 @@
             "ms": "^2.1.1"
           }
         },
-        "execa": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^6.0.0",
-            "get-stream": "^4.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          }
-        },
         "find-up": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -7339,21 +6745,6 @@
             "symlink-or-copy": "^1.1.8"
           }
         },
-        "get-stream": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-          "dev": true
-        },
         "locate-path": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -7368,21 +6759,6 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "npm-run-path": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-          "dev": true,
-          "requires": {
-            "path-key": "^2.0.0"
-          }
-        },
-        "p-finally": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
           "dev": true
         },
         "p-limit": {
@@ -7439,9 +6815,9 @@
       }
     },
     "ember-cli-babel": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.8.0.tgz",
-      "integrity": "sha512-xUBgJQ81fqd7k/KIiGU+pjpoXhrmmRf9pUrqLenNSU5N+yeNFT5a1+w0b+p1F7oBphfXVwuxApdZxrmAHOdA3Q==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.10.0.tgz",
+      "integrity": "sha512-eNgPXobC+Pke5L3XzoJ0BXbb2+eYzZI+LljqbwXNuG4q63pF000aARFpTQ0p/NWkfGQxKi2L6tVIa1ZOYdQS+A==",
       "requires": {
         "@babel/core": "^7.0.0",
         "@babel/plugin-proposal-class-properties": "^7.3.4",
@@ -7453,7 +6829,7 @@
         "@babel/runtime": "^7.2.0",
         "amd-name-resolver": "^1.2.1",
         "babel-plugin-debug-macros": "^0.3.0",
-        "babel-plugin-ember-modules-api-polyfill": "^2.9.0",
+        "babel-plugin-ember-modules-api-polyfill": "^2.11.0",
         "babel-plugin-module-resolver": "^3.1.1",
         "broccoli-babel-transpiler": "^7.1.2",
         "broccoli-debug": "^0.6.4",
@@ -8307,15 +7683,6 @@
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.6"
-          }
-        },
-        "klaw": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
-          "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.9"
           }
         },
         "merge-trees": {
@@ -9970,21 +9337,6 @@
             "ms": "^2.1.1"
           }
         },
-        "execa": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^6.0.0",
-            "get-stream": "^4.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          }
-        },
         "fs-extra": {
           "version": "7.0.1",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
@@ -9996,40 +9348,10 @@
             "universalify": "^0.1.0"
           }
         },
-        "get-stream": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-          "dev": true
-        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "npm-run-path": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-          "dev": true,
-          "requires": {
-            "path-key": "^2.0.0"
-          }
-        },
-        "p-finally": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
           "dev": true
         },
         "rsvp": {
@@ -10065,144 +9387,6 @@
       "requires": {
         "broccoli-uglify-sourcemap": "^2.1.1",
         "lodash.defaultsdeep": "^4.6.0"
-      }
-    },
-    "ember-cli-update": {
-      "version": "0.34.13",
-      "resolved": "https://registry.npmjs.org/ember-cli-update/-/ember-cli-update-0.34.13.tgz",
-      "integrity": "sha512-KdU/2dyrtpNdEogwEPOrZvPfuCSflbtUvGL5HxS4Y9kMxqvRGcncZopH16El3Jd6XhL8faIygajvd9gT4JD+Gw==",
-      "requires": {
-        "boilerplate-update": "0.22.6",
-        "debug": "^4.1.1",
-        "fs-extra": "^8.0.0",
-        "resolve": "^1.10.0",
-        "semver": "^6.0.0",
-        "update-notifier": "^3.0.0",
-        "which": "^1.3.1",
-        "yargs": "^13.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-        },
-        "cliui": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-          "requires": {
-            "string-width": "^3.1.0",
-            "strip-ansi": "^5.2.0",
-            "wrap-ansi": "^5.1.0"
-          }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "fs-extra": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "p-limit": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        },
-        "y18n": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
-        },
-        "yargs": {
-          "version": "13.3.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
-          "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
-          "requires": {
-            "cliui": "^5.0.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^2.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^3.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^13.1.1"
-          }
-        }
       }
     },
     "ember-cli-version-checker": {
@@ -10875,6 +10059,18 @@
         "silent-error": "^1.1.1"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "9.6.50",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.50.tgz",
+          "integrity": "sha512-9Yzqn2NzJxwFzon4W+aqUAMl3FiVnJ965f5F3H5T+EpUrHqb2Is1SPp/lsj2WFBqXrhIINJ5SzSwneLMg5PgSQ==",
+          "dev": true
+        },
+        "acorn": {
+          "version": "5.7.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+          "dev": true
+        },
         "broccoli-file-creator": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/broccoli-file-creator/-/broccoli-file-creator-2.1.1.tgz",
@@ -10885,6 +10081,36 @@
             "mkdirp": "^0.5.1"
           }
         },
+        "broccoli-rollup": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/broccoli-rollup/-/broccoli-rollup-2.1.1.tgz",
+          "integrity": "sha512-aky/Ovg5DbsrsJEx2QCXxHLA6ZR+9u1TNVTf85soP4gL8CjGGKQ/JU8R3BZ2ntkWzo6/83RCKzX6O+nlNKR5MQ==",
+          "dev": true,
+          "requires": {
+            "@types/node": "^9.6.0",
+            "amd-name-resolver": "^1.2.0",
+            "broccoli-plugin": "^1.2.1",
+            "fs-tree-diff": "^0.5.2",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.7",
+            "magic-string": "^0.24.0",
+            "node-modules-path": "^1.0.1",
+            "rollup": "^0.57.1",
+            "symlink-or-copy": "^1.1.8",
+            "walk-sync": "^0.3.1"
+          },
+          "dependencies": {
+            "heimdalljs": {
+              "version": "0.2.6",
+              "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.2.6.tgz",
+              "integrity": "sha512-o9bd30+5vLBvBtzCPwwGqpry2+n0Hi6H1+qwt6y+0kwRHGGF8TFIhJPmnuM0xO97zaKrDZMwO/V56fAnn8m/tA==",
+              "dev": true,
+              "requires": {
+                "rsvp": "~3.2.1"
+              }
+            }
+          }
+        },
         "heimdalljs": {
           "version": "0.3.3",
           "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.3.3.tgz",
@@ -10892,6 +10118,25 @@
           "dev": true,
           "requires": {
             "rsvp": "~3.2.1"
+          }
+        },
+        "rollup": {
+          "version": "0.57.1",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.57.1.tgz",
+          "integrity": "sha512-I18GBqP0qJoJC1K1osYjreqA8VAKovxuI3I81RSk0Dmr4TgloI0tAULjZaox8OsJ+n7XRrhH6i0G2By/pj1LCA==",
+          "dev": true,
+          "requires": {
+            "@types/acorn": "^4.0.3",
+            "acorn": "^5.5.3",
+            "acorn-dynamic-import": "^3.0.0",
+            "date-time": "^2.1.0",
+            "is-reference": "^1.1.0",
+            "locate-character": "^2.0.5",
+            "pretty-ms": "^3.1.0",
+            "require-relative": "^0.8.7",
+            "rollup-pluginutils": "^2.0.1",
+            "signal-exit": "^3.0.2",
+            "sourcemap-codec": "^1.4.1"
           }
         },
         "rsvp": {
@@ -13868,12 +13113,11 @@
       }
     },
     "ember-promise-helpers": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/ember-promise-helpers/-/ember-promise-helpers-1.0.8.tgz",
-      "integrity": "sha512-zfPFBjqXCI/hk3Vdx8tSVNOuccbbJucmOQQqL+hmrtzxPl2tg1RQ2Y63XBHyYuYDHR/OoW8uixOuYE4RRjH9ig==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/ember-promise-helpers/-/ember-promise-helpers-1.0.9.tgz",
+      "integrity": "sha512-BDcx2X28baEL0YMKSmDGQzvdyfiFSlx4Byf34hVrAw6W7VO17YYLjeXPebVBOXLA1BMWmUo0Bb2pZRZ09MQYYA==",
       "requires": {
-        "ember-cli-babel": "^6.16.0",
-        "ember-cli-update": "^0.34.10"
+        "ember-cli-babel": "^6.16.0"
       },
       "dependencies": {
         "amd-name-resolver": {
@@ -15103,9 +14347,9 @@
       }
     },
     "ember-resolver": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ember-resolver/-/ember-resolver-5.2.0.tgz",
-      "integrity": "sha512-vL7YnifeHA2g6OM3KF7PSCIcUBvPISfcxByqGmWgjynbZpd3KmBUpHVxAlqXUYqhO4viRcM0sohAgZ41bCv7QQ==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ember-resolver/-/ember-resolver-5.2.1.tgz",
+      "integrity": "sha512-Ciz5qsrtILr7AGXO9mTSFs3/XKXpMYJqISNCfvIY0C8PlMgq+9RYbmUoBpAlvBUc/mUi3ORZKJ4csd9qchvxZw==",
       "dev": true,
       "requires": {
         "@glimmer/resolver": "^0.4.1",
@@ -15268,9 +14512,9 @@
       }
     },
     "ember-rfc176-data": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.9.tgz",
-      "integrity": "sha512-EiTo5YQS0Duy0xp9gCP8ekzv9vxirNi7MnIB4zWs+thtWp/mEKgf5mkiiLU2+oo8C5DuavVHhoPQDmyxh8Io1Q=="
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.11.tgz",
+      "integrity": "sha512-c46uisicHswFHo0R515LPM0L/X/Ju+N7KonJPuHx9C6cWD3AWzkNG9ASv+Bc85mq/9l3LFFsFpljdM1m2YnQ6A=="
     },
     "ember-router-generator": {
       "version": "1.2.3",
@@ -15624,100 +14868,6 @@
       "dev": true,
       "requires": {
         "got": "^8.0.1"
-      },
-      "dependencies": {
-        "@sindresorhus/is": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
-          "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
-          "dev": true
-        },
-        "cacheable-request": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
-          "integrity": "sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=",
-          "dev": true,
-          "requires": {
-            "clone-response": "1.0.2",
-            "get-stream": "3.0.0",
-            "http-cache-semantics": "3.8.1",
-            "keyv": "3.0.0",
-            "lowercase-keys": "1.0.0",
-            "normalize-url": "2.0.1",
-            "responselike": "1.0.2"
-          },
-          "dependencies": {
-            "lowercase-keys": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-              "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
-              "dev": true
-            }
-          }
-        },
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-          "dev": true
-        },
-        "got": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/got/-/got-8.3.2.tgz",
-          "integrity": "sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==",
-          "dev": true,
-          "requires": {
-            "@sindresorhus/is": "^0.7.0",
-            "cacheable-request": "^2.1.1",
-            "decompress-response": "^3.3.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^3.0.0",
-            "into-stream": "^3.1.0",
-            "is-retry-allowed": "^1.1.0",
-            "isurl": "^1.0.0-alpha5",
-            "lowercase-keys": "^1.0.0",
-            "mimic-response": "^1.0.0",
-            "p-cancelable": "^0.4.0",
-            "p-timeout": "^2.0.1",
-            "pify": "^3.0.0",
-            "safe-buffer": "^5.1.1",
-            "timed-out": "^4.0.1",
-            "url-parse-lax": "^3.0.0",
-            "url-to-options": "^1.0.1"
-          }
-        },
-        "http-cache-semantics": {
-          "version": "3.8.1",
-          "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
-          "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
-          "dev": true
-        },
-        "keyv": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
-          "integrity": "sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==",
-          "dev": true,
-          "requires": {
-            "json-buffer": "3.0.0"
-          }
-        },
-        "normalize-url": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
-          "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
-          "dev": true,
-          "requires": {
-            "prepend-http": "^2.0.0",
-            "query-string": "^5.0.1",
-            "sort-keys": "^2.0.0"
-          }
-        },
-        "p-cancelable": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
-          "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
-          "dev": true
-        }
       }
     },
     "ember-tag-input": {
@@ -15873,9 +15023,9 @@
       "dev": true
     },
     "ember-template-lint": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/ember-template-lint/-/ember-template-lint-1.5.1.tgz",
-      "integrity": "sha512-/n5o6KnDADGPg2/OuzrNR/u2w8WIfEjfJhESVw4DAS6jaF8uO0WZrNI60RvmM4Rp813iX5p8pp1dVUUz4Euy7w==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/ember-template-lint/-/ember-template-lint-1.5.2.tgz",
+      "integrity": "sha512-uAGmYrIHoBS8jjmvb2SNprX5zPEs647amO+OHT0OtrO1HjFnhS4GyOXH2xx6h38co65WpPll0o3HFyE4cEh0NA==",
       "dev": true,
       "requires": {
         "@glimmer/compiler": "^0.41.0",
@@ -16263,55 +15413,10 @@
             "ms": "^2.1.1"
           }
         },
-        "execa": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^6.0.0",
-            "get-stream": "^4.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-          "dev": true
-        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "npm-run-path": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-          "dev": true,
-          "requires": {
-            "path-key": "^2.0.0"
-          }
-        },
-        "p-finally": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
           "dev": true
         },
         "rsvp": {
@@ -16347,88 +15452,11 @@
         "semver": "^5.5.0"
       },
       "dependencies": {
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-          "dev": true
-        },
-        "got": {
-          "version": "6.7.1",
-          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-          "dev": true,
-          "requires": {
-            "create-error-class": "^3.0.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^3.0.0",
-            "is-redirect": "^1.0.0",
-            "is-retry-allowed": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "lowercase-keys": "^1.0.0",
-            "safe-buffer": "^5.0.1",
-            "timed-out": "^4.0.0",
-            "unzip-response": "^2.0.1",
-            "url-parse-lax": "^1.0.0"
-          }
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-          "dev": true
-        },
-        "package-json": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
-          "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
-          "dev": true,
-          "requires": {
-            "got": "^6.7.1",
-            "registry-auth-token": "^3.0.1",
-            "registry-url": "^3.0.3",
-            "semver": "^5.1.0"
-          }
-        },
-        "prepend-http": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-          "dev": true
-        },
-        "registry-auth-token": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
-          "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
-          "dev": true,
-          "requires": {
-            "rc": "^1.1.6",
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "registry-url": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-          "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-          "dev": true,
-          "requires": {
-            "rc": "^1.0.1"
-          }
-        },
         "rsvp": {
           "version": "4.8.5",
           "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
           "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
           "dev": true
-        },
-        "url-parse-lax": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-          "dev": true,
-          "requires": {
-            "prepend-http": "^1.0.1"
-          }
         }
       }
     },
@@ -17020,9 +16048,10 @@
       "dev": true
     },
     "emoji-regex": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "emojis-list": {
       "version": "2.1.0",
@@ -17040,6 +16069,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -17200,9 +16230,9 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
-      "integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
+      "integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
       "dev": true,
       "requires": {
         "esprima": "^3.1.3",
@@ -17388,9 +16418,9 @@
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
       "dev": true
     },
     "esm": {
@@ -17407,6 +16437,14 @@
       "requires": {
         "acorn": "^5.5.0",
         "acorn-jsx": "^3.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.7.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+          "dev": true
+        }
       }
     },
     "esprima-fb": {
@@ -17433,9 +16471,9 @@
       }
     },
     "estraverse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true
     },
     "estree-walker": {
@@ -17489,34 +16527,18 @@
       "dev": true
     },
     "execa": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-2.0.3.tgz",
-      "integrity": "sha512-iM124nlyGSrXmuyZF1EMe83ESY2chIYVyDRZKgmcDynid2Q2v/+GuE7gNMl6Sy9Niwf4MC0DDxagOxeMPjuLsw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "dev": true,
       "requires": {
-        "cross-spawn": "^6.0.5",
-        "get-stream": "^5.0.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^3.0.0",
-        "onetime": "^5.1.0",
-        "p-finally": "^2.0.0",
-        "signal-exit": "^3.0.2",
-        "strip-final-newline": "^2.0.0"
-      },
-      "dependencies": {
-        "mimic-fn": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
-        },
-        "onetime": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
-          "requires": {
-            "mimic-fn": "^2.1.0"
-          }
-        }
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       }
     },
     "exists-stat": {
@@ -18055,39 +17077,6 @@
         }
       }
     },
-    "fixturify": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fixturify/-/fixturify-1.2.0.tgz",
-      "integrity": "sha512-b5CMQmBZKsGR6HGqdSrLOGYGHIqrR0CUrcGU/lDL0mYy+DtGm5cnb61Z0UiIUqMVZIoV0CbN+u9/Gwjj+ICg0A==",
-      "requires": {
-        "@types/fs-extra": "^5.0.5",
-        "@types/minimatch": "^3.0.3",
-        "@types/rimraf": "^2.0.2",
-        "fs-extra": "^7.0.1",
-        "matcher-collection": "^2.0.0"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "matcher-collection": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.0.tgz",
-          "integrity": "sha512-wSi4BgQGTFfBN5J+pIaS78rEKk4qIkjrw+NfJYdHsd2cRVIQsbDi3BZtNAXTFA2WHvlbS9kLGtTjv3cPJKuRSw==",
-          "requires": {
-            "@types/minimatch": "^3.0.3",
-            "minimatch": "^3.0.2"
-          }
-        }
-      }
-    },
     "flat-cache": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
@@ -18098,6 +17087,17 @@
         "graceful-fs": "^4.1.2",
         "rimraf": "~2.6.2",
         "write": "^0.2.1"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "flush-write-stream": {
@@ -18324,7 +17324,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -18739,7 +17740,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -18795,6 +17797,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -18838,12 +17841,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -18914,7 +17919,8 @@
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
     },
     "get-stdin": {
       "version": "4.0.1",
@@ -18922,9 +17928,10 @@
       "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
     },
     "get-stream": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-      "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
       "requires": {
         "pump": "^3.0.0"
       }
@@ -18949,146 +17956,6 @@
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
-        }
-      }
-    },
-    "git-diff-apply": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/git-diff-apply/-/git-diff-apply-0.19.1.tgz",
-      "integrity": "sha512-cIV8vzH7Qpgji3ltFJFCR9r6IBvCo0ZGmt1aY8NvSVl4LtGwMQQqtxDnVUbSNZSLiBhpd6RcqXSh14YcUs2XKQ==",
-      "requires": {
-        "debug": "^4.0.0",
-        "fixturify": "^1.0.0",
-        "fs-extra": "^8.0.0",
-        "klaw": "^3.0.0",
-        "tmp": "0.1.0",
-        "uuid": "^3.1.0",
-        "yargs": "^13.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-        },
-        "cliui": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-          "requires": {
-            "string-width": "^3.1.0",
-            "strip-ansi": "^5.2.0",
-            "wrap-ansi": "^5.1.0"
-          }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "fs-extra": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "p-limit": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        },
-        "tmp": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-          "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
-          "requires": {
-            "rimraf": "^2.6.3"
-          }
-        },
-        "y18n": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
-        },
-        "yargs": {
-          "version": "13.3.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
-          "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
-          "requires": {
-            "cliui": "^5.0.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^2.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^3.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^13.1.1"
-          }
         }
       }
     },
@@ -19221,14 +18088,6 @@
       "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
       "dev": true
     },
-    "global-dirs": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
-      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
-      "requires": {
-        "ini": "^1.3.4"
-      }
-    },
     "global-modules": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
@@ -19303,37 +18162,42 @@
       }
     },
     "got": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
-      "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/got/-/got-8.3.2.tgz",
+      "integrity": "sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==",
+      "dev": true,
       "requires": {
-        "@sindresorhus/is": "^0.14.0",
-        "@szmarczak/http-timer": "^1.1.2",
-        "cacheable-request": "^6.0.0",
+        "@sindresorhus/is": "^0.7.0",
+        "cacheable-request": "^2.1.1",
         "decompress-response": "^3.3.0",
         "duplexer3": "^0.1.4",
-        "get-stream": "^4.1.0",
-        "lowercase-keys": "^1.0.1",
-        "mimic-response": "^1.0.1",
-        "p-cancelable": "^1.0.0",
-        "to-readable-stream": "^1.0.0",
-        "url-parse-lax": "^3.0.0"
+        "get-stream": "^3.0.0",
+        "into-stream": "^3.1.0",
+        "is-retry-allowed": "^1.1.0",
+        "isurl": "^1.0.0-alpha5",
+        "lowercase-keys": "^1.0.0",
+        "mimic-response": "^1.0.0",
+        "p-cancelable": "^0.4.0",
+        "p-timeout": "^2.0.1",
+        "pify": "^3.0.0",
+        "safe-buffer": "^5.1.1",
+        "timed-out": "^4.0.1",
+        "url-parse-lax": "^3.0.0",
+        "url-to-options": "^1.0.1"
       },
       "dependencies": {
         "get-stream": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-          "requires": {
-            "pump": "^3.0.0"
-          }
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
         }
       }
     },
     "graceful-fs": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.1.tgz",
-      "integrity": "sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw=="
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+      "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q=="
     },
     "graceful-readlink": {
       "version": "1.0.1",
@@ -19512,11 +18376,6 @@
         }
       }
     },
-    "has-yarn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
-      "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw=="
-    },
     "hash-base": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
@@ -19618,7 +18477,8 @@
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -19639,30 +18499,10 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.2.tgz",
-      "integrity": "sha512-CyjlXII6LMsPMyUzxpTt8fzh5QwzGqPmQXgY/Jyf4Zfp27t/FvfhwoE/8laaMUcMy816CkWF20I7NeQhwwY88w==",
-      "dev": true,
-      "requires": {
-        "lru-cache": "^5.1.1"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-          "dev": true,
-          "requires": {
-            "yallist": "^3.0.2"
-          }
-        },
-        "yallist": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
-        }
-      }
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
+      "integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
+      "dev": true
     },
     "html-encoding-sniffer": {
       "version": "1.0.2",
@@ -19674,9 +18514,10 @@
       }
     },
     "http-cache-semantics": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
-      "integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew=="
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
+      "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
+      "dev": true
     },
     "http-errors": {
       "version": "1.6.3",
@@ -19766,15 +18607,11 @@
       "dev": true,
       "optional": true
     },
-    "import-lazy": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
-    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
     },
     "include-path-searcher": {
       "version": "0.1.0",
@@ -19817,7 +18654,8 @@
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true
     },
     "inline-source-map-comment": {
       "version": "1.0.5",
@@ -19958,14 +18796,6 @@
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
       "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
     },
-    "is-ci": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
-      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
-      "requires": {
-        "ci-info": "^2.0.0"
-      }
-    },
     "is-data-descriptor": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
@@ -20039,15 +18869,6 @@
         "is-extglob": "^2.1.0"
       }
     },
-    "is-installed-globally": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
-      "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
-      "requires": {
-        "global-dirs": "^0.1.0",
-        "is-path-inside": "^1.0.0"
-      }
-    },
     "is-integer": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.7.tgz",
@@ -20055,11 +18876,6 @@
       "requires": {
         "is-finite": "^1.0.0"
       }
-    },
-    "is-npm": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-3.0.0.tgz",
-      "integrity": "sha512-wsigDr1Kkschp2opC4G3yA6r9EgVA6NjRpWzIi9axXqeIaAATPRJc4uLujXe3Nd9uO8KoDyA4MD6aZSeXTADhA=="
     },
     "is-number": {
       "version": "3.0.0",
@@ -20073,21 +18889,14 @@
     "is-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
     },
     "is-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
       "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
       "dev": true
-    },
-    "is-path-inside": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-      "requires": {
-        "path-is-inside": "^1.0.1"
-      }
     },
     "is-plain-obj": {
       "version": "1.1.0",
@@ -20119,6 +18928,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.1.3.tgz",
       "integrity": "sha512-W1iHHv/oyBb2pPxkBxtaewxa1BC58Pn5J0hogyCdefwUIvb6R+TGbAcIa4qPNYLqLhb3EnOgUf2MQkkF76BcKw==",
+      "dev": true,
       "requires": {
         "@types/estree": "0.0.39"
       }
@@ -20144,9 +18954,10 @@
       "dev": true
     },
     "is-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
     },
     "is-symbol": {
       "version": "1.0.2",
@@ -20185,12 +18996,8 @@
     "is-wsl": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
-    },
-    "is-yarn-global": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
-      "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw=="
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+      "dev": true
     },
     "isarray": {
       "version": "1.0.0",
@@ -20210,7 +19017,8 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
     },
     "isobject": {
       "version": "3.0.1",
@@ -20444,12 +19252,6 @@
         "xml-name-validator": "^3.0.0"
       },
       "dependencies": {
-        "acorn": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
-          "integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
-          "dev": true
-        },
         "ajv": {
           "version": "6.10.2",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
@@ -20610,7 +19412,8 @@
     "json-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+      "dev": true
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -20699,9 +19502,10 @@
       }
     },
     "keyv": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
-      "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
+      "integrity": "sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==",
+      "dev": true,
       "requires": {
         "json-buffer": "3.0.0"
       }
@@ -20715,19 +19519,12 @@
       }
     },
     "klaw": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
-      "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.9"
-      }
-    },
-    "latest-version": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
-      "integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
-      "requires": {
-        "package-json": "^6.3.0"
       }
     },
     "layout-bin-packer": {
@@ -21229,7 +20026,8 @@
     "locate-character": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-2.0.5.tgz",
-      "integrity": "sha512-n2GmejDXtOPBAZdIiEFy5dJ5N38xBCXLNOtw2WpB9kGh6pnrEuKlwYI+Tkpofc4wDtVXHtoAOJaMRlYG/oYaxg=="
+      "integrity": "sha512-n2GmejDXtOPBAZdIiEFy5dJ5N38xBCXLNOtw2WpB9kGh6pnrEuKlwYI+Tkpofc4wDtVXHtoAOJaMRlYG/oYaxg==",
+      "dev": true
     },
     "locate-path": {
       "version": "2.0.0",
@@ -21547,21 +20345,32 @@
     "lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "dev": true
     },
     "lru-cache": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
       "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dev": true,
       "requires": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "dev": true
+        }
       }
     },
     "magic-string": {
       "version": "0.24.1",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.24.1.tgz",
       "integrity": "sha512-YBfNxbJiixMzxW40XqJEIldzHyh5f7CZKalo1uZffevyrPEX8Qgo9s0dmcORLHdV47UyvJg8/zD+6hQG3qvJrA==",
+      "dev": true,
       "requires": {
         "sourcemap-codec": "^1.4.1"
       }
@@ -21570,6 +20379,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+      "dev": true,
       "requires": {
         "pify": "^3.0.0"
       }
@@ -21732,20 +20542,6 @@
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true
     },
-    "merge-package.json": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/merge-package.json/-/merge-package.json-3.0.2.tgz",
-      "integrity": "sha512-Aj8UmsAZ3z/Cn1xxU4ch2uVC1kqTLfWLliHwTI9GMAK8Eskz8WxyyDaBZCY4XXJSEUjwScKoSmiOG+DDx4NPUg==",
-      "requires": {
-        "rfc6902-ordered": "^4.0.0",
-        "three-way-merger": "0.5.7"
-      }
-    },
-    "merge-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
-    },
     "merge-trees": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-2.0.0.tgz",
@@ -21835,7 +20631,8 @@
     "mimic-response": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -21870,14 +20667,6 @@
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
-      },
-      "dependencies": {
-        "yallist": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
-        }
       }
     },
     "mississippi": {
@@ -22097,7 +20886,8 @@
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
     },
     "no-case": {
       "version": "2.3.2",
@@ -22218,9 +21008,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.26",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
-      "integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
+      "version": "1.1.27",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.27.tgz",
+      "integrity": "sha512-9iXUqHKSGo6ph/tdXVbHFbhRVQln4ZDTIBJCzsa90HimnBYc5jw8RWYt4wBYFHehGyC3koIz5O4mb2fHrbPOuA==",
       "requires": {
         "semver": "^5.3.0"
       }
@@ -22250,9 +21040,15 @@
       "dev": true
     },
     "normalize-url": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.3.0.tgz",
-      "integrity": "sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
+      "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
+      "dev": true,
+      "requires": {
+        "prepend-http": "^2.0.0",
+        "query-string": "^5.0.1",
+        "sort-keys": "^2.0.0"
+      }
     },
     "npm-git-info": {
       "version": "1.0.3",
@@ -22272,18 +21068,12 @@
       }
     },
     "npm-run-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
-      "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
       "requires": {
-        "path-key": "^3.0.0"
-      },
-      "dependencies": {
-        "path-key": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
-          "integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg=="
-        }
+        "path-key": "^2.0.0"
       }
     },
     "npmlog": {
@@ -22296,3382 +21086,6 @@
         "console-control-strings": "~1.1.0",
         "gauge": "~2.7.3",
         "set-blocking": "~2.0.0"
-      }
-    },
-    "npx": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/npx/-/npx-10.2.0.tgz",
-      "integrity": "sha512-DqjFkzET0DeaXYXNJnirnvEovwk4lBa33ZQCw1jxMuas4yH9jdU8q2U8L3cLaB2UqzgmW2Ssqk8lcGiPRL8pRg==",
-      "requires": {
-        "libnpx": "10.2.0",
-        "npm": "5.1.0"
-      },
-      "dependencies": {
-        "ansi-align": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "string-width": "^2.0.0"
-          }
-        },
-        "ansi-regex": {
-          "version": "3.0.0",
-          "bundled": true
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "bundled": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "boxen": {
-          "version": "1.3.0",
-          "bundled": true,
-          "requires": {
-            "ansi-align": "^2.0.0",
-            "camelcase": "^4.0.0",
-            "chalk": "^2.0.1",
-            "cli-boxes": "^1.0.0",
-            "string-width": "^2.0.0",
-            "term-size": "^1.2.0",
-            "widest-line": "^2.0.0"
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "builtins": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "camelcase": {
-          "version": "4.1.0",
-          "bundled": true
-        },
-        "capture-stack-trace": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "chalk": {
-          "version": "2.3.2",
-          "bundled": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "ci-info": {
-          "version": "1.1.3",
-          "bundled": true
-        },
-        "cli-boxes": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "cliui": {
-          "version": "4.0.0",
-          "bundled": true,
-          "requires": {
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0",
-            "wrap-ansi": "^2.0.0"
-          }
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "color-convert": {
-          "version": "1.9.1",
-          "bundled": true,
-          "requires": {
-            "color-name": "^1.1.1"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "bundled": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "configstore": {
-          "version": "3.1.2",
-          "bundled": true,
-          "requires": {
-            "dot-prop": "^4.1.0",
-            "graceful-fs": "^4.1.2",
-            "make-dir": "^1.0.0",
-            "unique-string": "^1.0.0",
-            "write-file-atomic": "^2.0.0",
-            "xdg-basedir": "^3.0.0"
-          }
-        },
-        "create-error-class": {
-          "version": "3.0.2",
-          "bundled": true,
-          "requires": {
-            "capture-stack-trace": "^1.0.0"
-          }
-        },
-        "cross-spawn": {
-          "version": "5.1.0",
-          "bundled": true,
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
-        "crypto-random-string": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "decamelize": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "bundled": true
-        },
-        "dot-prop": {
-          "version": "4.2.0",
-          "bundled": true,
-          "requires": {
-            "is-obj": "^1.0.0"
-          }
-        },
-        "dotenv": {
-          "version": "5.0.1",
-          "bundled": true
-        },
-        "duplexer3": {
-          "version": "0.1.4",
-          "bundled": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "execa": {
-          "version": "0.7.0",
-          "bundled": true,
-          "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          }
-        },
-        "find-up": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "get-caller-file": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "get-stream": {
-          "version": "3.0.0",
-          "bundled": true
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "global-dirs": {
-          "version": "0.1.1",
-          "bundled": true,
-          "requires": {
-            "ini": "^1.3.4"
-          }
-        },
-        "got": {
-          "version": "6.7.1",
-          "bundled": true,
-          "requires": {
-            "create-error-class": "^3.0.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^3.0.0",
-            "is-redirect": "^1.0.0",
-            "is-retry-allowed": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "lowercase-keys": "^1.0.0",
-            "safe-buffer": "^5.0.1",
-            "timed-out": "^4.0.0",
-            "unzip-response": "^2.0.1",
-            "url-parse-lax": "^1.0.0"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "bundled": true
-        },
-        "hosted-git-info": {
-          "version": "2.6.0",
-          "bundled": true
-        },
-        "import-lazy": {
-          "version": "2.1.0",
-          "bundled": true
-        },
-        "imurmurhash": {
-          "version": "0.1.4",
-          "bundled": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "ini": {
-          "version": "1.3.5",
-          "bundled": true
-        },
-        "invert-kv": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "is-ci": {
-          "version": "1.1.0",
-          "bundled": true,
-          "requires": {
-            "ci-info": "^1.0.0"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "is-installed-globally": {
-          "version": "0.1.0",
-          "bundled": true,
-          "requires": {
-            "global-dirs": "^0.1.0",
-            "is-path-inside": "^1.0.0"
-          }
-        },
-        "is-npm": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "is-obj": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "is-path-inside": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "path-is-inside": "^1.0.1"
-          }
-        },
-        "is-redirect": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "is-retry-allowed": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "isexe": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "latest-version": {
-          "version": "3.1.0",
-          "bundled": true,
-          "requires": {
-            "package-json": "^4.0.0"
-          }
-        },
-        "lcid": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "invert-kv": "^1.0.0"
-          }
-        },
-        "libnpx": {
-          "version": "10.2.0",
-          "bundled": true,
-          "requires": {
-            "dotenv": "^5.0.1",
-            "npm-package-arg": "^6.0.0",
-            "rimraf": "^2.6.2",
-            "safe-buffer": "^5.1.0",
-            "update-notifier": "^2.3.0",
-            "which": "^1.3.0",
-            "y18n": "^4.0.0",
-            "yargs": "^11.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "lowercase-keys": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "lru-cache": {
-          "version": "4.1.2",
-          "bundled": true,
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          }
-        },
-        "make-dir": {
-          "version": "1.2.0",
-          "bundled": true,
-          "requires": {
-            "pify": "^3.0.0"
-          }
-        },
-        "mem": {
-          "version": "1.1.0",
-          "bundled": true,
-          "requires": {
-            "mimic-fn": "^1.0.0"
-          }
-        },
-        "mimic-fn": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "npm": {
-          "version": "5.1.0",
-          "bundled": true,
-          "requires": {
-            "JSONStream": "~1.3.1",
-            "abbrev": "~1.1.0",
-            "ansi-regex": "~3.0.0",
-            "ansicolors": "~0.3.2",
-            "ansistyles": "~0.1.3",
-            "aproba": "~1.1.2",
-            "archy": "~1.0.0",
-            "bluebird": "~3.5.0",
-            "cacache": "~9.2.9",
-            "call-limit": "~1.1.0",
-            "chownr": "~1.0.1",
-            "cmd-shim": "~2.0.2",
-            "columnify": "~1.5.4",
-            "config-chain": "~1.1.11",
-            "debuglog": "*",
-            "detect-indent": "~5.0.0",
-            "dezalgo": "~1.0.3",
-            "editor": "~1.0.0",
-            "fs-vacuum": "~1.2.10",
-            "fs-write-stream-atomic": "~1.0.10",
-            "fstream": "~1.0.11",
-            "fstream-npm": "~1.2.1",
-            "glob": "~7.1.2",
-            "graceful-fs": "~4.1.11",
-            "has-unicode": "~2.0.1",
-            "hosted-git-info": "~2.5.0",
-            "iferr": "~0.1.5",
-            "imurmurhash": "*",
-            "inflight": "~1.0.6",
-            "inherits": "~2.0.3",
-            "ini": "~1.3.4",
-            "init-package-json": "~1.10.1",
-            "lazy-property": "~1.0.0",
-            "lockfile": "~1.0.3",
-            "lodash._baseindexof": "*",
-            "lodash._baseuniq": "~4.6.0",
-            "lodash._bindcallback": "*",
-            "lodash._cacheindexof": "*",
-            "lodash._createcache": "*",
-            "lodash._getnative": "*",
-            "lodash.clonedeep": "~4.5.0",
-            "lodash.restparam": "*",
-            "lodash.union": "~4.6.0",
-            "lodash.uniq": "~4.5.0",
-            "lodash.without": "~4.4.0",
-            "lru-cache": "~4.1.1",
-            "mississippi": "~1.3.0",
-            "mkdirp": "~0.5.1",
-            "move-concurrently": "~1.0.1",
-            "node-gyp": "~3.6.2",
-            "nopt": "~4.0.1",
-            "normalize-package-data": "~2.4.0",
-            "npm-cache-filename": "~1.0.2",
-            "npm-install-checks": "~3.0.0",
-            "npm-package-arg": "~5.1.2",
-            "npm-registry-client": "~8.4.0",
-            "npm-user-validate": "~1.0.0",
-            "npmlog": "~4.1.2",
-            "once": "~1.4.0",
-            "opener": "~1.4.3",
-            "osenv": "~0.1.4",
-            "pacote": "~2.7.38",
-            "path-is-inside": "~1.0.2",
-            "promise-inflight": "~1.0.1",
-            "read": "~1.0.7",
-            "read-cmd-shim": "~1.0.1",
-            "read-installed": "~4.0.3",
-            "read-package-json": "~2.0.9",
-            "read-package-tree": "~5.1.6",
-            "readable-stream": "~2.3.2",
-            "readdir-scoped-modules": "*",
-            "request": "~2.81.0",
-            "retry": "~0.10.1",
-            "rimraf": "~2.6.1",
-            "safe-buffer": "~5.1.1",
-            "semver": "~5.3.0",
-            "sha": "~2.0.1",
-            "slide": "~1.1.6",
-            "sorted-object": "~2.0.1",
-            "sorted-union-stream": "~2.1.3",
-            "ssri": "~4.1.6",
-            "strip-ansi": "~4.0.0",
-            "tar": "~2.2.1",
-            "text-table": "~0.2.0",
-            "uid-number": "0.0.6",
-            "umask": "~1.1.0",
-            "unique-filename": "~1.1.0",
-            "unpipe": "~1.0.0",
-            "update-notifier": "~2.2.0",
-            "uuid": "~3.1.0",
-            "validate-npm-package-license": "*",
-            "validate-npm-package-name": "~3.0.0",
-            "which": "~1.2.14",
-            "worker-farm": "~1.3.1",
-            "wrappy": "~1.0.2",
-            "write-file-atomic": "~2.1.0"
-          },
-          "dependencies": {
-            "JSONStream": {
-              "version": "1.3.1",
-              "bundled": true,
-              "requires": {
-                "jsonparse": "^1.2.0",
-                "through": ">=2.2.7 <3"
-              },
-              "dependencies": {
-                "jsonparse": {
-                  "version": "1.3.1",
-                  "bundled": true
-                },
-                "through": {
-                  "version": "2.3.8",
-                  "bundled": true
-                }
-              }
-            },
-            "abbrev": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "ansi-regex": {
-              "version": "3.0.0",
-              "bundled": true
-            },
-            "ansicolors": {
-              "version": "0.3.2",
-              "bundled": true
-            },
-            "ansistyles": {
-              "version": "0.1.3",
-              "bundled": true
-            },
-            "aproba": {
-              "version": "1.1.2",
-              "bundled": true
-            },
-            "archy": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "bluebird": {
-              "version": "3.5.0",
-              "bundled": true
-            },
-            "cacache": {
-              "version": "9.2.9",
-              "bundled": true,
-              "requires": {
-                "bluebird": "^3.5.0",
-                "chownr": "^1.0.1",
-                "glob": "^7.1.2",
-                "graceful-fs": "^4.1.11",
-                "lru-cache": "^4.1.1",
-                "mississippi": "^1.3.0",
-                "mkdirp": "^0.5.1",
-                "move-concurrently": "^1.0.1",
-                "promise-inflight": "^1.0.1",
-                "rimraf": "^2.6.1",
-                "ssri": "^4.1.6",
-                "unique-filename": "^1.1.0",
-                "y18n": "^3.2.1"
-              },
-              "dependencies": {
-                "lru-cache": {
-                  "version": "4.1.1",
-                  "bundled": true,
-                  "requires": {
-                    "pseudomap": "^1.0.2",
-                    "yallist": "^2.1.2"
-                  },
-                  "dependencies": {
-                    "pseudomap": {
-                      "version": "1.0.2",
-                      "bundled": true
-                    },
-                    "yallist": {
-                      "version": "2.1.2",
-                      "bundled": true
-                    }
-                  }
-                },
-                "y18n": {
-                  "version": "3.2.1",
-                  "bundled": true
-                }
-              }
-            },
-            "call-limit": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "chownr": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "cmd-shim": {
-              "version": "2.0.2",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "mkdirp": "~0.5.0"
-              }
-            },
-            "columnify": {
-              "version": "1.5.4",
-              "bundled": true,
-              "requires": {
-                "strip-ansi": "^3.0.0",
-                "wcwidth": "^1.0.0"
-              },
-              "dependencies": {
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "ansi-regex": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.1.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "wcwidth": {
-                  "version": "1.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "defaults": "^1.0.3"
-                  },
-                  "dependencies": {
-                    "defaults": {
-                      "version": "1.0.3",
-                      "bundled": true,
-                      "requires": {
-                        "clone": "^1.0.2"
-                      },
-                      "dependencies": {
-                        "clone": {
-                          "version": "1.0.2",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "config-chain": {
-              "version": "1.1.11",
-              "bundled": true,
-              "requires": {
-                "ini": "^1.3.4",
-                "proto-list": "~1.2.1"
-              },
-              "dependencies": {
-                "proto-list": {
-                  "version": "1.2.4",
-                  "bundled": true
-                }
-              }
-            },
-            "debuglog": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "detect-indent": {
-              "version": "5.0.0",
-              "bundled": true
-            },
-            "dezalgo": {
-              "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "asap": "^2.0.0",
-                "wrappy": "1"
-              },
-              "dependencies": {
-                "asap": {
-                  "version": "2.0.5",
-                  "bundled": true
-                }
-              }
-            },
-            "editor": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "fs-vacuum": {
-              "version": "1.2.10",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "path-is-inside": "^1.0.1",
-                "rimraf": "^2.5.2"
-              }
-            },
-            "fs-write-stream-atomic": {
-              "version": "1.0.10",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "iferr": "^0.1.5",
-                "imurmurhash": "^0.1.4",
-                "readable-stream": "1 || 2"
-              }
-            },
-            "fstream": {
-              "version": "1.0.11",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "inherits": "~2.0.0",
-                "mkdirp": ">=0.5 0",
-                "rimraf": "2"
-              }
-            },
-            "fstream-npm": {
-              "version": "1.2.1",
-              "bundled": true,
-              "requires": {
-                "fstream-ignore": "^1.0.0",
-                "inherits": "2"
-              },
-              "dependencies": {
-                "fstream-ignore": {
-                  "version": "1.0.5",
-                  "bundled": true,
-                  "requires": {
-                    "fstream": "^1.0.0",
-                    "inherits": "2",
-                    "minimatch": "^3.0.0"
-                  },
-                  "dependencies": {
-                    "minimatch": {
-                      "version": "3.0.4",
-                      "bundled": true,
-                      "requires": {
-                        "brace-expansion": "^1.1.7"
-                      },
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.8",
-                          "bundled": true,
-                          "requires": {
-                            "balanced-match": "^1.0.0",
-                            "concat-map": "0.0.1"
-                          },
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "glob": {
-              "version": "7.1.2",
-              "bundled": true,
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              },
-              "dependencies": {
-                "fs.realpath": {
-                  "version": "1.0.0",
-                  "bundled": true
-                },
-                "minimatch": {
-                  "version": "3.0.4",
-                  "bundled": true,
-                  "requires": {
-                    "brace-expansion": "^1.1.7"
-                  },
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.8",
-                      "bundled": true,
-                      "requires": {
-                        "balanced-match": "^1.0.0",
-                        "concat-map": "0.0.1"
-                      },
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.1",
-                  "bundled": true
-                }
-              }
-            },
-            "graceful-fs": {
-              "version": "4.1.11",
-              "bundled": true
-            },
-            "has-unicode": {
-              "version": "2.0.1",
-              "bundled": true
-            },
-            "hosted-git-info": {
-              "version": "2.5.0",
-              "bundled": true
-            },
-            "iferr": {
-              "version": "0.1.5",
-              "bundled": true
-            },
-            "imurmurhash": {
-              "version": "0.1.4",
-              "bundled": true
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "bundled": true,
-              "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "ini": {
-              "version": "1.3.4",
-              "bundled": true
-            },
-            "init-package-json": {
-              "version": "1.10.1",
-              "bundled": true,
-              "requires": {
-                "glob": "^7.1.1",
-                "npm-package-arg": "^4.0.0 || ^5.0.0",
-                "promzard": "^0.3.0",
-                "read": "~1.0.1",
-                "read-package-json": "1 || 2",
-                "semver": "2.x || 3.x || 4 || 5",
-                "validate-npm-package-license": "^3.0.1",
-                "validate-npm-package-name": "^3.0.0"
-              },
-              "dependencies": {
-                "promzard": {
-                  "version": "0.3.0",
-                  "bundled": true,
-                  "requires": {
-                    "read": "1"
-                  }
-                }
-              }
-            },
-            "lazy-property": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "lockfile": {
-              "version": "1.0.3",
-              "bundled": true
-            },
-            "lodash._baseindexof": {
-              "version": "3.1.0",
-              "bundled": true
-            },
-            "lodash._baseuniq": {
-              "version": "4.6.0",
-              "bundled": true,
-              "requires": {
-                "lodash._createset": "~4.0.0",
-                "lodash._root": "~3.0.0"
-              },
-              "dependencies": {
-                "lodash._createset": {
-                  "version": "4.0.3",
-                  "bundled": true
-                },
-                "lodash._root": {
-                  "version": "3.0.1",
-                  "bundled": true
-                }
-              }
-            },
-            "lodash._bindcallback": {
-              "version": "3.0.1",
-              "bundled": true
-            },
-            "lodash._cacheindexof": {
-              "version": "3.0.2",
-              "bundled": true
-            },
-            "lodash._createcache": {
-              "version": "3.1.2",
-              "bundled": true,
-              "requires": {
-                "lodash._getnative": "^3.0.0"
-              }
-            },
-            "lodash._getnative": {
-              "version": "3.9.1",
-              "bundled": true
-            },
-            "lodash.clonedeep": {
-              "version": "4.5.0",
-              "bundled": true
-            },
-            "lodash.restparam": {
-              "version": "3.6.1",
-              "bundled": true
-            },
-            "lodash.union": {
-              "version": "4.6.0",
-              "bundled": true
-            },
-            "lodash.uniq": {
-              "version": "4.5.0",
-              "bundled": true
-            },
-            "lodash.without": {
-              "version": "4.4.0",
-              "bundled": true
-            },
-            "lru-cache": {
-              "version": "4.1.1",
-              "bundled": true,
-              "requires": {
-                "pseudomap": "^1.0.2",
-                "yallist": "^2.1.2"
-              },
-              "dependencies": {
-                "pseudomap": {
-                  "version": "1.0.2",
-                  "bundled": true
-                },
-                "yallist": {
-                  "version": "2.1.2",
-                  "bundled": true
-                }
-              }
-            },
-            "mississippi": {
-              "version": "1.3.0",
-              "bundled": true,
-              "requires": {
-                "concat-stream": "^1.5.0",
-                "duplexify": "^3.4.2",
-                "end-of-stream": "^1.1.0",
-                "flush-write-stream": "^1.0.0",
-                "from2": "^2.1.0",
-                "parallel-transform": "^1.1.0",
-                "pump": "^1.0.0",
-                "pumpify": "^1.3.3",
-                "stream-each": "^1.1.0",
-                "through2": "^2.0.0"
-              },
-              "dependencies": {
-                "concat-stream": {
-                  "version": "1.6.0",
-                  "bundled": true,
-                  "requires": {
-                    "inherits": "^2.0.3",
-                    "readable-stream": "^2.2.2",
-                    "typedarray": "^0.0.6"
-                  },
-                  "dependencies": {
-                    "typedarray": {
-                      "version": "0.0.6",
-                      "bundled": true
-                    }
-                  }
-                },
-                "duplexify": {
-                  "version": "3.5.0",
-                  "bundled": true,
-                  "requires": {
-                    "end-of-stream": "1.0.0",
-                    "inherits": "^2.0.1",
-                    "readable-stream": "^2.0.0",
-                    "stream-shift": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "end-of-stream": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "once": "~1.3.0"
-                      },
-                      "dependencies": {
-                        "once": {
-                          "version": "1.3.3",
-                          "bundled": true,
-                          "requires": {
-                            "wrappy": "1"
-                          }
-                        }
-                      }
-                    },
-                    "stream-shift": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "end-of-stream": {
-                  "version": "1.4.0",
-                  "bundled": true,
-                  "requires": {
-                    "once": "^1.4.0"
-                  }
-                },
-                "flush-write-stream": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "requires": {
-                    "inherits": "^2.0.1",
-                    "readable-stream": "^2.0.4"
-                  }
-                },
-                "from2": {
-                  "version": "2.3.0",
-                  "bundled": true,
-                  "requires": {
-                    "inherits": "^2.0.1",
-                    "readable-stream": "^2.0.0"
-                  }
-                },
-                "parallel-transform": {
-                  "version": "1.1.0",
-                  "bundled": true,
-                  "requires": {
-                    "cyclist": "~0.2.2",
-                    "inherits": "^2.0.3",
-                    "readable-stream": "^2.1.5"
-                  },
-                  "dependencies": {
-                    "cyclist": {
-                      "version": "0.2.2",
-                      "bundled": true
-                    }
-                  }
-                },
-                "pump": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "requires": {
-                    "end-of-stream": "^1.1.0",
-                    "once": "^1.3.1"
-                  }
-                },
-                "pumpify": {
-                  "version": "1.3.5",
-                  "bundled": true,
-                  "requires": {
-                    "duplexify": "^3.1.2",
-                    "inherits": "^2.0.1",
-                    "pump": "^1.0.0"
-                  }
-                },
-                "stream-each": {
-                  "version": "1.2.0",
-                  "bundled": true,
-                  "requires": {
-                    "end-of-stream": "^1.1.0",
-                    "stream-shift": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "stream-shift": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "through2": {
-                  "version": "2.0.3",
-                  "bundled": true,
-                  "requires": {
-                    "readable-stream": "^2.1.5",
-                    "xtend": "~4.0.1"
-                  },
-                  "dependencies": {
-                    "xtend": {
-                      "version": "4.0.1",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "bundled": true,
-              "requires": {
-                "minimist": "0.0.8"
-              },
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "bundled": true
-                }
-              }
-            },
-            "move-concurrently": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "aproba": "^1.1.1",
-                "copy-concurrently": "^1.0.0",
-                "fs-write-stream-atomic": "^1.0.8",
-                "mkdirp": "^0.5.1",
-                "rimraf": "^2.5.4",
-                "run-queue": "^1.0.3"
-              },
-              "dependencies": {
-                "copy-concurrently": {
-                  "version": "1.0.3",
-                  "bundled": true,
-                  "requires": {
-                    "aproba": "^1.1.1",
-                    "fs-write-stream-atomic": "^1.0.8",
-                    "iferr": "^0.1.5",
-                    "mkdirp": "^0.5.1",
-                    "rimraf": "^2.5.4",
-                    "run-queue": "^1.0.0"
-                  }
-                },
-                "run-queue": {
-                  "version": "1.0.3",
-                  "bundled": true,
-                  "requires": {
-                    "aproba": "^1.1.1"
-                  }
-                }
-              }
-            },
-            "node-gyp": {
-              "version": "3.6.2",
-              "bundled": true,
-              "requires": {
-                "fstream": "^1.0.0",
-                "glob": "^7.0.3",
-                "graceful-fs": "^4.1.2",
-                "minimatch": "^3.0.2",
-                "mkdirp": "^0.5.0",
-                "nopt": "2 || 3",
-                "npmlog": "0 || 1 || 2 || 3 || 4",
-                "osenv": "0",
-                "request": "2",
-                "rimraf": "2",
-                "semver": "~5.3.0",
-                "tar": "^2.0.0",
-                "which": "1"
-              },
-              "dependencies": {
-                "minimatch": {
-                  "version": "3.0.4",
-                  "bundled": true,
-                  "requires": {
-                    "brace-expansion": "^1.1.7"
-                  },
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.8",
-                      "bundled": true,
-                      "requires": {
-                        "balanced-match": "^1.0.0",
-                        "concat-map": "0.0.1"
-                      },
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "nopt": {
-                  "version": "3.0.6",
-                  "bundled": true,
-                  "requires": {
-                    "abbrev": "1"
-                  }
-                }
-              }
-            },
-            "nopt": {
-              "version": "4.0.1",
-              "bundled": true,
-              "requires": {
-                "abbrev": "1",
-                "osenv": "^0.1.4"
-              }
-            },
-            "normalize-package-data": {
-              "version": "2.4.0",
-              "bundled": true,
-              "requires": {
-                "hosted-git-info": "^2.1.4",
-                "is-builtin-module": "^1.0.0",
-                "semver": "2 || 3 || 4 || 5",
-                "validate-npm-package-license": "^3.0.1"
-              },
-              "dependencies": {
-                "is-builtin-module": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "builtin-modules": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "builtin-modules": {
-                      "version": "1.1.1",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
-            "npm-cache-filename": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "npm-install-checks": {
-              "version": "3.0.0",
-              "bundled": true,
-              "requires": {
-                "semver": "^2.3.0 || 3.x || 4 || 5"
-              }
-            },
-            "npm-package-arg": {
-              "version": "5.1.2",
-              "bundled": true,
-              "requires": {
-                "hosted-git-info": "^2.4.2",
-                "osenv": "^0.1.4",
-                "semver": "^5.1.0",
-                "validate-npm-package-name": "^3.0.0"
-              }
-            },
-            "npm-registry-client": {
-              "version": "8.4.0",
-              "bundled": true,
-              "requires": {
-                "concat-stream": "^1.5.2",
-                "graceful-fs": "^4.1.6",
-                "normalize-package-data": "~1.0.1 || ^2.0.0",
-                "npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0",
-                "npmlog": "2 || ^3.1.0 || ^4.0.0",
-                "once": "^1.3.3",
-                "request": "^2.74.0",
-                "retry": "^0.10.0",
-                "semver": "2 >=2.2.1 || 3.x || 4 || 5",
-                "slide": "^1.1.3",
-                "ssri": "^4.1.2"
-              },
-              "dependencies": {
-                "concat-stream": {
-                  "version": "1.6.0",
-                  "bundled": true,
-                  "requires": {
-                    "inherits": "^2.0.3",
-                    "readable-stream": "^2.2.2",
-                    "typedarray": "^0.0.6"
-                  },
-                  "dependencies": {
-                    "typedarray": {
-                      "version": "0.0.6",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
-            "npm-user-validate": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "npmlog": {
-              "version": "4.1.2",
-              "bundled": true,
-              "requires": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
-              },
-              "dependencies": {
-                "are-we-there-yet": {
-                  "version": "1.1.4",
-                  "bundled": true,
-                  "requires": {
-                    "delegates": "^1.0.0",
-                    "readable-stream": "^2.0.6"
-                  },
-                  "dependencies": {
-                    "delegates": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "console-control-strings": {
-                  "version": "1.1.0",
-                  "bundled": true
-                },
-                "gauge": {
-                  "version": "2.7.4",
-                  "bundled": true,
-                  "requires": {
-                    "aproba": "^1.0.3",
-                    "console-control-strings": "^1.0.0",
-                    "has-unicode": "^2.0.0",
-                    "object-assign": "^4.1.0",
-                    "signal-exit": "^3.0.0",
-                    "string-width": "^1.0.1",
-                    "strip-ansi": "^3.0.1",
-                    "wide-align": "^1.1.0"
-                  },
-                  "dependencies": {
-                    "object-assign": {
-                      "version": "4.1.1",
-                      "bundled": true
-                    },
-                    "signal-exit": {
-                      "version": "3.0.2",
-                      "bundled": true
-                    },
-                    "string-width": {
-                      "version": "1.0.2",
-                      "bundled": true,
-                      "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
-                      },
-                      "dependencies": {
-                        "code-point-at": {
-                          "version": "1.1.0",
-                          "bundled": true
-                        },
-                        "is-fullwidth-code-point": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "number-is-nan": "^1.0.0"
-                          },
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "strip-ansi": {
-                      "version": "3.0.1",
-                      "bundled": true,
-                      "requires": {
-                        "ansi-regex": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.1.1",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "wide-align": {
-                      "version": "1.1.2",
-                      "bundled": true,
-                      "requires": {
-                        "string-width": "^1.0.2"
-                      }
-                    }
-                  }
-                },
-                "set-blocking": {
-                  "version": "2.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "once": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "wrappy": "1"
-              }
-            },
-            "opener": {
-              "version": "1.4.3",
-              "bundled": true
-            },
-            "osenv": {
-              "version": "0.1.4",
-              "bundled": true,
-              "requires": {
-                "os-homedir": "^1.0.0",
-                "os-tmpdir": "^1.0.0"
-              },
-              "dependencies": {
-                "os-homedir": {
-                  "version": "1.0.2",
-                  "bundled": true
-                },
-                "os-tmpdir": {
-                  "version": "1.0.2",
-                  "bundled": true
-                }
-              }
-            },
-            "pacote": {
-              "version": "2.7.38",
-              "bundled": true,
-              "requires": {
-                "bluebird": "^3.5.0",
-                "cacache": "^9.2.9",
-                "glob": "^7.1.2",
-                "lru-cache": "^4.1.1",
-                "make-fetch-happen": "^2.4.13",
-                "minimatch": "^3.0.4",
-                "mississippi": "^1.2.0",
-                "normalize-package-data": "^2.4.0",
-                "npm-package-arg": "^5.1.2",
-                "npm-pick-manifest": "^1.0.4",
-                "osenv": "^0.1.4",
-                "promise-inflight": "^1.0.1",
-                "promise-retry": "^1.1.1",
-                "protoduck": "^4.0.0",
-                "safe-buffer": "^5.1.1",
-                "semver": "^5.3.0",
-                "ssri": "^4.1.6",
-                "tar-fs": "^1.15.3",
-                "tar-stream": "^1.5.4",
-                "unique-filename": "^1.1.0",
-                "which": "^1.2.12"
-              },
-              "dependencies": {
-                "make-fetch-happen": {
-                  "version": "2.4.13",
-                  "bundled": true,
-                  "requires": {
-                    "agentkeepalive": "^3.3.0",
-                    "cacache": "^9.2.9",
-                    "http-cache-semantics": "^3.7.3",
-                    "http-proxy-agent": "^2.0.0",
-                    "https-proxy-agent": "^2.0.0",
-                    "lru-cache": "^4.1.1",
-                    "mississippi": "^1.2.0",
-                    "node-fetch-npm": "^2.0.1",
-                    "promise-retry": "^1.1.1",
-                    "socks-proxy-agent": "^3.0.0",
-                    "ssri": "^4.1.6"
-                  },
-                  "dependencies": {
-                    "agentkeepalive": {
-                      "version": "3.3.0",
-                      "bundled": true,
-                      "requires": {
-                        "humanize-ms": "^1.2.1"
-                      },
-                      "dependencies": {
-                        "humanize-ms": {
-                          "version": "1.2.1",
-                          "bundled": true,
-                          "requires": {
-                            "ms": "^2.0.0"
-                          },
-                          "dependencies": {
-                            "ms": {
-                              "version": "2.0.0",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "http-cache-semantics": {
-                      "version": "3.7.3",
-                      "bundled": true
-                    },
-                    "http-proxy-agent": {
-                      "version": "2.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "agent-base": "4",
-                        "debug": "2"
-                      },
-                      "dependencies": {
-                        "agent-base": {
-                          "version": "4.1.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promisify": "^5.0.0"
-                          },
-                          "dependencies": {
-                            "es6-promisify": {
-                              "version": "5.0.0",
-                              "bundled": true,
-                              "requires": {
-                                "es6-promise": "^4.0.3"
-                              },
-                              "dependencies": {
-                                "es6-promise": {
-                                  "version": "4.1.1",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "debug": {
-                          "version": "2.6.8",
-                          "bundled": true,
-                          "requires": {
-                            "ms": "2.0.0"
-                          },
-                          "dependencies": {
-                            "ms": {
-                              "version": "2.0.0",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "https-proxy-agent": {
-                      "version": "2.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "agent-base": "^4.1.0",
-                        "debug": "^2.4.1"
-                      },
-                      "dependencies": {
-                        "agent-base": {
-                          "version": "4.1.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promisify": "^5.0.0"
-                          },
-                          "dependencies": {
-                            "es6-promisify": {
-                              "version": "5.0.0",
-                              "bundled": true,
-                              "requires": {
-                                "es6-promise": "^4.0.3"
-                              },
-                              "dependencies": {
-                                "es6-promise": {
-                                  "version": "4.1.1",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "debug": {
-                          "version": "2.6.8",
-                          "bundled": true,
-                          "requires": {
-                            "ms": "2.0.0"
-                          },
-                          "dependencies": {
-                            "ms": {
-                              "version": "2.0.0",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "node-fetch-npm": {
-                      "version": "2.0.1",
-                      "bundled": true,
-                      "requires": {
-                        "encoding": "^0.1.11",
-                        "json-parse-helpfulerror": "^1.0.3",
-                        "safe-buffer": "^5.0.1"
-                      },
-                      "dependencies": {
-                        "encoding": {
-                          "version": "0.1.12",
-                          "bundled": true,
-                          "requires": {
-                            "iconv-lite": "~0.4.13"
-                          },
-                          "dependencies": {
-                            "iconv-lite": {
-                              "version": "0.4.18",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "json-parse-helpfulerror": {
-                          "version": "1.0.3",
-                          "bundled": true,
-                          "requires": {
-                            "jju": "^1.1.0"
-                          },
-                          "dependencies": {
-                            "jju": {
-                              "version": "1.3.0",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "socks-proxy-agent": {
-                      "version": "3.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "agent-base": "^4.0.1",
-                        "socks": "^1.1.10"
-                      },
-                      "dependencies": {
-                        "agent-base": {
-                          "version": "4.1.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promisify": "^5.0.0"
-                          },
-                          "dependencies": {
-                            "es6-promisify": {
-                              "version": "5.0.0",
-                              "bundled": true,
-                              "requires": {
-                                "es6-promise": "^4.0.3"
-                              },
-                              "dependencies": {
-                                "es6-promise": {
-                                  "version": "4.1.1",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "socks": {
-                          "version": "1.1.10",
-                          "bundled": true,
-                          "requires": {
-                            "ip": "^1.1.4",
-                            "smart-buffer": "^1.0.13"
-                          },
-                          "dependencies": {
-                            "ip": {
-                              "version": "1.1.5",
-                              "bundled": true
-                            },
-                            "smart-buffer": {
-                              "version": "1.1.15",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "minimatch": {
-                  "version": "3.0.4",
-                  "bundled": true,
-                  "requires": {
-                    "brace-expansion": "^1.1.7"
-                  },
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.8",
-                      "bundled": true,
-                      "requires": {
-                        "balanced-match": "^1.0.0",
-                        "concat-map": "0.0.1"
-                      },
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "npm-pick-manifest": {
-                  "version": "1.0.4",
-                  "bundled": true,
-                  "requires": {
-                    "npm-package-arg": "^5.1.2",
-                    "semver": "^5.3.0"
-                  }
-                },
-                "promise-retry": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "requires": {
-                    "err-code": "^1.0.0",
-                    "retry": "^0.10.0"
-                  },
-                  "dependencies": {
-                    "err-code": {
-                      "version": "1.1.2",
-                      "bundled": true
-                    }
-                  }
-                },
-                "protoduck": {
-                  "version": "4.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "genfun": "^4.0.1"
-                  },
-                  "dependencies": {
-                    "genfun": {
-                      "version": "4.0.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "tar-fs": {
-                  "version": "1.15.3",
-                  "bundled": true,
-                  "requires": {
-                    "chownr": "^1.0.1",
-                    "mkdirp": "^0.5.1",
-                    "pump": "^1.0.0",
-                    "tar-stream": "^1.1.2"
-                  },
-                  "dependencies": {
-                    "pump": {
-                      "version": "1.0.2",
-                      "bundled": true,
-                      "requires": {
-                        "end-of-stream": "^1.1.0",
-                        "once": "^1.3.1"
-                      },
-                      "dependencies": {
-                        "end-of-stream": {
-                          "version": "1.4.0",
-                          "bundled": true,
-                          "requires": {
-                            "once": "^1.4.0"
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "tar-stream": {
-                  "version": "1.5.4",
-                  "bundled": true,
-                  "requires": {
-                    "bl": "^1.0.0",
-                    "end-of-stream": "^1.0.0",
-                    "readable-stream": "^2.0.0",
-                    "xtend": "^4.0.0"
-                  },
-                  "dependencies": {
-                    "bl": {
-                      "version": "1.2.1",
-                      "bundled": true,
-                      "requires": {
-                        "readable-stream": "^2.0.5"
-                      }
-                    },
-                    "end-of-stream": {
-                      "version": "1.4.0",
-                      "bundled": true,
-                      "requires": {
-                        "once": "^1.4.0"
-                      }
-                    },
-                    "xtend": {
-                      "version": "4.0.1",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
-            "path-is-inside": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "promise-inflight": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "read": {
-              "version": "1.0.7",
-              "bundled": true,
-              "requires": {
-                "mute-stream": "~0.0.4"
-              },
-              "dependencies": {
-                "mute-stream": {
-                  "version": "0.0.7",
-                  "bundled": true
-                }
-              }
-            },
-            "read-cmd-shim": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "^4.1.2"
-              }
-            },
-            "read-installed": {
-              "version": "4.0.3",
-              "bundled": true,
-              "requires": {
-                "debuglog": "^1.0.1",
-                "graceful-fs": "^4.1.2",
-                "read-package-json": "^2.0.0",
-                "readdir-scoped-modules": "^1.0.0",
-                "semver": "2 || 3 || 4 || 5",
-                "slide": "~1.1.3",
-                "util-extend": "^1.0.1"
-              },
-              "dependencies": {
-                "util-extend": {
-                  "version": "1.0.3",
-                  "bundled": true
-                }
-              }
-            },
-            "read-package-json": {
-              "version": "2.0.9",
-              "bundled": true,
-              "requires": {
-                "glob": "^7.1.1",
-                "graceful-fs": "^4.1.2",
-                "json-parse-helpfulerror": "^1.0.2",
-                "normalize-package-data": "^2.0.0"
-              },
-              "dependencies": {
-                "json-parse-helpfulerror": {
-                  "version": "1.0.3",
-                  "bundled": true,
-                  "requires": {
-                    "jju": "^1.1.0"
-                  },
-                  "dependencies": {
-                    "jju": {
-                      "version": "1.3.0",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
-            "read-package-tree": {
-              "version": "5.1.6",
-              "bundled": true,
-              "requires": {
-                "debuglog": "^1.0.1",
-                "dezalgo": "^1.0.0",
-                "once": "^1.3.0",
-                "read-package-json": "^2.0.0",
-                "readdir-scoped-modules": "^1.0.0"
-              }
-            },
-            "readable-stream": {
-              "version": "2.3.2",
-              "bundled": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~1.0.6",
-                "safe-buffer": "~5.1.0",
-                "string_decoder": "~1.0.0",
-                "util-deprecate": "~1.0.1"
-              },
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "bundled": true
-                },
-                "isarray": {
-                  "version": "1.0.0",
-                  "bundled": true
-                },
-                "process-nextick-args": {
-                  "version": "1.0.7",
-                  "bundled": true
-                },
-                "string_decoder": {
-                  "version": "1.0.3",
-                  "bundled": true,
-                  "requires": {
-                    "safe-buffer": "~5.1.0"
-                  }
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "bundled": true
-                }
-              }
-            },
-            "readdir-scoped-modules": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "debuglog": "^1.0.1",
-                "dezalgo": "^1.0.0",
-                "graceful-fs": "^4.1.2",
-                "once": "^1.3.0"
-              }
-            },
-            "request": {
-              "version": "2.81.0",
-              "bundled": true,
-              "requires": {
-                "aws-sign2": "~0.6.0",
-                "aws4": "^1.2.1",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.5",
-                "extend": "~3.0.0",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.1.1",
-                "har-validator": "~4.2.1",
-                "hawk": "~3.1.3",
-                "http-signature": "~1.1.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.7",
-                "oauth-sign": "~0.8.1",
-                "performance-now": "^0.2.0",
-                "qs": "~6.4.0",
-                "safe-buffer": "^5.0.1",
-                "stringstream": "~0.0.4",
-                "tough-cookie": "~2.3.0",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.0.0"
-              },
-              "dependencies": {
-                "aws-sign2": {
-                  "version": "0.6.0",
-                  "bundled": true
-                },
-                "aws4": {
-                  "version": "1.6.0",
-                  "bundled": true
-                },
-                "caseless": {
-                  "version": "0.12.0",
-                  "bundled": true
-                },
-                "combined-stream": {
-                  "version": "1.0.5",
-                  "bundled": true,
-                  "requires": {
-                    "delayed-stream": "~1.0.0"
-                  },
-                  "dependencies": {
-                    "delayed-stream": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "extend": {
-                  "version": "3.0.1",
-                  "bundled": true
-                },
-                "forever-agent": {
-                  "version": "0.6.1",
-                  "bundled": true
-                },
-                "form-data": {
-                  "version": "2.1.4",
-                  "bundled": true,
-                  "requires": {
-                    "asynckit": "^0.4.0",
-                    "combined-stream": "^1.0.5",
-                    "mime-types": "^2.1.12"
-                  },
-                  "dependencies": {
-                    "asynckit": {
-                      "version": "0.4.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "har-validator": {
-                  "version": "4.2.1",
-                  "bundled": true,
-                  "requires": {
-                    "ajv": "^4.9.1",
-                    "har-schema": "^1.0.5"
-                  },
-                  "dependencies": {
-                    "ajv": {
-                      "version": "4.11.8",
-                      "bundled": true,
-                      "requires": {
-                        "co": "^4.6.0",
-                        "json-stable-stringify": "^1.0.1"
-                      },
-                      "dependencies": {
-                        "co": {
-                          "version": "4.6.0",
-                          "bundled": true
-                        },
-                        "json-stable-stringify": {
-                          "version": "1.0.1",
-                          "bundled": true,
-                          "requires": {
-                            "jsonify": "~0.0.0"
-                          },
-                          "dependencies": {
-                            "jsonify": {
-                              "version": "0.0.0",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "har-schema": {
-                      "version": "1.0.5",
-                      "bundled": true
-                    }
-                  }
-                },
-                "hawk": {
-                  "version": "3.1.3",
-                  "bundled": true,
-                  "requires": {
-                    "boom": "2.x.x",
-                    "cryptiles": "2.x.x",
-                    "hoek": "2.x.x",
-                    "sntp": "1.x.x"
-                  },
-                  "dependencies": {
-                    "boom": {
-                      "version": "2.10.1",
-                      "bundled": true,
-                      "requires": {
-                        "hoek": "2.x.x"
-                      }
-                    },
-                    "cryptiles": {
-                      "version": "2.0.5",
-                      "bundled": true,
-                      "requires": {
-                        "boom": "2.x.x"
-                      }
-                    },
-                    "hoek": {
-                      "version": "2.16.3",
-                      "bundled": true
-                    },
-                    "sntp": {
-                      "version": "1.0.9",
-                      "bundled": true,
-                      "requires": {
-                        "hoek": "2.x.x"
-                      }
-                    }
-                  }
-                },
-                "http-signature": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "requires": {
-                    "assert-plus": "^0.2.0",
-                    "jsprim": "^1.2.2",
-                    "sshpk": "^1.7.0"
-                  },
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "0.2.0",
-                      "bundled": true
-                    },
-                    "jsprim": {
-                      "version": "1.4.0",
-                      "bundled": true,
-                      "requires": {
-                        "assert-plus": "1.0.0",
-                        "extsprintf": "1.0.2",
-                        "json-schema": "0.2.3",
-                        "verror": "1.3.6"
-                      },
-                      "dependencies": {
-                        "assert-plus": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        },
-                        "extsprintf": {
-                          "version": "1.0.2",
-                          "bundled": true
-                        },
-                        "json-schema": {
-                          "version": "0.2.3",
-                          "bundled": true
-                        },
-                        "verror": {
-                          "version": "1.3.6",
-                          "bundled": true,
-                          "requires": {
-                            "extsprintf": "1.0.2"
-                          }
-                        }
-                      }
-                    },
-                    "sshpk": {
-                      "version": "1.13.1",
-                      "bundled": true,
-                      "requires": {
-                        "asn1": "~0.2.3",
-                        "assert-plus": "^1.0.0",
-                        "bcrypt-pbkdf": "^1.0.0",
-                        "dashdash": "^1.12.0",
-                        "ecc-jsbn": "~0.1.1",
-                        "getpass": "^0.1.1",
-                        "jsbn": "~0.1.0",
-                        "tweetnacl": "~0.14.0"
-                      },
-                      "dependencies": {
-                        "asn1": {
-                          "version": "0.2.3",
-                          "bundled": true
-                        },
-                        "assert-plus": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        },
-                        "bcrypt-pbkdf": {
-                          "version": "1.0.1",
-                          "bundled": true,
-                          "optional": true,
-                          "requires": {
-                            "tweetnacl": "^0.14.3"
-                          }
-                        },
-                        "dashdash": {
-                          "version": "1.14.1",
-                          "bundled": true,
-                          "requires": {
-                            "assert-plus": "^1.0.0"
-                          }
-                        },
-                        "ecc-jsbn": {
-                          "version": "0.1.1",
-                          "bundled": true,
-                          "optional": true,
-                          "requires": {
-                            "jsbn": "~0.1.0"
-                          }
-                        },
-                        "getpass": {
-                          "version": "0.1.7",
-                          "bundled": true,
-                          "requires": {
-                            "assert-plus": "^1.0.0"
-                          }
-                        },
-                        "jsbn": {
-                          "version": "0.1.1",
-                          "bundled": true,
-                          "optional": true
-                        },
-                        "tweetnacl": {
-                          "version": "0.14.5",
-                          "bundled": true,
-                          "optional": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "is-typedarray": {
-                  "version": "1.0.0",
-                  "bundled": true
-                },
-                "isstream": {
-                  "version": "0.1.2",
-                  "bundled": true
-                },
-                "json-stringify-safe": {
-                  "version": "5.0.1",
-                  "bundled": true
-                },
-                "mime-types": {
-                  "version": "2.1.15",
-                  "bundled": true,
-                  "requires": {
-                    "mime-db": "~1.27.0"
-                  },
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.27.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "oauth-sign": {
-                  "version": "0.8.2",
-                  "bundled": true
-                },
-                "performance-now": {
-                  "version": "0.2.0",
-                  "bundled": true
-                },
-                "qs": {
-                  "version": "6.4.0",
-                  "bundled": true
-                },
-                "stringstream": {
-                  "version": "0.0.5",
-                  "bundled": true
-                },
-                "tough-cookie": {
-                  "version": "2.3.2",
-                  "bundled": true,
-                  "requires": {
-                    "punycode": "^1.4.1"
-                  },
-                  "dependencies": {
-                    "punycode": {
-                      "version": "1.4.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "tunnel-agent": {
-                  "version": "0.6.0",
-                  "bundled": true,
-                  "requires": {
-                    "safe-buffer": "^5.0.1"
-                  }
-                }
-              }
-            },
-            "retry": {
-              "version": "0.10.1",
-              "bundled": true
-            },
-            "rimraf": {
-              "version": "2.6.1",
-              "bundled": true,
-              "requires": {
-                "glob": "^7.0.5"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.1",
-              "bundled": true
-            },
-            "semver": {
-              "version": "5.3.0",
-              "bundled": true
-            },
-            "sha": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "readable-stream": "^2.0.2"
-              }
-            },
-            "slide": {
-              "version": "1.1.6",
-              "bundled": true
-            },
-            "sorted-object": {
-              "version": "2.0.1",
-              "bundled": true
-            },
-            "sorted-union-stream": {
-              "version": "2.1.3",
-              "bundled": true,
-              "requires": {
-                "from2": "^1.3.0",
-                "stream-iterate": "^1.1.0"
-              },
-              "dependencies": {
-                "from2": {
-                  "version": "1.3.0",
-                  "bundled": true,
-                  "requires": {
-                    "inherits": "~2.0.1",
-                    "readable-stream": "~1.1.10"
-                  },
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "1.1.14",
-                      "bundled": true,
-                      "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
-                      },
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2",
-                          "bundled": true
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "bundled": true
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "stream-iterate": {
-                  "version": "1.2.0",
-                  "bundled": true,
-                  "requires": {
-                    "readable-stream": "^2.1.5",
-                    "stream-shift": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "stream-shift": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
-            "ssri": {
-              "version": "4.1.6",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "^5.1.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "4.0.0",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "^3.0.0"
-              },
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "3.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "tar": {
-              "version": "2.2.1",
-              "bundled": true,
-              "requires": {
-                "block-stream": "*",
-                "fstream": "^1.0.2",
-                "inherits": "2"
-              },
-              "dependencies": {
-                "block-stream": {
-                  "version": "0.0.9",
-                  "bundled": true,
-                  "requires": {
-                    "inherits": "~2.0.0"
-                  }
-                }
-              }
-            },
-            "text-table": {
-              "version": "0.2.0",
-              "bundled": true
-            },
-            "uid-number": {
-              "version": "0.0.6",
-              "bundled": true
-            },
-            "umask": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "unique-filename": {
-              "version": "1.1.0",
-              "bundled": true,
-              "requires": {
-                "unique-slug": "^2.0.0"
-              },
-              "dependencies": {
-                "unique-slug": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "imurmurhash": "^0.1.4"
-                  }
-                }
-              }
-            },
-            "unpipe": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "update-notifier": {
-              "version": "2.2.0",
-              "bundled": true,
-              "requires": {
-                "boxen": "^1.0.0",
-                "chalk": "^1.0.0",
-                "configstore": "^3.0.0",
-                "import-lazy": "^2.1.0",
-                "is-npm": "^1.0.0",
-                "latest-version": "^3.0.0",
-                "semver-diff": "^2.0.0",
-                "xdg-basedir": "^3.0.0"
-              },
-              "dependencies": {
-                "boxen": {
-                  "version": "1.1.0",
-                  "bundled": true,
-                  "requires": {
-                    "ansi-align": "^2.0.0",
-                    "camelcase": "^4.0.0",
-                    "chalk": "^1.1.1",
-                    "cli-boxes": "^1.0.0",
-                    "string-width": "^2.0.0",
-                    "term-size": "^0.1.0",
-                    "widest-line": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "ansi-align": {
-                      "version": "2.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "string-width": "^2.0.0"
-                      }
-                    },
-                    "camelcase": {
-                      "version": "4.1.0",
-                      "bundled": true
-                    },
-                    "cli-boxes": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    },
-                    "string-width": {
-                      "version": "2.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^4.0.0"
-                      },
-                      "dependencies": {
-                        "is-fullwidth-code-point": {
-                          "version": "2.0.0",
-                          "bundled": true
-                        },
-                        "strip-ansi": {
-                          "version": "4.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "ansi-regex": "^3.0.0"
-                          }
-                        }
-                      }
-                    },
-                    "term-size": {
-                      "version": "0.1.1",
-                      "bundled": true,
-                      "requires": {
-                        "execa": "^0.4.0"
-                      },
-                      "dependencies": {
-                        "execa": {
-                          "version": "0.4.0",
-                          "bundled": true,
-                          "requires": {
-                            "cross-spawn-async": "^2.1.1",
-                            "is-stream": "^1.1.0",
-                            "npm-run-path": "^1.0.0",
-                            "object-assign": "^4.0.1",
-                            "path-key": "^1.0.0",
-                            "strip-eof": "^1.0.0"
-                          },
-                          "dependencies": {
-                            "cross-spawn-async": {
-                              "version": "2.2.5",
-                              "bundled": true,
-                              "requires": {
-                                "lru-cache": "^4.0.0",
-                                "which": "^1.2.8"
-                              }
-                            },
-                            "is-stream": {
-                              "version": "1.1.0",
-                              "bundled": true
-                            },
-                            "npm-run-path": {
-                              "version": "1.0.0",
-                              "bundled": true,
-                              "requires": {
-                                "path-key": "^1.0.0"
-                              }
-                            },
-                            "object-assign": {
-                              "version": "4.1.1",
-                              "bundled": true
-                            },
-                            "path-key": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            },
-                            "strip-eof": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "widest-line": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "string-width": "^1.0.1"
-                      },
-                      "dependencies": {
-                        "string-width": {
-                          "version": "1.0.2",
-                          "bundled": true,
-                          "requires": {
-                            "code-point-at": "^1.0.0",
-                            "is-fullwidth-code-point": "^1.0.0",
-                            "strip-ansi": "^3.0.0"
-                          },
-                          "dependencies": {
-                            "code-point-at": {
-                              "version": "1.1.0",
-                              "bundled": true
-                            },
-                            "is-fullwidth-code-point": {
-                              "version": "1.0.0",
-                              "bundled": true,
-                              "requires": {
-                                "number-is-nan": "^1.0.0"
-                              },
-                              "dependencies": {
-                                "number-is-nan": {
-                                  "version": "1.0.1",
-                                  "bundled": true
-                                }
-                              }
-                            },
-                            "strip-ansi": {
-                              "version": "3.0.1",
-                              "bundled": true,
-                              "requires": {
-                                "ansi-regex": "^2.0.0"
-                              },
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.1.1",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "chalk": {
-                  "version": "1.1.3",
-                  "bundled": true,
-                  "requires": {
-                    "ansi-styles": "^2.2.1",
-                    "escape-string-regexp": "^1.0.2",
-                    "has-ansi": "^2.0.0",
-                    "strip-ansi": "^3.0.0",
-                    "supports-color": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "ansi-styles": {
-                      "version": "2.2.1",
-                      "bundled": true
-                    },
-                    "escape-string-regexp": {
-                      "version": "1.0.5",
-                      "bundled": true
-                    },
-                    "has-ansi": {
-                      "version": "2.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "ansi-regex": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.1.1",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "strip-ansi": {
-                      "version": "3.0.1",
-                      "bundled": true,
-                      "requires": {
-                        "ansi-regex": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.1.1",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "supports-color": {
-                      "version": "2.0.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "configstore": {
-                  "version": "3.1.0",
-                  "bundled": true,
-                  "requires": {
-                    "dot-prop": "^4.1.0",
-                    "graceful-fs": "^4.1.2",
-                    "make-dir": "^1.0.0",
-                    "unique-string": "^1.0.0",
-                    "write-file-atomic": "^2.0.0",
-                    "xdg-basedir": "^3.0.0"
-                  },
-                  "dependencies": {
-                    "dot-prop": {
-                      "version": "4.1.1",
-                      "bundled": true,
-                      "requires": {
-                        "is-obj": "^1.0.0"
-                      },
-                      "dependencies": {
-                        "is-obj": {
-                          "version": "1.0.1",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "make-dir": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "pify": "^2.3.0"
-                      },
-                      "dependencies": {
-                        "pify": {
-                          "version": "2.3.0",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "unique-string": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "crypto-random-string": "^1.0.0"
-                      },
-                      "dependencies": {
-                        "crypto-random-string": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "import-lazy": {
-                  "version": "2.1.0",
-                  "bundled": true
-                },
-                "is-npm": {
-                  "version": "1.0.0",
-                  "bundled": true
-                },
-                "latest-version": {
-                  "version": "3.1.0",
-                  "bundled": true,
-                  "requires": {
-                    "package-json": "^4.0.0"
-                  },
-                  "dependencies": {
-                    "package-json": {
-                      "version": "4.0.1",
-                      "bundled": true,
-                      "requires": {
-                        "got": "^6.7.1",
-                        "registry-auth-token": "^3.0.1",
-                        "registry-url": "^3.0.3",
-                        "semver": "^5.1.0"
-                      },
-                      "dependencies": {
-                        "got": {
-                          "version": "6.7.1",
-                          "bundled": true,
-                          "requires": {
-                            "create-error-class": "^3.0.0",
-                            "duplexer3": "^0.1.4",
-                            "get-stream": "^3.0.0",
-                            "is-redirect": "^1.0.0",
-                            "is-retry-allowed": "^1.0.0",
-                            "is-stream": "^1.0.0",
-                            "lowercase-keys": "^1.0.0",
-                            "safe-buffer": "^5.0.1",
-                            "timed-out": "^4.0.0",
-                            "unzip-response": "^2.0.1",
-                            "url-parse-lax": "^1.0.0"
-                          },
-                          "dependencies": {
-                            "create-error-class": {
-                              "version": "3.0.2",
-                              "bundled": true,
-                              "requires": {
-                                "capture-stack-trace": "^1.0.0"
-                              },
-                              "dependencies": {
-                                "capture-stack-trace": {
-                                  "version": "1.0.0",
-                                  "bundled": true
-                                }
-                              }
-                            },
-                            "duplexer3": {
-                              "version": "0.1.4",
-                              "bundled": true
-                            },
-                            "get-stream": {
-                              "version": "3.0.0",
-                              "bundled": true
-                            },
-                            "is-redirect": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            },
-                            "is-retry-allowed": {
-                              "version": "1.1.0",
-                              "bundled": true
-                            },
-                            "is-stream": {
-                              "version": "1.1.0",
-                              "bundled": true
-                            },
-                            "lowercase-keys": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            },
-                            "timed-out": {
-                              "version": "4.0.1",
-                              "bundled": true
-                            },
-                            "unzip-response": {
-                              "version": "2.0.1",
-                              "bundled": true
-                            },
-                            "url-parse-lax": {
-                              "version": "1.0.0",
-                              "bundled": true,
-                              "requires": {
-                                "prepend-http": "^1.0.1"
-                              },
-                              "dependencies": {
-                                "prepend-http": {
-                                  "version": "1.0.4",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "registry-auth-token": {
-                          "version": "3.3.1",
-                          "bundled": true,
-                          "requires": {
-                            "rc": "^1.1.6",
-                            "safe-buffer": "^5.0.1"
-                          },
-                          "dependencies": {
-                            "rc": {
-                              "version": "1.2.1",
-                              "bundled": true,
-                              "requires": {
-                                "deep-extend": "~0.4.0",
-                                "ini": "~1.3.0",
-                                "minimist": "^1.2.0",
-                                "strip-json-comments": "~2.0.1"
-                              },
-                              "dependencies": {
-                                "deep-extend": {
-                                  "version": "0.4.2",
-                                  "bundled": true
-                                },
-                                "minimist": {
-                                  "version": "1.2.0",
-                                  "bundled": true
-                                },
-                                "strip-json-comments": {
-                                  "version": "2.0.1",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "registry-url": {
-                          "version": "3.1.0",
-                          "bundled": true,
-                          "requires": {
-                            "rc": "^1.0.1"
-                          },
-                          "dependencies": {
-                            "rc": {
-                              "version": "1.2.1",
-                              "bundled": true,
-                              "requires": {
-                                "deep-extend": "~0.4.0",
-                                "ini": "~1.3.0",
-                                "minimist": "^1.2.0",
-                                "strip-json-comments": "~2.0.1"
-                              },
-                              "dependencies": {
-                                "deep-extend": {
-                                  "version": "0.4.2",
-                                  "bundled": true
-                                },
-                                "minimist": {
-                                  "version": "1.2.0",
-                                  "bundled": true
-                                },
-                                "strip-json-comments": {
-                                  "version": "2.0.1",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "semver-diff": {
-                  "version": "2.1.0",
-                  "bundled": true,
-                  "requires": {
-                    "semver": "^5.0.3"
-                  }
-                },
-                "xdg-basedir": {
-                  "version": "3.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "uuid": {
-              "version": "3.1.0",
-              "bundled": true
-            },
-            "validate-npm-package-license": {
-              "version": "3.0.1",
-              "bundled": true,
-              "requires": {
-                "spdx-correct": "~1.0.0",
-                "spdx-expression-parse": "~1.0.0"
-              },
-              "dependencies": {
-                "spdx-correct": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "requires": {
-                    "spdx-license-ids": "^1.0.2"
-                  },
-                  "dependencies": {
-                    "spdx-license-ids": {
-                      "version": "1.2.2",
-                      "bundled": true
-                    }
-                  }
-                },
-                "spdx-expression-parse": {
-                  "version": "1.0.4",
-                  "bundled": true
-                }
-              }
-            },
-            "validate-npm-package-name": {
-              "version": "3.0.0",
-              "bundled": true,
-              "requires": {
-                "builtins": "^1.0.3"
-              },
-              "dependencies": {
-                "builtins": {
-                  "version": "1.0.3",
-                  "bundled": true
-                }
-              }
-            },
-            "which": {
-              "version": "1.2.14",
-              "bundled": true,
-              "requires": {
-                "isexe": "^2.0.0"
-              },
-              "dependencies": {
-                "isexe": {
-                  "version": "2.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "worker-farm": {
-              "version": "1.3.1",
-              "bundled": true,
-              "requires": {
-                "errno": ">=0.1.1 <0.2.0-0",
-                "xtend": ">=4.0.0 <4.1.0-0"
-              },
-              "dependencies": {
-                "errno": {
-                  "version": "0.1.4",
-                  "bundled": true,
-                  "requires": {
-                    "prr": "~0.0.0"
-                  },
-                  "dependencies": {
-                    "prr": {
-                      "version": "0.0.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "xtend": {
-                  "version": "4.0.1",
-                  "bundled": true
-                }
-              }
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "write-file-atomic": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "^4.1.11",
-                "imurmurhash": "^0.1.4",
-                "slide": "^1.1.5"
-              }
-            }
-          }
-        },
-        "npm-package-arg": {
-          "version": "6.1.0",
-          "bundled": true,
-          "requires": {
-            "hosted-git-info": "^2.6.0",
-            "osenv": "^0.1.5",
-            "semver": "^5.5.0",
-            "validate-npm-package-name": "^3.0.0"
-          }
-        },
-        "npm-run-path": {
-          "version": "2.0.2",
-          "bundled": true,
-          "requires": {
-            "path-key": "^2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "os-locale": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
-          }
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "osenv": {
-          "version": "0.1.5",
-          "bundled": true,
-          "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
-          }
-        },
-        "p-finally": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "p-limit": {
-          "version": "1.2.0",
-          "bundled": true,
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "package-json": {
-          "version": "4.0.1",
-          "bundled": true,
-          "requires": {
-            "got": "^6.7.1",
-            "registry-auth-token": "^3.0.1",
-            "registry-url": "^3.0.3",
-            "semver": "^5.1.0"
-          }
-        },
-        "path-exists": {
-          "version": "3.0.0",
-          "bundled": true
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "path-is-inside": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "path-key": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "pify": {
-          "version": "3.0.0",
-          "bundled": true
-        },
-        "prepend-http": {
-          "version": "1.0.4",
-          "bundled": true
-        },
-        "pseudomap": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "rc": {
-          "version": "1.2.6",
-          "bundled": true,
-          "requires": {
-            "deep-extend": "~0.4.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
-          }
-        },
-        "registry-auth-token": {
-          "version": "3.3.2",
-          "bundled": true,
-          "requires": {
-            "rc": "^1.1.6",
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "registry-url": {
-          "version": "3.1.0",
-          "bundled": true,
-          "requires": {
-            "rc": "^1.0.1"
-          }
-        },
-        "require-directory": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "require-main-filename": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "rimraf": {
-          "version": "2.6.2",
-          "bundled": true,
-          "requires": {
-            "glob": "^7.0.5"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "bundled": true
-        },
-        "semver": {
-          "version": "5.5.0",
-          "bundled": true
-        },
-        "semver-diff": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "semver": "^5.0.3"
-          }
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "shebang-command": {
-          "version": "1.2.0",
-          "bundled": true,
-          "requires": {
-            "shebang-regex": "^1.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "bundled": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "bundled": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        },
-        "strip-eof": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "supports-color": {
-          "version": "5.3.0",
-          "bundled": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        },
-        "term-size": {
-          "version": "1.2.0",
-          "bundled": true,
-          "requires": {
-            "execa": "^0.7.0"
-          }
-        },
-        "timed-out": {
-          "version": "4.0.1",
-          "bundled": true
-        },
-        "unique-string": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "crypto-random-string": "^1.0.0"
-          }
-        },
-        "unzip-response": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "update-notifier": {
-          "version": "2.4.0",
-          "bundled": true,
-          "requires": {
-            "boxen": "^1.2.1",
-            "chalk": "^2.0.1",
-            "configstore": "^3.0.0",
-            "import-lazy": "^2.1.0",
-            "is-ci": "^1.0.10",
-            "is-installed-globally": "^0.1.0",
-            "is-npm": "^1.0.0",
-            "latest-version": "^3.0.0",
-            "semver-diff": "^2.0.0",
-            "xdg-basedir": "^3.0.0"
-          }
-        },
-        "url-parse-lax": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "prepend-http": "^1.0.1"
-          }
-        },
-        "validate-npm-package-name": {
-          "version": "3.0.0",
-          "bundled": true,
-          "requires": {
-            "builtins": "^1.0.3"
-          }
-        },
-        "which": {
-          "version": "1.3.0",
-          "bundled": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        },
-        "which-module": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "widest-line": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "string-width": "^2.1.1"
-          }
-        },
-        "wrap-ansi": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "2.1.1",
-              "bundled": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              }
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "^2.0.0"
-              }
-            }
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "write-file-atomic": {
-          "version": "2.3.0",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "signal-exit": "^3.0.2"
-          }
-        },
-        "xdg-basedir": {
-          "version": "3.0.0",
-          "bundled": true
-        },
-        "y18n": {
-          "version": "4.0.0",
-          "bundled": true
-        },
-        "yallist": {
-          "version": "2.1.2",
-          "bundled": true
-        },
-        "yargs": {
-          "version": "11.0.0",
-          "bundled": true,
-          "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.1.1",
-            "find-up": "^2.1.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^9.0.2"
-          },
-          "dependencies": {
-            "y18n": {
-              "version": "3.2.1",
-              "bundled": true
-            }
-          }
-        },
-        "yargs-parser": {
-          "version": "9.0.2",
-          "bundled": true,
-          "requires": {
-            "camelcase": "^4.1.0"
-          }
-        }
       }
     },
     "num2fraction": {
@@ -25816,14 +21230,6 @@
         "mimic-fn": "^1.0.0"
       }
     },
-    "open": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
-      "integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
-      "requires": {
-        "is-wsl": "^1.1.0"
-      }
-    },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
@@ -25932,14 +21338,16 @@
       }
     },
     "p-cancelable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+      "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
+      "dev": true
     },
     "p-finally": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
-      "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
     },
     "p-is-promise": {
       "version": "1.1.0",
@@ -25963,11 +21371,6 @@
         "p-limit": "^1.1.0"
       }
     },
-    "p-reduce": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
-      "integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw=="
-    },
     "p-timeout": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
@@ -25975,14 +21378,6 @@
       "dev": true,
       "requires": {
         "p-finally": "^1.0.0"
-      },
-      "dependencies": {
-        "p-finally": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-          "dev": true
-        }
       }
     },
     "p-try": {
@@ -25991,20 +21386,56 @@
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
     },
     "package-json": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
-      "integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+      "dev": true,
       "requires": {
-        "got": "^9.6.0",
-        "registry-auth-token": "^4.0.0",
-        "registry-url": "^5.0.0",
-        "semver": "^6.2.0"
+        "got": "^6.7.1",
+        "registry-auth-token": "^3.0.1",
+        "registry-url": "^3.0.3",
+        "semver": "^5.1.0"
       },
       "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        },
+        "got": {
+          "version": "6.7.1",
+          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+          "dev": true,
+          "requires": {
+            "create-error-class": "^3.0.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "is-redirect": "^1.0.0",
+            "is-retry-allowed": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "lowercase-keys": "^1.0.0",
+            "safe-buffer": "^5.0.1",
+            "timed-out": "^4.0.0",
+            "unzip-response": "^2.0.1",
+            "url-parse-lax": "^1.0.0"
+          }
+        },
+        "prepend-http": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+          "dev": true
+        },
+        "url-parse-lax": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+          "dev": true,
+          "requires": {
+            "prepend-http": "^1.0.1"
+          }
         }
       }
     },
@@ -26068,7 +21499,8 @@
     "parse-ms": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
-      "integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0="
+      "integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0=",
+      "dev": true
     },
     "parse-passwd": {
       "version": "1.0.0",
@@ -26137,12 +21569,14 @@
     "path-is-inside": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
     },
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
     },
     "path-parse": {
       "version": "1.0.6",
@@ -26205,7 +21639,8 @@
     "pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+      "dev": true
     },
     "pinkie": {
       "version": "2.0.4",
@@ -26360,7 +21795,8 @@
     "prepend-http": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
+      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+      "dev": true
     },
     "pretender": {
       "version": "2.1.1",
@@ -26377,6 +21813,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-3.2.0.tgz",
       "integrity": "sha512-ZypexbfVUGTFxb0v+m1bUyy92DHe5SyYlnyY0msyms5zd3RwyvNgyxZZsXXgoyzlxjx5MiqtXUdhUfvQbe0A2Q==",
+      "dev": true,
       "requires": {
         "parse-ms": "^1.0.0"
       }
@@ -26473,7 +21910,8 @@
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
     },
     "psl": {
       "version": "1.3.0",
@@ -26499,6 +21937,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -26753,6 +22192,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -26763,7 +22203,8 @@
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
         }
       }
     },
@@ -26957,12 +22398,12 @@
       }
     },
     "regexpu-core": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
-      "integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.5.tgz",
+      "integrity": "sha512-FpI67+ky9J+cDizQUJlIlNZFKual/lUkFr1AG6zOCpwZ9cLrg8UUVakyUQJD7fCDIe9Z2nwTQJNPyonatNmDFQ==",
       "requires": {
         "regenerate": "^1.4.0",
-        "regenerate-unicode-properties": "^8.0.2",
+        "regenerate-unicode-properties": "^8.1.0",
         "regjsgen": "^0.5.0",
         "regjsparser": "^0.6.0",
         "unicode-match-property-ecmascript": "^1.0.4",
@@ -26970,20 +22411,22 @@
       }
     },
     "registry-auth-token": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.0.0.tgz",
-      "integrity": "sha512-lpQkHxd9UL6tb3k/aHAVfnVtn+Bcs9ob5InuFLLEDqSqeq+AljB8GZW9xY0x7F+xYwEcjKe07nyoxzEYz6yvkw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
+      "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
+      "dev": true,
       "requires": {
-        "rc": "^1.2.8",
+        "rc": "^1.1.6",
         "safe-buffer": "^5.0.1"
       }
     },
     "registry-url": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
-      "integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+      "dev": true,
       "requires": {
-        "rc": "^1.2.8"
+        "rc": "^1.0.1"
       }
     },
     "regjsgen": {
@@ -27101,20 +22544,11 @@
         "tough-cookie": "^2.3.3"
       }
     },
-    "require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
-    },
-    "require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
-    },
     "require-relative": {
       "version": "0.8.7",
       "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
-      "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4="
+      "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
+      "dev": true
     },
     "require-uncached": {
       "version": "1.0.3",
@@ -27190,6 +22624,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
       "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+      "dev": true,
       "requires": {
         "lowercase-keys": "^1.0.0"
       }
@@ -27209,35 +22644,6 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
-    "rfc6902": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/rfc6902/-/rfc6902-3.0.4.tgz",
-      "integrity": "sha512-OnzreaZXrwT5w2ikKXWr5QcuI7NZpL+J3hIkAwozjOnKVUL7fPsB8Vcmu8YBiiou1/r3V0Jc0T1uQDyfAPvLzA=="
-    },
-    "rfc6902-ordered": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/rfc6902-ordered/-/rfc6902-ordered-4.0.0.tgz",
-      "integrity": "sha512-uGpjTewv2UxexoQPtYDpAZKt3WX/ujxkw3TqJAZOUu3WkwCNsu67Dlk+KPn/RY851+U3PvSTNOKs58d9YBubeQ==",
-      "requires": {
-        "debug": "^4.0.0",
-        "rfc6902": "^3.0.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
-      }
-    },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
@@ -27247,9 +22653,9 @@
       }
     },
     "rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "requires": {
         "glob": "^7.1.3"
       }
@@ -27265,21 +22671,13 @@
       }
     },
     "rollup": {
-      "version": "0.57.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.57.1.tgz",
-      "integrity": "sha512-I18GBqP0qJoJC1K1osYjreqA8VAKovxuI3I81RSk0Dmr4TgloI0tAULjZaox8OsJ+n7XRrhH6i0G2By/pj1LCA==",
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.19.4.tgz",
+      "integrity": "sha512-G24w409GNj7i/Yam2cQla6qV2k6Nug8bD2DZg9v63QX/cH/dEdbNJg8H4lUm5M1bRpPKRUC465Rm9H51JTKOfQ==",
       "requires": {
-        "@types/acorn": "^4.0.3",
-        "acorn": "^5.5.3",
-        "acorn-dynamic-import": "^3.0.0",
-        "date-time": "^2.1.0",
-        "is-reference": "^1.1.0",
-        "locate-character": "^2.0.5",
-        "pretty-ms": "^3.1.0",
-        "require-relative": "^0.8.7",
-        "rollup-pluginutils": "^2.0.1",
-        "signal-exit": "^3.0.2",
-        "sourcemap-codec": "^1.4.1"
+        "@types/estree": "0.0.39",
+        "@types/node": "^12.6.9",
+        "acorn": "^6.2.1"
       }
     },
     "rollup-pluginutils": {
@@ -27335,6 +22733,7 @@
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
       "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
+      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -27381,55 +22780,10 @@
         "walker": "~1.0.5"
       },
       "dependencies": {
-        "execa": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^6.0.0",
-            "get-stream": "^4.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-          "dev": true
-        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "npm-run-path": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-          "dev": true,
-          "requires": {
-            "path-key": "^2.0.0"
-          }
-        },
-        "p-finally": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
           "dev": true
         }
       }
@@ -27491,17 +22845,9 @@
       "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
     },
     "semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
-    },
-    "semver-diff": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
-      "requires": {
-        "semver": "^5.0.3"
-      }
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "send": {
       "version": "0.17.1",
@@ -27572,7 +22918,8 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
     },
     "set-value": {
       "version": "2.0.1",
@@ -27623,6 +22970,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
       "requires": {
         "shebang-regex": "^1.0.0"
       }
@@ -27986,7 +23334,8 @@
     "sourcemap-codec": {
       "version": "1.4.6",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.6.tgz",
-      "integrity": "sha512-1ZooVLYFxC448piVLBbtOxFcXwnymH9oUF8nRd3CuYDVvkRBxRl6pB4Mtas5a4drtL+E8LDgFkQNcgIw6tc8Hg=="
+      "integrity": "sha512-1ZooVLYFxC448piVLBbtOxFcXwnymH9oUF8nRd3CuYDVvkRBxRl6pB4Mtas5a4drtL+E8LDgFkQNcgIw6tc8Hg==",
+      "dev": true
     },
     "sourcemap-validator": {
       "version": "1.1.1",
@@ -28298,17 +23647,14 @@
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
-    },
-    "strip-final-newline": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
     },
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
     },
     "styled_string": {
       "version": "0.0.1",
@@ -28436,69 +23782,23 @@
       "dev": true,
       "requires": {
         "rimraf": "~2.6.2"
-      }
-    },
-    "term-size": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
-      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
-      "requires": {
-        "execa": "^0.7.0"
       },
       "dependencies": {
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
           "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "glob": "^7.1.3"
           }
-        },
-        "execa": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-          "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-        },
-        "npm-run-path": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-          "requires": {
-            "path-key": "^2.0.0"
-          }
-        },
-        "p-finally": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
         }
       }
     },
     "terser": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.1.3.tgz",
-      "integrity": "sha512-on13d+cnpn5bMouZu+J8tPYQecsdRJCJuxFJ+FVoPBoLJgk5bCBkp+Uen2hWyi0KIUm6eDarnlAlH+KgIx/PuQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.1.4.tgz",
+      "integrity": "sha512-+ZwXJvdSwbd60jG0Illav0F06GDJF0R4ydZ21Q3wGAFKoBGyJGo34F63vzJHgvYxc1ukOtIjvwEvl9MkjzM6Pg==",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",
@@ -28633,51 +23933,6 @@
           "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
           "dev": true
         },
-        "execa": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^6.0.0",
-            "get-stream": "^4.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-          "dev": true
-        },
-        "npm-run-path": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-          "dev": true,
-          "requires": {
-            "path-key": "^2.0.0"
-          }
-        },
-        "p-finally": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-          "dev": true
-        },
         "tmp": {
           "version": "0.0.33",
           "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -28704,21 +23959,6 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.5.0.tgz",
       "integrity": "sha512-1IkVr355eHcomgK7fgj1Xsokturx6L5S2JRT5WcRdA6v5shk9sxWuO/w/VbpQexwkXJMQIa/j1dBi3oo7+HhcA=="
-    },
-    "three-way-merger": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/three-way-merger/-/three-way-merger-0.5.7.tgz",
-      "integrity": "sha512-aD2nvGowCgJxoH49Izou5uR4PLCuH2yiw6+BJPg0H7RCLzpLy/4J9onM9sPXetmsq/AVfZ8fEyf8lbGKxKPrcA==",
-      "requires": {
-        "semver": "^6.0.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-        }
-      }
     },
     "through": {
       "version": "2.3.8",
@@ -28765,7 +24005,8 @@
     "time-zone": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
-      "integrity": "sha1-mcW/VZWJZq9tBtg73zgA3IL67F0="
+      "integrity": "sha1-mcW/VZWJZq9tBtg73zgA3IL67F0=",
+      "dev": true
     },
     "timed-out": {
       "version": "4.0.1",
@@ -28774,9 +24015,9 @@
       "dev": true
     },
     "timers-browserify": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
-      "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
+      "integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
       "dev": true,
       "requires": {
         "setimmediate": "^1.0.4"
@@ -28857,11 +24098,6 @@
       "requires": {
         "kind-of": "^3.0.2"
       }
-    },
-    "to-readable-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
-      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q=="
     },
     "to-regex": {
       "version": "3.0.2",
@@ -28961,7 +24197,8 @@
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "dev": true
     },
     "tty-browserify": {
       "version": "0.0.0",
@@ -28994,9 +24231,10 @@
       }
     },
     "type-fest": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
-      "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ=="
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
+      "integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==",
+      "dev": true
     },
     "type-is": {
       "version": "1.6.18",
@@ -29130,6 +24368,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+      "dev": true,
       "requires": {
         "crypto-random-string": "^1.0.0"
       }
@@ -29206,25 +24445,6 @@
       "integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
       "dev": true
     },
-    "update-notifier": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-3.0.1.tgz",
-      "integrity": "sha512-grrmrB6Zb8DUiyDIaeRTBCkgISYUgETNe7NglEbVsrLWXeESnlCSP50WfRSj/GmzMPl6Uchj24S/p80nP/ZQrQ==",
-      "requires": {
-        "boxen": "^3.0.0",
-        "chalk": "^2.0.1",
-        "configstore": "^4.0.0",
-        "has-yarn": "^2.1.0",
-        "import-lazy": "^2.1.0",
-        "is-ci": "^2.0.0",
-        "is-installed-globally": "^0.1.0",
-        "is-npm": "^3.0.0",
-        "is-yarn-global": "^0.3.0",
-        "latest-version": "^5.0.0",
-        "semver-diff": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
-      }
-    },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -29270,6 +24490,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
       "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+      "dev": true,
       "requires": {
         "prepend-http": "^2.0.0"
       }
@@ -29336,7 +24557,8 @@
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "dev": true
     },
     "validate-npm-package-name": {
       "version": "3.0.0",
@@ -29489,6 +24711,12 @@
         "webpack-sources": "^1.3.0"
       },
       "dependencies": {
+        "acorn": {
+          "version": "5.7.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+          "dev": true
+        },
         "ajv": {
           "version": "6.10.2",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
@@ -29596,14 +24824,10 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }
-    },
-    "which-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "wide-align": {
       "version": "1.1.3",
@@ -29612,14 +24836,6 @@
       "dev": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
-      }
-    },
-    "widest-line": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
-      "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
-      "requires": {
-        "string-width": "^2.1.1"
       }
     },
     "window-size": {
@@ -29658,41 +24874,6 @@
         }
       }
     },
-    "wrap-ansi": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-      "requires": {
-        "ansi-styles": "^3.2.0",
-        "string-width": "^3.0.0",
-        "strip-ansi": "^5.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        }
-      }
-    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -29711,6 +24892,7 @@
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
       "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
@@ -29729,7 +24911,8 @@
     "xdg-basedir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
+      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+      "dev": true
     },
     "xml-name-validator": {
       "version": "3.0.0",
@@ -29767,9 +24950,10 @@
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
     },
     "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+      "dev": true
     },
     "yam": {
       "version": "1.0.0",
@@ -29805,22 +24989,6 @@
         "os-locale": "^1.4.0",
         "window-size": "^0.1.2",
         "y18n": "^3.2.0"
-      }
-    },
-    "yargs-parser": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
-      "requires": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-        }
       }
     },
     "yeast": {

--- a/packages/reports/package.json
+++ b/packages/reports/package.json
@@ -57,7 +57,6 @@
     "broccoli-asset-rev": "^2.7.0",
     "ember-basic-dropdown": "1.1.2",
     "ember-basic-dropdown-hover": "^0.6.0",
-    "ember-c3": "0.2.3",
     "ember-cli": "~3.9.0",
     "ember-cli-autoprefixer": "~0.8.1",
     "ember-cli-bootstrap-datepicker": "0.5.3",


### PR DESCRIPTION
Resolves #315 

<!-- The above line will close the issue upon merge -->

## Description

Update ember-c3 which takes c3 and d3 out of bower.

## Proposed Changes

- Updates ember c3, which not only gets rid of bower controlled c3 and d3, but allows us to use a newer version of the c3 lib. which means we can get rid of a lot of c3 enhancements that are no longer necessary. (though introduced a new bug that we had to work around for now with unloading the component)

- Translation calculation moved out of the d3 api, so had to create a utility.

- Goal gauge api changed a bit, so small changes to get the same behavior was needed.

- property name changes in ember-c3

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
