### PR TITLE
Update: Rename bard-facts service to navi-facts

### DIFF
--- a/packages/core/config/environment.js
+++ b/packages/core/config/environment.js
@@ -8,7 +8,7 @@ module.exports = function(/* environment, appConfig */) {
     navi: {
       user: 'navi_user',
       dataEpoch: '2013-01-01',
-      dataSources: [{ name: 'dummy', uri: 'https://data.naviapp.io' }],
+      dataSources: [{ name: 'dummy', uri: 'https://data.naviapp.io', type: 'bard-facts' }],
       appPersistence: {
         type: 'webservice',
         uri: 'https://persistence.naviapp.io',

--- a/packages/core/tests/dummy/config/environment.js
+++ b/packages/core/tests/dummy/config/environment.js
@@ -26,7 +26,7 @@ module.exports = function(environment) {
     navi: {
       user: 'navi_user',
       dataEpoch: '2013-01-01',
-      dataSources: [{ name: 'dummy', uri: 'https://data.naviapp.io' }],
+      dataSources: [{ name: 'dummy', uri: 'https://data.naviapp.io', type: 'bard-facts' }],
       appPersistence: {
         type: 'webservice',
         uri: 'https://persistence.naviapp.io',

--- a/packages/dashboards/addon/services/dashboard-data.js
+++ b/packages/dashboards/addon/services/dashboard-data.js
@@ -14,9 +14,9 @@ import DS from 'ember-data';
 
 export default Service.extend({
   /**
-   * @property {Ember.Service} bardFacts
+   * @property {Ember.Service} naviFacts
    */
-  bardFacts: service(),
+  naviFacts: service(),
 
   /**
    * @property {Ember.Service} store
@@ -187,6 +187,6 @@ export default Service.extend({
    * @returns {Promise} response from request
    */
   _fetch(request, options) {
-    return get(this, 'bardFacts').fetch(request, options);
+    return get(this, 'naviFacts').fetch(request, options);
   }
 });

--- a/packages/data/addon/services/navi-facts.js
+++ b/packages/data/addon/services/navi-facts.js
@@ -30,7 +30,9 @@ export default Service.extend({
   init() {
     this._super(...arguments);
 
-    const type = config.navi.dataSources[0].type;
+    //default datasource type to bard-facts if not defined
+    const type = config.navi.dataSources[0].type || 'bard-facts';
+
     //Instantiating the bard response adapter & serializer
     this.set('_adapter', getOwner(this).lookup(`adapter:${type}`));
     this.set('_serializer', getOwner(this).lookup(`serializer:${type}`));

--- a/packages/data/addon/services/navi-facts.js
+++ b/packages/data/addon/services/navi-facts.js
@@ -13,29 +13,23 @@ import config from 'ember-get-config';
 
 export default Service.extend({
   /**
-   * @private
-   * @property {Object} adapter - the adapter object
+   * @method _adapterFor
+   *
+   * @param {String} type
+   * @returns {Adapter} adpater instance for type
    */
-  _adapter: undefined,
+  _adapterFor(type = 'bard-facts') {
+    return getOwner(this).lookup(`adapter:${type}`);
+  },
 
   /**
-   * @private
-   * @property {Object} serializer - the serializer object
+   * @method _serializerFor
+   *
+   * @param {String} type
+   * @returns {Serializer} serializer instance for type
    */
-  _serializer: undefined,
-
-  /**
-   * @method init
-   */
-  init() {
-    this._super(...arguments);
-
-    //default datasource type to bard-facts if not defined
-    const type = config.navi.dataSources[0].type || 'bard-facts';
-
-    //Instantiating the bard response adapter & serializer
-    this.set('_adapter', getOwner(this).lookup(`adapter:${type}`));
-    this.set('_serializer', getOwner(this).lookup(`serializer:${type}`));
+  _serializerFor(type = 'bard-facts') {
+    return getOwner(this).lookup(`serializer:${type}`);
   },
 
   /**
@@ -56,7 +50,8 @@ export default Service.extend({
    * @returns {String} - url for the request
    */
   getURL(request, options) {
-    let adapter = this.get('_adapter');
+    const type = config.navi.dataSources[0].type,
+      adapter = this._adapterFor(type);
     return adapter.urlForFindQuery(request, options);
   },
 
@@ -70,8 +65,10 @@ export default Service.extend({
    * @returns {Promise} - Promise with the bard response model object
    */
   fetch(request, options) {
-    let adapter = this.get('_adapter'),
-      serializer = this.get('_serializer');
+    const type = config.navi.dataSources[0].type,
+      adapter = this._adapterFor(type),
+      serializer = this._serializerFor(type);
+
     return adapter.fetchDataForRequest(request, options).then(payload => {
       return NaviFactsModel.create({
         request: request,

--- a/packages/data/addon/services/navi-facts.js
+++ b/packages/data/addon/services/navi-facts.js
@@ -9,6 +9,7 @@ import Service from '@ember/service';
 import { getOwner } from '@ember/application';
 import NaviFactsModel from 'navi-data/models/navi-facts';
 import RequestBuilder from 'navi-data/builder/request';
+import config from 'ember-get-config';
 
 export default Service.extend({
   /**
@@ -29,11 +30,10 @@ export default Service.extend({
   init() {
     this._super(...arguments);
 
+    const type = config.navi.dataSources[0].type;
     //Instantiating the bard response adapter & serializer
-    let adapter = getOwner(this).lookup('adapter:bard-facts');
-
-    this.set('_adapter', adapter);
-    this.set('_serializer', getOwner(this).lookup('serializer:bard-facts'));
+    this.set('_adapter', getOwner(this).lookup(`adapter:${type}`));
+    this.set('_serializer', getOwner(this).lookup(`serializer:${type}`));
   },
 
   /**
@@ -81,25 +81,21 @@ export default Service.extend({
 
   /**
    * @method fetchNext
-   * @param {Object} response 
-   * @param {Object} request 
+   * @param {Object} response
+   * @param {Object} request
    * @return {Promise|null} returns the promise with the next set of results or null
    */
   fetchNext(response, request) {
     if (response.meta.pagination) {
-      const {
-        perPage,
-        numberOfResults, 
-        currentPage
-      } = response.meta.pagination;
-      
+      const { perPage, numberOfResults, currentPage } = response.meta.pagination;
+
       const totalPages = numberOfResults / perPage;
-      
+
       if (currentPage < totalPages) {
         let options = {
-            page: currentPage + 1,
-            perPage: perPage
-          };
+          page: currentPage + 1,
+          perPage: perPage
+        };
 
         return this.fetch(request, options);
       }
@@ -109,11 +105,11 @@ export default Service.extend({
 
   /**
    * @method fetchPrevious
-   * @param {Object} response 
-   * @param {Object} request 
+   * @param {Object} response
+   * @param {Object} request
    * @return {Promise|null} returns the promise with the previous set of results or null
    */
-  fetchPrevious(response, request){
+  fetchPrevious(response, request) {
     if (response.meta.pagination) {
       if (response.meta.pagination.currentPage > 1) {
         const options = {

--- a/packages/data/app/services/bard-facts.js
+++ b/packages/data/app/services/bard-facts.js
@@ -1,1 +1,0 @@
-export { default } from 'navi-data/services/bard-facts';

--- a/packages/data/app/services/navi-facts.js
+++ b/packages/data/app/services/navi-facts.js
@@ -1,0 +1,1 @@
+export { default } from 'navi-data/services/navi-facts';

--- a/packages/data/tests/dummy/config/environment.js
+++ b/packages/data/tests/dummy/config/environment.js
@@ -26,8 +26,8 @@ module.exports = function(environment) {
 
     navi: {
       dataSources: [
-        { name: 'dummy', uri: 'https://data.naviapp.io' },
-        { name: 'blockhead', uri: 'https://data2.naviapp.com' }
+        { name: 'dummy', uri: 'https://data.naviapp.io', type: 'bard-facts' },
+        { name: 'blockhead', uri: 'https://data2.naviapp.com', type: 'bard-facts' }
       ],
       searchThresholds: {
         contains: 600,

--- a/packages/data/tests/unit/services/navi-facts-test.js
+++ b/packages/data/tests/unit/services/navi-facts-test.js
@@ -49,11 +49,11 @@ const Response = {
 
 const HOST = config.navi.dataSources[0].uri;
 
-module('Unit | Service | Bard Facts', function(hooks) {
+module('Unit | Service | Navi Facts', function(hooks) {
   setupTest(hooks);
 
   hooks.beforeEach(function() {
-    Service = this.owner.lookup('service:bard-facts');
+    Service = this.owner.lookup('service:navi-facts');
 
     //setup Pretender
     Server = new Pretender(function() {
@@ -114,14 +114,14 @@ module('Unit | Service | Bard Facts', function(hooks) {
     assert.expect(3);
 
     return Service.fetch(TestRequest).then(function(model) {
-      assert.deepEqual(model.response, Response, 'Fetch returns a bardResponse model object for TestRequest');
+      assert.deepEqual(model.response, Response, 'Fetch returns a navi response model object for TestRequest');
 
-      assert.deepEqual(model.request, TestRequest, 'Fetch returns a bardResponse model object with the TestRequest');
+      assert.deepEqual(model.request, TestRequest, 'Fetch returns a navi response model object with the TestRequest');
 
       assert.deepEqual(
         model._factsService,
         Service,
-        'Fetch returns a bardResponse model object with the service instance'
+        'Fetch returns a navi response model object with the service instance'
       );
     });
   });
@@ -140,7 +140,7 @@ module('Unit | Service | Bard Facts', function(hooks) {
             }
           }
         },
-        'Fetch returns a bardResponse model object for the paginated request'
+        'Fetch returns a navi response model object for the paginated request'
       );
     });
   });
@@ -166,7 +166,7 @@ module('Unit | Service | Bard Facts', function(hooks) {
       assert.equal(
         response.payload.reason,
         'Result set too large.  Try reducing interval or dimensions.',
-        'Bard error is passed to catch block'
+        'error is passed to catch block'
       );
     });
   });
@@ -208,7 +208,7 @@ module('Unit | Service | Bard Facts', function(hooks) {
 
   test('fetchNext', function(assert) {
     assert.expect(2);
-    
+
     const originalFetch = Service.fetch;
     Service.fetch = (request, options) => {
       assert.equal(options.page, 3, 'FetchNext calls fetch with updated options');
@@ -225,19 +225,18 @@ module('Unit | Service | Bard Facts', function(hooks) {
       }
     };
     const request = {};
-    
+
     Service.fetchNext(response, request);
 
     response.meta.pagination.currentPage = 3;
     assert.equal(Service.fetchNext(response, request), null, 'fetchNext returns null when the last page is reached');
-    
 
     Service.fetch = originalFetch;
   });
 
   test('fetchPrevious', function(assert) {
     assert.expect(2);
-    
+
     const originalFetch = Service.fetch;
     Service.fetch = (request, options) => {
       assert.equal(options.page, 1, 'FetchPrevious calls fetch with updated options');
@@ -254,12 +253,16 @@ module('Unit | Service | Bard Facts', function(hooks) {
       }
     };
     const request = {};
-    
+
     Service.fetchPrevious(response, request);
 
     response.meta.pagination.currentPage = 1;
-    assert.equal(Service.fetchPrevious(response, request), null, 'fetchPrevious returns null when the first page is reached');
-    
+    assert.equal(
+      Service.fetchPrevious(response, request),
+      null,
+      'fetchPrevious returns null when the first page is reached'
+    );
+
     Service.fetch = originalFetch;
   });
 });

--- a/packages/reports/addon/components/common-actions/get-api.js
+++ b/packages/reports/addon/components/common-actions/get-api.js
@@ -24,7 +24,7 @@ export default Component.extend({
   /**
    * @property {Service} facts - instance of bard facts service
    */
-  facts: service('bard-facts'),
+  facts: service('navi-facts'),
 
   /**
    * @property {String} requestUrl - API link

--- a/packages/reports/addon/components/report-actions/export.js
+++ b/packages/reports/addon/components/report-actions/export.js
@@ -39,9 +39,9 @@ export default Component.extend({
   attributeBindings: ['target', 'href', 'download'],
 
   /**
-   * @property {Service} facts - instance of bard facts service
+   * @property {Service} facts - instance of navi facts service
    */
-  facts: service('bard-facts'),
+  facts: service('navi-facts'),
 
   /**
    * @property {Boolean} download - Boolean to check if request is valid and set download

--- a/packages/reports/addon/components/report-actions/multiple-format-export.js
+++ b/packages/reports/addon/components/report-actions/multiple-format-export.js
@@ -24,9 +24,9 @@ export default Component.extend({
   classNames: ['report-control', 'multiple-format-export'],
 
   /**
-   * @property {Service} facts - instance of bard facts service
+   * @property {Service} facts - instance of navi facts service
    */
-  facts: service('bard-facts'),
+  facts: service('navi-facts'),
 
   /**
    * @property {Service} compression

--- a/packages/reports/addon/routes/reports/report/view.js
+++ b/packages/reports/addon/routes/reports/report/view.js
@@ -11,9 +11,9 @@ import { reject } from 'rsvp';
 
 export default Route.extend({
   /**
-   * @property {Service} facts - instance of bard facts service
+   * @property {Service} facts - instance of navi facts service
    */
-  facts: service('bard-facts'),
+  facts: service('navi-facts'),
 
   /**
    * @property {Service} naviVisualizations - instance of navi visualizations service

--- a/packages/reports/config/environment.js
+++ b/packages/reports/config/environment.js
@@ -8,7 +8,7 @@ module.exports = function(/* environment, appConfig */) {
     navi: {
       user: 'navi_user',
       dataEpoch: '2013-01-01',
-      dataSources: [{ name: 'dummy', uri: 'https://data.naviapp.io' }],
+      dataSources: [{ name: 'dummy', uri: 'https://data.naviapp.io', type: 'bard-facts' }],
       appPersistence: {
         type: 'webservice',
         uri: 'https://persistence.naviapp.io',

--- a/packages/reports/tests/dummy/config/environment.js
+++ b/packages/reports/tests/dummy/config/environment.js
@@ -32,7 +32,7 @@ module.exports = function(environment) {
 
     navi: {
       user: 'navi_user',
-      dataSources: [{ name: 'dummy', uri: 'https://data.naviapp.io' }],
+      dataSources: [{ name: 'dummy', uri: 'https://data.naviapp.io', type: 'bard-facts' }],
       appPersistence: {
         type: 'webservice',
         uri: 'https://persistence.naviapp.io',

--- a/packages/reports/tests/integration/components/common-actions/get-api-test.js
+++ b/packages/reports/tests/integration/components/common-actions/get-api-test.js
@@ -31,7 +31,7 @@ module('Integration | Component | common actions/get api', function(hooks) {
 
     // Mock fact service
     this.owner.register(
-      'service:bard-facts',
+      'service:navi-facts',
       Service.extend({
         getURL: () => MockUrl
       })

--- a/packages/reports/tests/integration/components/report-actions/export-test.js
+++ b/packages/reports/tests/integration/components/report-actions/export-test.js
@@ -29,7 +29,7 @@ module('Integration | Component | report actions - export', function(hooks) {
   test('Component Renders', function(assert) {
     assert.expect(4);
 
-    let factService = this.owner.lookup('service:bard-facts'),
+    let factService = this.owner.lookup('service:navi-facts'),
       reportPromise = this.owner
         .lookup('service:bard-metadata')
         .loadMetadata()

--- a/packages/reports/tests/integration/components/report-actions/multiple-format-export-test.js
+++ b/packages/reports/tests/integration/components/report-actions/multiple-format-export-test.js
@@ -44,7 +44,7 @@ module('Integration | Component | report actions - multiple-format-export', func
   test('export links', async function(assert) {
     assert.expect(3);
 
-    let factService = this.owner.lookup('service:bard-facts');
+    let factService = this.owner.lookup('service:navi-facts');
 
     await render(TEMPLATE);
 


### PR DESCRIPTION
**BREAKING CHANGE**

Update: Rename bard-facts service to navi-facts
- Make the adpater and serializer types configurable
- update environment config to contain adpater and serializer type like below
```js
dataSources: [{ name: 'dummy', uri: 'https://data.naviapp.io', type: 'bard-facts' }]
```