### PR TITLE
Update: Move Metric Parameter Config to Request Preview Column Config

### DIFF
--- a/packages/core/addon/models/bard-request/fragments/metric.js
+++ b/packages/core/addon/models/bard-request/fragments/metric.js
@@ -6,7 +6,7 @@
 import DS from 'ember-data';
 import Fragment from 'ember-data-model-fragments/fragment';
 import { validator, buildValidations } from 'ember-cp-validations';
-import { computed, get } from '@ember/object';
+import { computed, get, set } from '@ember/object';
 import { canonicalizeMetric } from 'navi-data/utils/metric';
 import { Copyable } from 'ember-copy';
 
@@ -26,7 +26,7 @@ export default Fragment.extend(Copyable, Validations, {
    * ex: revenue(currency=USD)
    * @return string
    */
-  canonicalName: computed('metric', 'parameters', function() {
+  canonicalName: computed('metric.name', 'parameters.{}', function() {
     const metric = get(this, 'metric.name'),
       parameters = get(this, 'parameters') || {};
 
@@ -35,6 +35,17 @@ export default Fragment.extend(Copyable, Validations, {
       parameters
     });
   }),
+
+  /**
+   *
+   * @param {Object} parameter -
+   */
+  updateParameter(paramId, paramKey) {
+    const newParam = { [paramKey]: paramId };
+    const parameters = this.parameters;
+
+    set(this, 'parameters', Object.assign({}, parameters, newParam));
+  },
 
   /**
    * Overrides Ember.Copyable implemented in Fragment.copy

--- a/packages/core/addon/models/bard-request/fragments/metric.js
+++ b/packages/core/addon/models/bard-request/fragments/metric.js
@@ -38,8 +38,8 @@ export default Fragment.extend(Copyable, Validations, {
 
   /**
    * @method updateParameter - Update a parameter of the metric
-   * @param {String} parameterId - id property of parameter metadata object
-   * @param {String} parameterKey - name of the parameter type (e.g. currency)
+   * @param {String} paramId - id property of parameter metadata object
+   * @param {String} paramKey - name of the parameter type (e.g. currency)
    */
   updateParameter(paramId, paramKey) {
     const newParam = { [paramKey]: paramId };

--- a/packages/core/addon/models/bard-request/fragments/metric.js
+++ b/packages/core/addon/models/bard-request/fragments/metric.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018, Yahoo Holdings Inc.
+ * Copyright 2019, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 

--- a/packages/core/addon/models/bard-request/fragments/metric.js
+++ b/packages/core/addon/models/bard-request/fragments/metric.js
@@ -37,8 +37,9 @@ export default Fragment.extend(Copyable, Validations, {
   }),
 
   /**
-   *
-   * @param {Object} parameter -
+   * @method updateParameter - Update a parameter of the metric
+   * @param {String} parameterId - id property of parameter metadata object
+   * @param {String} parameterKey - name of the parameter type (e.g. currency)
    */
   updateParameter(paramId, paramKey) {
     const newParam = { [paramKey]: paramId };

--- a/packages/data/addon/services/metric-parameter.js
+++ b/packages/data/addon/services/metric-parameter.js
@@ -58,7 +58,6 @@ export default Service.extend({
     const promises = {};
     const parameterObj = metricMeta.parameters || {};
     const supportedTypes = this.supportedTypes();
-    const allParametersMap = {};
     const parameters = Object.entries(parameterObj).filter(([, paramMeta]) =>
       supportedTypes.includes(get(paramMeta, 'type'))
     );
@@ -68,6 +67,7 @@ export default Service.extend({
     });
 
     const promiseHash = hash(promises).then(res => {
+      const allParametersMap = {};
       //add property param to every element in each array
       Object.entries(res).forEach(([key, values]) => {
         const valArray = Array.isArray(values) ? values : values.toArray();

--- a/packages/reports/addon/components/navi-request-column-config/date-time.js
+++ b/packages/reports/addon/components/navi-request-column-config/date-time.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2019, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ *
+ * Description: Navi Request Column Config DateTime Component
+ *
+ * Usage:
+ *  <NaviRequestColumnConfig::DateTime
+ *    @column={{editingColumn}}
+ *    @metadata={{visualization.metadata}}
+ *    @onClose={{action "onClose"}}
+ *    @onUpdateColumnName={{action "onUpdateColumnName"}}
+ *  />
+ */
+import Component from '@ember/component';
+import { layout as templateLayout, tagName } from '@ember-decorators/component';
+import layout from '../../templates/components/navi-request-column-config/date-time';
+
+@tagName('')
+@templateLayout(layout)
+class DateTime extends Component {}
+
+export default DateTime;

--- a/packages/reports/addon/components/navi-request-column-config/dimension.js
+++ b/packages/reports/addon/components/navi-request-column-config/dimension.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2019, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ *
+ * Description: Navi Request Column Config Dimension Component
+ *
+ * Usage:
+ *  <NaviRequestColumnConfig::Dimension
+ *    @column={{editingColumn}}
+ *    @metadata={{visualization.metadata}}
+ *    @onClose={{action "onClose"}}
+ *    @onUpdateColumnName={{action "onUpdateColumnName"}}
+ *  />
+ */
+import Component from '@ember/component';
+import { layout as templateLayout, tagName } from '@ember-decorators/component';
+import layout from '../../templates/components/navi-request-column-config/dimension';
+
+@tagName('')
+@templateLayout(layout)
+class Dimension extends Component {}
+
+export default Dimension;

--- a/packages/reports/addon/components/navi-request-column-config/metric.js
+++ b/packages/reports/addon/components/navi-request-column-config/metric.js
@@ -41,7 +41,7 @@ class Metric extends Component {
    * @method didReceiveAttrs
    */
   didReceiveAttrs() {
-    super.didUpdateAttrs(...arguments);
+    super.didReceiveAttrs(...arguments);
     const { metric, canonicalName } = this.column.fragment;
     const prevMetricName = this._previousMetricName;
 

--- a/packages/reports/addon/components/navi-request-column-config/metric.js
+++ b/packages/reports/addon/components/navi-request-column-config/metric.js
@@ -1,0 +1,114 @@
+/**
+ * Copyright 2019, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ *
+ * Description: Navi Request Column Config Metric Component
+ *
+ * Usage:
+ *  <NaviRequestColumnConfig::Metric
+ *    @column={{editingColumn}}
+ *    @metadata={{visualization.metadata}}
+ *    @onClose={{action "onClose"}}
+ *    @onUpdateColumnName={{action "onUpdateColumnName"}}
+ *  />
+ */
+import Component from '@ember/component';
+import { layout as templateLayout, tagName } from '@ember-decorators/component';
+import layout from '../../templates/components/navi-request-column-config/metric';
+import { action, set, computed } from '@ember/object';
+import { inject as service } from '@ember/service';
+
+@tagName('')
+@templateLayout(layout)
+class Metric extends Component {
+  /**
+   * @service
+   */
+  @service('metric-parameter') parameterService;
+
+  /**
+   * @override
+   * @method init
+   */
+  init() {
+    super.init(...arguments);
+    this._previousMetric = null;
+    this._parametersPromise = null;
+  }
+
+  /**
+   * @override
+   * @method didReceiveAttrs
+   */
+  didReceiveAttrs() {
+    super.didUpdateAttrs(...arguments);
+    const { metric, canonicalName } = this.column.fragment;
+    const prevMetricName = this._previousMetricName;
+
+    if (!prevMetricName || canonicalName !== prevMetricName) {
+      this._fetchParameters(metric);
+    }
+
+    this._previousMetricName = canonicalName;
+  }
+
+  /**
+   * @property {Promise} currentParameter - Returns promise that returns parameter object of the currently applied parameter
+   */
+  @computed('column.fragment.parameters.{}', 'allParameters')
+  get currentParameter() {
+    const params = this.column.fragment.parameters || {};
+    const paramId = Object.keys(params).find(key => key !== 'as' && params[key]);
+    const loadedParamVals = this.allParameters;
+
+    if (!paramId) {
+      return null;
+    }
+
+    return loadedParamVals.then(vals => vals.find(param => param.param === paramId && param.id === params[paramId]));
+  }
+
+  /**
+   * @private
+   * @method _fetchParameters - fetch all parameter values for a given metric
+   * @param {Object} metric - metric meta data object
+   */
+  _fetchParameters(metric) {
+    if (!metric.hasParameters) {
+      this.set('allParameters', null);
+      return;
+    }
+
+    set(
+      this,
+      'allParameters',
+      this.parameterService.fetchAllParams(metric).then(result => {
+        return Object.values(result);
+      })
+    );
+  }
+
+  /**
+   * @action
+   * @param {Object} param - parameter object to be added to the metric
+   */
+  @action
+  updateMetricParam(param) {
+    const visMetadata = this.get('metadata.style.aliases');
+    const oldMetricName = this.column.fragment.canonicalName;
+
+    this.onUpdateMetricParam(oldMetricName, param.id, param.param);
+
+    const newMetricName = this.column.fragment.canonicalName;
+
+    if (Array.isArray(visMetadata)) {
+      const existingAlias = visMetadata.find(alias => alias.name === oldMetricName);
+
+      if (existingAlias) {
+        existingAlias.name = newMetricName;
+      }
+    }
+  }
+}
+
+export default Metric;

--- a/packages/reports/addon/components/navi-request-preview.js
+++ b/packages/reports/addon/components/navi-request-preview.js
@@ -46,16 +46,32 @@ class NaviRequestPreview extends Component {
   metricName;
 
   /**
+   * @private
+   * @property {Number} _editingColumnIndex - null when not editing column, index of the edited column otherwise
+   */
+  _editingColumnIndex = null;
+
+  /**
    * @property {Object} editingColumn - The column object that is currently being edited, null if not editing
    */
-  editingColumn = null;
+  @computed('_editingColumnIndex', 'columns.[]')
+  get editingColumn() {
+    const columnIndex = this._editingColumnIndex;
+    const columns = this.columns;
+
+    if (typeof columnIndex === 'number' && columnIndex > -1 && columnIndex < this.columns.length) {
+      return columns[columnIndex];
+    }
+    return null;
+  }
 
   /**
    * @property {Object[]} columns - column objects rendered in the template
    */
   @computed(
-    'request.{sort.@each.direction,metrics.[],dimensions.[],logicalTable.timeGrain}',
-    'visualization.metadata.style.aliases.@each.as'
+    'request.{sort.@each.direction,metrics.@each.parameters,dimensions.[],logicalTable.timeGrain}',
+    'visualization.metadata.style.aliases.@each.as',
+    'editingColumn.fragment.parameters.[]'
   )
   get columns() {
     const {
@@ -67,7 +83,8 @@ class NaviRequestPreview extends Component {
         type: 'metric',
         name: metric.canonicalName,
         displayName: this.getDisplayName(metric, 'metric', visualization),
-        sort: (sort.findBy('metric.canonicalName', metric.canonicalName) || { direction: 'none' }).direction
+        sort: (sort.findBy('metric.canonicalName', metric.canonicalName) || { direction: 'none' }).direction,
+        fragment: metric
       };
     });
     const dimensions = this.request.dimensions.toArray().map(dimension => {
@@ -75,7 +92,8 @@ class NaviRequestPreview extends Component {
         type: 'dimension',
         name: dimension.dimension.name,
         displayName: this.getDisplayName(dimension, 'dimension', visualization),
-        sort: null //TODO: Support sorts on dimensions
+        sort: null, //TODO: Support sorts on dimensions
+        fragment: dimension
       };
     });
     const columns = [...dimensions, ...metrics];
@@ -86,7 +104,8 @@ class NaviRequestPreview extends Component {
         type: 'dateTime',
         name: 'dateTime',
         displayName: this.getDisplayName(timeGrain, 'dateTime', visualization),
-        sort: (sort.findBy('metric.canonicalName', 'dateTime') || { direction: 'none' }).direction
+        sort: (sort.findBy('metric.canonicalName', 'dateTime') || { direction: 'none' }).direction,
+        fragment: timeGrain
       });
     }
 
@@ -158,8 +177,12 @@ class NaviRequestPreview extends Component {
       );
 
       if (existingAlias) {
-        set(existingAlias, 'as', newName);
-      } else {
+        if (newName === '') {
+          aliases.removeObject(existingAlias);
+        } else {
+          set(existingAlias, 'as', newName);
+        }
+      } else if (newName !== '') {
         aliases.pushObject({
           type: editingColumn.type,
           name: editingColumn.name,
@@ -198,13 +221,13 @@ class NaviRequestPreview extends Component {
 
   /**
    * @action
-   * @param {Object} column - contains type and name of column to remove from request
+   * @param {Object} index - index of the column we want to edit
    * @param {Object} dropdown - ember basic dropdown public api, used to close dropdown on edit
    */
   @action
-  editColumn(column, dropdown) {
+  editColumn(index, dropdown) {
     dropdown.actions.close();
-    this.set('editingColumn', column);
+    this.set('_editingColumnIndex', index);
   }
 
   /**
@@ -212,7 +235,7 @@ class NaviRequestPreview extends Component {
    */
   @action
   closeColumnConfig() {
-    this.set('editingColumn', null);
+    this.set('_editingColumnIndex', null);
   }
 
   /**

--- a/packages/reports/addon/components/navi-request-preview.js
+++ b/packages/reports/addon/components/navi-request-preview.js
@@ -56,10 +56,9 @@ class NaviRequestPreview extends Component {
    */
   @computed('_editingColumnIndex', 'columns.[]')
   get editingColumn() {
-    const columnIndex = this._editingColumnIndex;
-    const columns = this.columns;
+    const { _editingColumnIndex: columnIndex, columns } = this;
 
-    if (typeof columnIndex === 'number' && columnIndex > -1 && columnIndex < this.columns.length) {
+    if (typeof columnIndex === 'number' && 0 <= columnIndex && columnIndex < this.columns.length) {
       return columns[columnIndex];
     }
     return null;

--- a/packages/reports/addon/consumers/request/metric.js
+++ b/packages/reports/addon/consumers/request/metric.js
@@ -46,7 +46,8 @@ export default ActionConsumer.extend({
      * @action UPDATE_METRIC_PARAM
      * @param {Object} route - route that has a model that contains a request property
      * @param {String} metric - canonical name of metric to add
-     * @param {Object} parameter - selected metric parameter
+     * @param {String} parameterId - id property of parameter object, value of param
+     * @param {String} parameterKey - type of parameter, e.g. 'currency'
      */
     [RequestActions.UPDATE_METRIC_PARAM]({ currentModel }, metric, parameterId, parameterKey) {
       const metricModel = get(currentModel, 'request.metrics').findBy('canonicalName', metric);

--- a/packages/reports/addon/consumers/request/metric.js
+++ b/packages/reports/addon/consumers/request/metric.js
@@ -43,6 +43,18 @@ export default ActionConsumer.extend({
     },
 
     /**
+     * @action UPDATE_METRIC_PARAM
+     * @param {Object} route - route that has a model that contains a request property
+     * @param {String} metric - canonical name of metric to add
+     * @param {Object} parameter - selected metric parameter
+     */
+    [RequestActions.UPDATE_METRIC_PARAM]({ currentModel }, metric, parameterId, parameterKey) {
+      const metricModel = get(currentModel, 'request.metrics').findBy('canonicalName', metric);
+
+      metricModel && metricModel.updateParameter(parameterId, parameterKey);
+    },
+
+    /**
      * @action REMOVE_METRIC_WITH_PARAM
      * @param {Object} route - route that has a model that contains a request property
      * @param {Object} metric - metadata model of metric to add

--- a/packages/reports/addon/consumers/request/metric.js
+++ b/packages/reports/addon/consumers/request/metric.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018, Yahoo Holdings Inc.
+ * Copyright 2019, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import { inject as service } from '@ember/service';

--- a/packages/reports/addon/services/request-action-dispatcher.js
+++ b/packages/reports/addon/services/request-action-dispatcher.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018, Yahoo Holdings Inc.
+ * Copyright 2019, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import ActionDispatcher from 'navi-core/services/action-dispatcher';
@@ -30,6 +30,7 @@ export const RequestActions = {
 
   UPDATE_FILTER: 'updateFilter',
   UPDATE_FILTER_PARAM: 'updateFilterParam',
+  UPDATE_METRIC_PARAM: 'updateMetricParam',
   UPDATE_TABLE: 'updateTable',
   UPSERT_SORT: 'upsertSort'
 };

--- a/packages/reports/addon/templates/components/navi-request-column-config/base.hbs
+++ b/packages/reports/addon/templates/components/navi-request-column-config/base.hbs
@@ -13,10 +13,21 @@
       <Input 
         class="navi-request-column-config__column-name-input navi-request-column-config__option-input"
         @id="columnName" 
-        @value={{readonly column.displayName}}
-        @focus-out={{action onUpdateColumnName}}
-        @key-up={{action onUpdateColumnName}}
+        @value={{@column.displayName}}
+        @key-up={{action @onUpdateColumnName}}
       />
     </div>
+
+    {{#let (component (concat "navi-request-column-config/" (dasherize @column.type))) 
+        as | ColumnConfig |
+    }}
+      <ColumnConfig
+        @column={{@column}} 
+        @metadata={{@metadata}}
+        @onClose={{action @onClose}}
+        @onUpdateColumnName={{action @onUpdateColumnName}}
+        @onUpdateMetricParam={{update-report-action "UPDATE_METRIC_PARAM"}}
+      />
+    {{/let}}
   </div>
 </div>

--- a/packages/reports/addon/templates/components/navi-request-column-config/date-time.hbs
+++ b/packages/reports/addon/templates/components/navi-request-column-config/date-time.hbs
@@ -1,0 +1,2 @@
+{{!-- Copyright 2019, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{yield}}

--- a/packages/reports/addon/templates/components/navi-request-column-config/dimension.hbs
+++ b/packages/reports/addon/templates/components/navi-request-column-config/dimension.hbs
@@ -1,0 +1,2 @@
+{{!-- Copyright 2019, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{yield}}

--- a/packages/reports/addon/templates/components/navi-request-column-config/metric.hbs
+++ b/packages/reports/addon/templates/components/navi-request-column-config/metric.hbs
@@ -1,0 +1,38 @@
+{{!-- Copyright 2019, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+<div class="navi-request-column-config" ...attributes>
+  <div class="navi-request-column-config__header">
+    <span class="navi-request-column-config__header-label">Column Configuration</span>
+    <span class="navi-request-column-config__header-icons">
+      <NaviIcon @icon="star-o" class="navi-request-column-config__star-icon" role="button"/>
+      <NaviIcon @icon="times" class="navi-request-column-config__exit-icon" role="button" {{action this.onClose}}/>
+    </span>
+  </div>
+  <div class="navi-request-column-config__body">
+    <div class="navi-request-column-config__option navi-request-column-config__column-name">
+      <label for="columnName" class="navi-request-column-config__column-name-label navi-request-column-config__option-label">Column Name</label>
+      <Input 
+        class="navi-request-column-config__column-name-input navi-request-column-config__option-input"
+        @id="columnName" 
+        @value={{@column.displayName}}
+        @key-up={{action @onUpdateColumnName}}
+      />
+    </div>
+    {{#if this.column.fragment.metric.hasParameters}}
+      <div class="navi-request-column-config__option navi-request-column-config__parameter">
+        <label for="columnParameter" class="navi-request-column-config__parameter-label navi-request-column-config__option-label">Metric Parameter</label>
+        <PowerSelect 
+          @triggerClass="navi-request-column-config__parameter-trigger navi-request-column-config__option-input"
+          @triggerId="columnParameter" 
+          @dropdownClass="navi-request-column-config__parameter-dropdown"
+          @selected={{this.currentParameter}}
+          @searchPlaceholder="Type to search"
+          @options={{this.allParameters}}
+          @onchange={{action "updateMetricParam"}}
+          as | param |
+        >
+          {{param.description}} ({{param.id}})
+        </PowerSelect>
+      </div>
+    {{/if}}
+  </div>
+</div>

--- a/packages/reports/addon/templates/components/navi-request-column-config/metric.hbs
+++ b/packages/reports/addon/templates/components/navi-request-column-config/metric.hbs
@@ -1,38 +1,18 @@
 {{!-- Copyright 2019, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
-<div class="navi-request-column-config" ...attributes>
-  <div class="navi-request-column-config__header">
-    <span class="navi-request-column-config__header-label">Column Configuration</span>
-    <span class="navi-request-column-config__header-icons">
-      <NaviIcon @icon="star-o" class="navi-request-column-config__star-icon" role="button"/>
-      <NaviIcon @icon="times" class="navi-request-column-config__exit-icon" role="button" {{action this.onClose}}/>
-    </span>
+{{#if this.column.fragment.metric.hasParameters}}
+  <div class="navi-request-column-config__option navi-request-column-config__parameter">
+    <label for="columnParameter" class="navi-request-column-config__parameter-label navi-request-column-config__option-label">Metric Parameter</label>
+    <PowerSelect 
+      @triggerClass="navi-request-column-config__parameter-trigger navi-request-column-config__option-input"
+      @triggerId="columnParameter" 
+      @dropdownClass="navi-request-column-config__parameter-dropdown"
+      @selected={{this.currentParameter}}
+      @searchPlaceholder="Type to search"
+      @options={{this.allParameters}}
+      @onchange={{action "updateMetricParam"}}
+      as | param |
+    >
+      {{param.description}} ({{param.id}})
+    </PowerSelect>
   </div>
-  <div class="navi-request-column-config__body">
-    <div class="navi-request-column-config__option navi-request-column-config__column-name">
-      <label for="columnName" class="navi-request-column-config__column-name-label navi-request-column-config__option-label">Column Name</label>
-      <Input 
-        class="navi-request-column-config__column-name-input navi-request-column-config__option-input"
-        @id="columnName" 
-        @value={{@column.displayName}}
-        @key-up={{action @onUpdateColumnName}}
-      />
-    </div>
-    {{#if this.column.fragment.metric.hasParameters}}
-      <div class="navi-request-column-config__option navi-request-column-config__parameter">
-        <label for="columnParameter" class="navi-request-column-config__parameter-label navi-request-column-config__option-label">Metric Parameter</label>
-        <PowerSelect 
-          @triggerClass="navi-request-column-config__parameter-trigger navi-request-column-config__option-input"
-          @triggerId="columnParameter" 
-          @dropdownClass="navi-request-column-config__parameter-dropdown"
-          @selected={{this.currentParameter}}
-          @searchPlaceholder="Type to search"
-          @options={{this.allParameters}}
-          @onchange={{action "updateMetricParam"}}
-          as | param |
-        >
-          {{param.description}} ({{param.id}})
-        </PowerSelect>
-      </div>
-    {{/if}}
-  </div>
-</div>
+{{/if}}

--- a/packages/reports/addon/templates/components/navi-request-preview.hbs
+++ b/packages/reports/addon/templates/components/navi-request-preview.hbs
@@ -49,17 +49,12 @@
       </tbody>
     </table>
     {{#if editingColumn}}
-      {{#let (component (concat "navi-request-column-config/" (dasherize editingColumn.type))) 
-        as | ColumnConfig |
-      }}
-        <ColumnConfig
-          @column={{editingColumn}} 
-          @metadata={{visualization.metadata}}
-          @onClose={{action "closeColumnConfig"}}
-          @onUpdateColumnName={{action "updateColumnName"}}
-          @onUpdateMetricParam={{update-report-action "UPDATE_METRIC_PARAM"}}
-        />
-      {{/let}}
+      <NaviRequestColumnConfig::Base
+        @column={{editingColumn}} 
+        @metadata={{visualization.metadata}}
+        @onClose={{action "closeColumnConfig"}}
+        @onUpdateColumnName={{action "updateColumnName"}}
+      />
     {{/if}}
   </div>
 </div>

--- a/packages/reports/addon/templates/components/navi-request-preview.hbs
+++ b/packages/reports/addon/templates/components/navi-request-preview.hbs
@@ -3,7 +3,7 @@
   <div class="navi-request-preview__table-container">
     <table class="navi-request-preview__table">
       <thead class="navi-request-preview__table-header">
-        {{#each columns as |col|}}
+        {{#each columns as |col idx|}}
           <th class={{concat "navi-request-preview__column-header" " navi-request-preview__column-header--" col.type}}>
             <BasicDropdown 
               @calculatePosition={{calculatePosition}}
@@ -18,7 +18,7 @@
                     <NaviIcon @icon="trash-o" class="navi-request-preview__option-icon"/>
                     Remove
                   </li>
-                  <li class="navi-request-preview__column-header-option" role="button" {{action "editColumn" col dd}}>
+                  <li class="navi-request-preview__column-header-option" role="button" {{action "editColumn" idx dd}}>
                     <NaviIcon @icon="pencil" class="navi-request-preview__option-icon"/>
                     Edit
                   </li>
@@ -49,12 +49,17 @@
       </tbody>
     </table>
     {{#if editingColumn}}
-      <NaviRequestColumnConfig::Base 
-        @column={{editingColumn}} 
-        @metadata={{visualization.metadata}}
-        @onClose={{action "closeColumnConfig"}}
-        @onUpdateColumnName={{action "updateColumnName"}}
-      />
+      {{#let (component (concat "navi-request-column-config/" (dasherize editingColumn.type))) 
+        as | ColumnConfig |
+      }}
+        <ColumnConfig
+          @column={{editingColumn}} 
+          @metadata={{visualization.metadata}}
+          @onClose={{action "closeColumnConfig"}}
+          @onUpdateColumnName={{action "updateColumnName"}}
+          @onUpdateMetricParam={{update-report-action "UPDATE_METRIC_PARAM"}}
+        />
+      {{/let}}
     {{/if}}
   </div>
 </div>

--- a/packages/reports/app/components/navi-request-column-config/date-time.js
+++ b/packages/reports/app/components/navi-request-column-config/date-time.js
@@ -1,0 +1,1 @@
+export { default } from 'navi-reports/components/navi-request-column-config/base';

--- a/packages/reports/app/components/navi-request-column-config/date-time.js
+++ b/packages/reports/app/components/navi-request-column-config/date-time.js
@@ -1,1 +1,1 @@
-export { default } from 'navi-reports/components/navi-request-column-config/base';
+export { default } from 'navi-reports/components/navi-request-column-config/date-time';

--- a/packages/reports/app/components/navi-request-column-config/dimension.js
+++ b/packages/reports/app/components/navi-request-column-config/dimension.js
@@ -1,1 +1,1 @@
-export { default } from 'navi-reports/components/navi-request-column-config/base';
+export { default } from 'navi-reports/components/navi-request-column-config/dimension';

--- a/packages/reports/app/components/navi-request-column-config/dimension.js
+++ b/packages/reports/app/components/navi-request-column-config/dimension.js
@@ -1,0 +1,1 @@
+export { default } from 'navi-reports/components/navi-request-column-config/base';

--- a/packages/reports/app/components/navi-request-column-config/metric.js
+++ b/packages/reports/app/components/navi-request-column-config/metric.js
@@ -1,0 +1,1 @@
+export { default } from 'navi-reports/components/navi-request-column-config/metric';

--- a/packages/reports/app/styles/navi-reports/components/navi-request-column-config.less
+++ b/packages/reports/app/styles/navi-reports/components/navi-request-column-config.less
@@ -49,4 +49,35 @@
       padding: 10px 15px;
     }
   }
+
+  &__parameter {
+    &-trigger {
+      &,
+      &:focus {
+        border: none;
+      }
+
+      .ember-power-select-selected-item {
+        margin-left: 0;
+      }
+
+      .ember-power-select-status-icon {
+        display: inline-block;
+      }
+    }
+
+    &-dropdown.ember-power-select-dropdown {
+      border: 1px solid @navi-gray-300;
+      font-family: @font-family-sans-serif;
+      font-size: @font-size-mid-base;
+
+      .ember-power-select-search-input {
+        border: none;
+      }
+
+      .ember-power-select-option {
+        padding-left: 15px;
+      }
+    }
+  }
 }

--- a/packages/reports/tests/integration/components/navi-request-column-config/base-test.js
+++ b/packages/reports/tests/integration/components/navi-request-column-config/base-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
+import { helper as buildHelper } from '@ember/component/helper';
 import { render, triggerKeyEvent, click, fillIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
@@ -8,6 +9,7 @@ module('Integration | Component | navi-request-column-config/base', function(hoo
 
   test('it renders', async function(assert) {
     assert.expect(3);
+    this.owner.register('helper:update-report-action', buildHelper(() => {}), { instantiate: false });
 
     this.set('column', {
       name: 'property',

--- a/packages/reports/tests/integration/components/navi-request-column-config/metric-test.js
+++ b/packages/reports/tests/integration/components/navi-request-column-config/metric-test.js
@@ -1,0 +1,89 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click } from '@ember/test-helpers';
+import { A as arr } from '@ember/array';
+import { selectChoose } from 'ember-power-select/test-support/helpers';
+import hbs from 'htmlbars-inline-precompile';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+let MetadataService;
+
+module('Integration | Component | navi-request-column-config/metric', function(hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function() {
+    MetadataService = this.owner.lookup('service:bard-metadata');
+
+    return MetadataService.loadMetadata();
+  });
+
+  test('Configuring metric column', async function(assert) {
+    assert.expect(8);
+
+    const metric = this.owner.lookup('service:store').createFragment('bard-request/fragments/metric', {
+      metric: await MetadataService.findById('metric', 'revenue'),
+      parameters: {
+        currency: 'USD'
+      }
+    });
+    this.set('metadata', { style: { aliases: arr([]) } });
+    this.set('editingColumn', {
+      type: 'metric',
+      name: metric.canonicalName,
+      displayName: 'Revenue',
+      sort: 'none',
+      fragment: metric
+    });
+    this.set('onClose', () => {
+      assert.ok(true, 'onClose called');
+    });
+    this.set('onUpdateColumnName', newName => {
+      assert.equal(newName, 'Money', 'New display name is passed to name update action');
+    });
+    this.set('onUpdateMetricParam', (metricName, param) => {
+      assert.equal(metricName, 'revenue(currency=USD)', 'Metric name is passed with the currently selected parameter');
+      assert.equal(`${param.param}=${param.id}`, 'currency=CAD', 'Parameter is passed to onUpdateMetricParam method');
+      metric.set('parameters', { [param.param]: param.id });
+    });
+    await render(hbs`
+      <NaviRequestColumnConfig::Metric
+        @column={{editingColumn}} 
+        @metadata={{metadata}}
+        @onClose={{action onClose}}
+        @onUpdateColumnName={{action onUpdateColumnName}}
+        @onUpdateMetricParam={{action onUpdateMetricParam}}
+      />
+    `);
+
+    assert.dom('#columnName').hasValue('Revenue', 'Display name of column is shown in the column input');
+    assert.dom('#columnParameter').hasText('Dollars (USD)', 'Current parameter is displayed in the dropdown input');
+
+    await click('.navi-request-column-config__parameter-trigger.ember-power-select-trigger');
+    assert.deepEqual(
+      [...document.querySelectorAll('.ember-power-select-option')].map(el => el.textContent.trim()),
+      [
+        'NULL (-1)',
+        'UNKNOWN (-2)',
+        'Dirhams (AED)',
+        'Afghanis (AFA)',
+        'Leke (ALL)',
+        'Drams (AMD)',
+        'Guilders (ANG)',
+        'Kwanza (AOA)',
+        'Pesos (ARS)',
+        'Dollars (AUD)',
+        'Dollars (CAD)',
+        'Dollars (USD)',
+        'Euro (EUR)',
+        'Rupees (INR)'
+      ],
+      'The parameter values are loaded into the dropdown'
+    );
+    await selectChoose('#columnParameter', 'Dollars (CAD)');
+
+    assert.dom('#columnName').hasValue('Revenue', 'Custom display name is still shown when parameter is changed');
+    assert.dom('#columnParameter').hasText('Dollars (CAD)', 'Parameter selector shows new parameter value');
+    await click('.navi-request-column-config__exit-icon');
+  });
+});

--- a/packages/reports/tests/integration/components/navi-request-column-config/metric-test.js
+++ b/packages/reports/tests/integration/components/navi-request-column-config/metric-test.js
@@ -41,10 +41,10 @@ module('Integration | Component | navi-request-column-config/metric', function(h
     this.set('onUpdateColumnName', newName => {
       assert.equal(newName, 'Money', 'New display name is passed to name update action');
     });
-    this.set('onUpdateMetricParam', (metricName, param) => {
+    this.set('onUpdateMetricParam', (metricName, paramId, paramKey) => {
       assert.equal(metricName, 'revenue(currency=USD)', 'Metric name is passed with the currently selected parameter');
-      assert.equal(`${param.param}=${param.id}`, 'currency=CAD', 'Parameter is passed to onUpdateMetricParam method');
-      metric.set('parameters', { [param.param]: param.id });
+      assert.equal(`${paramKey}=${paramId}`, 'currency=CAD', 'Parameter is passed to onUpdateMetricParam method');
+      metric.set('parameters', { [paramKey]: paramId });
     });
     await render(hbs`
       <NaviRequestColumnConfig::Metric

--- a/packages/reports/tests/integration/components/navi-request-preview-test.js
+++ b/packages/reports/tests/integration/components/navi-request-preview-test.js
@@ -23,13 +23,14 @@ module('Integration | Component | navi-request-preview', function(hooks) {
     this.owner.register(
       'helper:update-report-action',
       buildHelper(([action]) => {
-        return (metricName, parameter) => {
+        return (metricName, parameterId, parameterKey) => {
           const actionName = UpdateReportActions[action];
           return UpdateReportAction.dispatch(
             actionName,
             { currentModel: { request: this.get('request') } },
             metricName,
-            parameter
+            parameterId,
+            parameterKey
           );
         };
       }),


### PR DESCRIPTION
## Description
Metric column config component should be able to change the parameter for a given metric column.

## Proposed Changes

- Add UPDATE_METRIC_PARAM method to metric fragment and request action consumer
- Move fetching of metric parameter values into the metric-parameter service
- Change `editingColumn` property to depend on index of the column instead of the `canonicalName` since that will change with param changes. This is a temporary solution until a rework in the request modeling is done.
- Add metric column config component with column name and metric parameter options
- Add components for dimension and date time as well that export the base column config component for now

## Screenshots
![Screen Shot 2019-12-10 at 5 56 00 PM](https://user-images.githubusercontent.com/23023478/70579473-5a1a8600-1b76-11ea-9ac8-ceb8e3bed2a5.png)

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
