### PR TITLE
Upgrade: Bump ember-cp-validation version in all packages

### DIFF
--- a/packages/app/package-lock.json
+++ b/packages/app/package-lock.json
@@ -8880,42 +8880,14 @@
       }
     },
     "ember-cp-validations": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/ember-cp-validations/-/ember-cp-validations-3.5.5.tgz",
-      "integrity": "sha512-3o2+aM0gEeHHQo7izfgfaeuY8yGhBHsaRt4yONef/2ilcfiShBlok8NqvDaVEpvV0+b7jqePE5LCcRM8ftuJSw==",
+      "version": "4.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/ember-cp-validations/-/ember-cp-validations-4.0.0-beta.9.tgz",
+      "integrity": "sha512-TfUBOkQFzhLvphtFauuTu0ogdY/JRXCtR4yF5++TS3cHPe/SJKwykGzKjjpu+mvO57NacNC8rh8GCanzzHQVxg==",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "^6.6.0",
-        "ember-cli-version-checker": "^2.0.0",
-        "ember-getowner-polyfill": "^2.2.0",
-        "ember-require-module": "0.1.3",
-        "ember-string-ishtmlsafe-polyfill": "^2.0.0",
-        "ember-validators": "1.0.4",
-        "exists-sync": "0.0.4",
-        "walk-sync": "^0.3.1"
-      },
-      "dependencies": {
-        "ember-cli-babel": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
-          "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
-          "dev": true,
-          "requires": {
-            "amd-name-resolver": "1.2.0",
-            "babel-plugin-debug-macros": "^0.2.0-beta.6",
-            "babel-plugin-ember-modules-api-polyfill": "^2.6.0",
-            "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
-            "babel-polyfill": "^6.26.0",
-            "babel-preset-env": "^1.7.0",
-            "broccoli-babel-transpiler": "^6.5.0",
-            "broccoli-debug": "^0.6.4",
-            "broccoli-funnel": "^2.0.0",
-            "broccoli-source": "^1.1.0",
-            "clone": "^2.0.0",
-            "ember-cli-version-checker": "^2.1.2",
-            "semver": "^5.5.0"
-          }
-        }
+        "ember-cli-babel": "^7.1.2",
+        "ember-require-module": "^0.3.0",
+        "ember-validators": "^2.0.0"
       }
     },
     "ember-data": {
@@ -10606,9 +10578,9 @@
       }
     },
     "ember-require-module": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ember-require-module/-/ember-require-module-0.1.3.tgz",
-      "integrity": "sha1-+C9gVSFCF5FS0o7Jfr112WfK4dw=",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ember-require-module/-/ember-require-module-0.3.0.tgz",
+      "integrity": "sha512-rYN4YoWbR9VlJISSmx0ZcYZOgMcXZLGR7kdvp3zDerjIvYmHm/3p+K56fEAYmJILA6W4F+cBe41Tq2HuQAZizA==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^6.9.2"
@@ -10892,15 +10864,6 @@
         "got": "^8.0.1"
       }
     },
-    "ember-string-ishtmlsafe-polyfill": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/ember-string-ishtmlsafe-polyfill/-/ember-string-ishtmlsafe-polyfill-2.0.2.tgz",
-      "integrity": "sha512-C6i9H4NFw6nzYG+hxSrJyl5XA2xkGdWlJdN5otr0wl9k1IHCQe8n1PQr4vIpJsWcz5EYQC2+I/dPWZzOHIh1Mw==",
-      "dev": true,
-      "requires": {
-        "ember-cli-version-checker": "^2.1.0"
-      }
-    },
     "ember-tag-input": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ember-tag-input/-/ember-tag-input-1.2.1.tgz",
@@ -11124,13 +11087,13 @@
       }
     },
     "ember-validators": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/ember-validators/-/ember-validators-1.0.4.tgz",
-      "integrity": "sha1-fYnCURlFxSvSDFOE5xUTj5AhM7s=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ember-validators/-/ember-validators-2.0.0.tgz",
+      "integrity": "sha512-OhXGN2UbFQY+lhkWOdW347NZsIWGj/fpTJbOfNxjyMQW/c3fvPEIvrhlvWf1JwHGKQTJDHpMQJgA/Luq39GDgQ==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^6.9.2",
-        "ember-require-module": "^0.1.2"
+        "ember-require-module": "^0.3.0"
       },
       "dependencies": {
         "ember-cli-babel": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -61,7 +61,7 @@
     "ember-cli-update": "^0.34.10",
     "ember-collection": "1.0.0-alpha.9",
     "ember-composable-helpers": "^2.1.0",
-    "ember-cp-validations": "^3.5.0",
+    "ember-cp-validations": "^4.0.0-beta.9",
     "ember-debounced-properties": "0.0.5",
     "ember-export-application-global": "^2.0.0",
     "ember-font-awesome": "^3.0.5",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
     "ember-composable-helpers": "^2.1.0",
     "ember-concurrency": "~0.8.27",
     "ember-copy": "^1.0.0",
-    "ember-cp-validations": "^4.0.0-beta.6",
+    "ember-cp-validations": "^4.0.0-beta.9",
     "ember-data-model-fragments": "~4.0.0",
     "ember-debounced-properties": "0.0.5",
     "ember-fetch": "^6.5.1",

--- a/packages/dashboards/package-lock.json
+++ b/packages/dashboards/package-lock.json
@@ -5839,8 +5839,7 @@
     "delegate": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
-      "dev": true
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
     },
     "delegates": {
       "version": "1.0.0",
@@ -9629,130 +9628,13 @@
       }
     },
     "ember-cp-validations": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/ember-cp-validations/-/ember-cp-validations-3.5.5.tgz",
-      "integrity": "sha512-3o2+aM0gEeHHQo7izfgfaeuY8yGhBHsaRt4yONef/2ilcfiShBlok8NqvDaVEpvV0+b7jqePE5LCcRM8ftuJSw==",
+      "version": "4.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/ember-cp-validations/-/ember-cp-validations-4.0.0-beta.9.tgz",
+      "integrity": "sha512-TfUBOkQFzhLvphtFauuTu0ogdY/JRXCtR4yF5++TS3cHPe/SJKwykGzKjjpu+mvO57NacNC8rh8GCanzzHQVxg==",
       "requires": {
-        "ember-cli-babel": "^6.6.0",
-        "ember-cli-version-checker": "^2.0.0",
-        "ember-getowner-polyfill": "^2.2.0",
-        "ember-require-module": "0.1.3",
-        "ember-string-ishtmlsafe-polyfill": "^2.0.0",
-        "ember-validators": "1.0.4",
-        "exists-sync": "0.0.4",
-        "walk-sync": "^0.3.1"
-      },
-      "dependencies": {
-        "amd-name-resolver": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz",
-          "integrity": "sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==",
-          "requires": {
-            "ensure-posix-path": "^1.0.1"
-          }
-        },
-        "babel-plugin-debug-macros": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz",
-          "integrity": "sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==",
-          "requires": {
-            "semver": "^5.3.0"
-          }
-        },
-        "broccoli-babel-transpiler": {
-          "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz",
-          "integrity": "sha512-w6GcnkxvHcNCte5FcLGEG1hUdQvlfvSN/6PtGWU/otg69Ugk8rUk51h41R0Ugoc+TNxyeFG1opRt2RlA87XzNw==",
-          "requires": {
-            "babel-core": "^6.26.0",
-            "broccoli-funnel": "^2.0.1",
-            "broccoli-merge-trees": "^2.0.0",
-            "broccoli-persistent-filter": "^1.4.3",
-            "clone": "^2.0.0",
-            "hash-for-dep": "^1.2.3",
-            "heimdalljs-logger": "^0.1.7",
-            "json-stable-stringify": "^1.0.0",
-            "rsvp": "^4.8.2",
-            "workerpool": "^2.3.0"
-          }
-        },
-        "broccoli-merge-trees": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.1.tgz",
-          "integrity": "sha512-WjaexJ+I8BxP5V5RNn6um/qDRSmKoiBC/QkRi79FT9ClHfldxRyCDs9mcV7mmoaPlsshmmPaUz5jdtcKA6DClQ==",
-          "requires": {
-            "broccoli-plugin": "^1.3.0",
-            "merge-trees": "^1.0.1"
-          }
-        },
-        "broccoli-persistent-filter": {
-          "version": "1.4.6",
-          "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.6.tgz",
-          "integrity": "sha512-0RejLwoC95kv4kta8KAa+FmECJCK78Qgm8SRDEK7YyU0N9Cx6KpY3UCDy9WELl3mCXLN8TokNxc7/hp3lL4lfw==",
-          "requires": {
-            "async-disk-cache": "^1.2.1",
-            "async-promise-queue": "^1.0.3",
-            "broccoli-plugin": "^1.0.0",
-            "fs-tree-diff": "^0.5.2",
-            "hash-for-dep": "^1.0.2",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.7",
-            "mkdirp": "^0.5.1",
-            "promise-map-series": "^0.2.1",
-            "rimraf": "^2.6.1",
-            "rsvp": "^3.0.18",
-            "symlink-or-copy": "^1.0.1",
-            "walk-sync": "^0.3.1"
-          },
-          "dependencies": {
-            "rsvp": {
-              "version": "3.6.2",
-              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-              "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
-            }
-          }
-        },
-        "ember-cli-babel": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
-          "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
-          "requires": {
-            "amd-name-resolver": "1.2.0",
-            "babel-plugin-debug-macros": "^0.2.0-beta.6",
-            "babel-plugin-ember-modules-api-polyfill": "^2.6.0",
-            "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
-            "babel-polyfill": "^6.26.0",
-            "babel-preset-env": "^1.7.0",
-            "broccoli-babel-transpiler": "^6.5.0",
-            "broccoli-debug": "^0.6.4",
-            "broccoli-funnel": "^2.0.0",
-            "broccoli-source": "^1.1.0",
-            "clone": "^2.0.0",
-            "ember-cli-version-checker": "^2.1.2",
-            "semver": "^5.5.0"
-          }
-        },
-        "merge-trees": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-1.0.1.tgz",
-          "integrity": "sha1-zL5nRWl4f53vF/1G5lJfVwC70j4=",
-          "requires": {
-            "can-symlink": "^1.0.0",
-            "fs-tree-diff": "^0.5.4",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.7",
-            "rimraf": "^2.4.3",
-            "symlink-or-copy": "^1.0.0"
-          }
-        },
-        "workerpool": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.3.tgz",
-          "integrity": "sha512-L1ovlYHp6UObYqElXXpbd214GgbEKDED0d3sj7pRdFXjNkb2+un/AUcCkceHizO0IVI6SOGGncrcjozruCkRgA==",
-          "requires": {
-            "object-assign": "4.1.1"
-          }
-        }
+        "ember-cli-babel": "^7.1.2",
+        "ember-require-module": "^0.3.0",
+        "ember-validators": "^2.0.0"
       }
     },
     "ember-data": {
@@ -11916,9 +11798,9 @@
       }
     },
     "ember-require-module": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ember-require-module/-/ember-require-module-0.1.3.tgz",
-      "integrity": "sha1-+C9gVSFCF5FS0o7Jfr112WfK4dw=",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ember-require-module/-/ember-require-module-0.3.0.tgz",
+      "integrity": "sha512-rYN4YoWbR9VlJISSmx0ZcYZOgMcXZLGR7kdvp3zDerjIvYmHm/3p+K56fEAYmJILA6W4F+cBe41Tq2HuQAZizA==",
       "requires": {
         "ember-cli-babel": "^6.9.2"
       },
@@ -12504,14 +12386,6 @@
           "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
           "dev": true
         }
-      }
-    },
-    "ember-string-ishtmlsafe-polyfill": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/ember-string-ishtmlsafe-polyfill/-/ember-string-ishtmlsafe-polyfill-2.0.2.tgz",
-      "integrity": "sha512-C6i9H4NFw6nzYG+hxSrJyl5XA2xkGdWlJdN5otr0wl9k1IHCQe8n1PQr4vIpJsWcz5EYQC2+I/dPWZzOHIh1Mw==",
-      "requires": {
-        "ember-cli-version-checker": "^2.1.0"
       }
     },
     "ember-tag-input": {
@@ -13403,12 +13277,12 @@
       }
     },
     "ember-validators": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/ember-validators/-/ember-validators-1.0.4.tgz",
-      "integrity": "sha1-fYnCURlFxSvSDFOE5xUTj5AhM7s=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ember-validators/-/ember-validators-2.0.0.tgz",
+      "integrity": "sha512-OhXGN2UbFQY+lhkWOdW347NZsIWGj/fpTJbOfNxjyMQW/c3fvPEIvrhlvWf1JwHGKQTJDHpMQJgA/Luq39GDgQ==",
       "requires": {
         "ember-cli-babel": "^6.9.2",
-        "ember-require-module": "^0.1.2"
+        "ember-require-module": "^0.3.0"
       },
       "dependencies": {
         "amd-name-resolver": {
@@ -13498,6 +13372,14 @@
             "clone": "^2.0.0",
             "ember-cli-version-checker": "^2.1.2",
             "semver": "^5.5.0"
+          }
+        },
+        "is-glob": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+          "requires": {
+            "is-extglob": "^2.1.1"
           }
         },
         "merge-trees": {
@@ -16127,7 +16009,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
       "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
-      "dev": true,
       "requires": {
         "delegate": "^3.1.2"
       }
@@ -16871,8 +16752,7 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
     "is-finite": {
       "version": "1.0.2",
@@ -18411,6 +18291,328 @@
         "readable-stream": "^2.0.1"
       },
       "dependencies": {
+        "amd-name-resolver": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz",
+          "integrity": "sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==",
+          "requires": {
+            "ensure-posix-path": "^1.0.1"
+          }
+        },
+        "babel-plugin-debug-macros": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz",
+          "integrity": "sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==",
+          "requires": {
+            "semver": "^5.3.0"
+          }
+        },
+        "broccoli-babel-transpiler": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz",
+          "integrity": "sha512-w6GcnkxvHcNCte5FcLGEG1hUdQvlfvSN/6PtGWU/otg69Ugk8rUk51h41R0Ugoc+TNxyeFG1opRt2RlA87XzNw==",
+          "requires": {
+            "babel-core": "^6.26.0",
+            "broccoli-funnel": "^2.0.1",
+            "broccoli-merge-trees": "^2.0.0",
+            "broccoli-persistent-filter": "^1.4.3",
+            "clone": "^2.0.0",
+            "hash-for-dep": "^1.2.3",
+            "heimdalljs-logger": "^0.1.7",
+            "json-stable-stringify": "^1.0.0",
+            "rsvp": "^4.8.2"
+          },
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+              "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+              "requires": {
+                "array-equal": "^1.0.0",
+                "blank-object": "^1.0.1",
+                "broccoli-plugin": "^1.3.0",
+                "debug": "^2.2.0",
+                "fast-ordered-set": "^1.0.0",
+                "fs-tree-diff": "^0.5.3",
+                "heimdalljs": "^0.2.0",
+                "minimatch": "^3.0.0",
+                "mkdirp": "^0.5.0",
+                "path-posix": "^1.0.0",
+                "rimraf": "^2.4.3",
+                "symlink-or-copy": "^1.0.0",
+                "walk-sync": "^0.3.1"
+              }
+            }
+          }
+        },
+        "broccoli-funnel": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+          "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+          "requires": {
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
+            "exists-sync": "0.0.4",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
+          }
+        },
+        "broccoli-merge-trees": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.1.tgz",
+          "integrity": "sha512-WjaexJ+I8BxP5V5RNn6um/qDRSmKoiBC/QkRi79FT9ClHfldxRyCDs9mcV7mmoaPlsshmmPaUz5jdtcKA6DClQ==",
+          "requires": {
+            "broccoli-plugin": "^1.3.0"
+          }
+        },
+        "broccoli-persistent-filter": {
+          "version": "1.4.6",
+          "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.6.tgz",
+          "integrity": "sha512-0RejLwoC95kv4kta8KAa+FmECJCK78Qgm8SRDEK7YyU0N9Cx6KpY3UCDy9WELl3mCXLN8TokNxc7/hp3lL4lfw==",
+          "requires": {
+            "async-disk-cache": "^1.2.1",
+            "async-promise-queue": "^1.0.3",
+            "broccoli-plugin": "^1.0.0",
+            "fs-tree-diff": "^0.5.2",
+            "hash-for-dep": "^1.0.2",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.7",
+            "mkdirp": "^0.5.1",
+            "promise-map-series": "^0.2.1",
+            "rimraf": "^2.6.1",
+            "rsvp": "^3.0.18",
+            "symlink-or-copy": "^1.0.1",
+            "walk-sync": "^0.3.1"
+          },
+          "dependencies": {
+            "rsvp": {
+              "version": "3.6.2",
+              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+              "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
+            }
+          }
+        },
+        "clipboard": {
+          "version": "1.7.1",
+          "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-1.7.1.tgz",
+          "integrity": "sha1-Ng1taUbpmnof7zleQrqStem1oWs=",
+          "requires": {
+            "good-listener": "^1.2.2",
+            "select": "^1.1.2",
+            "tiny-emitter": "^2.0.0"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="
+        },
+        "ember-cli-clipboard": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-clipboard/-/ember-cli-clipboard-0.8.1.tgz",
+          "integrity": "sha1-Wfjra6Rxp2aN/1kvzrt7BgFCQN0=",
+          "requires": {
+            "broccoli-funnel": "^1.1.0",
+            "clipboard": "^1.7.1",
+            "ember-cli-babel": "^6.8.0",
+            "ember-cli-htmlbars": "^2.0.2"
+          },
+          "dependencies": {
+            "ember-cli-babel": {
+              "version": "6.18.0",
+              "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
+              "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
+              "requires": {
+                "amd-name-resolver": "1.2.0",
+                "babel-plugin-debug-macros": "^0.2.0-beta.6",
+                "babel-plugin-ember-modules-api-polyfill": "^2.6.0",
+                "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
+                "babel-polyfill": "^6.26.0",
+                "babel-preset-env": "^1.7.0",
+                "broccoli-babel-transpiler": "^6.5.0",
+                "broccoli-debug": "^0.6.4",
+                "broccoli-funnel": "^2.0.0",
+                "broccoli-source": "^1.1.0",
+                "clone": "^2.0.0",
+                "ember-cli-version-checker": "^2.1.2",
+                "semver": "^5.5.0"
+              },
+              "dependencies": {
+                "broccoli-funnel": {
+                  "version": "2.0.2",
+                  "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+                  "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+                  "requires": {
+                    "array-equal": "^1.0.0",
+                    "blank-object": "^1.0.1",
+                    "broccoli-plugin": "^1.3.0",
+                    "debug": "^2.2.0",
+                    "fast-ordered-set": "^1.0.0",
+                    "fs-tree-diff": "^0.5.3",
+                    "heimdalljs": "^0.2.0",
+                    "minimatch": "^3.0.0",
+                    "mkdirp": "^0.5.0",
+                    "path-posix": "^1.0.0",
+                    "rimraf": "^2.4.3",
+                    "symlink-or-copy": "^1.0.0",
+                    "walk-sync": "^0.3.1"
+                  }
+                }
+              }
+            },
+            "ember-cli-htmlbars": {
+              "version": "2.0.5",
+              "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-2.0.5.tgz",
+              "integrity": "sha512-3f3PAxdnQ/fhQa8XP/3z4RLRgLHxV8j4Ln75aHbRdemOCjBa048KxL9l+acRLhCulbGQCMnLiIUIC89PAzLrcA==",
+              "requires": {
+                "broccoli-persistent-filter": "^1.4.3",
+                "hash-for-dep": "^1.2.3",
+                "json-stable-stringify": "^1.0.0",
+                "strip-bom": "^3.0.0"
+              }
+            }
+          }
+        },
+        "ember-cli-string-helpers": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-string-helpers/-/ember-cli-string-helpers-1.10.0.tgz",
+          "integrity": "sha512-z2eNT7BsTNSxp3qNrv7KAxjPwdLC1kIYCck9CERg0RM5vBGy2vK6ozZE3U6nWrtth1xO4PrYkgISwhSgN8NMeg==",
+          "requires": {
+            "broccoli-funnel": "^1.0.1",
+            "ember-cli-babel": "^6.6.0"
+          },
+          "dependencies": {
+            "ember-cli-babel": {
+              "version": "6.18.0",
+              "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
+              "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
+              "requires": {
+                "amd-name-resolver": "1.2.0",
+                "babel-plugin-debug-macros": "^0.2.0-beta.6",
+                "babel-plugin-ember-modules-api-polyfill": "^2.6.0",
+                "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
+                "babel-polyfill": "^6.26.0",
+                "babel-preset-env": "^1.7.0",
+                "broccoli-babel-transpiler": "^6.5.0",
+                "broccoli-debug": "^0.6.4",
+                "broccoli-funnel": "^2.0.0",
+                "broccoli-source": "^1.1.0",
+                "clone": "^2.0.0",
+                "ember-cli-version-checker": "^2.1.2",
+                "semver": "^5.5.0"
+              },
+              "dependencies": {
+                "broccoli-funnel": {
+                  "version": "2.0.2",
+                  "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+                  "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+                  "requires": {
+                    "array-equal": "^1.0.0",
+                    "blank-object": "^1.0.1",
+                    "broccoli-plugin": "^1.3.0",
+                    "debug": "^2.2.0",
+                    "fast-ordered-set": "^1.0.0",
+                    "fs-tree-diff": "^0.5.3",
+                    "heimdalljs": "^0.2.0",
+                    "minimatch": "^3.0.0",
+                    "mkdirp": "^0.5.0",
+                    "path-posix": "^1.0.0",
+                    "rimraf": "^2.4.3",
+                    "symlink-or-copy": "^1.0.0",
+                    "walk-sync": "^0.3.1"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ember-cp-validations": {
+          "version": "3.5.5",
+          "resolved": "https://registry.npmjs.org/ember-cp-validations/-/ember-cp-validations-3.5.5.tgz",
+          "integrity": "sha512-3o2+aM0gEeHHQo7izfgfaeuY8yGhBHsaRt4yONef/2ilcfiShBlok8NqvDaVEpvV0+b7jqePE5LCcRM8ftuJSw==",
+          "requires": {
+            "ember-cli-babel": "^6.6.0",
+            "ember-cli-version-checker": "^2.0.0",
+            "ember-getowner-polyfill": "^2.2.0",
+            "ember-require-module": "0.1.3",
+            "ember-validators": "1.0.4",
+            "exists-sync": "0.0.4",
+            "walk-sync": "^0.3.1"
+          },
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+              "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+              "requires": {
+                "array-equal": "^1.0.0",
+                "blank-object": "^1.0.1",
+                "broccoli-plugin": "^1.3.0",
+                "debug": "^2.2.0",
+                "fast-ordered-set": "^1.0.0",
+                "fs-tree-diff": "^0.5.3",
+                "heimdalljs": "^0.2.0",
+                "minimatch": "^3.0.0",
+                "mkdirp": "^0.5.0",
+                "path-posix": "^1.0.0",
+                "rimraf": "^2.4.3",
+                "symlink-or-copy": "^1.0.0",
+                "walk-sync": "^0.3.1"
+              }
+            },
+            "ember-cli-babel": {
+              "version": "6.18.0",
+              "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
+              "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
+              "requires": {
+                "amd-name-resolver": "1.2.0",
+                "babel-plugin-debug-macros": "^0.2.0-beta.6",
+                "babel-plugin-ember-modules-api-polyfill": "^2.6.0",
+                "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
+                "babel-polyfill": "^6.26.0",
+                "babel-preset-env": "^1.7.0",
+                "broccoli-babel-transpiler": "^6.5.0",
+                "broccoli-debug": "^0.6.4",
+                "broccoli-funnel": "^2.0.0",
+                "broccoli-source": "^1.1.0",
+                "clone": "^2.0.0",
+                "ember-cli-version-checker": "^2.1.2",
+                "semver": "^5.5.0"
+              }
+            },
+            "ember-require-module": {
+              "version": "0.1.3",
+              "resolved": "https://registry.npmjs.org/ember-require-module/-/ember-require-module-0.1.3.tgz",
+              "integrity": "sha1-+C9gVSFCF5FS0o7Jfr112WfK4dw=",
+              "requires": {
+                "ember-cli-babel": "^6.9.2"
+              }
+            },
+            "ember-validators": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/ember-validators/-/ember-validators-1.0.4.tgz",
+              "integrity": "sha1-fYnCURlFxSvSDFOE5xUTj5AhM7s=",
+              "requires": {
+                "ember-cli-babel": "^6.9.2",
+                "ember-require-module": "^0.1.2"
+              }
+            }
+          }
+        },
+        "ember-require-module": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/ember-require-module/-/ember-require-module-0.2.0.tgz",
+          "integrity": "sha512-groO9qBniJPjG1Z/wMZAYvZxhUR86iL+9wSncTDM7kL+WtdgbrcUXwazStIQOv3GeuqJ9rVt1gWKXvHlfWXUMg=="
+        },
         "readable-stream": {
           "version": "2.3.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
@@ -24660,8 +24862,7 @@
     "select": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
-      "dev": true
+      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
     },
     "semver": {
       "version": "5.7.0",
@@ -26011,8 +26212,7 @@
     "tiny-emitter": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-      "dev": true
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
     "tiny-lr": {
       "version": "1.1.1",

--- a/packages/dashboards/package.json
+++ b/packages/dashboards/package.json
@@ -29,7 +29,7 @@
     "ember-collection": "1.0.0-alpha.9",
     "ember-composable-helpers": "^2.2.0",
     "ember-concurrency": "~0.8.27",
-    "ember-cp-validations": "^3.5.4",
+    "ember-cp-validations": "^4.0.0-beta.9",
     "ember-data-model-fragments": "~4.0.0",
     "ember-get-config": "0.2.4",
     "ember-gridstack": "1.3.2",

--- a/packages/directory/package-lock.json
+++ b/packages/directory/package-lock.json
@@ -10204,140 +10204,14 @@
       }
     },
     "ember-cp-validations": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/ember-cp-validations/-/ember-cp-validations-3.5.5.tgz",
-      "integrity": "sha512-3o2+aM0gEeHHQo7izfgfaeuY8yGhBHsaRt4yONef/2ilcfiShBlok8NqvDaVEpvV0+b7jqePE5LCcRM8ftuJSw==",
+      "version": "4.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/ember-cp-validations/-/ember-cp-validations-4.0.0-beta.9.tgz",
+      "integrity": "sha512-TfUBOkQFzhLvphtFauuTu0ogdY/JRXCtR4yF5++TS3cHPe/SJKwykGzKjjpu+mvO57NacNC8rh8GCanzzHQVxg==",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "^6.6.0",
-        "ember-cli-version-checker": "^2.0.0",
-        "ember-getowner-polyfill": "^2.2.0",
-        "ember-require-module": "0.1.3",
-        "ember-string-ishtmlsafe-polyfill": "^2.0.0",
-        "ember-validators": "1.0.4",
-        "exists-sync": "0.0.4",
-        "walk-sync": "^0.3.1"
-      },
-      "dependencies": {
-        "amd-name-resolver": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz",
-          "integrity": "sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==",
-          "dev": true,
-          "requires": {
-            "ensure-posix-path": "^1.0.1"
-          }
-        },
-        "babel-plugin-debug-macros": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz",
-          "integrity": "sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==",
-          "dev": true,
-          "requires": {
-            "semver": "^5.3.0"
-          }
-        },
-        "broccoli-babel-transpiler": {
-          "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz",
-          "integrity": "sha512-w6GcnkxvHcNCte5FcLGEG1hUdQvlfvSN/6PtGWU/otg69Ugk8rUk51h41R0Ugoc+TNxyeFG1opRt2RlA87XzNw==",
-          "dev": true,
-          "requires": {
-            "babel-core": "^6.26.0",
-            "broccoli-funnel": "^2.0.1",
-            "broccoli-merge-trees": "^2.0.0",
-            "broccoli-persistent-filter": "^1.4.3",
-            "clone": "^2.0.0",
-            "hash-for-dep": "^1.2.3",
-            "heimdalljs-logger": "^0.1.7",
-            "json-stable-stringify": "^1.0.0",
-            "rsvp": "^4.8.2",
-            "workerpool": "^2.3.0"
-          }
-        },
-        "broccoli-merge-trees": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.1.tgz",
-          "integrity": "sha512-WjaexJ+I8BxP5V5RNn6um/qDRSmKoiBC/QkRi79FT9ClHfldxRyCDs9mcV7mmoaPlsshmmPaUz5jdtcKA6DClQ==",
-          "dev": true,
-          "requires": {
-            "broccoli-plugin": "^1.3.0",
-            "merge-trees": "^1.0.1"
-          }
-        },
-        "broccoli-persistent-filter": {
-          "version": "1.4.6",
-          "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.6.tgz",
-          "integrity": "sha512-0RejLwoC95kv4kta8KAa+FmECJCK78Qgm8SRDEK7YyU0N9Cx6KpY3UCDy9WELl3mCXLN8TokNxc7/hp3lL4lfw==",
-          "dev": true,
-          "requires": {
-            "async-disk-cache": "^1.2.1",
-            "async-promise-queue": "^1.0.3",
-            "broccoli-plugin": "^1.0.0",
-            "fs-tree-diff": "^0.5.2",
-            "hash-for-dep": "^1.0.2",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.7",
-            "mkdirp": "^0.5.1",
-            "promise-map-series": "^0.2.1",
-            "rimraf": "^2.6.1",
-            "rsvp": "^3.0.18",
-            "symlink-or-copy": "^1.0.1",
-            "walk-sync": "^0.3.1"
-          },
-          "dependencies": {
-            "rsvp": {
-              "version": "3.6.2",
-              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-              "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-              "dev": true
-            }
-          }
-        },
-        "ember-cli-babel": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
-          "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
-          "dev": true,
-          "requires": {
-            "amd-name-resolver": "1.2.0",
-            "babel-plugin-debug-macros": "^0.2.0-beta.6",
-            "babel-plugin-ember-modules-api-polyfill": "^2.6.0",
-            "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
-            "babel-polyfill": "^6.26.0",
-            "babel-preset-env": "^1.7.0",
-            "broccoli-babel-transpiler": "^6.5.0",
-            "broccoli-debug": "^0.6.4",
-            "broccoli-funnel": "^2.0.0",
-            "broccoli-source": "^1.1.0",
-            "clone": "^2.0.0",
-            "ember-cli-version-checker": "^2.1.2",
-            "semver": "^5.5.0"
-          }
-        },
-        "merge-trees": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-1.0.1.tgz",
-          "integrity": "sha1-zL5nRWl4f53vF/1G5lJfVwC70j4=",
-          "dev": true,
-          "requires": {
-            "can-symlink": "^1.0.0",
-            "fs-tree-diff": "^0.5.4",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.7",
-            "rimraf": "^2.4.3",
-            "symlink-or-copy": "^1.0.0"
-          }
-        },
-        "workerpool": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.3.tgz",
-          "integrity": "sha512-L1ovlYHp6UObYqElXXpbd214GgbEKDED0d3sj7pRdFXjNkb2+un/AUcCkceHizO0IVI6SOGGncrcjozruCkRgA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "4.1.1"
-          }
-        }
+        "ember-cli-babel": "^7.1.2",
+        "ember-require-module": "^0.3.0",
+        "ember-validators": "^2.0.0"
       }
     },
     "ember-data": {
@@ -11188,7 +11062,7 @@
         },
         "babylon": {
           "version": "5.8.38",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
+          "resolved": "http://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
           "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
           "dev": true
         },
@@ -11281,7 +11155,7 @@
         },
         "core-js": {
           "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
           "dev": true
         },
@@ -11523,7 +11397,7 @@
             },
             "ember-cli-babel": {
               "version": "5.2.8",
-              "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.8.tgz",
+              "resolved": "http://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.8.tgz",
               "integrity": "sha512-Mt9OOB5RaZwjde+LYef8EgwNVCAzsYDv4ktshblaXxr4m/Xm5/7/rxEu42RNrYkoy/qWpT9uhaD+JKK4riMf+w==",
               "dev": true,
               "requires": {
@@ -11564,7 +11438,7 @@
         },
         "globals": {
           "version": "6.4.1",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
+          "resolved": "http://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
           "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08=",
           "dev": true
         },
@@ -11586,13 +11460,13 @@
         },
         "json5": {
           "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+          "resolved": "http://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
           "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0=",
           "dev": true
         },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         },
@@ -13941,9 +13815,9 @@
       }
     },
     "ember-require-module": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ember-require-module/-/ember-require-module-0.1.3.tgz",
-      "integrity": "sha1-+C9gVSFCF5FS0o7Jfr112WfK4dw=",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ember-require-module/-/ember-require-module-0.3.0.tgz",
+      "integrity": "sha512-rYN4YoWbR9VlJISSmx0ZcYZOgMcXZLGR7kdvp3zDerjIvYmHm/3p+K56fEAYmJILA6W4F+cBe41Tq2HuQAZizA==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^6.9.2"
@@ -14831,15 +14705,6 @@
       "dev": true,
       "requires": {
         "got": "^8.0.1"
-      }
-    },
-    "ember-string-ishtmlsafe-polyfill": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/ember-string-ishtmlsafe-polyfill/-/ember-string-ishtmlsafe-polyfill-2.0.2.tgz",
-      "integrity": "sha512-C6i9H4NFw6nzYG+hxSrJyl5XA2xkGdWlJdN5otr0wl9k1IHCQe8n1PQr4vIpJsWcz5EYQC2+I/dPWZzOHIh1Mw==",
-      "dev": true,
-      "requires": {
-        "ember-cli-version-checker": "^2.1.0"
       }
     },
     "ember-tag-input": {
@@ -15803,13 +15668,13 @@
       }
     },
     "ember-validators": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/ember-validators/-/ember-validators-1.0.4.tgz",
-      "integrity": "sha1-fYnCURlFxSvSDFOE5xUTj5AhM7s=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ember-validators/-/ember-validators-2.0.0.tgz",
+      "integrity": "sha512-OhXGN2UbFQY+lhkWOdW347NZsIWGj/fpTJbOfNxjyMQW/c3fvPEIvrhlvWf1JwHGKQTJDHpMQJgA/Luq39GDgQ==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^6.9.2",
-        "ember-require-module": "^0.1.2"
+        "ember-require-module": "^0.3.0"
       },
       "dependencies": {
         "amd-name-resolver": {

--- a/packages/directory/package.json
+++ b/packages/directory/package.json
@@ -58,7 +58,7 @@
     "ember-compatibility-helpers": "^1.2.0",
     "ember-composable-helpers": "^2.1.0",
     "ember-concurrency": "~0.10.0",
-    "ember-cp-validations": "^3.5.3",
+    "ember-cp-validations": "^4.0.0-beta.9",
     "ember-data": "~3.7.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.0",

--- a/packages/reports/package-lock.json
+++ b/packages/reports/package-lock.json
@@ -10695,18 +10695,13 @@
       }
     },
     "ember-cp-validations": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/ember-cp-validations/-/ember-cp-validations-3.5.5.tgz",
-      "integrity": "sha512-3o2+aM0gEeHHQo7izfgfaeuY8yGhBHsaRt4yONef/2ilcfiShBlok8NqvDaVEpvV0+b7jqePE5LCcRM8ftuJSw==",
+      "version": "4.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/ember-cp-validations/-/ember-cp-validations-4.0.0-beta.9.tgz",
+      "integrity": "sha512-TfUBOkQFzhLvphtFauuTu0ogdY/JRXCtR4yF5++TS3cHPe/SJKwykGzKjjpu+mvO57NacNC8rh8GCanzzHQVxg==",
       "requires": {
-        "ember-cli-babel": "^6.6.0",
-        "ember-cli-version-checker": "^2.0.0",
-        "ember-getowner-polyfill": "^2.2.0",
-        "ember-require-module": "0.1.3",
-        "ember-string-ishtmlsafe-polyfill": "^2.0.0",
-        "ember-validators": "1.0.4",
-        "exists-sync": "0.0.4",
-        "walk-sync": "^0.3.1"
+        "ember-cli-babel": "^7.1.2",
+        "ember-require-module": "^0.3.0",
+        "ember-validators": "^2.0.0"
       },
       "dependencies": {
         "amd-name-resolver": {
@@ -10778,26 +10773,6 @@
             }
           }
         },
-        "ember-cli-babel": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
-          "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
-          "requires": {
-            "amd-name-resolver": "1.2.0",
-            "babel-plugin-debug-macros": "^0.2.0-beta.6",
-            "babel-plugin-ember-modules-api-polyfill": "^2.6.0",
-            "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
-            "babel-polyfill": "^6.26.0",
-            "babel-preset-env": "^1.7.0",
-            "broccoli-babel-transpiler": "^6.5.0",
-            "broccoli-debug": "^0.6.4",
-            "broccoli-funnel": "^2.0.0",
-            "broccoli-source": "^1.1.0",
-            "clone": "^2.0.0",
-            "ember-cli-version-checker": "^2.1.2",
-            "semver": "^5.5.0"
-          }
-        },
         "ember-cli-version-checker": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
@@ -10808,12 +10783,34 @@
           }
         },
         "ember-validators": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/ember-validators/-/ember-validators-1.0.4.tgz",
-          "integrity": "sha1-fYnCURlFxSvSDFOE5xUTj5AhM7s=",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ember-validators/-/ember-validators-2.0.0.tgz",
+          "integrity": "sha512-OhXGN2UbFQY+lhkWOdW347NZsIWGj/fpTJbOfNxjyMQW/c3fvPEIvrhlvWf1JwHGKQTJDHpMQJgA/Luq39GDgQ==",
           "requires": {
             "ember-cli-babel": "^6.9.2",
-            "ember-require-module": "^0.1.2"
+            "ember-require-module": "^0.3.0"
+          },
+          "dependencies": {
+            "ember-cli-babel": {
+              "version": "6.18.0",
+              "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
+              "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
+              "requires": {
+                "amd-name-resolver": "1.2.0",
+                "babel-plugin-debug-macros": "^0.2.0-beta.6",
+                "babel-plugin-ember-modules-api-polyfill": "^2.6.0",
+                "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
+                "babel-polyfill": "^6.26.0",
+                "babel-preset-env": "^1.7.0",
+                "broccoli-babel-transpiler": "^6.5.0",
+                "broccoli-debug": "^0.6.4",
+                "broccoli-funnel": "^2.0.0",
+                "broccoli-source": "^1.1.0",
+                "clone": "^2.0.0",
+                "ember-cli-version-checker": "^2.1.2",
+                "semver": "^5.5.0"
+              }
+            }
           }
         },
         "merge-trees": {
@@ -14605,9 +14602,9 @@
       }
     },
     "ember-require-module": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ember-require-module/-/ember-require-module-0.1.3.tgz",
-      "integrity": "sha1-+C9gVSFCF5FS0o7Jfr112WfK4dw=",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ember-require-module/-/ember-require-module-0.3.0.tgz",
+      "integrity": "sha512-rYN4YoWbR9VlJISSmx0ZcYZOgMcXZLGR7kdvp3zDerjIvYmHm/3p+K56fEAYmJILA6W4F+cBe41Tq2HuQAZizA==",
       "requires": {
         "ember-cli-babel": "^6.9.2"
       },
@@ -15721,25 +15718,6 @@
           "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
           "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
           "dev": true
-        }
-      }
-    },
-    "ember-string-ishtmlsafe-polyfill": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/ember-string-ishtmlsafe-polyfill/-/ember-string-ishtmlsafe-polyfill-2.0.2.tgz",
-      "integrity": "sha512-C6i9H4NFw6nzYG+hxSrJyl5XA2xkGdWlJdN5otr0wl9k1IHCQe8n1PQr4vIpJsWcz5EYQC2+I/dPWZzOHIh1Mw==",
-      "requires": {
-        "ember-cli-version-checker": "^2.1.0"
-      },
-      "dependencies": {
-        "ember-cli-version-checker": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-          "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-          "requires": {
-            "resolve": "^1.3.3",
-            "semver": "^5.3.0"
-          }
         }
       }
     },

--- a/packages/reports/package.json
+++ b/packages/reports/package.json
@@ -37,7 +37,7 @@
     "ember-compatibility-helpers": "^1.2.0",
     "ember-composable-helpers": "^2.2.0",
     "ember-concurrency": "~0.8.27",
-    "ember-cp-validations": "^3.5.4",
+    "ember-cp-validations": "^4.0.0-beta.9",
     "ember-data-model-fragments": "~4.0.0",
     "ember-modal-dialog": "^2.4.1",
     "ember-moment": "7.8.1",


### PR DESCRIPTION
Resolves #477 

## Description
Upgrade ember-cp-validation version in all packages
According to the [changelog](https://github.com/offirgolan/ember-cp-validations/blob/master/CHANGELOG.md#v400-beta9) should work with 3.10+

## Proposed Changes
- Bump versions in package.json

## Screenshots
NA

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
