### PR TITLE
Fix: Allow save when mustHaveData is toggled (fixes #532)

### DIFF
--- a/packages/reports/addon/components/common-actions/schedule.js
+++ b/packages/reports/addon/components/common-actions/schedule.js
@@ -200,6 +200,14 @@ export default Component.extend({
     },
 
     /**
+     * @action toggleMustHaveData - flips the value of the mustHaveData property of the deliveryRule scheduling rules
+     */
+    toggleMustHaveData() {
+      let mustHaveData = !get(this, 'localDeliveryRule.schedulingRules.mustHaveData');
+      set(this, 'localDeliveryRule.schedulingRules.mustHaveData', mustHaveData);
+    },
+
+    /**
      * @action updateRecipients
      * @param {Array} recipients - list of email strings
      */

--- a/packages/reports/addon/templates/components/common-actions/schedule.hbs
+++ b/packages/reports/addon/templates/components/common-actions/schedule.hbs
@@ -87,7 +87,7 @@
             size="small"
             class="schedule-modal__must-have-data-toggle"
             value=localDeliveryRule.schedulingRules.mustHaveData
-            onToggle=(mut localDeliveryRule.schedulingRules.mustHaveData)}}
+            onToggle=(action "toggleMustHaveData")}}
           <div class="schedule-modal__label">Only send if data is present</div>
         </div>
       {{/if}}


### PR DESCRIPTION
Resolves #532

<!-- The above line will close the issue upon merge -->

## Description
Depends on https://github.com/yahoo/navi/pull/533

We added the feature to only send reports via email if there is data. The schedule modal did not allow users to save a delivery rule if toggling the mustHaveData toggle was the only change. 
## Proposed Changes
Make schedulingRules an ember data model fragment so that the model passed to the schedule modal actions can actually listen for each rule in the schedulingRules object. 

x-toggle also doesn't implicitly flip the value of schedulingRules.mustHaveData. The way it was implemented seems like we assumed it would. ` Not sure why, but added an action that does this when called by x-toggle. 
`onToggle=(mut localDeliveryRule.schedulingRules.mustHaveData)` --> `onToggle=(action "toggleMustHaveData)`

Added tests for this case.

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
