### PR TITLE
Update: Match dashboard card style in builder

### DIFF
--- a/packages/reports/app/styles/navi-reports/components/navi-list-selector.less
+++ b/packages/reports/app/styles/navi-reports/components/navi-list-selector.less
@@ -32,12 +32,13 @@
 
   &__header {
     display: flex;
+    justify-content: space-between;
+    margin-bottom: 5px;
   }
 
   &__title {
     font-family: @font-family-strong;
     font-size: @font-size-base;
-    margin: auto 0;
     text-transform: uppercase;
   }
 
@@ -56,7 +57,7 @@
 
   &__search-input {
     flex: 1;
-    padding: 0 5px;
+    padding: 3px;
   }
 
   &__search-input-clear {
@@ -69,7 +70,6 @@
     .clickable;
     color: @navi-blue;
     font-size: @font-size-mid;
-    margin: 5px 0 5px auto;
     white-space: nowrap;
   }
 }

--- a/packages/reports/app/styles/navi-reports/components/report-builder.less
+++ b/packages/reports/app/styles/navi-reports/components/report-builder.less
@@ -15,12 +15,13 @@
   }
 
   &__container {
-    background-color: @nv-color-background-primary;
-    border: 1px solid @nv-color-border;
+    background: @navi-white;
+    border: 1px solid #f1f1f1;
+    border-bottom-color: rgba(0, 0, 0, 0.2);
     display: flex;
     flex: 1;
     margin: 5px;
-    padding: 5px 10px;
+    padding: 10px;
   }
 
   &__container--disabled {
@@ -68,7 +69,6 @@
     flex: 0 1 auto;
     margin-top: 5px;
     max-height: 35%;
-    padding: 5px 10px;
   }
 
   &__container-header {
@@ -95,7 +95,7 @@
   &__dimension-selector {
     display: flex;
     flex-basis: 0; // firefox flexbug
-    margin-bottom: 0;
+    margin-bottom: 10px;
     min-height: 0;
     overflow: hidden;
   }


### PR DESCRIPTION
## Description

Style change to bring dashboards and reports together

## Proposed Changes

- refactor reports cards to match dashboards
- improve padding around cards
- add padding to metric/dimension selector

## Screenshots

Before:
<img width="1680" alt="Screen Shot 2019-09-03 at 2 27 18 PM" src="https://user-images.githubusercontent.com/2983409/64202683-58df0c00-ce57-11e9-8978-7f7a2f9c7eab.png">


After:

<img width="1679" alt="Screen Shot 2019-09-03 at 2 29 37 PM" src="https://user-images.githubusercontent.com/2983409/64202693-5d0b2980-ce57-11e9-895b-b9080d16e833.png">

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
