### PR TITLE
Update: Use same class for checkbox and dimension/metric labels

### DIFF
--- a/packages/dashboards/tests/acceptance/explore-widget-test.js
+++ b/packages/dashboards/tests/acceptance/explore-widget-test.js
@@ -123,9 +123,7 @@ module('Acceptance | Exploring Widgets', function(hooks) {
     assert.dom('.navi-report-widget__revert-btn').isNotVisible('Revert changes button is not initially visible');
 
     // Remove a metric
-    await click(
-      $('.checkbox-selector--dimension .grouped-list__item:contains(Week) .grouped-list__item-checkbox-label')[0]
-    );
+    await click($('.checkbox-selector--dimension .grouped-list__item:contains(Week) .grouped-list__item-label')[0]);
     assert
       .dom('.navi-report-widget__revert-btn')
       .isVisible('Revert changes button is visible once a change has been made');

--- a/packages/reports/addon/templates/components/dimension-selector.hbs
+++ b/packages/reports/addon/templates/components/dimension-selector.hbs
@@ -18,12 +18,12 @@
         <input
           type="checkbox"
           class="grouped-list__item-checkbox"
-          id={{concat "grouped-list-checkbox-" (dasherize item.longName)}}
+          id={{concat "grouped-list-item-checkbox-" (dasherize item.longName)}}
           onchange={{action "itemClicked" item}}
           checked={{get itemsChecked item.name}}
         >
-        <label for={{concat "grouped-list-checkbox-" (dasherize item.longName)}}
-          class="grouped-list__item-checkbox-label">
+        <label for={{concat "grouped-list-item-checkbox-" (dasherize item.longName)}}
+          class="grouped-list__item-label">
           {{item.longName}}
         </label>
       </div>

--- a/packages/reports/addon/templates/components/metric-config.hbs
+++ b/packages/reports/addon/templates/components/metric-config.hbs
@@ -17,7 +17,7 @@
         @items={{this.allParameters}}
         @searchField="name"
         @selected={{this.selectedParams}}
-        @title={{metric.longName}}
+        @title={{this.metric.longName}}
         as | params |
       >
         <GroupedList

--- a/packages/reports/app/styles/navi-reports/components/grouped-list.less
+++ b/packages/reports/app/styles/navi-reports/components/grouped-list.less
@@ -60,49 +60,49 @@
       &-container {
         position: relative;
       }
+    }
 
-      &-label {
-        &:before {
-          border-radius: 1px;
-          box-shadow: 0 0 0 2px rgba(54, 151, 242, 0.5);
-          content: '';
-          display: inline-block;
-          height: 8px;
-          margin: 0 5px;
-          transition: all 0.2s;
-          width: 8px;
-        }
-      }
-
-      &:hover + &-label:before {
-        box-shadow: 0 0 0 2px @denali-brand-600;
-      }
-
-      &:focus + &-label:before {
+    &-checkbox + &-label {
+      &:before {
+        border-radius: 1px;
         box-shadow: 0 0 0 2px rgba(54, 151, 242, 0.5);
-      }
-
-      &:checked + &-label:before {
-        box-shadow: 0 0 0 2px @denali-brand-600;
-        background: @denali-brand-600;
-      }
-
-      &:checked + &-label:after {
-        border: solid #fff;
-        border-width: 0 2px 2px 0; // creates the inverted "L" shape
-        box-sizing: border-box;
-        content: ' ';
-        display: block;
+        content: '';
+        display: inline-block;
         height: 8px;
-        left: 6px;
-        position: absolute;
-        top: 4px;
-        transform: rotate(45deg);
-        width: 5px;
+        margin: 0 5px;
+        transition: all 0.2s;
+        width: 8px;
       }
     }
 
-    &-label {
+    &-checkbox:hover + &-label:before {
+      box-shadow: 0 0 0 2px @denali-brand-600;
+    }
+
+    &-checkbox:focus + &-label:before {
+      box-shadow: 0 0 0 2px rgba(54, 151, 242, 0.5);
+    }
+
+    &-checkbox:checked + &-label:before {
+      box-shadow: 0 0 0 2px @denali-brand-600;
+      background: @denali-brand-600;
+    }
+
+    &-checkbox:checked + &-label:after {
+      border: solid #fff;
+      border-width: 0 2px 2px 0; // creates the inverted "L" shape
+      box-sizing: border-box;
+      content: ' ';
+      display: block;
+      height: 8px;
+      left: 6px;
+      position: absolute;
+      top: 4px;
+      transform: rotate(45deg);
+      width: 5px;
+    }
+
+    span&-label {
       cursor: pointer;
       margin: 0 3px;
     }

--- a/packages/reports/tests/acceptance/navi-report-test.js
+++ b/packages/reports/tests/acceptance/navi-report-test.js
@@ -146,9 +146,7 @@ module('Acceptance | Navi Report', function(hooks) {
       .isChecked('Day timegrain is checked by default');
 
     // uncheck the day timegrain
-    await click(
-      $('.checkbox-selector--dimension .grouped-list__item:contains(Day) .grouped-list__item-checkbox-label')[0]
-    );
+    await click($('.checkbox-selector--dimension .grouped-list__item:contains(Day) .grouped-list__item-label')[0]);
 
     assert
       .dom('.grouped-list__item-checkbox', $('.checkbox-selector--dimension .grouped-list__item:contains(Day)')[0])
@@ -182,9 +180,7 @@ module('Acceptance | Navi Report', function(hooks) {
     );
 
     // Remove a metric
-    await click(
-      $('.checkbox-selector--dimension .grouped-list__item:contains(Week) .grouped-list__item-checkbox-label')[0]
-    );
+    await click($('.checkbox-selector--dimension .grouped-list__item:contains(Week) .grouped-list__item-label')[0]);
 
     assert.dom('.navi-report__revert-btn').isVisible('Revert changes button is visible once a change has been made');
 
@@ -283,9 +279,7 @@ module('Acceptance | Navi Report', function(hooks) {
     await click('.navi-report__save-btn');
 
     // Change the Dim
-    await click(
-      $('.checkbox-selector--dimension .grouped-list__item:contains(Week) .grouped-list__item-checkbox-label')[0]
-    );
+    await click($('.checkbox-selector--dimension .grouped-list__item:contains(Week) .grouped-list__item-label')[0]);
 
     // And click Save AS the report
     await click('.navi-report__save-as-btn');
@@ -338,9 +332,7 @@ module('Acceptance | Navi Report', function(hooks) {
     await visit('/reports/1');
 
     // Change the Dim
-    await click(
-      $('.checkbox-selector--dimension .grouped-list__item:contains(Week) .grouped-list__item-checkbox-label')[0]
-    );
+    await click($('.checkbox-selector--dimension .grouped-list__item:contains(Week) .grouped-list__item-label')[0]);
 
     // And click Save AS the report
     await click('.navi-report__save-as-btn');
@@ -381,9 +373,7 @@ module('Acceptance | Navi Report', function(hooks) {
     await visit('/reports/1');
 
     // Change the Dim
-    await click(
-      $('.checkbox-selector--dimension .grouped-list__item:contains(Week) .grouped-list__item-checkbox-label')[0]
-    );
+    await click($('.checkbox-selector--dimension .grouped-list__item:contains(Week) .grouped-list__item-label')[0]);
 
     // And click Save AS the report
     await click('.navi-report__save-as-btn');
@@ -984,9 +974,7 @@ module('Acceptance | Navi Report', function(hooks) {
       'After navigating out of the route, the report model is rolled back'
     );
 
-    await click(
-      $('.checkbox-selector--dimension .grouped-list__item:contains(Week) .grouped-list__item-checkbox-label')[0]
-    );
+    await click($('.checkbox-selector--dimension .grouped-list__item:contains(Week) .grouped-list__item-label')[0]);
 
     //Navigate out of report
     await click('.navi-report__breadcrumb-link');
@@ -1566,7 +1554,7 @@ module('Acceptance | Navi Report', function(hooks) {
     assert.expect(3);
 
     await visit('/reports/1');
-    await click($('.grouped-list__item-checkbox-label:contains(Month)')[0]);
+    await click($('.grouped-list__item-label:contains(Month)')[0]);
 
     // Select the month Jan
     await click('.custom-range-form .pick-value');
@@ -1577,7 +1565,7 @@ module('Acceptance | Navi Report', function(hooks) {
 
     assert.dom('.date-range__select-trigger').hasText('Jan 2015', 'Month is changed to Jan 2015');
 
-    await click($('.grouped-list__item-checkbox-label:contains(Day)')[0]);
+    await click($('.grouped-list__item-label:contains(Day)')[0]);
     await click('.navi-report__run-btn');
 
     assert
@@ -1587,7 +1575,7 @@ module('Acceptance | Navi Report', function(hooks) {
         'Switching to day preserves the day casts the dates to match the time period'
       );
 
-    await click($('.grouped-list__item-checkbox-label:contains(Week)')[0]);
+    await click($('.grouped-list__item-label:contains(Week)')[0]);
     await click('.navi-report__run-btn');
 
     assert

--- a/packages/reports/tests/integration/components/dimension-selector-test.js
+++ b/packages/reports/tests/integration/components/dimension-selector-test.js
@@ -143,10 +143,10 @@ module('Integration | Component | dimension selector', function(hooks) {
     //select first time grain
 
     //addTimeGrain when a different time grain is clicked
-    await click($('.grouped-list__item:contains(Week) .grouped-list__item-checkbox-label')[0]);
+    await click($('.grouped-list__item:contains(Week) .grouped-list__item-label')[0]);
 
     //removeTimeGrain when selected time grain is clicked
-    await click($('.grouped-list__item:contains(Day) .grouped-list__item-checkbox-label')[0]);
+    await click($('.grouped-list__item:contains(Day) .grouped-list__item-label')[0]);
 
     this.set('addDimension', item => {
       assert.equal(


### PR DESCRIPTION
## Description

Use the same class name for time grain checkboxes and dimension/metric labels - helpful for functional/acceptance tests.

## Proposed Changes

Change `.grouped-list__item-checkbox-label` to `.grouped-list__item-label` and adjust css accordingly.

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
