### PR TITLE
Fix: Dashboard filter alt primarykey support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ lerna-debug.log
 *.iml
 .idea/
 .vscode
+jsconfig.json

--- a/packages/dashboards/addon/components/dashboard-filters-collapsed-filter.js
+++ b/packages/dashboards/addon/components/dashboard-filters-collapsed-filter.js
@@ -8,6 +8,7 @@ import layout from '../templates/components/dashboard-filters-collapsed-filter';
 import { computed, get, getWithDefault } from '@ember/object';
 import { A as arr } from '@ember/array';
 import { isEmpty } from '@ember/utils';
+import { inject as service } from '@ember/service';
 
 const SUPPORTED_OPERATORS = {
   in: {
@@ -30,6 +31,7 @@ const SUPPORTED_OPERATORS = {
 export default Component.extend({
   layout,
   classNames: ['dashboard-filters-collapsed-filter'],
+  bardMetadata: service(),
 
   /**
    * The computed filter dimension display name.
@@ -69,6 +71,17 @@ export default Component.extend({
     }
 
     return getWithDefault(SUPPORTED_OPERATORS, `${op}.longName`, op);
+  }),
+
+  /**
+   * Which id field to use as ID display.
+   */
+  filterValueFieldId: computed('filter.{dimension.name,field}', function() {
+    const meta = this.bardMetadata.getById('dimension', get(this, 'filter.dimension.name'));
+    if (meta) {
+      return meta.idFieldName;
+    }
+    return get(this, 'filter.field');
   }),
 
   /**

--- a/packages/dashboards/addon/controllers/dashboards/dashboard/view.js
+++ b/packages/dashboards/addon/controllers/dashboards/dashboard/view.js
@@ -93,10 +93,12 @@ export default Controller.extend(ReportToWidget, {
       const filters = get(dashboard, 'filters')
         .toArray()
         .map(fil => fil.serialize()); //Native array of serialized filters
+      const dimensionMeta = bardMetadata.getById('dimension', dimension.dimension);
       const filter = store
         .createFragment('bard-request/fragments/filter', {
-          dimension: bardMetadata.getById('dimension', dimension.dimension),
-          operator: 'in'
+          dimension: dimensionMeta,
+          operator: 'in',
+          field: dimensionMeta.primaryKeyFieldName
         })
         .serialize();
 

--- a/packages/dashboards/addon/templates/components/dashboard-filters-collapsed-filter.hbs
+++ b/packages/dashboards/addon/templates/components/dashboard-filters-collapsed-filter.hbs
@@ -9,5 +9,5 @@
 </div>
 
 <div class="dashboard-filters-collapsed-filter__values">
-  {{#each filterValues as |value idx|}}{{if (not-eq idx 0) ", "}}<span class="dashboard-filters-collapsed-filter__value">{{format-dimension value filter.field}}</span>{{/each}}
+  {{#each filterValues as |value idx|}}{{if (not-eq idx 0) ", "}}<span class="dashboard-filters-collapsed-filter__value">{{format-dimension value filterValueFieldId}}</span>{{/each}}
 </div>

--- a/packages/dashboards/tests/acceptance/dashboard-filter-test.js
+++ b/packages/dashboards/tests/acceptance/dashboard-filter-test.js
@@ -136,8 +136,6 @@ module('Acceptance | Dashboard Filters', function(hooks) {
     assert
       .dom('.dashboard-filters-collapsed-filter__values')
       .matchesText(/[a-z ]+\(1\)/i, 'filter collapse display should show id and not key');
-
-    return new Promise(resolve => setTimeout(resolve, 5000));
   });
 
   test('dashboard filter query params - ui changes update the model', async function(assert) {

--- a/packages/dashboards/tests/acceptance/dashboard-filter-test.js
+++ b/packages/dashboards/tests/acceptance/dashboard-filter-test.js
@@ -104,6 +104,42 @@ module('Acceptance | Dashboard Filters', function(hooks) {
     );
   });
 
+  test('adding dimension with key primary id field creates correct request', async function(assert) {
+    await visit('/dashboards/1/view');
+
+    let dataRequests = [];
+
+    server.urlPrefix = `${config.navi.dataSources[0].uri}/v1`;
+    server.pretender.handledRequest = (verb, url, req) => {
+      if (url.includes('/v1/data')) {
+        dataRequests.push(req);
+      }
+      return { rows: [] };
+    };
+
+    await click('.dashboard-filters__expand-button');
+    await click('.dashboard-filters-expanded__add-filter-button');
+
+    await selectChoose('.dashboard-dimension-selector', 'Multi System Id');
+
+    await fillIn('.filter-builder-dimension__values input', '1');
+    await selectChoose('.filter-builder-dimension__values', '.item-row', 0);
+
+    assert.ok(
+      dataRequests.every(request => request.queryParams.filters == 'multiSystemId|key-in[k1]'),
+      'each widget request has the filter added using the key field'
+    );
+    assert.equal(dataRequests.length, 3, 'three data requests were made (one for each widget)');
+
+    await click('.dashboard-filters__expand-button');
+
+    assert
+      .dom('.dashboard-filters-collapsed-filter__values')
+      .matchesText(/[a-z ]+\(1\)/i, 'filter collapse display should show id and not key');
+
+    return new Promise(resolve => setTimeout(resolve, 5000));
+  });
+
   test('dashboard filter query params - ui changes update the model', async function(assert) {
     assert.expect(12);
 

--- a/packages/dashboards/tests/integration/components/dashboard-filters-collapsed-filter-test.js
+++ b/packages/dashboards/tests/integration/components/dashboard-filters-collapsed-filter-test.js
@@ -2,9 +2,16 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 module('Integration | Component | dashboard filters collapsed filter', function(hooks) {
   setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function() {
+    const MetadataService = this.owner.lookup('service:bard-metadata');
+    return MetadataService.loadMetadata();
+  });
 
   test('it renders', async function(assert) {
     this.filter = {
@@ -109,7 +116,7 @@ module('Integration | Component | dashboard filters collapsed filter', function(
     assert.dom(this.element).hasText('Property noop Something (1), ValueDesc (2)', 'falsy ops are rendered as "noop"');
   });
 
-  test('it respects the field provided by the filter', async function(assert) {
+  test('it respects the field provided by meta data', async function(assert) {
     this.filter = {
       dimension: {
         name: 'property',
@@ -120,7 +127,8 @@ module('Integration | Component | dashboard filters collapsed filter', function(
       rawValues: ['property|4', 'property|7', 'property|9'],
       values: [
         { key: 'property|7', id: 'property|4', description: 'Something' },
-        { key: 'property|4', id: 'property|7', description: 'ValueDesc' }
+        { key: 'property|4', id: 'property|7', description: 'ValueDesc' },
+        { key: 'property|9', id: 'property|9' }
       ]
     };
 
@@ -130,8 +138,8 @@ module('Integration | Component | dashboard filters collapsed filter', function(
     assert
       .dom(this.element)
       .hasText(
-        'property equals ValueDesc (property|4), Something (property|7), property|9',
-        'when field = "key" rawValues are matched against key prop, not id'
+        'property equals ValueDesc (property|7), Something (property|4), property|9',
+        'when field = "key" rawValues are matched against id prop, not key'
       );
   });
 });

--- a/packages/dashboards/tests/integration/components/dashboard-filters-collapsed-test.js
+++ b/packages/dashboards/tests/integration/components/dashboard-filters-collapsed-test.js
@@ -2,9 +2,16 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 module('Integration | Component | dashboard filters collapsed', function(hooks) {
   setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function() {
+    const MetadataService = this.owner.lookup('service:bard-metadata');
+    return MetadataService.loadMetadata();
+  });
 
   test('it renders empty', async function(assert) {
     await render(hbs`{{dashboard-filters-collapsed}}`);
@@ -25,7 +32,8 @@ module('Integration | Component | dashboard filters collapsed', function(hooks) 
           rawValues: ['property|4', 'property|7', 'property|9'],
           values: [
             { key: 'property|7', id: 'property|4', description: 'Something' },
-            { key: 'property|4', id: 'property|7', description: 'ValueDesc' }
+            { key: 'property|4', id: 'property|7', description: 'ValueDesc' },
+            { key: 'property|9', id: 'property|9' }
           ]
         },
         {
@@ -55,7 +63,7 @@ module('Integration | Component | dashboard filters collapsed', function(hooks) 
     assert
       .dom(this.element)
       .hasText(
-        'Property equals ValueDesc (property|4), Something (property|7), property|9 Fish contains Something (1), ValueDesc (2) Dog not equals 1, ValueDesc (2)',
+        'Property equals ValueDesc (property|7), Something (property|4), property|9 Fish contains Something (1), ValueDesc (2) Dog not equals 1, ValueDesc (2)',
         'All filters are correctly displayed'
       );
   });


### PR DESCRIPTION
<!-- The above line will close the issue upon merge -->

## Description

Found dashboards break when you use a dimension with alternative primary key.

## Proposed Changes

- Add support for looking up primaryKey field from metadata when filter is added.
- Change dimension display to pass in idField to formatter rather than filter field.

This will make it consistent with how we display dimension values in dropdowns and tag selectors.

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
