### PR TITLE
directory table filter click issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ See [CONTRUBUTING.md](https://github.com/yahoo/navi/blob/master/CONTRIBUTING.md)
 - `npm test`
 
 For more information on using ember-cli, visit [https://ember-cli.com/](https://ember-cli.com/).
-For more information on using lerna, visit [https://lernajs.io/](https://lernajs.io/)
+For more information on using lerna, visit [https://lerna.js.org](https://lerna.js.org)
 
 ## License
 

--- a/packages/directory/addon/templates/components/dir-table-filter.hbs
+++ b/packages/directory/addon/templates/components/dir-table-filter.hbs
@@ -1,9 +1,7 @@
 {{!-- Copyright 2019, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 {{#basic-dropdown classNames="dir-table-filter" as |dd|}}
   {{#dd.trigger class="dir-table-filter__trigger"}}
-    <span 
-      class="dir-table-filter__trigger-type" 
-    >
+    <span class="dir-table-filter__trigger-type">
       {{capitalize selectedFileType}}
     </span>
     {{navi-icon "caret-down" class="dir-table-filter__dropdown-icon"}}

--- a/packages/directory/addon/templates/components/dir-table-filter.hbs
+++ b/packages/directory/addon/templates/components/dir-table-filter.hbs
@@ -1,7 +1,11 @@
 {{!-- Copyright 2019, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 {{#basic-dropdown classNames="dir-table-filter" as |dd|}}
   {{#dd.trigger class="dir-table-filter__trigger"}}
-    {{capitalize selectedFileType}}
+    <span 
+      class="dir-table-filter__trigger-type" 
+    >
+      {{capitalize selectedFileType}}
+    </span>
     {{navi-icon "caret-down" class="dir-table-filter__dropdown-icon"}}
   {{/dd.trigger}}
 

--- a/packages/directory/app/styles/navi-directory/components/dir-table-filter.less
+++ b/packages/directory/app/styles/navi-directory/components/dir-table-filter.less
@@ -12,14 +12,19 @@
     border-radius: 5px;
     color: @navi-gray-700;
     cursor: pointer;
-    display: grid;
     font-family: @font-family-thin;
-    grid-template-columns: 1fr 5px;
     margin-left: auto;
     padding: 5px 10px;
     text-align: left;
     user-select: none;
     width: 120px;
+    display: flex;
+    justify-content: space-between;
+    
+    &-type {
+      margin-right: auto;
+      width: 100%;
+    }
   }
 
   &__dropdown-options {

--- a/packages/directory/app/styles/navi-directory/components/dir-table-filter.less
+++ b/packages/directory/app/styles/navi-directory/components/dir-table-filter.less
@@ -12,14 +12,14 @@
     border-radius: 5px;
     color: @navi-gray-700;
     cursor: pointer;
+    display: flex;
     font-family: @font-family-thin;
+    justify-content: space-between;
     margin-left: auto;
     padding: 5px 10px;
     text-align: left;
     user-select: none;
     width: 120px;
-    display: flex;
-    justify-content: space-between;
     
     &-type {
       margin-right: auto;


### PR DESCRIPTION
Resolves #545 

<!-- The above line will close the issue upon merge -->

## Description

The directory table filter only opens if you click on the text or dropdown

## Proposed Changes
- Wrapping text in `<span>` to increase its width.
- Adding required css.

## Screenshots




## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
