### PR TITLE
Update: Metric config alignment when no filter

### DIFF
--- a/packages/reports/addon/templates/components/metric-config.hbs
+++ b/packages/reports/addon/templates/components/metric-config.hbs
@@ -1,13 +1,13 @@
 {{!-- Copyright 2019, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
-{{#basic-dropdown
-  calculatePosition=calculatePosition
+<BasicDropdown
+  @calculatePosition={{calculatePosition}}
   as |dd|
-}}
-  {{#dd.trigger class="metric-config__dropdown-trigger" onMouseDown=(action "triggerFetch")}}
+>
+  <dd.trigger @class="metric-config__dropdown-trigger" @onMouseDown={{action "triggerFetch"}}>
     <NaviIcon @icon="cog" class="metric-config__trigger-icon" />
-  {{/dd.trigger}}
+  </dd.trigger>
 
-  {{#dd.content class="metric-config__dropdown-container"}}
+  <dd.content @class="metric-config__dropdown-container">
     {{#if (is-pending parametersPromise)}}
       <NaviLoader />
     {{else if (is-rejected parametersPromise)}}
@@ -50,5 +50,5 @@
         <div class="metric-config__done-btn btn btn-primary" role="button" onclick={{action dd.actions.close}}>Done</div>
       </div>
     {{/if}}
-  {{/dd.content}}
-{{/basic-dropdown}}
+  </dd.content>
+</BasicDropdown>

--- a/packages/reports/addon/templates/components/metric-selector.hbs
+++ b/packages/reports/addon/templates/components/metric-selector.hbs
@@ -32,7 +32,7 @@
         </EmberTooltip>
       </NaviIcon>
 
-      <div class="grouped-list__icon-set {{if (not (can-having metric)) "metric-selector__icon-set--no-filter"}}">
+      <div class="grouped-list__icon-set {{if (not (can-having metric)) "grouped-list__icon-set--no-filter"}}">
         {{#if (get metric "hasParameters")}}
           <MetricConfig
             @metric={{metric}}

--- a/packages/reports/app/styles/navi-reports/components/grouped-list.less
+++ b/packages/reports/app/styles/navi-reports/components/grouped-list.less
@@ -140,7 +140,7 @@
 
     &--no-filter {
       .metric-config {
-        margin-right: 21px;
+        margin: 0 5px;
       }
     }
   }

--- a/packages/reports/tests/integration/components/metric-selector-test.js
+++ b/packages/reports/tests/integration/components/metric-selector-test.js
@@ -267,8 +267,8 @@ module('Integration | Component | metric selector', function(hooks) {
   });
 
   test('hide filter if metric not allowed to show filter on base metric', function(assert) {
-    assert.dom('.metric-selector__icon-set--no-filter').exists({ count: 1 });
-    assert.dom('.metric-selector__icon-set--no-filter .grouped-list__filter').doesNotExist();
+    assert.dom('.grouped-list__icon-set--no-filter').exists({ count: 1 });
+    assert.dom('.grouped-list__icon-set--no-filter .grouped-list__filter').doesNotExist();
     assert.dom('.grouped-list__icon-set .grouped-list__filter').exists();
   });
 });


### PR DESCRIPTION
## Description

Tiny styling change - align metric config trigger icon when there's no filter

## Screenshots

![Screen Shot 2019-11-18 at 5 00 21 PM](https://user-images.githubusercontent.com/13946669/69107612-cea24f00-0a26-11ea-85d5-59f3eaac5ef9.png)

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
