### PR TITLE
Fix: Directory filter unclickable in firefox

### DIFF
--- a/packages/directory/app/styles/navi-directory/components/dir-table-filter.less
+++ b/packages/directory/app/styles/navi-directory/components/dir-table-filter.less
@@ -20,7 +20,7 @@
     text-align: left;
     user-select: none;
     width: 120px;
-    
+
     &-type {
       margin-right: auto;
       width: 100%;
@@ -78,4 +78,5 @@
 .directory__table-filter {
   align-self: flex-end;
   margin-bottom: -30px;
+  z-index: 99;
 }


### PR DESCRIPTION
<!-- The above line will close the issue upon merge -->

## Description

Filter dropdown in directory in firefox is unclickable due to overlapping elements

## Proposed Changes

- style change

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
