### PR TITLE
Add gold outline to Favorite Item on hover - Resolves #551

### DIFF
--- a/packages/reports/app/styles/navi-reports/components/favorite-item.less
+++ b/packages/reports/app/styles/navi-reports/components/favorite-item.less
@@ -5,8 +5,8 @@
 
 .favorite-item {
   color: @navi-dark-gray;
-}
 
-.favorite-item--active {
-  color: @favorite-gold;
+  &:hover, &--active {
+    color: @favorite-gold;
+  }
 }


### PR DESCRIPTION
Resolves #551

<!-- The above line will close the issue upon merge -->

## Description
Add hover color to the favorite button (.favorite-item)

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
