### PR TITLE
Update: Add support for multiple fact datasources.

### DIFF
--- a/packages/data/tests/dummy/config/environment.js
+++ b/packages/data/tests/dummy/config/environment.js
@@ -25,7 +25,10 @@ module.exports = function(environment) {
     },
 
     navi: {
-      dataSources: [{ name: 'dummy', uri: 'https://data.naviapp.io' }],
+      dataSources: [
+        { name: 'dummy', uri: 'https://data.naviapp.io' },
+        { name: 'blockhead', uri: 'https://data2.naviapp.com' }
+      ],
       searchThresholds: {
         contains: 600,
         in: 50000

--- a/packages/data/tests/unit/adapters/bard-facts-test.js
+++ b/packages/data/tests/unit/adapters/bard-facts-test.js
@@ -5,6 +5,7 @@ import config from 'ember-get-config';
 import { assign } from '@ember/polyfills';
 
 const HOST = config.navi.dataSources[0].uri;
+const HOST2 = config.navi.dataSources[1].uri;
 
 const TestRequest = {
     logicalTable: {
@@ -594,7 +595,7 @@ module('Unit | Bard facts Adapter', function(hooks) {
   });
 
   test('urlForFindQuery', function(assert) {
-    assert.expect(5);
+    assert.expect(6);
 
     assert.equal(
       decodeURIComponent(Adapter.urlForFindQuery(TestRequest)),
@@ -644,6 +645,15 @@ module('Unit | Bard facts Adapter', function(hooks) {
         'metrics=m1,m2,r(p=123)&filters=d3|id-in[v1,v2],d4|id-in[v3,v4],d5|id-notin[""]&having=m1-gt[0]&' +
         'format=json&_cache=false',
       'urlForFindQuery correctly built the URL for the provided request with the cache option'
+    );
+
+    assert.equal(
+      decodeURIComponent(Adapter.urlForFindQuery(TestRequest, { dataSourceName: 'blockhead' })),
+      HOST2 +
+        '/v1/data/table1/grain1/d1/d2/?dateTime=2015-01-03/2015-01-04&' +
+        'metrics=m1,m2,r(p=123)&filters=d3|id-in[v1,v2],d4|id-in[v3,v4],d5|id-notin[""]&having=m1-gt[0]&' +
+        'format=json',
+      'uriForFindQuery renders alternative host name if option is given'
     );
   });
 
@@ -726,5 +736,17 @@ module('Unit | Bard facts Adapter', function(hooks) {
         baz: 'qux'
       }
     });
+  });
+
+  test('fetchDataForRequest with alternative datasource', function(assert) {
+    assert.expect(1);
+
+    Server.get(`${HOST2}/v1/data/table1/grain1/d1/d2/`, request => {
+      assert.ok(request.url.startsWith(HOST2), 'Alternative host was accessed');
+
+      return MockBardResponse;
+    });
+
+    return Adapter.fetchDataForRequest(TestRequest, { dataSourceName: 'blockhead' });
   });
 });

--- a/packages/data/tests/unit/adapters/bard-facts-test.js
+++ b/packages/data/tests/unit/adapters/bard-facts-test.js
@@ -665,6 +665,13 @@ module('Unit | Bard facts Adapter', function(hooks) {
     });
   });
 
+  test('get host works correctly', function(assert) {
+    assert.equal(Adapter._getHost('dummy'), HOST, 'Returns the correct uri');
+    assert.equal(Adapter._getHost('blockhead'), HOST2, 'Returns the correct uri with alternative host');
+    assert.equal(Adapter._getHost('spoon'), HOST, 'Returns first uri when name is not configured');
+    assert.equal(Adapter._getHost(), HOST, 'Returns default when name is not given');
+  });
+
   test('fetchDataForRequest with pagination options', function(assert) {
     assert.expect(1);
     return Adapter.fetchDataForRequest(TestRequest, {


### PR DESCRIPTION
## Description

While we configure fact datasources in navi as an array, the adapter only uses the first defined.
This will allow the service or users of the service to pick which datasource they want to use.

## Proposed Changes

- Add a host method that decides which host to use in the adapter.
- Use `dataSourceName` to choose which datasource to use when using the fact service.

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
