### PR TITLE
Fix: Dashboard fixes

### DIFF
--- a/packages/core/addon/components/table-renderer-vertical-collection.js
+++ b/packages/core/addon/components/table-renderer-vertical-collection.js
@@ -95,11 +95,30 @@ export default Component.extend({
    * @returns {void}
    */
   _registerTableScroll() {
+    //detect passive feature
+    let supportsPassive = false;
+    try {
+      let opts = Object.defineProperty({}, 'passive', {
+        get: function() {
+          supportsPassive = true;
+          return true;
+        }
+      });
+      window.addEventListener('testPassive', null, opts);
+      window.removeEventListener('testPassive', null, opts);
+    } catch (e) {
+      // noop
+    }
+
     [get(this, 'tableWrapperDomElement'), get(this, 'tableHeadersDomElement')].forEach(elm =>
-      elm.addEventListener(SCROLL_EVENT, () => this._syncScroll())
+      elm.addEventListener(SCROLL_EVENT, () => this._syncScroll(), supportsPassive ? { passive: true } : false)
     );
 
-    get(this, 'tableHeadersDomElement').addEventListener(WHEEL_EVENT, e => this._headerWheelSync(e));
+    get(this, 'tableHeadersDomElement').addEventListener(
+      WHEEL_EVENT,
+      e => this._headerWheelSync(e),
+      supportsPassive ? { passive: true } : false
+    );
   },
 
   /**

--- a/packages/core/addon/components/table-renderer-vertical-collection.js
+++ b/packages/core/addon/components/table-renderer-vertical-collection.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018, Yahoo Holdings Inc.
+ * Copyright 2019, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Usage:
@@ -33,6 +33,21 @@ const SCROLL_EVENT = 'scroll';
  * @constant {String} WHEEL_EVENT - event for mouse and trackpad gestures
  */
 const WHEEL_EVENT = 'wheel';
+
+let supportsPassive = false;
+//detect passive feature
+try {
+  let opts = Object.defineProperty({}, 'passive', {
+    get: function() {
+      supportsPassive = true;
+      return true;
+    }
+  });
+  window.addEventListener('testPassive', null, opts);
+  window.removeEventListener('testPassive', null, opts);
+} catch (e) {
+  // noop
+}
 
 export default Component.extend({
   layout,
@@ -95,21 +110,6 @@ export default Component.extend({
    * @returns {void}
    */
   _registerTableScroll() {
-    //detect passive feature
-    let supportsPassive = false;
-    try {
-      let opts = Object.defineProperty({}, 'passive', {
-        get: function() {
-          supportsPassive = true;
-          return true;
-        }
-      });
-      window.addEventListener('testPassive', null, opts);
-      window.removeEventListener('testPassive', null, opts);
-    } catch (e) {
-      // noop
-    }
-
     [get(this, 'tableWrapperDomElement'), get(this, 'tableHeadersDomElement')].forEach(elm =>
       elm.addEventListener(SCROLL_EVENT, () => this._syncScroll(), supportsPassive ? { passive: true } : false)
     );

--- a/packages/core/app/styles/navi-core/visualizations/table.less
+++ b/packages/core/app/styles/navi-core/visualizations/table.less
@@ -45,6 +45,7 @@
     .display-flex;
     .flex-1;
     .flex-flow-column;
+    flex-basis: 0;
 
     &--vc {
       overflow-y: auto;


### PR DESCRIPTION
## Description

Dashboard widgets stopped scrolling

## Proposed Changes

- flex-basis is causing the table widget to be rendered in a overflowed hidden content.
- Add passive hints to table scroll events.

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
