### PR TITLE
Fix: Clone depth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ jdk:
   - openjdk8
 
 sudo: true
+git:
+  depth: false
 addons:
   chrome: stable
 before_cache:


### PR DESCRIPTION
Resolves #

<!-- The above line will close the issue upon merge -->

## Description

builds failing because it can't find the tagged release because the clone depth is too shallow.

## Proposed Changes

- https://docs.travis-ci.com/user/customizing-the-build/#git-clone-depth

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
