### PR TITLE
Update: Lock down navi dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "navi",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "navi",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Navi Project",
   "author": "team-navi@googlegroups.com",
   "license": "MIT",
@@ -13,7 +13,7 @@
     "start": "lerna exec --scope navi-app npm start",
     "postinstall": "lerna bootstrap --concurrency 2 --ci",
     "test": "lerna run test",
-    "lerna-ci-publish": "lerna publish --canary preminor --force-publish=* --yes"
+    "lerna-ci-publish": "lerna publish --canary --exact preminor --force-publish=* --yes"
   },
   "husky": {
     "hooks": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "navi-app",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Template project for your Navi application",
   "repository": {
     "type": "git",
@@ -60,11 +60,11 @@
     "eslint-config-prettier": "^3.0.1",
     "eslint-plugin-ember": "^5.2.0",
     "loader.js": "^4.7.0",
-    "navi-core": "^0.1.0",
-    "navi-data": "^0.1.0",
-    "navi-dashboards": "^0.1.0",
-    "navi-directory": "^0.1.0",
-    "navi-reports": "^0.1.0",
+    "navi-core": "0.2.0",
+    "navi-data": "0.2.0",
+    "navi-dashboards": "0.2.0",
+    "navi-directory": "0.2.0",
+    "navi-reports": "0.2.0",
     "qunit-dom": "^0.8.0"
   },
   "engines": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "navi-core",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Library of common logic, components, and styles for navi",
   "scripts": {
     "build": "ember build",
@@ -37,7 +37,7 @@
     "ember-tooltips": "^3.2.0",
     "ember-truth-helpers": "^2.0.0",
     "json-url": "~2.4.1",
-    "navi-data": "^0.1.0",
+    "navi-data": "0.2.0",
     "numeral": "^2.0.6",
     "resize-observer-polyfill": "^1.5.1"
   },
@@ -77,7 +77,6 @@
     "eslint-plugin-ember": "^5.2.0",
     "eslint-plugin-node": "^7.0.1",
     "loader.js": "^4.7.0",
-    "navi-data": "^0.1.0",
     "qunit-dom": "^0.8.0"
   },
   "keywords": [

--- a/packages/dashboards/package.json
+++ b/packages/dashboards/package.json
@@ -1,6 +1,6 @@
 {
   "name": "navi-dashboards",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Analytics dashboard library for navi",
   "keywords": [
     "ember-addon"
@@ -48,9 +48,9 @@
     "ember-truth-helpers": "^2.1.0",
     "ember-uuid": "^1.0.1",
     "liquid-fire": "^0.29.5",
-    "navi-core": "^0.1.0",
-    "navi-data": "^0.1.0",
-    "navi-reports": "^0.1.0"
+    "navi-core": "0.2.0",
+    "navi-data": "0.2.0",
+    "navi-reports": "0.2.0"
   },
   "devDependencies": {
     "@ember/jquery": "^0.6.0",

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "navi-data",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Analytics data library for navi",
   "keywords": [
     "ember-addon"

--- a/packages/directory/package.json
+++ b/packages/directory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "navi-directory",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"
@@ -32,10 +32,10 @@
     "ember-moment": "^7.8.1",
     "ember-power-select": "^2.3.5",
     "ember-responsive": "^3.0.0-beta.3",
-    "navi-core": "^0.1.0",
-    "navi-dashboards": "^0.1.0",
-    "navi-data": "^0.1.0",
-    "navi-reports": "^0.1.0"
+    "navi-core": "0.2.0",
+    "navi-dashboards": "0.2.0",
+    "navi-data": "0.2.0",
+    "navi-reports": "0.2.0"
   },
   "devDependencies": {
     "@ember/jquery": "^0.6.0",

--- a/packages/reports/package.json
+++ b/packages/reports/package.json
@@ -1,6 +1,6 @@
 {
   "name": "navi-reports",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Analytics reporting library for navi",
   "keywords": [
     "ember-addon"
@@ -50,8 +50,8 @@
     "ember-truth-helpers": "^2.0.0",
     "ember-uuid": "^1.0.0",
     "liquid-fire": "^0.29.2",
-    "navi-core": "^0.1.0",
-    "navi-data": "^0.1.0"
+    "navi-core": "0.2.0",
+    "navi-data": "0.2.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.7.0",


### PR DESCRIPTION
Resolves #

<!-- The above line will close the issue upon merge -->

## Description

Lock down navi dependency versions

## Proposed Changes

- Set versions to `0.2.0` as that is what we are currently publishing
- Change navi dependencies from floating the minor to a static version

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
