### PR TITLE
Fix: Allow save when mustHaveData is toggled (fixes #532)

### DIFF
--- a/packages/core/addon/mirage/fixtures/delivery-rules.js
+++ b/packages/core/addon/mirage/fixtures/delivery-rules.js
@@ -59,10 +59,7 @@ export default [
     },
     deliveryType: 'dashboard',
     frequency: 'week',
-    schedulingRules: {
-      stopAfter: '2017-09-04 00:00:00',
-      every: '2 weeks'
-    },
+    schedulingRules: {},
     format: {
       type: 'pdf'
     },

--- a/packages/core/addon/models/delivery-rule.js
+++ b/packages/core/addon/models/delivery-rule.js
@@ -5,7 +5,7 @@
 
 import DS from 'ember-data';
 import { validator, buildValidations } from 'ember-cp-validations';
-import { featureFlag } from 'navi-core/helpers/feature-flag';
+import { fragment } from 'ember-data-model-fragments/attributes';
 
 const Validations = buildValidations({
   frequency: [
@@ -34,7 +34,11 @@ export default DS.Model.extend(Validations, {
   updatedOn: DS.attr('moment'),
   deliveryType: DS.attr('string', { defaultValue: 'report' }),
   frequency: DS.attr('string', { defaultValue: 'week' }),
-  schedulingRules: DS.attr({ defaultValue: () => {return featureFlag('enabledNotifyIfData') ? {mustHaveData: false} : {} }}),
+  schedulingRules: fragment('fragments/scheduling-rules', {
+    defaultValue: () => {
+      return { mustHaveData: false };
+    }
+  }),
   format: DS.attr({ defaultValue: () => {} }),
   recipients: DS.attr({ defaultValue: () => [] }),
   version: DS.attr('number', { defaultValue: '1' }),

--- a/packages/core/addon/models/fragments/scheduling-rules.js
+++ b/packages/core/addon/models/fragments/scheduling-rules.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright 2019, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+
+import DS from 'ember-data';
+import Fragment from 'ember-data-model-fragments/fragment';
+
+export default Fragment.extend({
+  mustHaveData: DS.attr('boolean')
+});

--- a/packages/core/app/models/fragments/scheduling-rules.js
+++ b/packages/core/app/models/fragments/scheduling-rules.js
@@ -1,0 +1,1 @@
+export { default } from 'navi-core/models/fragments/scheduling-rules';

--- a/packages/core/tests/unit/models/delivery-rule-test.js
+++ b/packages/core/tests/unit/models/delivery-rule-test.js
@@ -13,8 +13,7 @@ const ExpectedDeliveryRule = {
   deliveryType: 'report',
   frequency: 'week',
   schedulingRules: {
-    stopAfter: '2017-09-04 00:00:00',
-    every: '2 weeks'
+    mustHaveData: false
   },
   format: {
     type: 'csv'

--- a/packages/reports/addon/templates/components/common-actions/schedule.hbs
+++ b/packages/reports/addon/templates/components/common-actions/schedule.hbs
@@ -87,7 +87,7 @@
             size="small"
             class="schedule-modal__must-have-data-toggle"
             value=localDeliveryRule.schedulingRules.mustHaveData
-            onToggle=(mut localDeliveryRule.schedulingRules.mustHaveData)}}
+            onToggle=(action (toggle "mustHaveData" localDeliveryRule.schedulingRules))}}
           <div class="schedule-modal__label">Only send if data is present</div>
         </div>
       {{/if}}

--- a/packages/reports/tests/acceptance/schedule-modal-test.js
+++ b/packages/reports/tests/acceptance/schedule-modal-test.js
@@ -13,7 +13,7 @@ module('Acceptance | Navi Report Schedule Modal', function(hooks) {
   setupMirage(hooks);
 
   test('schedule modal save new schedule', async function(assert) {
-    assert.expect(12);
+    assert.expect(13);
     await visit('/reports');
 
     // Click "Schedule"
@@ -22,6 +22,7 @@ module('Acceptance | Navi Report Schedule Modal', function(hooks) {
 
     assert.dom('.schedule-modal__header .primary-header').isVisible('Schedule modal pops up when action is clicked');
 
+    // Default View
     assert
       .dom('.schedule-modal__delete-btn')
       .isNotVisible('The delete button is not present when creating a new schedule');
@@ -46,12 +47,16 @@ module('Acceptance | Navi Report Schedule Modal', function(hooks) {
       .dom('.schedule-modal__must-have-data-toggle .x-toggle')
       .isNotChecked('mustHaveData is toggled off by default');
 
+    // Enter email address
     await fillIn('.js-ember-tag-input-new', 'navi_user@navi.io');
     await blur('.js-ember-tag-input-new');
 
-    // Set frequency to Day
+    // Set frequency to 'Day'
     await click('.schedule-modal__dropdown--frequency .ember-power-select-trigger');
     await click($('.ember-power-select-option:contains(Day)')[0]);
+
+    // Toggle mustHaveData to 'on'
+    await click('.schedule-modal__must-have-data-toggle .x-toggle');
 
     //Save the schedule
     await click('.schedule-modal__save-btn');
@@ -80,24 +85,50 @@ module('Acceptance | Navi Report Schedule Modal', function(hooks) {
     assert
       .dom('.schedule-modal__input--recipients .navi-email-tag')
       .hasText('navi_user@navi.io', 'Recipients field is set by the saved delivery rule');
+
+    assert
+      .dom('.schedule-modal__must-have-data-toggle .x-toggle')
+      .isChecked('mustHaveData field is set by the saved delivery rule');
   });
 
   test('schedule modal save changes to existing schedule', async function(assert) {
-    assert.expect(6);
+    assert.expect(8);
     await visit('/reports');
 
     // Open an existing schedule
     await triggerEvent('.navi-collection__row2', 'mouseover');
     await click('.navi-collection__row2 .schedule .btn');
 
+    // The initial state of the Cancel button should say "Close"
+    assert
+      .dom('.schedule-modal__cancel-btn')
+      .hasText('Close', 'The cancel button says "Close" upon opening the schedule modal');
+
+    // Change the value of the mustHaveData toggle and make sure the model detects changes
+    await click('.schedule-modal__must-have-data-toggle .x-toggle');
+    assert
+      .dom('.schedule-modal__cancel-btn')
+      .hasText(
+        'Cancel',
+        'The cancel button says "Cancel" and not "Close" after a user modifies the state of the mustHaveData toggled'
+      );
+
+    // Reverting the changes are also detected by the model and reflected to the user
+    await click('.schedule-modal__must-have-data-toggle .x-toggle');
+    assert
+      .dom('.schedule-modal__cancel-btn')
+      .hasText(
+        'Close',
+        'The cancel button says "Close" after a user puts the mustHaveData toggle value back to its initial state'
+      );
+
+    // Enter emails
     await fillIn('.js-ember-tag-input-new', 'navi_user@navi.io');
     await blur('.js-ember-tag-input-new');
 
     // Set frequency to Day
     await click('.schedule-modal__dropdown--frequency .ember-power-select-trigger');
     await click($('.ember-power-select-option:contains(Day)')[0]);
-
-    await click('.schedule-modal__must-have-data-toggle .x-toggle');
 
     //Save the schedule
     await click('.schedule-modal__save-btn');
@@ -122,10 +153,6 @@ module('Acceptance | Navi Report Schedule Modal', function(hooks) {
     assert
       .dom('.schedule-modal__dropdown--frequency .ember-power-select-selected-item')
       .hasText('Day', 'Changes made to the frequency field are kept after clicking save changes');
-
-    assert
-      .dom('.schedule-modal__must-have-data-toggle .x-toggle')
-      .isChecked('mustHaveData should be toggled on after toggling it on');
 
     assert.deepEqual(
       findAll('.schedule-modal__input--recipients .navi-email-tag').map(e => e.innerText.trim()),
@@ -204,12 +231,14 @@ module('Acceptance | Navi Report Schedule Modal', function(hooks) {
   });
 
   test('schedule modal cancel existing schedule', async function(assert) {
-    assert.expect(4);
+    assert.expect(5);
     await visit('/reports');
 
     // Click "Schedule"
     await triggerEvent('.navi-collection__row2', 'mouseover');
     await click('.navi-collection__row2 .schedule .btn');
+
+    assert.dom('.schedule-modal__must-have-data-toggle .x-toggle').isNotChecked('mustHaveData is false initially');
 
     await fillIn('.js-ember-tag-input-new', 'navi_user@navi.io');
     await blur('.js-ember-tag-input-new');
@@ -254,6 +283,7 @@ module('Acceptance | Navi Report Schedule Modal', function(hooks) {
     await triggerEvent('.navi-collection__row0', 'mouseover');
     await click('.navi-collection__row0 .schedule .btn');
 
+    // Enter an email
     await fillIn('.js-ember-tag-input-new', 'navi_user@navi.io');
     await blur('.js-ember-tag-input-new');
 
@@ -264,7 +294,7 @@ module('Acceptance | Navi Report Schedule Modal', function(hooks) {
     // Set mustHaveData to be true
     await click('.schedule-modal__must-have-data-toggle .x-toggle');
 
-    //Cancel changes to the schedule
+    // Cancel changes to the schedule
     await click('.schedule-modal__cancel-btn');
 
     // Reopen the same schedule modal
@@ -283,7 +313,7 @@ module('Acceptance | Navi Report Schedule Modal', function(hooks) {
 
     assert
       .dom('.schedule-modal__must-have-data-toggle .x-toggle')
-      .isNotChecked('mustHaveData changes to an existing schedule are discarded after clicking cancel');
+      .isChecked('mustHaveData field changes to a new schedule are kept but not saved to the store');
 
     assert
       .dom('.schedule-modal__save-btn')


### PR DESCRIPTION
Resolves #532

<!-- The above line will close the issue upon merge -->

## Description
We added the feature to only send reports via email if there is data. The schedule modal did not allow users to save a delivery rule if toggling the mustHaveData toggle was the only change.

## Proposed Changes
Make schedulingRules an ember data model fragment so that the model passed to the schedule modal actions can actually listen for each rule in the schedulingRules object.

There's a corresponding change to the schedule.js and hbs common actions that depend on this navi-core update
-

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
