### PR TITLE
Fix: Print for dashboards/reports

### DIFF
--- a/packages/app/tests/acceptance/print-views-test.js
+++ b/packages/app/tests/acceptance/print-views-test.js
@@ -1,0 +1,36 @@
+import { visit } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+module('Acceptance | print views', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  test('Viewing /print/reports', async function(assert) {
+    assert.expect(2);
+
+    await visit('/print/reports/1/view');
+
+    assert.dom('.navi-report__title').hasText('Kart Wins By Character', 'The report title shows up');
+    assert.deepEqual(
+      [...document.querySelectorAll('.line-chart-widget .c3-legend-item')].map(el => el.textContent),
+      ['Mario', 'Luigi', 'Peach', 'Toad', 'Daisy', 'Bowser', 'Boo', 'Dry Bowser', 'Wario', 'Rosalina'],
+      'The legend fills in with widget dimensions'
+    );
+  });
+
+  test('Viewing /print/dashboards', async function(assert) {
+    assert.expect(3);
+
+    await visit('/print/dashboards/1/view');
+
+    assert.dom('.navi-widget__title').hasText('Kart Wins By Character', 'The widget title shows up');
+    assert.dom('.c3-axis-y-label').hasText('Wins', 'The widget y-axis title shows up');
+    assert.deepEqual(
+      [...document.querySelectorAll('.line-chart-widget .c3-legend-item')].map(el => el.textContent.trim()),
+      ['Dry Bowser', 'Daisy', 'Wario'],
+      'Dashboard widget legend should fill in with dimensions'
+    );
+  });
+});

--- a/packages/dashboards/addon/router.js
+++ b/packages/dashboards/addon/router.js
@@ -31,11 +31,9 @@ export function dashboardCollectionRoutes(router) {
 }
 
 export function dashboardPrintRoutes(router) {
-  router.route('dashboards-print', { path: '/print' }, function() {
-    this.route('dashboards', function() {
-      this.route('dashboard', { path: '/:dashboard_id' }, function() {
-        this.route('view');
-      });
+  router.route('dashboards-print.dashboards', { path: '/print/dashboards' }, function() {
+    this.route('dashboard', { path: '/:dashboard_id' }, function() {
+      this.route('view');
     });
   });
 }

--- a/packages/dashboards/tests/acceptance/print-dashboard-test.js
+++ b/packages/dashboards/tests/acceptance/print-dashboard-test.js
@@ -15,15 +15,35 @@ module('Acceptance | print dashboard', function(hooks) {
   });
 
   test('print dashboards view', async function(assert) {
-    assert.expect(4);
+    assert.expect(12);
     await visit('/print/dashboards/1/view');
 
-    assert.dom('.page-title').isNotVisible('Title should not be visible');
+    assert.dom('.page-title').isNotVisible('Page title should not be visible');
 
     assert.dom('.editable-label__icon').isNotVisible('Title edit icon should not be visible');
 
     assert.dom('.favorite-item').isNotVisible('Favorite icon should not be visible');
 
     assert.dom('.dashboard-actions').isNotVisible('Dashboard actions should not be visible');
+
+    assert.deepEqual(
+      [...document.querySelectorAll('.navi-widget__title')].map(el => el.textContent.trim()),
+      ['Mobile DAU Goal', 'Mobile DAU Graph', 'Mobile DAU Table'],
+      'Dashboard widget titles should appear'
+    );
+
+    assert.dom('.goal-gauge-widget').isVisible('Goal gauge shows up');
+    assert.dom('.c3-chart-arcs-title .value-title').hasText('571', 'Goal gauge shows correct value');
+    assert.dom('.c3-chart-arcs-title .metric-title').hasText('Ad Clicks', 'Goal gauge shows correct value');
+
+    assert.dom('.line-chart-widget').isVisible('Line chart shows up');
+    assert.deepEqual(
+      [...document.querySelectorAll('.line-chart-widget .c3-legend-item')].map(el => el.textContent),
+      ['Ad Clicks', 'Nav Link Clicks'],
+      'The legends fill in with widget dimensions'
+    );
+
+    assert.dom('.table-widget').isVisible('Table shows up');
+    assert.dom('.table-widget .table-row').exists('Table rows show up');
   });
 });

--- a/packages/reports/addon/router.js
+++ b/packages/reports/addon/router.js
@@ -23,13 +23,11 @@ export function reportCollectionRoutes(router) {
 }
 
 export function reportPrintRoutes(router) {
-  router.route('reports-print', { path: '/print' }, function() {
-    this.route('reports', function() {
-      this.route('new');
-      this.route('report', { path: '/:report_id' }, function() {
-        this.route('view');
-        this.route('invalid');
-      });
+  router.route('reports-print.reports', { path: '/print/reports' }, function() {
+    this.route('new');
+    this.route('report', { path: '/:report_id' }, function() {
+      this.route('view');
+      this.route('invalid');
     });
   });
 }

--- a/packages/reports/tests/acceptance/print-report-test.js
+++ b/packages/reports/tests/acceptance/print-report-test.js
@@ -21,7 +21,7 @@ module('Acceptance | print report', function(hooks) {
   });
 
   test('print reports view', async function(assert) {
-    assert.expect(3);
+    assert.expect(5);
     await visit('/print/reports/1/view');
 
     assert.dom('.navi-report__title').hasText('Hyrule News', 'Should show report title');
@@ -29,6 +29,13 @@ module('Acceptance | print report', function(hooks) {
     assert.dom('.print-report-view__visualization').isVisible('Should show report visualization');
 
     assert.dom('.print-report-view__visualization-header').isNotVisible('Should not show report visualization header');
+
+    assert.dom('.c3-axis-y-label').hasText('Ad Clicks', 'Report chart should have y-axis label');
+    assert.deepEqual(
+      [...document.querySelectorAll('.c3-legend-item')].map(el => el.textContent.trim()),
+      ['Property 1', 'Property 2', 'Property 3'],
+      'The legend fills in with widget dimensions'
+    );
   });
 
   test('print reports error', async function(assert) {


### PR DESCRIPTION
## Description
- Only dashboardPrintRoutes or reportPrintRoutes works, not both

https://github.com/yahoo/navi/blob/4696d9518b58cf40c25eb8577ed32b8944320a5f/packages/app/app/router.js#L19-L24

✅ : https://yahoo.github.io/navi/#/print/dashboards/1/view
❌ : https://yahoo.github.io/navi/#/print/reports/1/view

## Proposed Changes
Fixup the route name so they don't override each other

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
