### PR TITLE
Fix: Adjust apply button size (fixes #543)

### DIFF
--- a/packages/reports/app/styles/navi-reports/components/navi-date-range-picker.less
+++ b/packages/reports/app/styles/navi-reports/components/navi-date-range-picker.less
@@ -55,10 +55,9 @@
 
   &__apply-btn {
     font-size: @font-size-mid;
-    border-radius: 5px;
     border-width: 0 0 3px 0;
-    padding: 2px 13px;
-    margin: 0 0 4px 10px;
+    margin: 0 0 0 10px;
+    vertical-align: inherit;
   }
 
   &__controls {


### PR DESCRIPTION
Resolves #543 

<!-- The above line will close the issue upon merge -->

## Description
The custom date range picker's apply button is not sized correctly

## Proposed Changes
Change the apply button to match the reset button

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
