### PR TITLE
Webservice publish

### DIFF
--- a/packages/webservice/LICENSE.md
+++ b/packages/webservice/LICENSE.md
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2019, Yahoo Holdings Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/webservice/README.md
+++ b/packages/webservice/README.md
@@ -1,0 +1,42 @@
+# navi-webservice
+
+The webservice that powers navi's persistence
+
+# Installation
+
+Latest models version: [ ![Download](https://api.bintray.com/packages/yahoo/maven/navi/images/download.svg) ](https://bintray.com/yahoo/maven/navi/_latestVersion)
+
+We provide a collection of models to use with [Elide](https://github.com/yahoo/elide) (check out the [demo app](./app) for usage)
+
+<details open=true><summary>Gradle</summary>
+
+```
+compile 'com.yahoo.navi:models:0.2.0'
+```
+
+</details>
+
+<details><summary>Maven</summary>
+
+```xml
+<dependency>
+  <groupId>com.yahoo.navi</groupId>
+  <artifactId>models</artifactId>
+  <version>0.2.0</version>
+  <type>pom</type>
+</dependency>
+```
+
+</details>
+
+# Running
+
+To run the demo app
+
+```shell script
+$ ./gradlew run
+```
+
+# License
+
+This project is licensed under the [MIT License](LICENSE.md)

--- a/packages/webservice/app/src/main/kotlin/com/yahoo/navi/ws/app/Main.kt
+++ b/packages/webservice/app/src/main/kotlin/com/yahoo/navi/ws/app/Main.kt
@@ -6,6 +6,9 @@ package com.yahoo.navi.ws.app
 import com.yahoo.elide.standalone.ElideStandalone
 
 fun main(args: Array<String>) {
-    val app = ElideStandalone(Settings())
+    val settings = Settings()
+    val app = ElideStandalone(settings)
+
+    println("Webservice running on http://localhost:${settings.port}")
     app.start()
 }

--- a/packages/webservice/build.gradle.kts
+++ b/packages/webservice/build.gradle.kts
@@ -1,7 +1,16 @@
+import groovy.json.JsonSlurper
+
+fun readVersion(): String {
+    val inputFile = File("${project.projectDir}/../../package.json")
+    val json = JsonSlurper().parseText(inputFile.readText()) as Map<*, *>
+    return json["version"] as String
+}
+val parentVersion = readVersion()
+
 allprojects {
-    group = "com.yahoo.navi.ws"
-    description = "webservice"
-    version = "1.0-SNAPSHOT"
+    group = "com.yahoo.navi"
+    description = "The persistence webservice for navi application data"
+    version = parentVersion
 }
 
 buildscript {
@@ -13,7 +22,7 @@ buildscript {
     }
 
     dependencies {
-        classpath(kotlin("gradle-plugin", version = "1.3.31"))
+        classpath(kotlin("gradle-plugin", version = "1.3.50"))
         classpath("org.jmailen.gradle:kotlinter-gradle:1.26.0")
     }
 }
@@ -21,7 +30,7 @@ buildscript {
 plugins {
     java
     base
-    kotlin("jvm") version "1.3.31" apply false
+    kotlin("jvm") version "1.3.50" apply false
     id("org.jmailen.kotlinter") version "1.26.0"
 }
 
@@ -40,8 +49,8 @@ subprojects {
     }
 
     dependencies {
-        implementation(kotlin("stdlib-jdk8", "1.3.31"))
-        implementation("com.yahoo.elide", "elide-standalone", "4.4.4")
+        implementation(kotlin("stdlib-jdk8", "1.3.50"))
+        implementation("com.yahoo.elide", "elide-standalone", "4.5.4")
         implementation("org.slf4j", "slf4j-api", "1.7.25")
         implementation("ch.qos.logback", "logback-core", "1.2.3")
         implementation("org.hibernate", "hibernate-validator", "4.0.2.GA")

--- a/packages/webservice/models/build.gradle.kts
+++ b/packages/webservice/models/build.gradle.kts
@@ -1,13 +1,60 @@
-description = "models"
+import com.jfrog.bintray.gradle.BintrayExtension
+
+description = "The models required to be stored for the webservice"
 
 plugins {
     base
     kotlin("jvm")
+    `maven-publish`
+    id("com.jfrog.bintray") version "1.8.4"
 }
 
 java {
     sourceSets {
         getByName("main").java.setSrcDirs(arrayListOf("src/main/kotlin"))
         getByName("test").java.setSrcDirs(arrayListOf("src/test/kotlin"))
+    }
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("models") {
+            from(components["java"])
+            pom {
+                name.set("Navi: Webservice models")
+                description.set(project.description)
+                url.set("https://github.com/yahoo/navi/tree/master/packages/webservice")
+                licenses {
+                    license {
+                        name.set("MIT License")
+                        url.set("http://www.opensource.org/licenses/mit-license.php")
+                        distribution.set("repo")
+                    }
+                }
+                developers {
+                    developer {
+                        email.set("team-navi@googlegroups.com")
+                    }
+                }
+            }
+        }
+    }
+
+    bintray {
+        user = System.getenv("BINTRAY_USER")
+        key = System.getenv("BINTRAY_KEY")
+        publish = true
+        setPublications("models")
+        pkg(delegateClosureOf<BintrayExtension.PackageConfig> {
+            repo = "maven"
+            name = "navi"
+            userOrg = "yahoo"
+            desc = "Navi is a production quality analytics reporting UI with out of the box support for Fili."
+            websiteUrl = "https://github.com/yahoo/navi/tree/master/packages/webservice"
+            issueTrackerUrl = "https://github.com/yahoo/navi/issues"
+            vcsUrl = "https://github.com/yahoo/navi.git"
+            setLabels("navi", "reports", "dashboards", "visualizations", "elide", "webservice")
+            setLicenses("MIT")
+        })
     }
 }


### PR DESCRIPTION
Part of #367 

## Description
The webservice is 
- already building

## Proposed Changes
adds ability to
- read version from top-level `package.json`
- push to [bintray](https://bintray.com/yahoo/maven/navi)/artifactory (for snapshots), but not set up for travis yet

---

I did not enable pushing from travis yet as we have to decide how versions will be managed
- should we publish a snapshot on every commit to master? (maybe yes)
- should we tie our version numbers to the rest of the packages? (currently yes)
- how will we create releases (not snapshots)? This depends on the previous question, I'm thinking manually bump versions in all the `package.json` files, reflect changes in changelog, submit a PR, merge, create a `git tag ...` for that release and have a workflow in travis for tags

There is currently a manually pushed version at `0.2.0`


## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
