### PR TITLE
Update: Enable Directory when installing navi-directory

### DIFF
--- a/packages/app/config/environment.js
+++ b/packages/app/config/environment.js
@@ -26,7 +26,6 @@ module.exports = function(environment) {
 
     navi: {
       FEATURES: {
-        enableDirectory: true,
         enableMultipleExport: false,
         enableTableEditing: true,
         enableChartStacking: true

--- a/packages/dashboards/tests/dummy/config/environment.js
+++ b/packages/dashboards/tests/dummy/config/environment.js
@@ -24,7 +24,6 @@ module.exports = function(environment) {
 
     navi: {
       FEATURES: {
-        enableDirectory: false,
         enableDashboardExport: true,
         enableMultipleExport: true,
         enableScheduleDashboards: true,

--- a/packages/directory/config/environment.js
+++ b/packages/directory/config/environment.js
@@ -1,3 +1,11 @@
 'use strict';
 
-module.exports = function(/* environment, appConfig */) {};
+module.exports = function(/* environment, appConfig */) {
+  return {
+    navi: {
+      FEATURES: {
+        enableDirectory: true //Enable directory whenever this addon is installed
+      }
+    }
+  };
+};

--- a/packages/directory/tests/dummy/config/environment.js
+++ b/packages/directory/tests/dummy/config/environment.js
@@ -21,7 +21,6 @@ module.exports = function(environment) {
 
     navi: {
       FEATURES: {
-        enableDirectory: true,
         exploreWidget: true,
         enableScheduleReports: true,
         enableScheduleDashboards: true

--- a/packages/reports/tests/dummy/config/environment.js
+++ b/packages/reports/tests/dummy/config/environment.js
@@ -12,7 +12,6 @@ module.exports = function(environment) {
          * Here you can enable experimental features on an ember canary build
          * e.g. 'with-controller': true
          */
-        enableDirectory: true
       },
       EXTEND_PROTOTYPES: {
         // Prevent Ember Data from overriding Date.parse.


### PR DESCRIPTION
Partially resolves #570 
## Description
App devs shouldn't need to enable directory if they install the addon.

## Proposed Changes

- Enable directory feature flag within the navi-directory environment.js

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
