### PR TITLE
Fix: Dashboard Filters were not being updated by query params

### DIFF
--- a/packages/dashboards/addon/routes/dashboards/dashboard/view.js
+++ b/packages/dashboards/addon/routes/dashboards/dashboard/view.js
@@ -60,7 +60,7 @@ export default Route.extend({
    */
   async model(_, transition) {
     const dashboard = this.modelFor('dashboards.dashboard');
-    const filterQueryParams = get(transition, 'queryParams.filters');
+    const filterQueryParams = get(transition, 'to.queryParams.filters');
     const cachedWidgetData = this.get('_widgetDataCache');
 
     //Record filters before and after setting from query params

--- a/packages/dashboards/addon/routes/dashboards/dashboard/view.js
+++ b/packages/dashboards/addon/routes/dashboards/dashboard/view.js
@@ -60,7 +60,7 @@ export default Route.extend({
    */
   async model(_, transition) {
     const dashboard = this.modelFor('dashboards.dashboard');
-    const filterQueryParams = get(transition, 'to.queryParams.filters');
+    const filterQueryParams = transition.to.queryParams.filters;
     const cachedWidgetData = this.get('_widgetDataCache');
 
     //Record filters before and after setting from query params


### PR DESCRIPTION
Resolves #

<!-- The above line will close the issue upon merge -->

## Description
Dashboard filters are not adding or updating.
It seems the `queryParams` property was moved in the `transition` object in the model hook. It now resides behind `to` and `from` rather than being a top level property.

## Proposed Changes
- Access `to.queryParams`

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
