### PR TITLE
Fix: Remove selector button color

### DIFF
--- a/packages/core/app/styles/navi-core/common/pills.less
+++ b/packages/core/app/styles/navi-core/common/pills.less
@@ -12,8 +12,8 @@
   font-size: @font-size-mid-base;
   margin: 2px 3px 0 3px;
   padding: 0 4px;
+}
 
-  .ember-power-select-multiple-remove-btn {
-    color: @navi-blue-300;
-  }
+.navi-pill-remove-button {
+  .ember-power-select-multiple-remove-btn;
 }

--- a/packages/reports/app/styles/navi-reports/vendor/ember-tag-input.less
+++ b/packages/reports/app/styles/navi-reports/vendor/ember-tag-input.less
@@ -19,7 +19,7 @@
     padding: 0;
 
     &-remove {
-      opacity: 0.5;
+      .navi-pill-remove-button;
       cursor: pointer;
       user-select: none;
     }
@@ -28,10 +28,6 @@
     &-input {
       font: @font-size-mid-base @font-family-thin;
       padding: 0 4px;
-    }
-
-    &-tag--remove {
-      opacity: 0.5;
     }
 
     &-remove:before {

--- a/packages/reports/app/styles/navi-reports/vendor/ember-tag-input.less
+++ b/packages/reports/app/styles/navi-reports/vendor/ember-tag-input.less
@@ -20,7 +20,6 @@
 
     &-remove {
       .navi-pill-remove-button;
-      cursor: pointer;
       user-select: none;
     }
 


### PR DESCRIPTION
## Description
The remove buttons for ember-power-select have different styles from our remove button

## Proposed Changes
Copy ember-power-select, now they get darker on hover

## Screenshots
Before:
![different colors](https://user-images.githubusercontent.com/12093492/65723272-b2f87900-e073-11e9-83d7-593d6690aa07.png)
After:
![same color](https://user-images.githubusercontent.com/12093492/65723327-d0c5de00-e073-11e9-9ddc-c2d86f914935.png)

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
