### PR TITLE
Fix: Revert removal of onAddMetricWithParameter

### DIFF
--- a/packages/reports/addon/templates/components/metric-config.hbs
+++ b/packages/reports/addon/templates/components/metric-config.hbs
@@ -30,7 +30,7 @@
           <div class="grouped-list__item-container">
             <span class="grouped-list__item-label" onclick={{action "paramToggled" metric param}} role="button">
               <NaviIcon
-                @icon={{if (and (get parametersChecked (concat param.param "|" param.id))) "minus-circle" "plus-circle"}}
+                @icon={{if (get parametersChecked (concat param.param "|" param.id)) "minus-circle" "plus-circle"}}
                 class="grouped-list__add-icon {{if (not (get parametersChecked (concat param.param "|" param.id))) "grouped-list__add-icon--deselected"}}"
               />
               {{param.description}} ({{param.id}})

--- a/packages/reports/addon/templates/components/report-builder.hbs
+++ b/packages/reports/addon/templates/components/report-builder.hbs
@@ -23,6 +23,7 @@
         class=(concat "report-builder__container report-builder__metric-selector" (if disabled " report-builder__container--disabled" ""))
         request=request
         onAddMetric=(update-report-action "ADD_METRIC")
+        onAddMetricWithParameter=(update-report-action "ADD_METRIC_WITH_PARAM")
         onRemoveMetric=(update-report-action "REMOVE_METRIC")
         onToggleMetricFilter=(update-report-action "TOGGLE_METRIC_FILTER")
       }}


### PR DESCRIPTION
## Description

Wrongly removed, was used by one of the apps. Also remove redundant `and`

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
