### PR TITLE
Update: Line chart config styles

### DIFF
--- a/packages/core/addon/components/chart-series-config.js
+++ b/packages/core/addon/components/chart-series-config.js
@@ -23,16 +23,6 @@ export default Component.extend({
   classNames: ['line-chart-config__series-config'],
 
   /**
-   * @property {Array} classNameBindings
-   */
-  classNameBindings: ['isOpen'],
-
-  /**
-   * @property {Boolean} isOpen - whether the content is visible
-   */
-  isOpen: false,
-
-  /**
    * @property {String} seriesConfigDataKey - object key of `seriesConfig` to read from and update when reordering
    */
   seriesConfigDataKey: computed('seriesType', function() {

--- a/packages/core/addon/templates/components/chart-series-config.hbs
+++ b/packages/core/addon/templates/components/chart-series-config.hbs
@@ -1,9 +1,5 @@
 {{!-- Copyright 2019, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
-<div class="line-chart-config__series-config__header" role="button"
-  onclick={{toggle "isOpen" this}}>
-  Stack Order
-  {{navi-icon (concat "angle-" (if isOpen "down" "right"))}}
-</div>
+<div class="line-chart-config__series-config__header">Stack Order</div>
 <div class="line-chart-config__series-config__content">
   {{#sortable-group
     class="line-chart-config__series-config__collection"

--- a/packages/core/addon/templates/components/visualization-config/line-chart.hbs
+++ b/packages/core/addon/templates/components/visualization-config/line-chart.hbs
@@ -16,10 +16,9 @@
           {{#power-select
             triggerClass="line-chart-config__curve-opt-select"
             options=curveOptions
-            selected=(readonly options.style.curve)
+            selected=(or (readonly options.style.curve) "line")
             onchange=(action "onUpdateStyle" "curve")
             searchEnabled=false
-            placeholder="Line"
             as |curve|}}
             {{capitalize curve}}
           {{/power-select}}

--- a/packages/core/app/styles/navi-core/components/visualization-config/line-chart.less
+++ b/packages/core/app/styles/navi-core/components/visualization-config/line-chart.less
@@ -27,12 +27,12 @@
   &__curve-opt,
   &__area-opt,
   &__stacked-opt {
+    align-items: center;
     display: flex;
     justify-content: space-between;
     margin: 8px 0;
     &-title {
       text-align: left;
-      color: @navi-gray;
     }
   }
 
@@ -62,14 +62,9 @@
 
     &__content {
       .config-section();
-      display: none;
       margin: 0;
       margin-top: 5px;
       padding: @report-selector-padding-left;
-
-      .is-open & {
-        display: block;
-      }
     }
 
     &__collection {
@@ -79,11 +74,11 @@
 
     &__item {
       .generate-chart-colors-for(border-left-color);
+      align-items: center;
       border: 1px solid #f1f1f5;
       border-left-width: 5px;
       border-radius: 5px;
       display: flex;
-      font-size: 12px;
       justify-content: space-between;
       margin-bottom: 5px;
 
@@ -97,7 +92,7 @@
       &__handler {
         background-color: #e7e7e7;
         cursor: move;
-        padding-top: 5px;
+        padding: 8px 0;
 
         div {
           background-color: #aaaaaa;

--- a/packages/core/app/styles/navi-core/vendor/navi-ember-power-select.less
+++ b/packages/core/app/styles/navi-core/vendor/navi-ember-power-select.less
@@ -16,6 +16,10 @@
   color: @navi-gray-800;
 }
 
+.ember-power-select-trigger {
+  border-radius: unset;
+}
+
 .ember-power-select-option {
   padding: 3px 8px 3px 16px;
 

--- a/packages/core/tests/integration/components/chart-series-config-test.js
+++ b/packages/core/tests/integration/components/chart-series-config-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, findAll, click } from '@ember/test-helpers';
+import { render, findAll } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { setupMock, teardownMock } from '../../helpers/mirage-helper';
 
@@ -15,35 +15,43 @@ const TEMPLATE = hbs`
 `;
 
 const SERIES_CONFIG = {
-  metrics: [{
-    metric: "adClicks",
-    parameters: {}
-  }, {
-    metric: "revenue",
-    parameters: {
-      currency: "CAD",
-      as: "m1"
+  metrics: [
+    {
+      metric: 'adClicks',
+      parameters: {}
+    },
+    {
+      metric: 'revenue',
+      parameters: {
+        currency: 'CAD',
+        as: 'm1'
+      }
+    },
+    {
+      metric: 'revenue',
+      parameters: {
+        currency: 'EUR',
+        as: 'm2'
+      }
     }
-  }, {
-    metric: "revenue",
-    parameters: {
-      currency: "EUR",
-      as: "m2"
+  ],
+  dimensions: [
+    {
+      name: 'Property 1'
+    },
+    {
+      name: 'Property 2'
+    },
+    {
+      name: 'Property 3'
     }
-  }],
-  dimensions: [{
-    name: "Property 1"
-  }, {
-    name: "Property 2"
-  }, {
-    name: "Property 3"
-  }]
+  ]
 };
 
-module('Integration | Component | chart series config', function (hooks) {
+module('Integration | Component | chart series config', function(hooks) {
   setupRenderingTest(hooks);
 
-  hooks.beforeEach(function () {
+  hooks.beforeEach(function() {
     setupMock();
 
     this.setProperties({
@@ -56,68 +64,31 @@ module('Integration | Component | chart series config', function (hooks) {
     return MetadataService.loadMetadata();
   });
 
-  hooks.afterEach(function () {
+  hooks.afterEach(function() {
     teardownMock();
   });
 
-  test('Component renders', async function (assert) {
+  test('Component renders', async function(assert) {
     assert.expect(1);
 
     await render(TEMPLATE);
 
-    assert
-      .dom('.line-chart-config__series-config')
-      .exists('The chart series config component is rendered');
+    assert.dom('.line-chart-config__series-config').exists('The chart series config component is rendered');
   });
 
-  test('Component is collapsible', async function (assert) {
-    assert.expect(6);
-
-    await render(TEMPLATE);
-
-    assert
-      .dom('.line-chart-config__series-config__header .fa-angle-right')
-      .exists('The chart series config component is closed by default');
-
-    assert
-      .dom('.line-chart-config__series-config__content')
-      .isNotVisible('The chart series config component is not visible by default');
-
-    await click('.line-chart-config__series-config__header');
-
-    assert
-      .dom('.line-chart-config__series-config__header .fa-angle-down')
-      .exists('The chart series config component is open after clicking header');
-
-    assert
-      .dom('.line-chart-config__series-config__content')
-      .isVisible('The chart series config component is visible after clicking header');
-
-    await click('.line-chart-config__series-config__header');
-
-    assert
-      .dom('.line-chart-config__series-config__header .fa-angle-right')
-      .exists('The chart series config component is closed after clicking header twice');
-
-    assert
-      .dom('.line-chart-config__series-config__content')
-      .isNotVisible('The chart series config component is not visible after clicking header twice');
-  });
-
-  test('Component renders dimensions correctly', async function (assert) {
+  test('Component renders dimensions correctly', async function(assert) {
     assert.expect(1);
-
-    this.set('isOpen', true);
 
     await render(TEMPLATE);
 
     assert.deepEqual(
       findAll('.line-chart-config__series-config__item__content').map(el => el.textContent.trim()),
       ['Property 1', 'Property 2', 'Property 3'],
-      'Component renders dimension names correctly');
+      'Component renders dimension names correctly'
+    );
   });
 
-  test('Component renders formatted metrics correctly', async function (assert) {
+  test('Component renders formatted metrics correctly', async function(assert) {
     assert.expect(1);
 
     this.setProperties({
@@ -130,6 +101,7 @@ module('Integration | Component | chart series config', function (hooks) {
     assert.deepEqual(
       findAll('.line-chart-config__series-config__item__content').map(el => el.textContent.trim()),
       ['Ad Clicks', 'Revenue (CAD)', 'Revenue (EUR)'],
-      'Component renders metric names correctly');
+      'Component renders metric names correctly'
+    );
   });
 });


### PR DESCRIPTION
## Description

Line chart config styles

## Proposed Changes

- Selects are no longer rounded
- Text color and font are aligned
- Stack chart series is now always displayed when stacked is enabled

## Screenshots

Before:
<img width="375" alt="Screen Shot 2019-09-11 at 9 58 52 PM" src="https://user-images.githubusercontent.com/2983409/64751049-8a537980-d4e0-11e9-807c-7579f8c968ce.png">

After:
<img width="375" alt="Screen Shot 2019-09-11 at 9 59 54 PM" src="https://user-images.githubusercontent.com/2983409/64751059-95a6a500-d4e0-11e9-9876-079f18687266.png">


## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
