### PR TITLE
Update: Publish to artifactory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,3 +59,7 @@ jobs:
       name: 'GitHub Pages'
       node_js: '8'
       if: branch = master AND repo = yahoo/navi AND type = push
+    - script: bash ./scripts/artifactory-publish.sh
+      name: 'Artifactory'
+      node_js: '8'
+      if: branch = master AND repo = yahoo/navi AND type = push

--- a/packages/webservice/README.md
+++ b/packages/webservice/README.md
@@ -4,7 +4,7 @@ The webservice that powers navi's persistence
 
 # Installation
 
-Latest models version: [ ![Download](https://api.bintray.com/packages/yahoo/maven/navi/images/download.svg) ](https://bintray.com/yahoo/maven/navi/_latestVersion)
+Latest models release: [ ![Download](https://api.bintray.com/packages/yahoo/maven/navi/images/download.svg) ](https://bintray.com/yahoo/maven/navi/_latestVersion)
 
 We provide a collection of models to use with [Elide](https://github.com/yahoo/elide) (check out the [demo app](./app) for usage)
 
@@ -28,6 +28,20 @@ compile 'com.yahoo.navi:models:0.2.0'
 ```
 
 </details>
+
+---
+
+You can also try the latest builds using the `0.2.0-SNAPSHOT` version by adding the snapshot repo
+
+_build.gradle.kts_
+
+```
+repositories {
+    maven {
+        url = uri("https://oss.jfrog.org/artifactory/oss-snapshot-local")
+    }
+}
+```
 
 # Running
 

--- a/packages/webservice/models/build.gradle.kts
+++ b/packages/webservice/models/build.gradle.kts
@@ -46,6 +46,14 @@ publishing {
 
 }
 
+tasks {
+    "artifactoryPublish" {
+        doFirst {
+            version = "$version-SNAPSHOT"
+        }
+    }
+}
+
 // Config for snapshot deploys
 artifactory {
     setContextUrl("https://oss.jfrog.org")
@@ -53,9 +61,8 @@ artifactory {
     publish(closureOf<PublisherConfig> {
         repository(closureOf<DoubleDelegateWrapper> {
             this.invokeMethod("setRepoKey", "oss-snapshot-local")
-            this.invokeMethod("setUsername", System.getenv("BINTRAY_USER"))
-            this.invokeMethod("setPassword", System.getenv("BINTRAY_KEY"))
-
+            this.invokeMethod("setUsername", System.getenv("ARTIFACTORY_USER"))
+            this.invokeMethod("setPassword", System.getenv("ARTIFACTORY_KEY"))
         })
         defaults(closureOf<ArtifactoryTask> {
             publications("models")

--- a/packages/webservice/models/build.gradle.kts
+++ b/packages/webservice/models/build.gradle.kts
@@ -47,9 +47,12 @@ publishing {
 }
 
 tasks {
-    "artifactoryPublish" {
+    "generatePomFileForModelsPublication" {
         doFirst {
-            version = "$version-SNAPSHOT"
+            if(project.gradle.taskGraph.hasTask(":models:artifactoryPublish")) {
+                version = "$version-SNAPSHOT"
+                println("Overriding version as $version for artifactory")
+            }
         }
     }
 }

--- a/scripts/artifactory-publish.sh
+++ b/scripts/artifactory-publish.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e # Exit with nonzero exit code if anything fails
+
+echo 'Deploying navi webservice models to artifactory'
+
+cd packages/webservice
+
+./gradlew -p models artifactoryPublish


### PR DESCRIPTION
Partially addresses #367 (still needs publishing for release versions)

## Description
The webservice should have some publishing set up so we don't have to manually deploy

## Proposed Changes
Upload snapshot builds from my artifactory account (the environment keys are set in travis) on pushes to master


## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
