### PR TITLE
Fix: Demo app needs ember-gridstack upgrade

### DIFF
--- a/packages/app/bower.json
+++ b/packages/app/bower.json
@@ -5,9 +5,6 @@
     "numeral": "~1.5.3",
     "d3": "3.5.17",
     "c3": "0.4.20",
-    "bootstrap-datepicker": "1.4.0",
-    "jquery-ui": "1.12.0",
-    "lodash": "^4.13.1",
-    "gridstack": "~0.2.6"
+    "bootstrap-datepicker": "1.4.0"
   }
 }

--- a/packages/app/package-lock.json
+++ b/packages/app/package-lock.json
@@ -9742,52 +9742,17 @@
       }
     },
     "ember-gridstack": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/ember-gridstack/-/ember-gridstack-1.3.0.tgz",
-      "integrity": "sha512-2c21DqXnJN0MFghSnPpipnL14tBDNWyGzzFRAnr4NXs3RVZOSMqZ5yMK2gu5awbOpZD6gVTDtFEwPpDkVubP2w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/ember-gridstack/-/ember-gridstack-1.3.2.tgz",
+      "integrity": "sha512-95qj+3IdUnFIkO4oRHXtb1ixna2uEhPujNPpVQyzoFOcK/Y0PKPLkoqYqZa5CPVqZc5L31DLXHlYs0PdlKHroA==",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "^6.6.0",
-        "ember-cli-htmlbars": "^2.0.1",
+        "ember-cli-babel": "^7.1.2",
+        "ember-cli-htmlbars": "^3.0.0",
         "gridstack": "^0.4.0",
-        "jquery": "^3.1.0",
+        "jquery": "^3.4.1",
         "jquery-ui": "1.12.1",
         "lodash": "^4.17.10"
-      },
-      "dependencies": {
-        "ember-cli-babel": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
-          "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
-          "dev": true,
-          "requires": {
-            "amd-name-resolver": "1.2.0",
-            "babel-plugin-debug-macros": "^0.2.0-beta.6",
-            "babel-plugin-ember-modules-api-polyfill": "^2.6.0",
-            "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
-            "babel-polyfill": "^6.26.0",
-            "babel-preset-env": "^1.7.0",
-            "broccoli-babel-transpiler": "^6.5.0",
-            "broccoli-debug": "^0.6.4",
-            "broccoli-funnel": "^2.0.0",
-            "broccoli-source": "^1.1.0",
-            "clone": "^2.0.0",
-            "ember-cli-version-checker": "^2.1.2",
-            "semver": "^5.5.0"
-          }
-        },
-        "ember-cli-htmlbars": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-2.0.5.tgz",
-          "integrity": "sha512-3f3PAxdnQ/fhQa8XP/3z4RLRgLHxV8j4Ln75aHbRdemOCjBa048KxL9l+acRLhCulbGQCMnLiIUIC89PAzLrcA==",
-          "dev": true,
-          "requires": {
-            "broccoli-persistent-filter": "^1.4.3",
-            "hash-for-dep": "^1.2.3",
-            "json-stable-stringify": "^1.0.0",
-            "strip-bom": "^3.0.0"
-          }
-        }
       }
     },
     "ember-hash-helper-polyfill": {
@@ -10683,18 +10648,18 @@
       }
     },
     "ember-resolver": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ember-resolver/-/ember-resolver-5.2.0.tgz",
-      "integrity": "sha512-vL7YnifeHA2g6OM3KF7PSCIcUBvPISfcxByqGmWgjynbZpd3KmBUpHVxAlqXUYqhO4viRcM0sohAgZ41bCv7QQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ember-resolver/-/ember-resolver-5.0.1.tgz",
+      "integrity": "sha512-Svhs/eseIVQ6Yik+4mFpixT639FREZW2UkIYo7197bRuSL63tofKDMfE+gOXUSSudQlQSaFHFeKDr9oD+0C2GQ==",
       "dev": true,
       "requires": {
         "@glimmer/resolver": "^0.4.1",
         "babel-plugin-debug-macros": "^0.1.10",
-        "broccoli-funnel": "^2.0.2",
+        "broccoli-funnel": "^2.0.1",
         "broccoli-merge-trees": "^3.0.0",
-        "ember-cli-babel": "^6.16.0",
-        "ember-cli-version-checker": "^3.1.3",
-        "resolve": "^1.12.0"
+        "ember-cli-babel": "^6.8.1",
+        "ember-cli-version-checker": "^2.0.0",
+        "resolve": "^1.3.3"
       },
       "dependencies": {
         "babel-plugin-debug-macros": {
@@ -10745,27 +10710,7 @@
               "requires": {
                 "semver": "^5.3.0"
               }
-            },
-            "ember-cli-version-checker": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-              "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-              "dev": true,
-              "requires": {
-                "resolve": "^1.3.3",
-                "semver": "^5.3.0"
-              }
             }
-          }
-        },
-        "ember-cli-version-checker": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-3.1.3.tgz",
-          "integrity": "sha512-PZNSvpzwWgv68hcXxyjREpj3WWb81A7rtYNQq1lLEgrWIchF8ApKJjWP3NBpHjaatwILkZAV8klair5WFlXAKg==",
-          "dev": true,
-          "requires": {
-            "resolve-package-path": "^1.2.6",
-            "semver": "^5.6.0"
           }
         },
         "merge-trees": {
@@ -16416,129 +16361,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
-    },
-    "navi-core": {
-      "version": "0.1.0",
-      "dev": true,
-      "requires": {
-        "@html-next/vertical-collection": "^1.0.0-beta.12",
-        "ember-auto-import": "^1.2.21",
-        "ember-cli-babel": "^7.1.2",
-        "ember-cli-format-number": "2.0.0",
-        "ember-cli-htmlbars": "^3.0.0",
-        "ember-cli-string-helpers": "^1.8.1",
-        "ember-collection": "1.0.0-alpha.9",
-        "ember-composable-helpers": "^2.1.0",
-        "ember-concurrency": "~0.8.27",
-        "ember-copy": "^1.0.0",
-        "ember-cp-validations": "^4.0.0-beta.6",
-        "ember-data-model-fragments": "~4.0.0",
-        "ember-debounced-properties": "0.0.5",
-        "ember-fetch": "^6.5.1",
-        "ember-get-config": "0.2.4",
-        "ember-lodash": "^4.19.4",
-        "ember-math-helpers": "^2.3.0",
-        "ember-moment": "7.5.0",
-        "ember-radio-button": "^1.2.1",
-        "ember-resize": "^0.2.4",
-        "ember-sortable": "1.12.3",
-        "ember-tether": "^1.0.0",
-        "ember-toggle": "^5.2.1",
-        "ember-tooltips": "^2.10.0",
-        "ember-truth-helpers": "^2.0.0",
-        "json-url": "~2.4.1",
-        "resize-observer-polyfill": "^1.5.1"
-      }
-    },
-    "navi-dashboards": {
-      "version": "0.1.0",
-      "dev": true,
-      "requires": {
-        "ember-ajax": "^5.0.0",
-        "ember-cli-babel": "^7.5.0",
-        "ember-cli-htmlbars": "^3.0.1",
-        "ember-collection": "1.0.0-alpha.9",
-        "ember-composable-helpers": "^2.2.0",
-        "ember-concurrency": "~0.8.27",
-        "ember-cp-validations": "^3.5.4",
-        "ember-data-model-fragments": "~4.0.0",
-        "ember-get-config": "0.2.4",
-        "ember-gridstack": "1.3.0",
-        "ember-lodash": "^4.19.4",
-        "ember-math-helpers": "^2.10.0",
-        "ember-modal-dialog": "^2.4.3",
-        "ember-moment": "7.8.1",
-        "ember-promise-helpers": "^1.0.6",
-        "ember-sortable": "1.12.6",
-        "ember-tag-input": "^1.2.2",
-        "ember-tether": "^1.0.0",
-        "ember-toggle": "5.3.2",
-        "ember-tooltips": "^3.2.0",
-        "ember-transition-helper": "^1.0.0",
-        "ember-truth-helpers": "^2.1.0",
-        "ember-uuid": "^1.0.1",
-        "liquid-fire": "^0.29.5"
-      }
-    },
-    "navi-data": {
-      "version": "0.1.0",
-      "dev": true,
-      "requires": {
-        "ember-ajax": "^5.0.0",
-        "ember-cli-babel": "^7.1.2",
-        "ember-cli-htmlbars": "^3.0.0",
-        "ember-get-config": "0.2.4",
-        "ember-lodash": "^4.19.4"
-      }
-    },
-    "navi-directory": {
-      "version": "0.1.0",
-      "dev": true,
-      "requires": {
-        "ember-cli-babel": "^7.1.2",
-        "ember-cli-htmlbars": "^3.0.0",
-        "ember-data-model-fragments": "~4.0.0",
-        "ember-get-config": "^0.2.4",
-        "ember-light-table": "^1.13.1",
-        "ember-power-select": "^2.2.3",
-        "ember-responsive": "^3.0.0-beta.3",
-        "ember-tether": "^1.0.0"
-      }
-    },
-    "navi-reports": {
-      "version": "0.1.0",
-      "dev": true,
-      "requires": {
-        "@ember/jquery": "^0.6.0",
-        "@ember/optional-features": "^0.6.4",
-        "@html-next/vertical-collection": "^1.0.0-beta.12",
-        "ember-ajax": "^5.0.0",
-        "ember-cli-babel": "^7.1.2",
-        "ember-cli-clipboard": "^0.8.1",
-        "ember-cli-htmlbars": "^3.0.0",
-        "ember-cli-node-assets": "0.2.2",
-        "ember-cli-shims": "^1.2.0",
-        "ember-cli-string-helpers": "^1.6.0",
-        "ember-collection": "1.0.0-alpha.9",
-        "ember-compatibility-helpers": "^1.2.0",
-        "ember-composable-helpers": "^2.2.0",
-        "ember-concurrency": "~0.8.27",
-        "ember-cp-validations": "^3.5.4",
-        "ember-data-model-fragments": "~4.0.0",
-        "ember-modal-dialog": "^2.4.1",
-        "ember-moment": "7.8.1",
-        "ember-pluralize": "0.2.0",
-        "ember-promise-helpers": "^1.0.6",
-        "ember-radio-button": "^1.2.1",
-        "ember-tag-input": "1.2.1",
-        "ember-tether": "^1.0.0",
-        "ember-toggle": "5.3.2",
-        "ember-tooltips": "^3.2.0",
-        "ember-truth-helpers": "^2.0.0",
-        "ember-uuid": "^1.0.0",
-        "ember-validators": "^1.1.1",
-        "liquid-fire": "^0.29.2"
-      }
     },
     "negotiator": {
       "version": "0.6.2",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -66,7 +66,7 @@
     "ember-export-application-global": "^2.0.0",
     "ember-font-awesome": "^3.0.5",
     "ember-get-config": "0.2.4",
-    "ember-gridstack": "1.3.0",
+    "ember-gridstack": "1.3.2",
     "ember-load-initializers": "^1.1.0",
     "ember-lodash": "^4.19.5",
     "ember-maybe-import-regenerator": "^0.1.6",


### PR DESCRIPTION
Resolves #473

<!-- The above line will close the issue upon merge -->

## Description

lodash import issues due to old version of ember-gridstack

## Proposed Changes

- Update ember-gridstack and get rid of unnecessary bower packages.

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
