### PR TITLE
Fix: Export goes away too fast on firefox

### DIFF
--- a/packages/reports/addon/templates/components/report-actions/multiple-format-export.hbs
+++ b/packages/reports/addon/templates/components/report-actions/multiple-format-export.hbs
@@ -1,6 +1,6 @@
 {{!-- Copyright 2019, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 
-{{#basic-dropdown-hover delay=0 renderInPlace=true as |dd|}}
+{{#basic-dropdown-hover openDelay=0 closeDelay=300 renderInPlace=true as |dd|}}
   {{#dd.trigger onMouseDown=(action "open")}}
     {{yield}}
   {{/dd.trigger}}


### PR DESCRIPTION
## Description

## Proposed Changes

-  Looks like delay was set to 0 so that it would open fast, but on firefox causes it to close too fast to interact with.  setting specific open and close delays as allowed by the component fixes this.

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
