### PR TITLE
Fix: Table selector style

### DIFF
--- a/packages/reports/app/styles/navi-reports/components/report-builder.less
+++ b/packages/reports/app/styles/navi-reports/components/report-builder.less
@@ -61,6 +61,7 @@
     flex: 0 0 33px;
     font-size: @font-size-mid-base;
     display: flex;
+    padding: 4px 10px;
   }
 
   &__container--filters {


### PR DESCRIPTION
## Description

Issue in which table selector was rendering slightly outside it's container.

## Proposed Changes

- put the right padding in place:

## Screenshots
Before:
![Screen Shot 2019-09-23 at 2 11 04 PM](https://user-images.githubusercontent.com/99422/65455127-33b53c00-de0c-11e9-897e-5357e360cf60.png)

After:
![Screen Shot 2019-09-23 at 2 10 45 PM](https://user-images.githubusercontent.com/99422/65455135-36179600-de0c-11e9-8e2c-fdb9430cd1d9.png)


## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
