### PR TITLE
Stream tests logs in travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,14 +37,14 @@ install:
     else
     nvm install ${NODE_VERSION};
     npm config set spin false;
-    travis_wait npm ci;
+    npm ci;
     npx lerna exec --scope ${PACKAGE} -- bower install || true;
     fi
 script:
   - if [[ "${PACKAGE}" == "navi-webservice" ]]; then
     pushd packages/webservice && ./gradlew check && popd;
     else
-    travis_wait npx lerna run test --scope ${PACKAGE};
+    npx lerna run test --scope ${PACKAGE} --stream;
     fi
 jobs:
   include:


### PR DESCRIPTION
## Description
Sometimes when we push to travis, things fail (during tests/etc) and we can't see why (see #468) because we added `travis_wait` to some commands which take longer to run #57

## Proposed Changes
Set lerna to [stream the logs](https://github.com/lerna/lerna/tree/master/commands/run#--stream) of running tests so that travis should no longer time out since no tests are run in parallel and now we can see the output of tests as they happen instead of getting a dump of all the results at once

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
