### PR TITLE
Update: Use ember-set-helper instead of the mut helper

### DIFF
--- a/packages/app/package-lock.json
+++ b/packages/app/package-lock.json
@@ -3664,6 +3664,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
+      "optional": true,
       "requires": {
         "hoek": "2.x.x"
       }
@@ -10058,7 +10059,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -10079,12 +10081,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -10099,17 +10103,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -10226,7 +10233,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -10238,6 +10246,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -10252,6 +10261,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -10259,12 +10269,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -10283,6 +10295,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -10363,7 +10376,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -10375,6 +10389,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -10460,7 +10475,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -10496,6 +10512,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -10515,6 +10532,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -10558,12 +10576,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -11169,7 +11189,8 @@
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "home-or-tmp": {
       "version": "2.0.0",

--- a/packages/core/addon/templates/components/number-format-dropdown.hbs
+++ b/packages/core/addon/templates/components/number-format-dropdown.hbs
@@ -6,6 +6,6 @@ terms. --}}
   {{/dd.trigger}}
 
   {{#dd.content class="number-format-dropdown__container"}}
-    {{number-format-selector format=format onUpdateFormat=(action (mut format))}}
+    {{number-format-selector format=format onUpdateFormat=(action (set this "format" _))}}
   {{/dd.content}}
 {{/basic-dropdown}}

--- a/packages/core/addon/templates/components/table-renderer-vertical-collection.hbs
+++ b/packages/core/addon/templates/components/table-renderer-vertical-collection.hbs
@@ -13,8 +13,8 @@
           model=(readonly column)
           group=group
           click=(action headerClicked column)
-          onDragStart=(action (mut isDragged) true)
-          onDragStop=(action (mut isDragged) false)
+          onDragStart=(action (set this "isDragged" true))
+          onDragStop=(action (set this "isDragged" false))
         }}
           <span
             class="table-header-cell__title {{if column.hasCustomDisplayName "table-header-cell__title--custom-name"}}"

--- a/packages/core/addon/templates/components/visualization-config/table.hbs
+++ b/packages/core/addon/templates/components/visualization-config/table.hbs
@@ -26,7 +26,7 @@
           class="table-config__total-toggle-button table-config__total-toggle-button--subtotal"
           value=(readonly showSubtotalDropdown)
           size="small"
-          onToggle=(queue (action (mut showSubtotalDropdown)) (action "onToggleSubtotal"))
+          onToggle=(queue (toggle-action "showSubtotalDropdown" this) (action "onToggleSubtotal"))
         }}
       </div>
 

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -10477,6 +10477,29 @@
         "ember-cli-babel": "^7.1.0"
       }
     },
+    "ember-modifier-manager-polyfill": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.2.0.tgz",
+      "integrity": "sha512-bnaKF1LLKMkBNeDoetvIJ4vhwRPKIIumWr6dbVuW6W6p4QV8ZiO+GdF8J7mxDNlog9CeL9Z/7wam4YS86G8BYA==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.10.0",
+        "ember-cli-version-checker": "^2.1.2",
+        "ember-compatibility-helpers": "^1.2.0"
+      },
+      "dependencies": {
+        "ember-cli-version-checker": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
+          "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
+          "dev": true,
+          "requires": {
+            "resolve": "^1.3.3",
+            "semver": "^5.3.0"
+          }
+        }
+      }
+    },
     "ember-moment": {
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/ember-moment/-/ember-moment-7.8.1.tgz",
@@ -10826,6 +10849,18 @@
             "object-assign": "4.1.1"
           }
         }
+      }
+    },
+    "ember-on-modifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ember-on-modifier/-/ember-on-modifier-1.0.0.tgz",
+      "integrity": "sha512-OPX5QrNiyXXQ//uN4cFj7gz5pt0rBK5c6LPEMP5iSK2I1J+WtiHM5Kg7mVCM7VziMiRUBVe3wp8CAE26m45hsA==",
+      "dev": true,
+      "requires": {
+        "broccoli-funnel": "^2.0.2",
+        "ember-cli-babel": "^7.8.0",
+        "ember-cli-version-checker": "^3.1.3",
+        "ember-modifier-manager-polyfill": "^1.0.3"
       }
     },
     "ember-power-select": {
@@ -11771,6 +11806,16 @@
             "object-assign": "4.1.1"
           }
         }
+      }
+    },
+    "ember-set-helper": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ember-set-helper/-/ember-set-helper-0.1.1.tgz",
+      "integrity": "sha512-iv+Iw8WPWtdvfrVzvEs6ZEux8Lm2Tj+bHjcmXRQfHQGK9DVS2o97I9cEb75LONSIDawPToHW8p8XXCGijwogBA==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.7.3",
+        "ember-on-modifier": "^1.0.0"
       }
     },
     "ember-sortable": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -70,6 +70,7 @@
     "ember-qunit": "^4.4.1",
     "ember-qunit-assert-helpers": "^0.2.1",
     "ember-resolver": "^5.0.1",
+    "ember-set-helper": "^0.1.1",
     "ember-source": "~3.12.0",
     "ember-source-channel-url": "^1.1.0",
     "ember-try": "^1.0.0",

--- a/packages/dashboards/addon/templates/components/dashboard-actions/add-widget.hbs
+++ b/packages/dashboards/addon/templates/components/dashboard-actions/add-widget.hbs
@@ -15,7 +15,7 @@
       selected=selectedReport
       searchField="title"
       searchPlaceholder="Search for a report..."
-      onchange=(action (mut selectedReport))
+      onchange=(action (set this "selectedReport" _))
       classNames="report-select"
       tagName="div"
       renderInPlace=true

--- a/packages/dashboards/addon/templates/components/report-actions/add-to-dashboard.hbs
+++ b/packages/dashboards/addon/templates/components/report-actions/add-to-dashboard.hbs
@@ -30,7 +30,7 @@
         selected=selectedDashboard
         searchField="title"
         searchPlaceholder="Search for a dashboard..."
-        onchange=(action (mut selectedDashboard))
+        onchange=(action (set this "selectedDashboard" _))
         classNames="dashboard-select"
         tagName="div"
         renderInPlace=true

--- a/packages/dashboards/package-lock.json
+++ b/packages/dashboards/package-lock.json
@@ -9870,6 +9870,16 @@
         }
       }
     },
+    "ember-modifier-manager-polyfill": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.2.0.tgz",
+      "integrity": "sha512-bnaKF1LLKMkBNeDoetvIJ4vhwRPKIIumWr6dbVuW6W6p4QV8ZiO+GdF8J7mxDNlog9CeL9Z/7wam4YS86G8BYA==",
+      "requires": {
+        "ember-cli-babel": "^7.10.0",
+        "ember-cli-version-checker": "^2.1.2",
+        "ember-compatibility-helpers": "^1.2.0"
+      }
+    },
     "ember-moment": {
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/ember-moment/-/ember-moment-7.8.1.tgz",
@@ -9988,6 +9998,28 @@
           "integrity": "sha512-L1ovlYHp6UObYqElXXpbd214GgbEKDED0d3sj7pRdFXjNkb2+un/AUcCkceHizO0IVI6SOGGncrcjozruCkRgA==",
           "requires": {
             "object-assign": "4.1.1"
+          }
+        }
+      }
+    },
+    "ember-on-modifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ember-on-modifier/-/ember-on-modifier-1.0.0.tgz",
+      "integrity": "sha512-OPX5QrNiyXXQ//uN4cFj7gz5pt0rBK5c6LPEMP5iSK2I1J+WtiHM5Kg7mVCM7VziMiRUBVe3wp8CAE26m45hsA==",
+      "requires": {
+        "broccoli-funnel": "^2.0.2",
+        "ember-cli-babel": "^7.8.0",
+        "ember-cli-version-checker": "^3.1.3",
+        "ember-modifier-manager-polyfill": "^1.0.3"
+      },
+      "dependencies": {
+        "ember-cli-version-checker": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-3.1.3.tgz",
+          "integrity": "sha512-PZNSvpzwWgv68hcXxyjREpj3WWb81A7rtYNQq1lLEgrWIchF8ApKJjWP3NBpHjaatwILkZAV8klair5WFlXAKg==",
+          "requires": {
+            "resolve-package-path": "^1.2.6",
+            "semver": "^5.6.0"
           }
         }
       }
@@ -10563,6 +10595,15 @@
             "object-assign": "4.1.1"
           }
         }
+      }
+    },
+    "ember-set-helper": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ember-set-helper/-/ember-set-helper-0.1.1.tgz",
+      "integrity": "sha512-iv+Iw8WPWtdvfrVzvEs6ZEux8Lm2Tj+bHjcmXRQfHQGK9DVS2o97I9cEb75LONSIDawPToHW8p8XXCGijwogBA==",
+      "requires": {
+        "ember-cli-babel": "^7.7.3",
+        "ember-on-modifier": "^1.0.0"
       }
     },
     "ember-sortable": {
@@ -13085,7 +13126,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -13103,11 +13145,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -13120,15 +13164,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -13231,7 +13278,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -13241,6 +13289,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -13253,17 +13302,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -13280,6 +13332,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -13352,7 +13405,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -13362,6 +13416,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -13437,7 +13492,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -13467,6 +13523,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -13484,6 +13541,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -13522,11 +13580,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/packages/dashboards/package.json
+++ b/packages/dashboards/package.json
@@ -40,6 +40,7 @@
     "ember-modal-dialog": "^2.4.3",
     "ember-moment": "^7.8.1",
     "ember-promise-helpers": "^1.0.6",
+    "ember-set-helper": "^0.1.1",
     "ember-sortable": "1.12.3",
     "ember-tag-input": "^1.2.2",
     "ember-toggle": "^5.3.3",

--- a/packages/directory/addon/templates/components/dir-search-bar.hbs
+++ b/packages/directory/addon/templates/components/dir-search-bar.hbs
@@ -9,5 +9,5 @@
 {{navi-icon "search" class="dir-search-bar__search-icon"}}
 {{navi-icon "times"
     class=(concat "dir-search-bar__clear-icon" (if (not-eq query.length 0) " dir-search-bar__clear-icon--show"))
-    click=(action (mut query) "")
+    click=(action (set this "query" ""))
 }}

--- a/packages/directory/addon/templates/components/dir-sidebar.hbs
+++ b/packages/directory/addon/templates/components/dir-sidebar.hbs
@@ -3,7 +3,7 @@
   {{#each directories as | directory |}}
     {{#link-to directory.routeLink (query-params filter=null)
       classNames="dir-sidebar__group"
-      click=(pipe (action (mut selectedDirectory) directory) (action (mut selectedFilter) (object-at 0 directory.filters)))
+      click=(pipe (action (set this "selectedDirectory" directory)) (action (set this "selectedFilter" (object-at 0 directory.filters))))
     }}
       <div>
         <span class="dir-sidebar__group--icon">{{navi-icon "folder-o"}}</span>

--- a/packages/directory/package-lock.json
+++ b/packages/directory/package-lock.json
@@ -2972,6 +2972,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
+      "optional": true,
       "requires": {
         "hoek": "2.x.x"
       }
@@ -10260,6 +10261,16 @@
         }
       }
     },
+    "ember-modifier-manager-polyfill": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.2.0.tgz",
+      "integrity": "sha512-bnaKF1LLKMkBNeDoetvIJ4vhwRPKIIumWr6dbVuW6W6p4QV8ZiO+GdF8J7mxDNlog9CeL9Z/7wam4YS86G8BYA==",
+      "requires": {
+        "ember-cli-babel": "^7.10.0",
+        "ember-cli-version-checker": "^2.1.2",
+        "ember-compatibility-helpers": "^1.2.0"
+      }
+    },
     "ember-moment": {
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/ember-moment/-/ember-moment-7.8.1.tgz",
@@ -10378,6 +10389,28 @@
           "integrity": "sha512-L1ovlYHp6UObYqElXXpbd214GgbEKDED0d3sj7pRdFXjNkb2+un/AUcCkceHizO0IVI6SOGGncrcjozruCkRgA==",
           "requires": {
             "object-assign": "4.1.1"
+          }
+        }
+      }
+    },
+    "ember-on-modifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ember-on-modifier/-/ember-on-modifier-1.0.0.tgz",
+      "integrity": "sha512-OPX5QrNiyXXQ//uN4cFj7gz5pt0rBK5c6LPEMP5iSK2I1J+WtiHM5Kg7mVCM7VziMiRUBVe3wp8CAE26m45hsA==",
+      "requires": {
+        "broccoli-funnel": "^2.0.2",
+        "ember-cli-babel": "^7.8.0",
+        "ember-cli-version-checker": "^3.1.3",
+        "ember-modifier-manager-polyfill": "^1.0.3"
+      },
+      "dependencies": {
+        "ember-cli-version-checker": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-3.1.3.tgz",
+          "integrity": "sha512-PZNSvpzwWgv68hcXxyjREpj3WWb81A7rtYNQq1lLEgrWIchF8ApKJjWP3NBpHjaatwILkZAV8klair5WFlXAKg==",
+          "requires": {
+            "resolve-package-path": "^1.2.6",
+            "semver": "^5.6.0"
           }
         }
       }
@@ -11369,6 +11402,15 @@
             "object-assign": "4.1.1"
           }
         }
+      }
+    },
+    "ember-set-helper": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ember-set-helper/-/ember-set-helper-0.1.1.tgz",
+      "integrity": "sha512-iv+Iw8WPWtdvfrVzvEs6ZEux8Lm2Tj+bHjcmXRQfHQGK9DVS2o97I9cEb75LONSIDawPToHW8p8XXCGijwogBA==",
+      "requires": {
+        "ember-cli-babel": "^7.7.3",
+        "ember-on-modifier": "^1.0.0"
       }
     },
     "ember-sortable": {
@@ -13803,7 +13845,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -13821,11 +13864,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -13838,15 +13883,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -13949,7 +13997,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -13959,6 +14008,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -13971,17 +14021,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -13998,6 +14051,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -14070,7 +14124,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -14080,6 +14135,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -14155,7 +14211,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -14185,6 +14242,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -14202,6 +14260,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -14240,11 +14299,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -14844,7 +14905,8 @@
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "home-or-tmp": {
       "version": "2.0.0",

--- a/packages/directory/package.json
+++ b/packages/directory/package.json
@@ -32,6 +32,7 @@
     "ember-moment": "^7.8.1",
     "ember-power-select": "^2.3.5",
     "ember-responsive": "^3.0.0-beta.3",
+    "ember-set-helper": "^0.1.1",
     "navi-core": "0.2.0",
     "navi-dashboards": "0.2.0",
     "navi-data": "0.2.0",

--- a/packages/reports/addon/templates/components/common-actions/schedule.hbs
+++ b/packages/reports/addon/templates/components/common-actions/schedule.hbs
@@ -58,7 +58,7 @@
             disabled=(is-rejected deliveryRule)
             searchEnabled=false
             tagName="div"
-            onchange=(action (mut localDeliveryRule.frequency))
+            onchange=(action (set localDeliveryRule "frequency" _))
             as | frequency |
           }}
             {{capitalize frequency}}

--- a/packages/reports/addon/templates/components/dropdown-date-picker.hbs
+++ b/packages/reports/addon/templates/components/dropdown-date-picker.hbs
@@ -8,7 +8,7 @@
     {{navi-date-picker
       date=_selectedDate
       dateTimePeriod="day"
-      onUpdate=(action (mut _selectedDate))
+      onUpdate=(action (set this "_selectedDate" _))
     }}
 
     <div class="dropdown-date-picker__controls">

--- a/packages/reports/addon/templates/components/navi-collection.hbs
+++ b/packages/reports/addon/templates/components/navi-collection.hbs
@@ -3,7 +3,7 @@
   {{pick-single
     selection=filter
     options=filterOptions
-    onUpdateSelection=(action (mut filter))
+    onUpdateSelection=(action (set this "filter" _))
     idField="filterKey"
     displayField="name"
   }}

--- a/packages/reports/addon/templates/components/navi-list-selector.hbs
+++ b/packages/reports/addon/templates/components/navi-list-selector.hbs
@@ -18,7 +18,7 @@
     spellcheck=false 
     class="navi-list-selector__search-input"
   }}
-  {{navi-icon "times-circle" class="navi-list-selector__search-input-clear" click=(action (mut query) undefined)}}
+  {{navi-icon "times-circle" class="navi-list-selector__search-input-clear" click=(action (set this "query" undefined))}}
 </div>
 <div class="navi-list-selector__content">
   {{#if (eq filteredItems.length 0)}}

--- a/packages/reports/addon/templates/components/power-select-bulk-import-trigger.hbs
+++ b/packages/reports/addon/templates/components/power-select-bulk-import-trigger.hbs
@@ -49,7 +49,7 @@
   {{dimension-bulk-import
     dimension=extra.filter.subject
     queryIds=_bulkImportQueryIds
-    onSelectValues=(pipe (action "importValues") (action (mut _showBulkImport) false))
-    onCancel=(action (mut _showBulkImport) false)
+    onSelectValues=(pipe (action "importValues") (action (set this "_showBulkImport" false)))
+    onCancel=(action (set this "_showBulkImport" false))
   }}
 {{/navi-modal}}

--- a/packages/reports/package-lock.json
+++ b/packages/reports/package-lock.json
@@ -3050,6 +3050,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
+      "optional": true,
       "requires": {
         "hoek": "2.x.x"
       }
@@ -10687,6 +10688,27 @@
         }
       }
     },
+    "ember-modifier-manager-polyfill": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.2.0.tgz",
+      "integrity": "sha512-bnaKF1LLKMkBNeDoetvIJ4vhwRPKIIumWr6dbVuW6W6p4QV8ZiO+GdF8J7mxDNlog9CeL9Z/7wam4YS86G8BYA==",
+      "requires": {
+        "ember-cli-babel": "^7.10.0",
+        "ember-cli-version-checker": "^2.1.2",
+        "ember-compatibility-helpers": "^1.2.0"
+      },
+      "dependencies": {
+        "ember-cli-version-checker": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
+          "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
+          "requires": {
+            "resolve": "^1.3.3",
+            "semver": "^5.3.0"
+          }
+        }
+      }
+    },
     "ember-moment": {
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/ember-moment/-/ember-moment-7.8.1.tgz",
@@ -10821,6 +10843,17 @@
             "object-assign": "4.1.1"
           }
         }
+      }
+    },
+    "ember-on-modifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ember-on-modifier/-/ember-on-modifier-1.0.0.tgz",
+      "integrity": "sha512-OPX5QrNiyXXQ//uN4cFj7gz5pt0rBK5c6LPEMP5iSK2I1J+WtiHM5Kg7mVCM7VziMiRUBVe3wp8CAE26m45hsA==",
+      "requires": {
+        "broccoli-funnel": "^2.0.2",
+        "ember-cli-babel": "^7.8.0",
+        "ember-cli-version-checker": "^3.1.3",
+        "ember-modifier-manager-polyfill": "^1.0.3"
       }
     },
     "ember-power-select": {
@@ -11888,6 +11921,15 @@
             "object-assign": "4.1.1"
           }
         }
+      }
+    },
+    "ember-set-helper": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ember-set-helper/-/ember-set-helper-0.1.1.tgz",
+      "integrity": "sha512-iv+Iw8WPWtdvfrVzvEs6ZEux8Lm2Tj+bHjcmXRQfHQGK9DVS2o97I9cEb75LONSIDawPToHW8p8XXCGijwogBA==",
+      "requires": {
+        "ember-cli-babel": "^7.7.3",
+        "ember-on-modifier": "^1.0.0"
       }
     },
     "ember-sortable": {
@@ -14458,7 +14500,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -14479,12 +14522,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -14499,17 +14544,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -14626,7 +14674,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -14638,6 +14687,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -14652,6 +14702,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -14659,12 +14710,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -14683,6 +14736,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -14763,7 +14817,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -14775,6 +14830,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -14860,7 +14916,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -14896,6 +14953,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -14915,6 +14973,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -14958,12 +15017,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -15581,7 +15642,8 @@
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "home-or-tmp": {
       "version": "2.0.0",

--- a/packages/reports/package.json
+++ b/packages/reports/package.json
@@ -44,6 +44,7 @@
     "ember-moment": "^7.8.1",
     "ember-promise-helpers": "^1.0.6",
     "ember-radio-button": "^1.2.1",
+    "ember-set-helper": "^0.1.1",
     "ember-tag-input": "^1.2.2",
     "ember-toggle": "^5.3.3",
     "ember-tooltips": "^3.2.0",


### PR DESCRIPTION
## Description
`mut` is a bit ambiguous in how it actually works under the hood. Read more about the issues with `mut` and how to live without it here https://www.pzuraq.com/on-mut-and-2-way-binding/
Essentially, the common usage of `mut` is not the behavior intended when it was created. The set helper is more explicit in what it is doing. 

## Proposed Changes

- Use `ember-set-helper` to be more explicit about how we set values in our actions

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
