### PR TITLE
Fix widget nav

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "start": "lerna exec --scope navi-app npm start",
-    "postinstall": "lerna bootstrap --concurrency 2",
+    "postinstall": "lerna bootstrap --concurrency 2 --ci",
     "test": "lerna run test",
     "lerna-ci-publish": "lerna publish --canary preminor --force-publish=* --yes"
   },

--- a/packages/dashboards/addon/controllers/dashboards/dashboard.js
+++ b/packages/dashboards/addon/controllers/dashboards/dashboard.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright 2019, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+  /**
+   * @param {Object} queryCache - Used to store query parameters from the parent route
+   */
+  queryCache: null
+});

--- a/packages/dashboards/addon/controllers/dashboards/dashboard/widgets/widget.js
+++ b/packages/dashboards/addon/controllers/dashboards/dashboard/widgets/widget.js
@@ -5,5 +5,8 @@
 import ReportController from 'navi-reports/controllers/reports/report';
 
 export default ReportController.extend({
+  /**
+   * @param {Object} parentQueryParams - Used to store query parameters from the parent route
+   */
   parentQueryParams: null
 });

--- a/packages/dashboards/addon/controllers/dashboards/dashboard/widgets/widget.js
+++ b/packages/dashboards/addon/controllers/dashboards/dashboard/widgets/widget.js
@@ -4,4 +4,6 @@
  */
 import ReportController from 'navi-reports/controllers/reports/report';
 
-export default ReportController.extend({});
+export default ReportController.extend({
+  parentQueryParams: null
+});

--- a/packages/dashboards/addon/controllers/dashboards/dashboard/widgets/widget.js
+++ b/packages/dashboards/addon/controllers/dashboards/dashboard/widgets/widget.js
@@ -3,10 +3,16 @@
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import ReportController from 'navi-reports/controllers/reports/report';
+import { computed } from '@ember/object';
+import { inject as controller } from '@ember/controller';
 
 export default ReportController.extend({
   /**
+   * @param {Controller} - dashboard controller
+   */
+  dashboard: controller('dashboards.dashboard'),
+  /**
    * @param {Object} parentQueryParams - Used to store query parameters from the parent route
    */
-  parentQueryParams: null
+  parentQueryParams: computed.alias('dashboard.queryCache')
 });

--- a/packages/dashboards/addon/routes/dashboards/dashboard.js
+++ b/packages/dashboards/addon/routes/dashboards/dashboard.js
@@ -90,7 +90,7 @@ export default Route.extend({
     this._super(...arguments);
     const dashboard = this.modelFor(this.routeName);
     // don't rollback attributes if dashboard was unloaded.
-    if (typeof dashboard.isEmpty !== 'boolean' || !dashboard.isEmpty) {
+    if (dashboard.isEmpty !== true) {
       dashboard.rollbackAttributes();
     }
   },
@@ -183,9 +183,13 @@ export default Route.extend({
       dashboard.rollbackAttributes();
     },
 
+    /**
+     * Prompts user if they are leaving the route with unsaved changes.
+     * @param {Transition} transition
+     */
     willTransition(transition) {
       //subroute just continue
-      if (transition.targetName.startsWith('dashboards.dashboard')) {
+      if (transition.targetName.startsWith(this.routeName)) {
         return true;
       }
 

--- a/packages/dashboards/addon/routes/dashboards/dashboard.js
+++ b/packages/dashboards/addon/routes/dashboards/dashboard.js
@@ -95,6 +95,26 @@ export default Route.extend({
     }
   },
 
+  /**
+   * If traveling to the same route as the current dashboard, cache the query for breadcrumb purposes
+   * @param {Transition} transition
+   */
+  cacheQuery(transition) {
+    const controller = this.controllerFor(this.routeName);
+    if (transition.from && transition.from.queryParams) {
+      const fromRoute = transition.from.find(info => info.paramNames.includes('dashboard_id'));
+      const fromDashboardId = fromRoute ? fromRoute.params.dashboard_id : null;
+      const toRoute = transition.to && transition.to.find(info => info.paramNames.includes('dashboard_id'));
+      const toDashboardId = toRoute ? toRoute.params.dashboard_id : null;
+
+      if (fromDashboardId === toDashboardId) {
+        controller.set('queryCache', transition.from.queryParams);
+        return;
+      }
+    }
+    this.controller.set('queryCache', null);
+  },
+
   actions: {
     /**
      * @action didUpdateLayout - updates dashboard's layout property and save it
@@ -188,8 +208,9 @@ export default Route.extend({
      * @param {Transition} transition
      */
     willTransition(transition) {
-      //subroute just continue
+      //subroute cache queryString and continue
       if (transition.targetName.startsWith(this.routeName)) {
+        this.cacheQuery(transition);
         return true;
       }
 

--- a/packages/dashboards/addon/routes/dashboards/dashboard.js
+++ b/packages/dashboards/addon/routes/dashboards/dashboard.js
@@ -90,7 +90,7 @@ export default Route.extend({
     this._super(...arguments);
     const dashboard = this.modelFor(this.routeName);
     // don't rollback attributes if dashboard was unloaded.
-    if (!dashboard.isEmpty) {
+    if (typeof dashboard.isEmpty !== 'boolean' || !dashboard.isEmpty) {
       dashboard.rollbackAttributes();
     }
   },

--- a/packages/dashboards/addon/routes/dashboards/dashboard/view.js
+++ b/packages/dashboards/addon/routes/dashboards/dashboard/view.js
@@ -154,10 +154,5 @@ export default Route.extend({
 
     this.get('controller').set('filters', null);
     this.set('_widgetDataCache', null);
-    const dashboard = this.modelFor(this.routeName).dashboard;
-    // don't rollback attributes if dashboard was unloaded.
-    if (!dashboard.isEmpty) {
-      dashboard.rollbackAttributes();
-    }
   }
 });

--- a/packages/dashboards/addon/routes/dashboards/dashboard/widgets/widget.js
+++ b/packages/dashboards/addon/routes/dashboards/dashboard/widgets/widget.js
@@ -8,27 +8,6 @@ import ReportRoute from 'navi-reports/routes/reports/report';
 
 export default ReportRoute.extend({
   /**
-   * Decide if we need to store the query params of the parent route so we can add them to breadcrumbs
-   * @param {Ember.Transition} transition - current route transition.
-   */
-  beforeModel(transition) {
-    const controller = this.controllerFor(this.routeName);
-    const fromRoute = transition.from && transition.from.find(info => info.paramNames.includes('dashboard_id'));
-    const fromDashboardId = fromRoute ? fromRoute.params.dashboard_id : null;
-    const toRoute = transition.to && transition.to.find(info => info.paramNames.includes('dashboard_id'));
-    const toDashboardId = toRoute ? toRoute.params.dashboard_id : null;
-
-    if (
-      transition.from &&
-      transition.from.name.startsWith('dashboards.dashboard') &&
-      fromDashboardId === toDashboardId
-    ) {
-      controller.set('parentQueryParams', transition.from.queryParams);
-    } else {
-      controller.set('parentQueryParams', null);
-    }
-  },
-  /**
    * @method model
    * @param {Object} params
    * @param {String} params.widgetId - persisted id or temp id of widget to fetch

--- a/packages/dashboards/addon/routes/dashboards/dashboard/widgets/widget.js
+++ b/packages/dashboards/addon/routes/dashboards/dashboard/widgets/widget.js
@@ -7,11 +7,15 @@ import { getOwner } from '@ember/application';
 import ReportRoute from 'navi-reports/routes/reports/report';
 
 export default ReportRoute.extend({
+  /**
+   * Decide if we need to store the query params of the parent route so we can add them to breadcrumbs
+   * @param {Ember.Transition} transition - current route transition.
+   */
   beforeModel(transition) {
     const controller = this.controllerFor(this.routeName);
     const fromRoute = transition.from && transition.from.find(info => info.paramNames.includes('dashboard_id'));
     const fromDashboardId = fromRoute ? fromRoute.params.dashboard_id : null;
-    const toRoute = transition.to.find(info => info.paramNames.includes('dashboard_id'));
+    const toRoute = transition.to && transition.to.find(info => info.paramNames.includes('dashboard_id'));
     const toDashboardId = toRoute ? toRoute.params.dashboard_id : null;
 
     if (

--- a/packages/dashboards/addon/routes/dashboards/dashboard/widgets/widget.js
+++ b/packages/dashboards/addon/routes/dashboards/dashboard/widgets/widget.js
@@ -7,6 +7,23 @@ import { getOwner } from '@ember/application';
 import ReportRoute from 'navi-reports/routes/reports/report';
 
 export default ReportRoute.extend({
+  beforeModel(transition) {
+    const controller = this.controllerFor(this.routeName);
+    const fromRoute = transition.from && transition.from.find(info => info.paramNames.includes('dashboard_id'));
+    const fromDashboardId = fromRoute ? fromRoute.params.dashboard_id : null;
+    const toRoute = transition.to.find(info => info.paramNames.includes('dashboard_id'));
+    const toDashboardId = toRoute ? toRoute.params.dashboard_id : null;
+
+    if (
+      transition.from &&
+      transition.from.name.startsWith('dashboards.dashboard') &&
+      fromDashboardId === toDashboardId
+    ) {
+      controller.set('parentQueryParams', transition.from.queryParams);
+    } else {
+      controller.set('parentQueryParams', null);
+    }
+  },
   /**
    * @method model
    * @param {Object} params

--- a/packages/dashboards/addon/templates/dashboards/dashboard/widgets/widget.hbs
+++ b/packages/dashboards/addon/templates/dashboards/dashboard/widgets/widget.hbs
@@ -9,7 +9,7 @@
     {{/if}}
     {{navi-icon "angle-right"}}
     {{#with (model-for "dashboards.dashboard") as |parentDashboard|}}
-      {{#link-to "dashboards.dashboard" parentDashboard.id class="navi-report-widget__breadcrumb-link"}}
+      {{#link-to "dashboards.dashboard" parentDashboard.id (query-params filters=parentQueryParams.filters) class="navi-report-widget__breadcrumb-link"}}
         {{parentDashboard.title}}
       {{/link-to}}
     {{/with}}

--- a/packages/dashboards/addon/templates/dashboards/dashboard/widgets/widget.hbs
+++ b/packages/dashboards/addon/templates/dashboards/dashboard/widgets/widget.hbs
@@ -9,9 +9,15 @@
     {{/if}}
     {{navi-icon "angle-right"}}
     {{#with (model-for "dashboards.dashboard") as |parentDashboard|}}
-      {{#link-to "dashboards.dashboard" parentDashboard.id (query-params filters=parentQueryParams.filters) class="navi-report-widget__breadcrumb-link"}}
-        {{parentDashboard.title}}
-      {{/link-to}}
+      {{#if parentQueryParams}}
+        {{#link-to "dashboards.dashboard" parentDashboard.id (query-params filters=parentQueryParams.filters) class="navi-report-widget__breadcrumb-link"}}
+          {{parentDashboard.title}}
+        {{/link-to}}
+      {{else}}
+        {{#link-to "dashboards.dashboard" parentDashboard.id class="navi-report-widget__breadcrumb-link"}}
+          {{parentDashboard.title}}
+        {{/link-to}}
+      {{/if}}
     {{/with}}
     {{navi-icon "angle-right"}}
   </div>

--- a/packages/dashboards/app/controllers/dashboards/dashboard.js
+++ b/packages/dashboards/app/controllers/dashboards/dashboard.js
@@ -1,0 +1,1 @@
+export { default } from 'navi-dashboards/controllers/dashboards/dashboard';

--- a/packages/dashboards/tests/acceptance/dashboards-test.js
+++ b/packages/dashboards/tests/acceptance/dashboards-test.js
@@ -8,9 +8,19 @@ import { Response } from 'ember-cli-mirage';
 import { selectChoose } from 'ember-power-select/test-support';
 import $ from 'jquery';
 
+let confirm;
+
 module('Acceptance | Dashboards', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+
+  hooks.beforeEach(() => {
+    confirm = window.confirm;
+  });
+
+  hooks.afterEach(() => {
+    window.confirm = confirm;
+  });
 
   test('dashboard success', async function(assert) {
     assert.expect(2);
@@ -357,7 +367,7 @@ module('Acceptance | Dashboards', function(hooks) {
   });
 
   test('New widget', async function(assert) {
-    assert.expect(4);
+    assert.expect(11);
 
     // Check original set of widgets
     await visit('/dashboards/1');
@@ -395,6 +405,38 @@ module('Acceptance | Dashboards', function(hooks) {
       ['Mobile DAU Goal', 'Mobile DAU Graph', 'Mobile DAU Table', 'Untitled Widget'],
       '"Untitled Widget" has been added to dashboard'
     );
+
+    // hover css events are hard
+    find('.navi-widget__actions').style.visibility = 'visible';
+    await click('.navi-widget__explore-btn');
+
+    assert.equal(currentURL(), '/dashboards/1/widgets/1/view', 'Taken to explore widget page');
+
+    await click(findAll('.navi-report-widget__breadcrumb-link')[1]);
+
+    assert.equal(currentURL(), '/dashboards/1/view', 'Taken back to dashboard page');
+
+    assert.deepEqual(
+      widgetsAfter,
+      ['Mobile DAU Goal', 'Mobile DAU Graph', 'Mobile DAU Table', 'Untitled Widget'],
+      '"Untitled Widget" is still on dashboard after navigating to subroute'
+    );
+
+    window.confirm = () => {
+      assert.step('navigation confirmation denied');
+      return false;
+    };
+
+    await click('.navi-dashboard__breadcrumb-link');
+
+    assert.equal(currentURL(), '/dashboards/1/view', 'We are still on the dashboard route');
+
+    await click('.navi-dashboard__save-button');
+    await click('.navi-dashboard__breadcrumb-link');
+
+    assert.equal(currentURL(), '/dashboards', 'successfully navigated away with no unsaved changes');
+
+    assert.verifySteps(['navigation confirmation denied']);
   });
 
   test('Failing to save a new widget', async function(assert) {


### PR DESCRIPTION
<!-- The above line will close the issue upon merge -->

## Description

Dashboards often lose saved state when navigating to other routes

## Proposed Changes

- Move the dashboard rollback to the parent route, that way subroutes like editing widgets can be done without losing dashboard changes.
- When navigating out of parent route, prompt the user if they have unsaved changes.
- Add filter query params to breadcrumb links in widgets

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
