### PR TITLE
Fixup gh-pages deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,11 +48,10 @@ script:
     fi
 jobs:
   include:
-    - stage: NPM Publish
+    - stage: 'Publish'
       if: branch = master AND repo = yahoo/navi AND type = push
       node_js: '8'
+      name: 'NPM'
       script: bash ./scripts/npm-publish.sh
-    - stage: GitHub Pages Publish
-      if: branch = master AND repo = yahoo/navi AND type = push
-      node_js: '8'
-      script: bash ./scripts/gh-pages-publish.sh
+    - script: bash ./scripts/gh-pages-publish.sh
+      name: 'GitHub Pages'

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,3 +55,5 @@ jobs:
       script: bash ./scripts/npm-publish.sh
     - script: bash ./scripts/gh-pages-publish.sh
       name: 'GitHub Pages'
+      node_js: '8'
+      if: branch = master AND repo = yahoo/navi AND type = push

--- a/scripts/gh-pages-publish.sh
+++ b/scripts/gh-pages-publish.sh
@@ -18,9 +18,10 @@ export GIT_SSH_COMMAND='ssh -i /tmp/.travis-secrets/deploy_rsa -v -o UserKnownHo
 echo 'Initiating connection to GitHub'
 git remote add ssh-origin git@github.com:yahoo/navi.git
 git fetch ssh-origin gh-pages
+git branch gh-pages ssh-origin/gh-pages # Force it to track from ssh-origin if master has gh-pages as well
 
 echo 'Building demo app'
-npx ember github-pages:commit --message "Deploy gh-pages from $COMMIT" --destination ../../
+travis_wait npx ember github-pages:commit --message "Deploy gh-pages from $COMMIT" --destination ../../
 
 echo 'Publishing demo app'
 git push ssh-origin gh-pages:gh-pages


### PR DESCRIPTION
Resolves #508 

## Description
- gh-pages was sometimes too slow to build and failed to push
- The gh-pages deploy got confused since both `origin` and `ssh-origin` have a `gh-pages` branch
- Both gh-pages and npm deploys can run in parallel [(but as separate builds)](https://docs.travis-ci.com/user/build-stages/#naming-your-jobs-within-build-stages) so let's do that

## Proposed Changes
- Add [travis_wait](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received) to gh-pages deploy
- Combine deploy steps so they should run in parallel

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
