### PR TITLE
Resize favorite icon

### DIFF
--- a/packages/dashboards/app/styles/navi-dashboards/components/navi-dashboard.less
+++ b/packages/dashboards/app/styles/navi-dashboards/components/navi-dashboard.less
@@ -32,6 +32,9 @@
 
   &__fav-icon {
     margin: 3px 10px;
+    .fa {
+      font-size: 18px;
+    }
   }
 
   &__widgets {

--- a/packages/reports/addon/templates/components/favorite-item.hbs
+++ b/packages/reports/addon/templates/components/favorite-item.hbs
@@ -1,3 +1,3 @@
 {{!-- Copyright 2017, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
-{{navi-icon (if isFavorite "star" "star-o") class="editable-label__icon"}}
+{{navi-icon (if isFavorite "star" "star-o")}}
 {{ember-tooltip text="Favorite" popperContainer="body" effect="none"}}

--- a/packages/reports/addon/templates/components/favorite-item.hbs
+++ b/packages/reports/addon/templates/components/favorite-item.hbs
@@ -1,3 +1,3 @@
 {{!-- Copyright 2017, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
-{{navi-icon (if isFavorite "star" "star-o" class="editable-label__icon")}}
+{{navi-icon (if isFavorite "star" "star-o") class="editable-label__icon"}}
 {{ember-tooltip text="Favorite" popperContainer="body" effect="none"}}

--- a/packages/reports/addon/templates/components/favorite-item.hbs
+++ b/packages/reports/addon/templates/components/favorite-item.hbs
@@ -1,3 +1,3 @@
 {{!-- Copyright 2017, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
-{{navi-icon (if isFavorite "star" "star-o")}}
+{{navi-icon (if isFavorite "star" "star-o" class="editable-label__icon")}}
 {{ember-tooltip text="Favorite" popperContainer="body" effect="none"}}


### PR DESCRIPTION
Resolves #

Added a star icon the same style as the edit icon
<!-- The above line will close the issue upon merge -->

## Description

Favorite and editing icons had different styles, as a result, they were displayed in different ways.

## Proposed Changes
-

## Screenshots

![image](https://user-images.githubusercontent.com/38421762/66697009-d0634f00-ecd1-11e9-8437-b4b2e6deba30.png)

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
