### PR TITLE
Breaking: Turn schedulingRules into a fragment (fixes #532)

### DIFF
--- a/packages/core/addon/mirage/fixtures/delivery-rules.js
+++ b/packages/core/addon/mirage/fixtures/delivery-rules.js
@@ -59,10 +59,7 @@ export default [
     },
     deliveryType: 'dashboard',
     frequency: 'week',
-    schedulingRules: {
-      stopAfter: '2017-09-04 00:00:00',
-      every: '2 weeks'
-    },
+    schedulingRules: {},
     format: {
       type: 'pdf'
     },

--- a/packages/core/addon/models/delivery-rule.js
+++ b/packages/core/addon/models/delivery-rule.js
@@ -6,6 +6,7 @@
 import DS from 'ember-data';
 import { validator, buildValidations } from 'ember-cp-validations';
 import { featureFlag } from 'navi-core/helpers/feature-flag';
+import { fragment } from 'ember-data-model-fragments/attributes';
 
 const Validations = buildValidations({
   frequency: [
@@ -34,7 +35,11 @@ export default DS.Model.extend(Validations, {
   updatedOn: DS.attr('moment'),
   deliveryType: DS.attr('string', { defaultValue: 'report' }),
   frequency: DS.attr('string', { defaultValue: 'week' }),
-  schedulingRules: DS.attr({ defaultValue: () => {return featureFlag('enabledNotifyIfData') ? {mustHaveData: false} : {} }}),
+  schedulingRules: fragment('fragments/scheduling-rules', {
+    defaultValue: () => {
+      return featureFlag('enabledNotifyIfData') ? { mustHaveData: false } : {};
+    }
+  }),
   format: DS.attr({ defaultValue: () => {} }),
   recipients: DS.attr({ defaultValue: () => [] }),
   version: DS.attr('number', { defaultValue: '1' }),

--- a/packages/core/addon/models/fragments/scheduling-rules.js
+++ b/packages/core/addon/models/fragments/scheduling-rules.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright 2019, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+
+import DS from 'ember-data';
+import Fragment from 'ember-data-model-fragments/fragment';
+
+export default Fragment.extend({
+  mustHaveData: DS.attr('boolean', { defaultValue: false })
+});

--- a/packages/core/app/models/fragments/scheduling-rules.js
+++ b/packages/core/app/models/fragments/scheduling-rules.js
@@ -1,0 +1,1 @@
+export { default } from 'navi-core/models/fragments/scheduling-rules';

--- a/packages/core/app/styles/navi-core/common/pills.less
+++ b/packages/core/app/styles/navi-core/common/pills.less
@@ -12,8 +12,8 @@
   font-size: @font-size-mid-base;
   margin: 2px 3px 0 3px;
   padding: 0 4px;
+}
 
-  .ember-power-select-multiple-remove-btn {
-    color: @navi-blue-300;
-  }
+.navi-pill-remove-button {
+  .ember-power-select-multiple-remove-btn;
 }

--- a/packages/core/tests/unit/models/delivery-rule-test.js
+++ b/packages/core/tests/unit/models/delivery-rule-test.js
@@ -13,8 +13,7 @@ const ExpectedDeliveryRule = {
   deliveryType: 'report',
   frequency: 'week',
   schedulingRules: {
-    stopAfter: '2017-09-04 00:00:00',
-    every: '2 weeks'
+    mustHaveData: false
   },
   format: {
     type: 'csv'

--- a/packages/reports/addon/components/common-actions/schedule.js
+++ b/packages/reports/addon/components/common-actions/schedule.js
@@ -200,6 +200,14 @@ export default Component.extend({
     },
 
     /**
+     * @action toggleMustHaveData - flips the value of the mustHaveData property of the deliveryRule scheduling rules
+     */
+    toggleMustHaveData() {
+      let mustHaveData = !get(this, 'localDeliveryRule.schedulingRules.mustHaveData');
+      set(this, 'localDeliveryRule.schedulingRules.mustHaveData', mustHaveData);
+    },
+
+    /**
      * @action updateRecipients
      * @param {Array} recipients - list of email strings
      */

--- a/packages/reports/addon/templates/components/common-actions/schedule.hbs
+++ b/packages/reports/addon/templates/components/common-actions/schedule.hbs
@@ -1,7 +1,8 @@
 {{!-- Copyright 2018, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 
 {{!-- Check if in need of disabling the button when the action should be disabled --}}
-<button class="schedule-action__button btn" disabled={{disabled}}  onclick={{queue (toggle "showModal" this) (action "onOpen")}}>
+<button class="schedule-action__button btn" disabled={{disabled}}
+  onclick={{queue (toggle "showModal" this) (action "onOpen")}}>
   {{navi-icon "clock-o" class="schedule-action__icon"}}
   {{#if hasBlock}}
     <span class="schedule-action__icon-label">{{yield}}</span>
@@ -17,7 +18,8 @@
     {{#if (is-rejected deliveryRule)}}
       <div class="schedule-modal__notification modal-notification alert failure">
         {{navi-icon "exclamation-circle"}}
-        <div class="notification-text">Oops! An error occurred while fetching the schedule for this {{localDeliveryRule.deliveryType}}.</div>
+        <div class="notification-text">Oops! An error occurred while fetching the schedule for this
+          {{localDeliveryRule.deliveryType}}.</div>
       </div>
     {{else}}
       {{#if notification}}
@@ -26,11 +28,12 @@
           {{navi-icon "times" class="notification-remove-icon clickable" click=(action "closeNotification")}}
         </div>
       {{else}}
-        <h5 class="schedule-modal__header--secondary secondary-header">Please provide delivery rules for your {{localDeliveryRule.deliveryType}}</h5>
+        <h5 class="schedule-modal__header--secondary secondary-header">Please provide delivery rules for your
+          {{localDeliveryRule.deliveryType}}</h5>
       {{/if}}
     {{/if}}
   </div>
-  
+
   {{#if (is-pending deliveryRule)}}
     {{navi-loader}}
   {{else}}
@@ -87,27 +90,21 @@
             size="small"
             class="schedule-modal__must-have-data-toggle"
             value=localDeliveryRule.schedulingRules.mustHaveData
-            onToggle=(mut localDeliveryRule.schedulingRules.mustHaveData)}}
+            onToggle=(action "toggleMustHaveData")}}
           <div class="schedule-modal__label">Only send if data is present</div>
         </div>
       {{/if}}
       <div class="schedule-modal__btn-container btn-container">
         <div class="button-group">
           {{#if (is-rejected deliveryRule)}}
-            <button
-              class="schedule-modal__cancel-btn btn btn-primary"
-              onclick={{queue (action "closeModal") (action onRevert localDeliveryRule)}}
-              disabled={{isSaving}}
-              type="button"
-            > Cancel
+            <button class="schedule-modal__cancel-btn btn btn-primary"
+              onclick={{queue (action "closeModal") (action onRevert localDeliveryRule)}} disabled={{isSaving}}
+              type="button"> Cancel
             </button>
           {{else}}
-            <button
-              class="schedule-modal__save-btn btn btn-primary"
-              onclick={{action (queue (toggle "isSaving" this) (action "onSave"))}}
-              disabled={{disableSave}}
-              type="button"
-            >
+            <button class="schedule-modal__save-btn btn btn-primary"
+              onclick={{action (queue (toggle "isSaving" this) (action "onSave"))}} disabled={{disableSave}}
+              type="button">
               {{#if isSaving}}
                 {{#loading-message}}
                   Saving schedule
@@ -116,12 +113,9 @@
                 {{#if localDeliveryRule.isNew}}Save{{else}}Save Changes{{/if}}
               {{/if}}
             </button>
-            <button
-              class="schedule-modal__cancel-btn btn btn-secondary"
-              onclick={{queue (action "closeModal") (action onRevert localDeliveryRule)}}
-              disabled={{isSaving}}
-              type="button"
-            >
+            <button class="schedule-modal__cancel-btn btn btn-secondary"
+              onclick={{queue (action "closeModal") (action onRevert localDeliveryRule)}} disabled={{isSaving}}
+              type="button">
               {{#if localDeliveryRule.hasDirtyAttributes}}
                 Cancel
               {{else}}

--- a/packages/reports/app/styles/navi-reports/vendor/ember-tag-input.less
+++ b/packages/reports/app/styles/navi-reports/vendor/ember-tag-input.less
@@ -19,8 +19,7 @@
     padding: 0;
 
     &-remove {
-      opacity: 0.5;
-      cursor: pointer;
+      .navi-pill-remove-button;
       user-select: none;
     }
 
@@ -28,10 +27,6 @@
     &-input {
       font: @font-size-mid-base @font-family-thin;
       padding: 0 4px;
-    }
-
-    &-tag--remove {
-      opacity: 0.5;
     }
 
     &-remove:before {


### PR DESCRIPTION
Resolves #532

<!-- The above line will close the issue upon merge -->

## Description
We added the feature to only send reports via email if there is data. The schedule modal did not allow users to save a delivery rule if toggling the mustHaveData toggle was the only change.

## Proposed Changes
Make schedulingRules an ember data model fragment so that the model passed to the schedule modal actions can actually listen for each rule in the schedulingRules object.

There's a corresponding change to the schedule.js and hbs common actions that depend on this navi-core update
-

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
