### PR TITLE
New Visualization Selector

### DIFF
--- a/packages/core/addon/models/line-chart.js
+++ b/packages/core/addon/models/line-chart.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 
@@ -27,7 +27,7 @@ const Validations = buildValidations(
       disabled: computed('chartType', function() {
         return get(this, 'chartType') !== METRIC_SERIES;
       }),
-      dependentKeys: ['model._request.metrics.[]']
+      dependentKeys: ['model._request.metrics.@each.parameters.{}']
     }),
 
     [`${CONFIG_PATH}.timeGrain`]: validator('request-time-grain', {
@@ -42,7 +42,7 @@ const Validations = buildValidations(
       disabled: computed('chartType', function() {
         return get(this, 'chartType') !== DIMENSION_SERIES && get(this, 'chartType') !== DATE_TIME_SERIES;
       }),
-      dependentKeys: ['model._request.metrics.[]']
+      dependentKeys: ['model._request.metrics.@each.parameters.{}']
     }),
 
     [`${CONFIG_PATH}.dimensionOrder`]: validator('request-dimension-order', {

--- a/packages/core/addon/models/pie-chart.js
+++ b/packages/core/addon/models/pie-chart.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 
@@ -27,7 +27,7 @@ const Validations = buildValidations(
       disabled: computed('chartType', function() {
         return get(this, 'chartType') !== METRIC_SERIES;
       }),
-      dependentKeys: ['model._request.metrics.[]']
+      dependentKeys: ['model._request.metrics.@each.parameters.{}']
     }),
 
     //Dimension Series Validations
@@ -35,7 +35,7 @@ const Validations = buildValidations(
       disabled: computed('chartType', function() {
         return get(this, 'chartType') !== DIMENSION_SERIES;
       }),
-      dependentKeys: ['model._request.metrics.[]']
+      dependentKeys: ['model._request.metrics.@each.parameters.{}']
     }),
 
     [`${CONFIG_PATH}.dimensionOrder`]: validator('request-dimension-order', {

--- a/packages/core/addon/models/table.js
+++ b/packages/core/addon/models/table.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import { readOnly } from '@ember/object/computed';
@@ -25,7 +25,7 @@ const Validations = buildValidations(
       },
       dependentKeys: [
         'model._request.dimensions.[]',
-        'model._request.metrics.[]',
+        'model._request.metrics.@each.parameters.{}',
         'model._request.logicalTable.timeGrain.name'
       ]
     })

--- a/packages/reports/addon/components/navi-request-preview.js
+++ b/packages/reports/addon/components/navi-request-preview.js
@@ -195,25 +195,21 @@ class NaviRequestPreview extends Component {
    * @action
    * @param {Object} column - contains type and name of column to remove from request
    * @param {Object} dropdown - ember basic dropdown public api, used to close dropdown on removal
+   * @param {Number} columnIndex - index of the column being removed
    */
   @action
-  removeColumn(column, dropdown) {
-    const { type, name } = column;
-    const request = this.request;
+  removeColumn(column, dropdown, columnIndex) {
+    const { type } = column;
     const removalType = type === 'dateTime' ? 'TimeGrain' : capitalize(type);
     const removalHandler = get(this, `onRemove${removalType}`);
-    const fragmentToRemove = {
-      dimension: () => request.dimensions.findBy('dimension.name', name).dimension,
-      metric: () => request.metrics.findBy('canonicalName', name).metric,
-      dateTime: () => request.logicalTable.timeGrain
-    }[type]();
+    const fragmentToRemove = column.fragment;
 
     if (removalHandler && fragmentToRemove) {
       removalHandler(fragmentToRemove);
       dropdown.actions.close();
 
-      if (this.editingColumn && this.editingColumn.type === type && this.editingColumn.name === name) {
-        this.set('editingColumn', null);
+      if (this._editingColumnIndex === columnIndex) {
+        this.set('_editingColumnIndex', null);
       }
     }
   }

--- a/packages/reports/addon/components/report-view.js
+++ b/packages/reports/addon/components/report-view.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Usage:
@@ -14,96 +14,114 @@ import { scheduleOnce, later } from '@ember/runloop';
 import { capitalize } from '@ember/string';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
-import { set, get, computed, observer } from '@ember/object';
+import { set, get, computed, action } from '@ember/object';
 import layout from '../templates/components/report-view';
 import { DETAILS_DURATION } from '../transitions';
+import { layout as templateLayout, classNames } from '@ember-decorators/component';
+import { observes } from '@ember-decorators/object';
 
 const VISUALIZATION_RESIZE_EVENT = 'resizestop';
 
-export default Component.extend({
-  layout,
-
+@templateLayout(layout)
+@classNames('report-view') //Cannot be tagless because of the resize event needing an element value on this component
+class ReportView extends Component {
   /**
    * @property {Number} warningAnimationDuration - amount of time in ms for missing intervals warning to expand
    */
-  warningAnimationDuration: DETAILS_DURATION,
-
-  /**
-   * @property {Array} classNames
-   */
-  classNames: ['report-view'],
+  warningAnimationDuration = DETAILS_DURATION;
 
   /**
    * Property representing any data useful for providing additional functionality to a visualization and request
    * Acts a hook to be extended by other navi addons
    * @property {Promise} annotationData
    */
-  annotationData: undefined,
+  annotationData = undefined;
 
   /**
    * @property {Object} request
    */
-  request: readOnly('report.request'),
+  @readOnly('report.request')
+  request;
 
   /**
    * @property {Service} naviVisualizations - navi visualizations service
    */
-  naviVisualizations: service(),
+  @service('navi-visualizations')
+  naviVisualizations;
+
+  @service('store')
+  store;
 
   /**
    * @property {Array} visualizations - array of available visualizations
    * annotated with a field corresponding to whether the visualization type is valid based on the request
    */
-  validVisualizations: computed('response.rows', function() {
+  @computed('response.rows')
+  get validVisualizations() {
     return get(this, 'naviVisualizations').validVisualizations(get(this, 'report.request'));
-  }),
+  }
 
   /**
    * @property {String} visualizationTypeLabel - Display name of the visualization type
    */
-  visualizationTypeLabel: computed('report.visualization.type', function() {
+  @computed('report.visualization.type')
+  get visualizationTypeLabel() {
     return get(this, 'report.visualization.type')
       .split('-')
       .map(capitalize)
       .join(' ');
-  }),
+  }
 
   /**
    * @property {Boolean} isEditingVisualization - Display visualization config or not
    */
-  isEditingVisualization: false,
+  isEditingVisualization = false;
 
   /**
    * @property {Boolean} hasMostRecentResponse - whether or not response matches the most recent version of report.request
    */
-  hasMostRecentResponse: false,
+  hasMostRecentResponse = false;
+
+  /**
+   * @property {Boolean} showRequestPreview - true if request preview is selected, false otherwise
+   */
+  showRequestPreview = false;
+
+  /**
+   * @property {String} currentView - request-preview or the visualization type of the report
+   */
+  @computed('showRequestPreview', 'report.visualization.type')
+  get currentView() {
+    return this.showRequestPreview ? 'request-preview' : this.report.visualization.type;
+  }
 
   /**
    * @property {Boolean} hasNoData - whether or not there is data to display
    */
-  hasNoData: computed('response.meta.pagination.numberOfResults', function() {
+  @computed('response.meta.pagination.numberOfResults')
+  get hasNoData() {
     return get(this, 'response.meta.pagination.numberOfResults') === 0;
-  }),
+  }
 
   /**
    * @method didReceiveAttrs
    * @override
    */
   didReceiveAttrs() {
-    this._super(...arguments);
+    super.didReceiveAttrs(...arguments);
 
     // Assume any new response is always the most recent
     set(this, 'hasMostRecentResponse', true);
-  },
+  }
 
   /**
-   * @method resizeVisualization
+   * @method doResizeVisualization
    */
-  resizeVisualization() {
+  doResizeVisualization() {
     if (this.$()) {
       this.$().trigger(VISUALIZATION_RESIZE_EVENT);
     }
-  },
+  }
 
   /**
    * Observer that resizes the visualization when the number of filters or collapsed state change
@@ -111,28 +129,53 @@ export default Component.extend({
    *
    * @method filterCountOrCollapsedDidChange
    */
-  filterCountOrCollapsedDidChange: observer(
-    'isFiltersCollapsed',
-    'report.request.{filters.[],having.[],intervals.[]}',
-    function() {
-      scheduleOnce('afterRender', this, 'resizeVisualization');
-    }
-  ),
-
-  actions: {
-    /**
-     * @action toggleEditVisualization
-     */
-    toggleEditVisualization() {
-      this.toggleProperty('isEditingVisualization');
-      scheduleOnce('afterRender', this, 'resizeVisualization');
-    },
-
-    /**
-     * @action resizeVisualization
-     */
-    resizeVisualization(delay) {
-      later(this, 'resizeVisualization', delay);
-    }
+  @observes('isFiltersCollapsed', 'report.request.{filters.[],having.[],intervals.[]}')
+  filterCountOrCollapsedDidChange() {
+    scheduleOnce('afterRender', this, 'resizeVisualization');
   }
-});
+
+  /**
+   * @action toggleEditVisualization
+   */
+  @action
+  toggleEditVisualization() {
+    this.toggleProperty('isEditingVisualization');
+    scheduleOnce('afterRender', this, 'resizeVisualization');
+  }
+
+  /**
+   * @action resizeVisualization
+   */
+  @action
+  resizeVisualization(delay) {
+    later(this, 'doResizeVisualization', delay);
+  }
+
+  /**
+   * @action onVisualizationTypeUpdate
+   * @param {String} type
+   */
+  @action
+  onVisualizationTypeUpdate(type) {
+    const {
+      report,
+      report: { request },
+      response
+    } = this;
+
+    if (type === 'request-preview') {
+      this.set('showRequestPreview', true);
+      this.set('isEditingVisualization', false);
+      return;
+    }
+
+    let newVisualization = this.store.createFragment(type, {
+      _request: request //Provide request for validation
+    });
+    newVisualization.rebuildConfig(request, response);
+    set(report, 'visualization', newVisualization);
+    this.set('showRequestPreview', false);
+  }
+}
+
+export default ReportView;

--- a/packages/reports/addon/components/report-visualization.js
+++ b/packages/reports/addon/components/report-visualization.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Usage:
@@ -11,22 +11,19 @@
 
 import Component from '@ember/component';
 import { get, computed } from '@ember/object';
+import { layout as templateLayout, tagName } from '@ember-decorators/component';
 import { getOwner } from '@ember/application';
 import layout from '../templates/components/report-visualization';
 
-export default Component.extend({
-  layout,
-
-  /**
-   * @property {Array} classNames
-   */
-  classNames: ['report-visualization'],
-
+@templateLayout(layout)
+@tagName('')
+class ReportVisualization extends Component {
   /**
    * Object representing the metadata required by the visualization
    * @property {Object} visualizationHash
    */
-  visualizationHash: computed('report.request', 'response', function() {
+  @computed('report.request', 'response')
+  get visualizationHash() {
     let request = get(this, 'report.request').serialize(), // Visualization wants serialized request
       response = get(this, 'response') || { rows: [] };
 
@@ -34,12 +31,13 @@ export default Component.extend({
       request,
       response
     };
-  }),
+  }
 
   /**
    * @property {String} visualizationComponent - name of the visualization component
    */
-  visualizationComponent: computed('report.visualization.type', 'print', function() {
+  @computed('report.visualization.type', 'print')
+  get visualizationComponent() {
     const visType = get(this, 'report.visualization.type');
     if (visType === 'request-preview') {
       return 'navi-request-preview';
@@ -53,5 +51,7 @@ export default Component.extend({
       }
     }
     return componentName;
-  })
-});
+  }
+}
+
+export default ReportVisualization;

--- a/packages/reports/addon/components/report-visualization.js
+++ b/packages/reports/addon/components/report-visualization.js
@@ -40,7 +40,12 @@ export default Component.extend({
    * @property {String} visualizationComponent - name of the visualization component
    */
   visualizationComponent: computed('report.visualization.type', 'print', function() {
-    let componentName = `navi-visualizations/${get(this, 'report.visualization.type')}`;
+    const visType = get(this, 'report.visualization.type');
+    if (visType === 'request-preview') {
+      return 'navi-request-preview';
+    }
+
+    let componentName = `navi-visualizations/${visType}`;
     if (get(this, 'print')) {
       let printComponent = `${componentName}-print`;
       if (getOwner(this).factoryFor(`component:${printComponent}`)) {

--- a/packages/reports/addon/components/visualization-selector.js
+++ b/packages/reports/addon/components/visualization-selector.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2020, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ *
+ * Usage:
+ *  {{visualization-selector
+ *    report=report
+ *    validVisualizations=validVisualizations
+ *    onVisualizationTypeUpdate=(action 'onVisualizationTypeUpdate')
+ *  }}
+ */
+import Component from '@ember/component';
+import layout from '../templates/components/visualization-selector';
+import { layout as templateLayout, classNames } from '@ember-decorators/component';
+import { computed } from '@ember/object';
+
+@templateLayout(layout)
+@classNames('visualization-selector')
+class VisualizationSelector extends Component {
+  @computed('validVisualizations')
+  get visualizations() {
+    return [
+      {
+        name: 'request-preview',
+        niceName: 'Request Preview',
+        icon: 'paint-brush'
+      },
+      ...this.validVisualizations
+    ];
+  }
+}
+
+export default VisualizationSelector;

--- a/packages/reports/addon/components/visualization-selector.js
+++ b/packages/reports/addon/components/visualization-selector.js
@@ -11,11 +11,11 @@
  */
 import Component from '@ember/component';
 import layout from '../templates/components/visualization-selector';
-import { layout as templateLayout, classNames } from '@ember-decorators/component';
+import { layout as templateLayout, tagName } from '@ember-decorators/component';
 import { computed } from '@ember/object';
 
 @templateLayout(layout)
-@classNames('visualization-selector')
+@tagName('')
 class VisualizationSelector extends Component {
   @computed('validVisualizations')
   get visualizations() {

--- a/packages/reports/addon/consumers/request/dimension.js
+++ b/packages/reports/addon/consumers/request/dimension.js
@@ -33,6 +33,15 @@ export default ActionConsumer.extend({
     },
 
     /**
+     * @action REMOVE_DIMENSION_FRAGMENT
+     * @param {Object} route - route that has a model that contains a request property
+     * @param {Object} dimension - DS.Fragment of a dimension that should be removed from the request
+     */
+    [RequestActions.REMOVE_DIMENSION_FRAGMENT]({ currentModel }, dimension) {
+      get(currentModel, 'request').removeRequestDimension(dimension);
+    },
+
+    /**
      * @action DID_UPDATE_TIME_GRAIN
      * @param {Object} route - route that has a model that contains a request property
      * @param {Object} timeGrain - newly updated time grain

--- a/packages/reports/addon/consumers/request/metric.js
+++ b/packages/reports/addon/consumers/request/metric.js
@@ -33,6 +33,15 @@ export default ActionConsumer.extend({
     },
 
     /**
+     * @action REMOVE_METRIC_FRAGMENT
+     * @param {Object} route - route that has a model that contains a request property
+     * @param {Object} metric - DS.Fragment of a metric that should be removed from the request
+     */
+    [RequestActions.REMOVE_METRIC_FRAGMENT]({ currentModel }, metric) {
+      get(currentModel, 'request').removeRequestMetric(metric);
+    },
+
+    /**
      * @action ADD_METRIC_WITH_PARAM
      * @param {Object} route - route that has a model that contains a request property
      * @param {Object} metric - metadata model of metric to add

--- a/packages/reports/addon/routes/reports/report/view.js
+++ b/packages/reports/addon/routes/reports/report/view.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import { get, set, computed } from '@ember/object';
@@ -125,9 +125,6 @@ export default Route.extend({
     runReport() {
       // Run the report only if there are request changes
       if (!this._hasRequestRun()) {
-        if (this.parentModel.visualization.type === 'request-preview') {
-          this.send('onVisualizationTypeUpdate', 'table');
-        }
         return this.refresh();
       } else {
         this.send('setReportState', 'completed');
@@ -141,9 +138,6 @@ export default Route.extend({
      * @returns {Transition} - refreshes model transition
      */
     forceRun() {
-      if (this.parentModel.visualization.type === 'request-preview') {
-        this.send('onVisualizationTypeUpdate', 'table');
-      }
       return this.refresh();
     },
 
@@ -190,27 +184,6 @@ export default Route.extend({
       this.send('setReportState', 'completed');
 
       return true;
-    },
-
-    /**
-     * @action onVisualizationTypeUpdate
-     * @param {String} type
-     */
-    onVisualizationTypeUpdate(type) {
-      let report = get(this, 'parentModel'),
-        request = get(report, 'request'),
-        response = this.currentModel.response;
-
-      if (type === 'request-preview') {
-        set(report, 'visualization', { type: 'request-preview' });
-        return;
-      }
-
-      let newVisualization = this.store.createFragment(type, {
-        _request: request //Provide request for validation
-      });
-      newVisualization.rebuildConfig(request, response);
-      set(report, 'visualization', newVisualization);
     }
   }
 });

--- a/packages/reports/addon/routes/reports/report/view.js
+++ b/packages/reports/addon/routes/reports/report/view.js
@@ -195,6 +195,11 @@ export default Route.extend({
         request = get(report, 'request'),
         response = this.currentModel.response;
 
+      if (type === 'request-preview') {
+        set(report, 'visualization', { type: 'request-preview' });
+        return;
+      }
+
       let newVisualization = this.store.createFragment(type, {
         _request: request //Provide request for validation
       });

--- a/packages/reports/addon/routes/reports/report/view.js
+++ b/packages/reports/addon/routes/reports/report/view.js
@@ -125,6 +125,9 @@ export default Route.extend({
     runReport() {
       // Run the report only if there are request changes
       if (!this._hasRequestRun()) {
+        if (this.parentModel.visualization.type === 'request-preview') {
+          this.send('onVisualizationTypeUpdate', 'table');
+        }
         return this.refresh();
       } else {
         this.send('setReportState', 'completed');
@@ -138,6 +141,9 @@ export default Route.extend({
      * @returns {Transition} - refreshes model transition
      */
     forceRun() {
+      if (this.parentModel.visualization.type === 'request-preview') {
+        this.send('onVisualizationTypeUpdate', 'table');
+      }
       return this.refresh();
     },
 

--- a/packages/reports/addon/services/request-action-dispatcher.js
+++ b/packages/reports/addon/services/request-action-dispatcher.js
@@ -16,7 +16,9 @@ export const RequestActions = {
   DID_UPDATE_TIME_GRAIN: 'didUpdateTimeGrain',
 
   REMOVE_DIMENSION: 'removeDimension',
+  REMOVE_DIMENSION_FRAGMENT: 'removeDimensionFragment',
   REMOVE_METRIC: 'removeMetric',
+  REMOVE_METRIC_FRAGMENT: 'removeMetricFragment',
   REMOVE_METRIC_WITH_PARAM: 'removeMetricWithParam',
   REMOVE_TIME_GRAIN: 'removeTimeGrain',
   REMOVE_FILTER: 'removeFilter',

--- a/packages/reports/addon/templates/components/navi-request-preview.hbs
+++ b/packages/reports/addon/templates/components/navi-request-preview.hbs
@@ -2,7 +2,7 @@
 <div class="navi-request-preview" ...attributes>
   <div class="navi-request-preview__table-container">
     <table class="navi-request-preview__table">
-      <thead class="navi-request-preview__table-header{{if this.editingColumn " navi-request-preview__table-header--editing"}}">
+      <thead class="navi-request-preview__table-header {{if this.editingColumn "navi-request-preview__table-header--editing"}}">
         {{#each columns as |col idx|}}
           <th class={{concat "navi-request-preview__column-header" " navi-request-preview__column-header--" col.type}}>
             <BasicDropdown 
@@ -32,7 +32,7 @@
             {{#unless (eq col.type "dimension")}} 
               <NaviIcon 
                 @icon={{if (eq col.sort "asc") "chevron-up" "chevron-down"}} 
-                class="navi-request-preview__column-header-sort navi-request-preview__icon {{if (eq col.sort "none") " inactive"}}"
+                class="navi-request-preview__column-header-sort navi-request-preview__icon {{if (eq col.sort "none") "inactive"}}"
                 role="button"
                 {{action "sortClicked" col}}
               />
@@ -40,7 +40,7 @@
           </th>
         {{/each}}
       </thead>
-      <tbody class="navi-request-preview__table-body{{if this.editingColumn " navi-request-preview__table-body--editing"}}">
+      <tbody class="navi-request-preview__table-body {{if this.editingColumn "navi-request-preview__table-body--editing"}}">
         <tr class="navi-request-preview__table-row">
           <td class="navi-request-preview__table-cell">
             {{!-- Nothing here yet! --}}

--- a/packages/reports/addon/templates/components/navi-request-preview.hbs
+++ b/packages/reports/addon/templates/components/navi-request-preview.hbs
@@ -4,7 +4,7 @@
     <table class="navi-request-preview__table">
       <thead class="navi-request-preview__table-header {{if this.editingColumn "navi-request-preview__table-header--editing"}}">
         {{#each columns as |col idx|}}
-          <th class={{concat "navi-request-preview__column-header " (if (eq idx this._editingColumnIndex) "navi-request-preview__column-header--editing ") "navi-request-preview__column-header--" col.type}}>
+          <th class="navi-request-preview__column-header navi-request-preview__column-header--{{col.type}} {{if (eq idx this._editingColumnIndex) "navi-request-preview__column-header--editing"}}">
             <BasicDropdown 
               @calculatePosition={{calculatePosition}}
               as |dd|
@@ -14,7 +14,7 @@
               </dd.trigger>
               <dd.content @class="navi-request-preview__column-header-options-content dropdown-arrow">
                 <ul class="navi-request-preview__column-header-options-list">
-                  <li class="navi-request-preview__column-header-option" role="button" {{action "removeColumn" col dd idx}}>
+                  <li class="navi-request-preview__column-header-option" role="button" {{on "click" (fn this.removeColumn col dd idx)}}>
                     <NaviIcon @icon="trash-o" class="navi-request-preview__option-icon"/>
                     Remove
                   </li>

--- a/packages/reports/addon/templates/components/navi-request-preview.hbs
+++ b/packages/reports/addon/templates/components/navi-request-preview.hbs
@@ -2,7 +2,7 @@
 <div class="navi-request-preview" ...attributes>
   <div class="navi-request-preview__table-container">
     <table class="navi-request-preview__table">
-      <thead class={{concat "navi-request-preview__table-header" (if this.editingColumn " navi-request-preview__table-header--editing")}}>
+      <thead class="navi-request-preview__table-header{{if this.editingColumn " navi-request-preview__table-header--editing"}}">
         {{#each columns as |col idx|}}
           <th class={{concat "navi-request-preview__column-header" " navi-request-preview__column-header--" col.type}}>
             <BasicDropdown 
@@ -32,7 +32,7 @@
             {{#unless (eq col.type "dimension")}} 
               <NaviIcon 
                 @icon={{if (eq col.sort "asc") "chevron-up" "chevron-down"}} 
-                class={{concat "navi-request-preview__column-header-sort navi-request-preview__icon" (if (eq col.sort "none") " inactive")}}
+                class="navi-request-preview__column-header-sort navi-request-preview__icon {{if (eq col.sort "none") " inactive"}}"
                 role="button"
                 {{action "sortClicked" col}}
               />
@@ -40,7 +40,7 @@
           </th>
         {{/each}}
       </thead>
-      <tbody class={{concat "navi-request-preview__table-body" (if this.editingColumn " navi-request-preview__table-body--editing")}}>
+      <tbody class="navi-request-preview__table-body{{if this.editingColumn " navi-request-preview__table-body--editing"}}">
         <tr class="navi-request-preview__table-row">
           <td class="navi-request-preview__table-cell">
             {{!-- Nothing here yet! --}}

--- a/packages/reports/addon/templates/components/navi-request-preview.hbs
+++ b/packages/reports/addon/templates/components/navi-request-preview.hbs
@@ -4,7 +4,7 @@
     <table class="navi-request-preview__table">
       <thead class="navi-request-preview__table-header {{if this.editingColumn "navi-request-preview__table-header--editing"}}">
         {{#each columns as |col idx|}}
-          <th class={{concat "navi-request-preview__column-header" " navi-request-preview__column-header--" col.type}}>
+          <th class={{concat "navi-request-preview__column-header " (if (eq idx this._editingColumnIndex) "navi-request-preview__column-header--editing ") "navi-request-preview__column-header--" col.type}}>
             <BasicDropdown 
               @calculatePosition={{calculatePosition}}
               as |dd|
@@ -14,7 +14,7 @@
               </dd.trigger>
               <dd.content @class="navi-request-preview__column-header-options-content dropdown-arrow">
                 <ul class="navi-request-preview__column-header-options-list">
-                  <li class="navi-request-preview__column-header-option" role="button" {{action "removeColumn" col dd}}>
+                  <li class="navi-request-preview__column-header-option" role="button" {{action "removeColumn" col dd idx}}>
                     <NaviIcon @icon="trash-o" class="navi-request-preview__option-icon"/>
                     Remove
                   </li>

--- a/packages/reports/addon/templates/components/navi-request-preview.hbs
+++ b/packages/reports/addon/templates/components/navi-request-preview.hbs
@@ -1,4 +1,4 @@
-{{!-- Copyright 2019, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 <div class="navi-request-preview" ...attributes>
   <div class="navi-request-preview__table-container">
     <table class="navi-request-preview__table">

--- a/packages/reports/addon/templates/components/navi-request-preview.hbs
+++ b/packages/reports/addon/templates/components/navi-request-preview.hbs
@@ -2,7 +2,7 @@
 <div class="navi-request-preview" ...attributes>
   <div class="navi-request-preview__table-container">
     <table class="navi-request-preview__table">
-      <thead class="navi-request-preview__table-header">
+      <thead class={{concat "navi-request-preview__table-header" (if this.editingColumn " navi-request-preview__table-header--editing")}}>
         {{#each columns as |col idx|}}
           <th class={{concat "navi-request-preview__column-header" " navi-request-preview__column-header--" col.type}}>
             <BasicDropdown 
@@ -40,7 +40,7 @@
           </th>
         {{/each}}
       </thead>
-      <tbody class="navi-request-preview__table-body">
+      <tbody class={{concat "navi-request-preview__table-body" (if this.editingColumn " navi-request-preview__table-body--editing")}}>
         <tr class="navi-request-preview__table-row">
           <td class="navi-request-preview__table-cell">
             {{!-- Nothing here yet! --}}

--- a/packages/reports/addon/templates/components/print-report-view.hbs
+++ b/packages/reports/addon/templates/components/print-report-view.hbs
@@ -1,15 +1,15 @@
-{{!-- Copyright 2018, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 <div class="print-report-view__visualization-main">
   {{#if hasNoData}}
     <div class="print-report-view__visualization-no-results">
       No results available.
     </div>
   {{else}}
-    {{report-visualization
-      classNames="print-report-view__visualization"
-      report=report
-      response=response
-      print=true
-    }}
+    <ReportVisualization
+      class="print-report-view__visualization"
+      @report={{report}}
+      @response={{response}}
+      @print={{true}}
+    />
   {{/if}}
 </div>

--- a/packages/reports/addon/templates/components/report-view.hbs
+++ b/packages/reports/addon/templates/components/report-view.hbs
@@ -13,13 +13,20 @@
     </div>
   {{else}}
     <div class="report-view__visualization-header">
-      {{#unless (feature-flag "enableRequestPreview")}}
+      {{#if (feature-flag "enableRequestPreview")}}
+        <span class="report-view__visualization-header__data-toggle">
+          <h3 class="report-view__visualization-header__title">
+            Data
+          </h3>
+          <NaviIcon @icon="angle-down" class="report-view__visualization-header__data-toggle-icon"/>
+        </span>
+      {{else}}
         {{visualization-toggle
           report=report
           validVisualizations=validVisualizations
           onVisualizationTypeUpdate=(route-action "onVisualizationTypeUpdate")
         }}
-      {{/unless}}
+      {{/if}}
       {{#if hasRequestRun}}
         {{#unless (or isEditingVisualization (eq this.report.visualization.type "request-preview"))}}
           <div class="clickable report-view__visualization-edit-btn" role="button" onclick={{action "toggleEditVisualization" this}}>

--- a/packages/reports/addon/templates/components/report-view.hbs
+++ b/packages/reports/addon/templates/components/report-view.hbs
@@ -2,8 +2,9 @@
 {{#if (feature-flag "enableRequestPreview")}}
   <VisualizationSelector
     @report={{@report}}
-    @validVisualizations={{validVisualizations}}
-    @onVisualizationTypeUpdate={{route-action "onVisualizationTypeUpdate"}}
+    @validVisualizations={{this.validVisualizations}}
+    @currentVisualization={{this.currentView}}
+    @onVisualizationTypeUpdate={{action "onVisualizationTypeUpdate"}}
   />
 {{/if}}
 <div class="report-view__visualization-main">
@@ -24,11 +25,11 @@
         {{visualization-toggle
           report=report
           validVisualizations=validVisualizations
-          onVisualizationTypeUpdate=(route-action "onVisualizationTypeUpdate")
+          onVisualizationTypeUpdate=(action "onVisualizationTypeUpdate")
         }}
       {{/if}}
       {{#if hasRequestRun}}
-        {{#unless (or isEditingVisualization (eq this.report.visualization.type "request-preview"))}}
+        {{#unless (or isEditingVisualization this.showRequestPreview)}}
           <div class="clickable report-view__visualization-edit-btn" role="button" onclick={{action "toggleEditVisualization" this}}>
             Edit {{visualizationTypeLabel}}
             {{navi-icon "pencil"}}
@@ -38,7 +39,7 @@
         <div class="report-view__info-text">{{navi-icon "exclamation-circle"}} Run request to update {{visualizationTypeLabel}}</div>
       {{/if}}
     </div>
-    {{#if (eq this.report.visualization.type "request-preview")}}
+    {{#if this.showRequestPreview}}
       <NaviRequestPreview
         @request={{this.report.request}}
         @visualization={{this.report.visualization}}

--- a/packages/reports/addon/templates/components/report-view.hbs
+++ b/packages/reports/addon/templates/components/report-view.hbs
@@ -49,19 +49,19 @@
         @onRemoveSort={{update-report-action "REMOVE_SORT"}}
       />
     {{else}}
-      {{report-visualization
-        classNames="report-view__visualization"
-        report=report
-        response=response
-        container=this
-        annotationData=annotationData
-        isEditing=(and isEditingVisualization hasRequestRun)
-        onUpdateReport=(pipe
+      <ReportVisualization
+        class="report-view__visualization"
+        @report={{this.report}}
+        @response={{this.response}}
+        @container={{this}}
+        @annotationData={{annotationData}}
+        @isEditing={{and isEditingVisualization hasRequestRun}}
+        @onUpdateReport={{pipe
           (route-action "onUpdateReport")
           (route-action "validate" report)
           (route-action "runReport" report)
-        )
-      }}
+        }}
+      />
     {{/if}}
     {{missing-intervals-warning
       response=response

--- a/packages/reports/addon/templates/components/report-view.hbs
+++ b/packages/reports/addon/templates/components/report-view.hbs
@@ -4,7 +4,7 @@
     @report={{@report}}
     @validVisualizations={{this.validVisualizations}}
     @currentVisualization={{this.currentView}}
-    @onVisualizationTypeUpdate={{action "onVisualizationTypeUpdate"}}
+    @onVisualizationTypeUpdate={{this.onVisualizationTypeUpdate}}
   />
 {{/if}}
 <div class="report-view__visualization-main">

--- a/packages/reports/addon/templates/components/report-view.hbs
+++ b/packages/reports/addon/templates/components/report-view.hbs
@@ -1,4 +1,11 @@
-{{!-- Copyright 2018, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{#if (feature-flag "enableRequestPreview")}}
+  <VisualizationSelector
+    @report={{@report}}
+    @validVisualizations={{validVisualizations}}
+    @onVisualizationTypeUpdate={{route-action "onVisualizationTypeUpdate"}}
+  />
+{{/if}}
 <div class="report-view__visualization-main">
   {{#if hasNoData}}
     <div class="report-view__visualization-no-results">
@@ -6,13 +13,15 @@
     </div>
   {{else}}
     <div class="report-view__visualization-header">
-      {{visualization-toggle
-        report=report
-        validVisualizations=validVisualizations
-        onVisualizationTypeUpdate=(route-action "onVisualizationTypeUpdate")
-      }}
+      {{#unless (feature-flag "enableRequestPreview")}}
+        {{visualization-toggle
+          report=report
+          validVisualizations=validVisualizations
+          onVisualizationTypeUpdate=(route-action "onVisualizationTypeUpdate")
+        }}
+      {{/unless}}
       {{#if hasRequestRun}}
-        {{#unless isEditingVisualization}}
+        {{#unless (or isEditingVisualization (eq this.report.visualization.type "request-preview"))}}
           <div class="clickable report-view__visualization-edit-btn" role="button" onclick={{action "toggleEditVisualization" this}}>
             Edit {{visualizationTypeLabel}}
             {{navi-icon "pencil"}}
@@ -22,19 +31,31 @@
         <div class="report-view__info-text">{{navi-icon "exclamation-circle"}} Run request to update {{visualizationTypeLabel}}</div>
       {{/if}}
     </div>
-    {{report-visualization
-      classNames="report-view__visualization"
-      report=report
-      response=response
-      container=this
-      annotationData=annotationData
-      isEditing=(and isEditingVisualization hasRequestRun)
-      onUpdateReport=(pipe
-        (route-action "onUpdateReport")
-        (route-action "validate" report)
-        (route-action "runReport" report)
-      )
-    }}
+    {{#if (eq this.report.visualization.type "request-preview")}}
+      <NaviRequestPreview
+        @request={{this.report.request}}
+        @visualization={{this.report.visualization}}
+        @onRemoveMetric={{update-report-action "REMOVE_METRIC"}}
+        @onRemoveDimension={{update-report-action "REMOVE_DIMENSION"}}
+        @onRemoveTimeGrain={{update-report-action "REMOVE_TIME_GRAIN"}}
+        @onAddSort={{update-report-action "UPSERT_SORT"}}
+        @onRemoveSort={{update-report-action "REMOVE_SORT"}}
+      />
+    {{else}}
+      {{report-visualization
+        classNames="report-view__visualization"
+        report=report
+        response=response
+        container=this
+        annotationData=annotationData
+        isEditing=(and isEditingVisualization hasRequestRun)
+        onUpdateReport=(pipe
+          (route-action "onUpdateReport")
+          (route-action "validate" report)
+          (route-action "runReport" report)
+        )
+      }}
+    {{/if}}
     {{missing-intervals-warning
       response=response
       onDetailsToggle=(action "resizeVisualization" warningAnimationDuration)

--- a/packages/reports/addon/templates/components/report-view.hbs
+++ b/packages/reports/addon/templates/components/report-view.hbs
@@ -43,8 +43,8 @@
       <NaviRequestPreview
         @request={{this.report.request}}
         @visualization={{this.report.visualization}}
-        @onRemoveMetric={{update-report-action "REMOVE_METRIC"}}
-        @onRemoveDimension={{update-report-action "REMOVE_DIMENSION"}}
+        @onRemoveMetric={{update-report-action "REMOVE_METRIC_FRAGMENT"}}
+        @onRemoveDimension={{update-report-action "REMOVE_DIMENSION_FRAGMENT"}}
         @onRemoveTimeGrain={{update-report-action "REMOVE_TIME_GRAIN"}}
         @onAddSort={{update-report-action "UPSERT_SORT"}}
         @onRemoveSort={{update-report-action "REMOVE_SORT"}}

--- a/packages/reports/addon/templates/components/report-visualization.hbs
+++ b/packages/reports/addon/templates/components/report-visualization.hbs
@@ -1,9 +1,11 @@
-{{!-- Copyright 2018, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
-{{component
+{{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+<div class="report-visualization" ...attributes>
+  {{component
     visualizationComponent
     model=(ember-array visualizationHash annotationData)
     options=report.visualization.metadata
     onUpdateReport=(optional onUpdateReport)
     containerComponent=(or container this)
     isEditing=isEditing
-}}
+  }}
+</div>

--- a/packages/reports/addon/templates/components/visualization-selector.hbs
+++ b/packages/reports/addon/templates/components/visualization-selector.hbs
@@ -4,6 +4,7 @@
     <li
       class="visualization-selector__option {{if (eq report.visualization.type visualization.name) "visualization-selector__option--is-active"}}"
       role="button"
+      title={{visualization.niceName}}
       onclick={{action onVisualizationTypeUpdate visualization.name}}
     >
       {{navi-icon visualization.icon class="visualization-selector__option-icon"}}

--- a/packages/reports/addon/templates/components/visualization-selector.hbs
+++ b/packages/reports/addon/templates/components/visualization-selector.hbs
@@ -1,0 +1,12 @@
+{{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+<ul class="visualization-selector__list">
+  {{#each visualizations as |visualization|}}
+    <li
+      class="visualization-selector__option {{if (eq report.visualization.type visualization.name) "visualization-selector__option--is-active"}}"
+      role="button"
+      onclick={{action onVisualizationTypeUpdate visualization.name}}
+    >
+      {{navi-icon visualization.icon class="visualization-selector__option-icon"}}
+    </li>
+  {{/each}}
+</ul>

--- a/packages/reports/addon/templates/components/visualization-selector.hbs
+++ b/packages/reports/addon/templates/components/visualization-selector.hbs
@@ -1,13 +1,15 @@
 {{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
-<ul class="visualization-selector__list">
-  {{#each visualizations as |visualization|}}
-    <li
-      class="visualization-selector__option {{if (eq report.visualization.type visualization.name) "visualization-selector__option--is-active"}}"
-      role="button"
-      title={{visualization.niceName}}
-      onclick={{action onVisualizationTypeUpdate visualization.name}}
-    >
-      {{navi-icon visualization.icon class="visualization-selector__option-icon"}}
-    </li>
-  {{/each}}
-</ul>
+<div class="visualization-selector" ...attributes>
+  <ul class="visualization-selector__list">
+    {{#each visualizations as |visualization|}}
+      <li
+        class="visualization-selector__option {{if (eq report.visualization.type visualization.name) "visualization-selector__option--is-active"}}"
+        role="button"
+        title={{visualization.niceName}}
+        {{on "click" (fn onVisualizationTypeUpdate visualization.name)}}
+      >
+        <NaviIcon @icon={{visualization.icon}} class="visualization-selector__option-icon"/>
+      </li>
+    {{/each}}
+  </ul>
+</div>

--- a/packages/reports/addon/templates/components/visualization-selector.hbs
+++ b/packages/reports/addon/templates/components/visualization-selector.hbs
@@ -3,7 +3,7 @@
   <ul class="visualization-selector__list">
     {{#each visualizations as |visualization|}}
       <li
-        class="visualization-selector__option {{if (eq report.visualization.type visualization.name) "visualization-selector__option--is-active"}}"
+        class="visualization-selector__option {{if (eq currentVisualization visualization.name) "visualization-selector__option--is-active"}}"
         role="button"
         title={{visualization.niceName}}
         {{on "click" (fn onVisualizationTypeUpdate visualization.name)}}

--- a/packages/reports/addon/templates/components/visualization-selector.hbs
+++ b/packages/reports/addon/templates/components/visualization-selector.hbs
@@ -6,7 +6,7 @@
         class="visualization-selector__option {{if (eq currentVisualization visualization.name) "visualization-selector__option--is-active"}}"
         role="button"
         title={{visualization.niceName}}
-        {{on "click" (fn onVisualizationTypeUpdate visualization.name)}}
+        {{on "click" (fn @onVisualizationTypeUpdate visualization.name)}}
       >
         <NaviIcon @icon={{visualization.icon}} class="visualization-selector__option-icon"/>
       </li>

--- a/packages/reports/app/components/visualization-selector.js
+++ b/packages/reports/app/components/visualization-selector.js
@@ -1,0 +1,1 @@
+export { default } from 'navi-reports/components/visualization-selector';

--- a/packages/reports/app/styles/navi-reports/components/index.less
+++ b/packages/reports/app/styles/navi-reports/components/index.less
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 
@@ -38,3 +38,4 @@
 @import 'metric-config';
 @import 'metric-filter-config';
 @import 'visualization-toggle';
+@import 'visualization-selector';

--- a/packages/reports/app/styles/navi-reports/components/navi-request-preview.less
+++ b/packages/reports/app/styles/navi-reports/components/navi-request-preview.less
@@ -72,6 +72,11 @@
       border-radius: 0 6px 0 0;
     }
 
+    &--editing {
+      border-bottom: 2px solid @denali-brand-600;
+      padding-bottom: 3px;
+    }
+
     &-option {
       cursor: pointer;
     }

--- a/packages/reports/app/styles/navi-reports/components/navi-request-preview.less
+++ b/packages/reports/app/styles/navi-reports/components/navi-request-preview.less
@@ -6,7 +6,7 @@
 .navi-request-preview {
   display: flex;
   height: 100%;
-  padding: 15px;
+  padding-left: 20px;
   width: 100%;
 
   &__table-container {
@@ -31,17 +31,29 @@
   &__table-body {
     border: 1px solid @navi-gray-400;
     border-top: none;
-    border-radius: 0 0 0 6px;
+    border-radius: 0 0 6px 6px;
     display: flex;
     flex: 2;
+
+    &--editing {
+      border-radius: 0 0 0 6px;
+    }
   }
 
   &__table-header {
     background-color: @navi-gray-300;
     border: 1px solid @navi-gray-400;
-    border-radius: 6px 0 0 0;
+    border-radius: 6px 6px 0 0;
     display: flex;
     flex-direction: row;
+
+    &--editing {
+      border-radius: 6px 0 0 0;
+
+      .navi-request-preview__column-header:last-of-type {
+        border-radius: 0;
+      }
+    }
   }
 
   &__column-header {
@@ -54,6 +66,10 @@
 
     &:first-of-type {
       border-left: none;
+    }
+
+    &:last-of-type {
+      border-radius: 0 6px 0 0;
     }
 
     &-option {

--- a/packages/reports/app/styles/navi-reports/components/navi-request-preview.less
+++ b/packages/reports/app/styles/navi-reports/components/navi-request-preview.less
@@ -1,8 +1,7 @@
 /**
- * Copyright 2019, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
-@background-stripe-color: #f5f8fe;
 
 .navi-request-preview {
   display: flex;
@@ -21,8 +20,8 @@
       to bottom,
       @navi-white,
       @navi-white 25px,
-      @background-stripe-color 25px,
-      @background-stripe-color 50px
+      @denali-brand-100 25px,
+      @denali-brand-100 50px
     );
     display: flex;
     flex: 1;

--- a/packages/reports/app/styles/navi-reports/components/report-view.less
+++ b/packages/reports/app/styles/navi-reports/components/report-view.less
@@ -54,8 +54,25 @@
   &__visualization-header {
     align-items: center;
     display: flex;
+    flex-direction: row;
     justify-content: space-between;
-    margin: 10px 10px 25px;
+    margin: 10px;
+
+    &__data-toggle {
+      align-items: center;
+      display: flex;
+      flex-direction: row;
+
+      &-icon {
+        color: @denali-brand-600;
+        font-size: @font-size-base-large;
+      }
+    }
+
+    &__title {
+      font-size: @font-size-base-large;
+      margin: 0 5px 0 10px;
+    }
   }
 
   &__visualization-main {

--- a/packages/reports/app/styles/navi-reports/components/report-view.less
+++ b/packages/reports/app/styles/navi-reports/components/report-view.less
@@ -65,12 +65,12 @@
 
       &-icon {
         color: @denali-brand-600;
-        font-size: @font-size-base-large;
+        font-size: @font-size-large;
       }
     }
 
     &__title {
-      font-size: @font-size-base-large;
+      font-size: @font-size-base;
       margin: 0 5px 0 10px;
     }
   }

--- a/packages/reports/app/styles/navi-reports/components/visualization-selector.less
+++ b/packages/reports/app/styles/navi-reports/components/visualization-selector.less
@@ -19,7 +19,6 @@
     color: @navi-blue-300;
     cursor: pointer;
     font-size: @font-size-xlarge;
-    margin-right: -1px;
     padding: 6px 15px;
 
     &:hover {

--- a/packages/reports/app/styles/navi-reports/components/visualization-selector.less
+++ b/packages/reports/app/styles/navi-reports/components/visualization-selector.less
@@ -7,7 +7,7 @@
   background-color: @denali-brand-100;
   display: flex;
   flex-direction: column;
-  padding: 15px 0;
+  padding: 10px 0;
 
   &__list {
     display: flex;

--- a/packages/reports/app/styles/navi-reports/components/visualization-selector.less
+++ b/packages/reports/app/styles/navi-reports/components/visualization-selector.less
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2020, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+
+.visualization-selector {
+  background-color: @denali-brand-100;
+  display: flex;
+  flex-direction: column;
+  padding: 15px 0;
+
+  &__list {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+  }
+
+  &__option {
+    color: @navi-blue-300;
+    cursor: pointer;
+    font-size: @font-size-xlarge;
+    margin-right: -1px;
+    padding: 6px 15px;
+
+    &:hover {
+      background-color: @navi-white;
+      color: @navi-black;
+    }
+
+    &--is-active {
+      background: @navi-white;
+      color: @navi-black;
+      pointer-events: none;
+    }
+  }
+}

--- a/packages/reports/package.json
+++ b/packages/reports/package.json
@@ -23,7 +23,7 @@
     "test:all": "ember try:each"
   },
   "dependencies": {
-    "@ember-decorators/component": "^6.1.1",
+    "ember-decorators": "^6.1.1",
     "@ember/jquery": "^0.6.0",
     "@ember/optional-features": "^0.7.0",
     "@html-next/vertical-collection": "^1.0.0",

--- a/packages/reports/tests/dummy/config/environment.js
+++ b/packages/reports/tests/dummy/config/environment.js
@@ -44,7 +44,8 @@ module.exports = function(environment) {
         enabledNotifyIfData: true,
         enableContains: true,
         enableTableEditing: true,
-        dateDimensionFilter: true
+        dateDimensionFilter: true,
+        enableRequestPreview: true
       }
     }
   };

--- a/packages/reports/tests/dummy/config/environment.js
+++ b/packages/reports/tests/dummy/config/environment.js
@@ -45,7 +45,7 @@ module.exports = function(environment) {
         enableContains: true,
         enableTableEditing: true,
         dateDimensionFilter: true,
-        enableRequestPreview: true
+        enableRequestPreview: false
       }
     }
   };

--- a/packages/reports/tests/integration/components/navi-request-preview-test.js
+++ b/packages/reports/tests/integration/components/navi-request-preview-test.js
@@ -10,7 +10,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import hbs from 'htmlbars-inline-precompile';
 
 let Store, MetadataService, AdClicks, Revenue, Age, UpdateReportAction;
-const textContentArray = selector => [...document.querySelectorAll(selector)].map(el => el.textContent.trim());
+const textContentArray = selector => findAll(selector).map(el => el.textContent.trim());
 
 module('Integration | Component | navi-request-preview', function(hooks) {
   setupRenderingTest(hooks);
@@ -107,7 +107,7 @@ module('Integration | Component | navi-request-preview', function(hooks) {
       assert.equal(fragment.metric.longName, 'Ad Clicks', 'onRemoveMetric is called with a metric column');
     });
     this.set('onRemoveDimension', fragment => {
-      assert.equal(fragment.dimension.longName, 'Age', 'onRemoveDimension is called with a metric column');
+      assert.equal(fragment.dimension.longName, 'Age', 'onRemoveDimension is called with a dimension column');
     });
     this.set('onRemoveTimeGrain', fragment => {
       assert.equal(fragment.longName, 'Day', 'onRemoveTimeGrain is called with a dateTime column');
@@ -124,11 +124,11 @@ module('Integration | Component | navi-request-preview', function(hooks) {
       <NaviRequestPreview
         @request={{this.request}}
         @visualization={{this.visualization}}
-        @onRemoveMetric={{action onRemoveMetric}}
-        @onRemoveDimension={{action onRemoveDimension}}
-        @onRemoveTimeGrain={{action onRemoveTimeGrain}}
-        @onAddSort={{action onAddSort}}
-        @onRemoveSort={{action onRemoveSort}}
+        @onRemoveMetric={{this.onRemoveMetric}}
+        @onRemoveDimension={{this.onRemoveDimension}}
+        @onRemoveTimeGrain={{this.onRemoveTimeGrain}}
+        @onAddSort={{this.onAddSort}}
+        @onRemoveSort={{this.onRemoveSort}}
       />
     `);
 
@@ -313,11 +313,11 @@ module('Integration | Component | navi-request-preview', function(hooks) {
       <NaviRequestPreview
         @request={{this.request}}
         @visualization={{this.visualization}}
-        @onRemoveMetric={{action onRemoveMetric}}
-        @onRemoveDimension={{action onRemoveDimension}}
-        @onRemoveTimeGrain={{action onRemoveTimeGrain}}
-        @onAddSort={{action onAddSort}}
-        @onRemoveSort={{action onRemoveSort}}
+        @onRemoveMetric={{this.onRemoveMetric}}
+        @onRemoveDimension={{this.onRemoveDimension}}
+        @onRemoveTimeGrain={{this.onRemoveTimeGrain}}
+        @onAddSort={{this.onAddSort}}
+        @onRemoveSort={{this.onRemoveSort}}
       />
     `);
 
@@ -367,7 +367,7 @@ module('Integration | Component | navi-request-preview', function(hooks) {
     assert.dom('.navi-request-column-config').isVisible('Column config is open');
     assert.dom('#columnName').hasValue('Age', 'Age column config is open');
 
-    // trigger Remove metric action for FIRST Ad Clicks (VideoAds) column
+    // trigger Remove metric action for SECOND Age column
     await click(selectColumnHeaderOptions('Age', 1));
     await click('.navi-request-preview__column-header-option:first-of-type');
 
@@ -382,7 +382,7 @@ module('Integration | Component | navi-request-preview', function(hooks) {
     assert.dom('.navi-request-column-config').isVisible('Column config is open for first age column');
     assert.dom('#columnName').hasValue('Age', 'Video Ads column config is open');
 
-    // trigger Remove metric action for SECOND Age column
+    // trigger Remove dimension action for SECOND Age column
     await click(selectColumnHeaderOptions('Age', 1));
     await click('.navi-request-preview__column-header-option:first-of-type');
 

--- a/packages/reports/tests/integration/components/navi-request-preview-test.js
+++ b/packages/reports/tests/integration/components/navi-request-preview-test.js
@@ -10,6 +10,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import hbs from 'htmlbars-inline-precompile';
 
 let Store, MetadataService, AdClicks, Revenue, Age, UpdateReportAction;
+const textContentArray = selector => [...document.querySelectorAll(selector)].map(el => el.textContent.trim());
 
 module('Integration | Component | navi-request-preview', function(hooks) {
   setupRenderingTest(hooks);
@@ -62,6 +63,12 @@ module('Integration | Component | navi-request-preview', function(hooks) {
               }
             },
             {
+              metric: AdClicks,
+              parameters: {
+                adType: 'VideoAds' //Need duplicate metric column
+              }
+            },
+            {
               metric: Revenue,
               parameters: {
                 currency: 'USD'
@@ -71,6 +78,9 @@ module('Integration | Component | navi-request-preview', function(hooks) {
           dimensions: arr([
             {
               dimension: Age
+            },
+            {
+              dimension: Age //Need duplicate dimension column
             }
           ]),
           sort: arr([
@@ -90,16 +100,14 @@ module('Integration | Component | navi-request-preview', function(hooks) {
   });
 
   test('columns render and options work properly', async function(assert) {
-    assert.expect(28);
-
-    const textContentArray = selector => [...document.querySelectorAll(selector)].map(el => el.textContent.trim());
+    assert.expect(29);
 
     this.set('visualization', { metadata: {} });
     this.set('onRemoveMetric', fragment => {
-      assert.equal(fragment.longName, 'Ad Clicks', 'onRemoveMetric is called with a metric column');
+      assert.equal(fragment.metric.longName, 'Ad Clicks', 'onRemoveMetric is called with a metric column');
     });
     this.set('onRemoveDimension', fragment => {
-      assert.equal(fragment.longName, 'Age', 'onRemoveDimension is called with a metric column');
+      assert.equal(fragment.dimension.longName, 'Age', 'onRemoveDimension is called with a metric column');
     });
     this.set('onRemoveTimeGrain', fragment => {
       assert.equal(fragment.longName, 'Day', 'onRemoveTimeGrain is called with a dateTime column');
@@ -126,7 +134,7 @@ module('Integration | Component | navi-request-preview', function(hooks) {
 
     assert.deepEqual(
       textContentArray('.navi-request-preview__column-header'),
-      ['Date', 'Age', 'Ad Clicks (BannerAds)', 'Ad Clicks (VideoAds)', 'Revenue (USD)'],
+      ['Date', 'Age', 'Age', 'Ad Clicks (BannerAds)', 'Ad Clicks (VideoAds)', 'Ad Clicks (VideoAds)', 'Revenue (USD)'],
       'Column headers are generated correctly for each column in the request'
     );
 
@@ -138,13 +146,13 @@ module('Integration | Component | navi-request-preview', function(hooks) {
 
     assert.deepEqual(
       textContentArray('.navi-request-preview__column-header--dimension'),
-      ['Age'],
-      'Dimension class is applied to the dimension column only'
+      ['Age', 'Age'],
+      'Dimension class is applied to the dimension columns only'
     );
 
     assert.deepEqual(
       textContentArray('.navi-request-preview__column-header--metric'),
-      ['Ad Clicks (BannerAds)', 'Ad Clicks (VideoAds)', 'Revenue (USD)'],
+      ['Ad Clicks (BannerAds)', 'Ad Clicks (VideoAds)', 'Ad Clicks (VideoAds)', 'Revenue (USD)'],
       'Metric class is applied to only the metric columns'
     );
 
@@ -180,6 +188,9 @@ module('Integration | Component | navi-request-preview', function(hooks) {
     );
     await click('.navi-request-preview__column-header-option:last-of-type');
 
+    assert
+      .dom('.navi-request-preview__column-header--metric.navi-request-preview__column-header--editing')
+      .hasText('Ad Clicks (BannerAds)', 'The editing column is highlighted');
     assert.dom('.navi-request-column-config').isVisible('Column config opens on edit option click');
     assert.dom('#columnName').hasValue('Ad Clicks (BannerAds)', 'Selected column name is displayed in input');
 
@@ -189,7 +200,7 @@ module('Integration | Component | navi-request-preview', function(hooks) {
     assert.dom('#columnName').hasValue('Banner Ad Clicks', 'Updated column name is in the input field');
     assert.deepEqual(
       textContentArray('.navi-request-preview__column-header'),
-      ['Date', 'Age', 'Banner Ad Clicks', 'Ad Clicks (VideoAds)', 'Revenue (USD)'],
+      ['Date', 'Age', 'Age', 'Banner Ad Clicks', 'Ad Clicks (VideoAds)', 'Ad Clicks (VideoAds)', 'Revenue (USD)'],
       'Only the selected column has the updated name'
     );
 
@@ -227,7 +238,7 @@ module('Integration | Component | navi-request-preview', function(hooks) {
     assert.dom('#columnName').hasValue('Revenue (CAD)', 'Column name updates with metric param');
     assert.deepEqual(
       textContentArray('.navi-request-preview__column-header'),
-      ['Date', 'Age', 'Banner Ad Clicks', 'Ad Clicks (VideoAds)', 'Revenue (CAD)'],
+      ['Date', 'Age', 'Age', 'Banner Ad Clicks', 'Ad Clicks (VideoAds)', 'Ad Clicks (VideoAds)', 'Revenue (CAD)'],
       'Column name updates in column headers'
     );
 
@@ -239,7 +250,15 @@ module('Integration | Component | navi-request-preview', function(hooks) {
       .hasText('Dollars (CAD)', 'Set parameter is still shown');
     assert.deepEqual(
       textContentArray('.navi-request-preview__column-header'),
-      ['Date', 'Age', 'Banner Ad Clicks', 'Ad Clicks (VideoAds)', "Dolla Dolla Bill Y'all"],
+      [
+        'Date',
+        'Age',
+        'Age',
+        'Banner Ad Clicks',
+        'Ad Clicks (VideoAds)',
+        'Ad Clicks (VideoAds)',
+        "Dolla Dolla Bill Y'all"
+      ],
       'Column name alias is shown in column headers for parameterized metric'
     );
 
@@ -250,8 +269,126 @@ module('Integration | Component | navi-request-preview', function(hooks) {
       .hasValue("Dolla Dolla Bill Y'all", 'Alias is still shown in input box after parameter change');
     assert.deepEqual(
       textContentArray('.navi-request-preview__column-header'),
-      ['Date', 'Age', 'Banner Ad Clicks', 'Ad Clicks (VideoAds)', "Dolla Dolla Bill Y'all"],
+      [
+        'Date',
+        'Age',
+        'Age',
+        'Banner Ad Clicks',
+        'Ad Clicks (VideoAds)',
+        'Ad Clicks (VideoAds)',
+        "Dolla Dolla Bill Y'all"
+      ],
       'Column name alias persists after metric parameter change'
     );
+  });
+
+  test('Remove and edit columns that have duplicates', async function(assert) {
+    assert.expect(19);
+
+    const selectColumnHeaderOptions = (content, index) =>
+      findAll('.navi-request-preview__column-header')
+        .filter(el => el.textContent.trim().includes(content))
+        [index].querySelector('.navi-request-preview__column-header-options-trigger');
+
+    this.set('visualization', { metadata: {} });
+    this.set('onRemoveMetric', fragment => {
+      assert.equal(fragment.index, 0, 'onRemoveMetric is called with the correct fragment');
+    });
+    this.set('onRemoveDimension', fragment => {
+      assert.equal(fragment.index, 1, 'onRemoveDimension is called with the correct fragment');
+    });
+    this.set('onRemoveTimeGrain', () => null);
+    this.set('onAddSort', () => null);
+    this.set('onRemoveSort', () => null);
+
+    this.request.metrics.filterBy('canonicalName', 'adClicks(adType=VideoAds)').map((metric, idx) => {
+      metric.index = idx; //Make each metric fragment identifiable for this test
+    });
+
+    this.request.dimensions.filterBy('dimension.longName', 'Age').map((dim, idx) => {
+      dim.index = idx; //Make each dimension fragment identifiable for this test
+    });
+
+    await render(hbs`
+      <NaviRequestPreview
+        @request={{this.request}}
+        @visualization={{this.visualization}}
+        @onRemoveMetric={{action onRemoveMetric}}
+        @onRemoveDimension={{action onRemoveDimension}}
+        @onRemoveTimeGrain={{action onRemoveTimeGrain}}
+        @onAddSort={{action onAddSort}}
+        @onRemoveSort={{action onRemoveSort}}
+      />
+    `);
+
+    assert.deepEqual(
+      textContentArray('.navi-request-preview__column-header'),
+      ['Date', 'Age', 'Age', 'Ad Clicks (BannerAds)', 'Ad Clicks (VideoAds)', 'Ad Clicks (VideoAds)', 'Revenue (USD)'],
+      'Column headers are generated correctly for each column in the request'
+    );
+
+    // Open column config for FIRST Ad Clicks (VideoAds) column
+    await click(selectColumnHeaderOptions('Video', 0));
+    await click('.navi-request-preview__column-header-option:last-of-type');
+
+    assert.dom('.navi-request-column-config').isVisible('Column config is open');
+    assert.dom('#columnName').hasValue('Ad Clicks (VideoAds)', 'Video Ads column config is open');
+
+    // trigger Remove metric action for FIRST Ad Clicks (VideoAds) column
+    await click(selectColumnHeaderOptions('Video', 0));
+    await click('.navi-request-preview__column-header-option:first-of-type');
+
+    assert
+      .dom('.navi-request-column-config')
+      .isNotVisible('Column config closes when the current editing column is closed');
+
+    // Open column config for SECOND Ad Clicks (VideoAds) column
+    await click(selectColumnHeaderOptions('Video', 1));
+    await click('.navi-request-preview__column-header-option:last-of-type');
+
+    assert.dom('.navi-request-column-config').isVisible('Column config is open for second video ads column');
+    assert.dom('#columnName').hasValue('Ad Clicks (VideoAds)', 'Video Ads column config is open');
+
+    // trigger Remove metric action for FIRST Ad Clicks (VideoAds) column
+    await click(selectColumnHeaderOptions('Video', 0));
+    await click('.navi-request-preview__column-header-option:first-of-type');
+
+    assert
+      .dom('.navi-request-column-config')
+      .isVisible('Column config is still open when remove action is triggered on other column');
+    assert.dom('#columnName').hasValue('Ad Clicks (VideoAds)', 'Video Ads column config is open');
+
+    // Dimension Columns
+
+    // Open column config for SECOND Age column
+    await click(selectColumnHeaderOptions('Age', 1));
+    await click('.navi-request-preview__column-header-option:last-of-type');
+
+    assert.dom('.navi-request-column-config').isVisible('Column config is open');
+    assert.dom('#columnName').hasValue('Age', 'Age column config is open');
+
+    // trigger Remove metric action for FIRST Ad Clicks (VideoAds) column
+    await click(selectColumnHeaderOptions('Age', 1));
+    await click('.navi-request-preview__column-header-option:first-of-type');
+
+    assert
+      .dom('.navi-request-column-config')
+      .isNotVisible('Column config closes when the current editing column is closed');
+
+    // Open column config for FIRST Age column
+    await click(selectColumnHeaderOptions('Age', 0));
+    await click('.navi-request-preview__column-header-option:last-of-type');
+
+    assert.dom('.navi-request-column-config').isVisible('Column config is open for first age column');
+    assert.dom('#columnName').hasValue('Age', 'Video Ads column config is open');
+
+    // trigger Remove metric action for SECOND Age column
+    await click(selectColumnHeaderOptions('Age', 1));
+    await click('.navi-request-preview__column-header-option:first-of-type');
+
+    assert
+      .dom('.navi-request-column-config')
+      .isVisible('Column config is still open when remove action is triggered on other column');
+    assert.dom('#columnName').hasValue('Age', 'Age column config is open');
   });
 });

--- a/packages/reports/tests/integration/components/visualization-selector-test.js
+++ b/packages/reports/tests/integration/components/visualization-selector-test.js
@@ -40,7 +40,7 @@ module('Integration | Component | visualization-selector', function(hooks) {
       @report={{report}}
       @validVisualizations={{validVisualizations}}
       @currentVisualization={{currentView}}
-      @onVisualizationTypeUpdate={{action onVisualizationTypeUpdate}}
+      @onVisualizationTypeUpdate={{this.onVisualizationTypeUpdate}}
     />`);
 
     assert.deepEqual(

--- a/packages/reports/tests/integration/components/visualization-selector-test.js
+++ b/packages/reports/tests/integration/components/visualization-selector-test.js
@@ -14,6 +14,7 @@ module('Integration | Component | visualization-selector', function(hooks) {
         type: 'line-chart'
       }
     };
+    this.currentView = 'line-chart';
     this.validVisualizations = [
       {
         name: 'line-chart',
@@ -38,6 +39,7 @@ module('Integration | Component | visualization-selector', function(hooks) {
     await render(hbs`<VisualizationSelector 
       @report={{report}}
       @validVisualizations={{validVisualizations}}
+      @currentVisualization={{currentView}}
       @onVisualizationTypeUpdate={{action onVisualizationTypeUpdate}}
     />`);
 

--- a/packages/reports/tests/integration/components/visualization-selector-test.js
+++ b/packages/reports/tests/integration/components/visualization-selector-test.js
@@ -1,26 +1,56 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, findAll, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | visualization-selector', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function(assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val) { ... });
+    assert.expect(3);
 
-    await render(hbs`<VisualizationSelector />`);
+    this.report = {
+      visualization: {
+        type: 'line-chart'
+      }
+    };
+    this.validVisualizations = [
+      {
+        name: 'line-chart',
+        niceName: 'Line Chart',
+        icon: 'line-chart'
+      },
+      {
+        name: 'bar-chart',
+        niceName: 'Bar Chart',
+        icon: 'bar-chart'
+      },
+      {
+        name: 'table',
+        niceName: 'Data Table',
+        icon: 'table'
+      }
+    ];
+    this.onVisualizationTypeUpdate = name => {
+      assert.equal(name, 'request-preview', 'The clicked visualization type is sent to the update type action');
+    };
 
-    assert.equal(this.element.textContent.trim(), '');
+    await render(hbs`<VisualizationSelector 
+      @report={{report}}
+      @validVisualizations={{validVisualizations}}
+      @onVisualizationTypeUpdate={{action onVisualizationTypeUpdate}}
+    />`);
 
-    // Template block usage:
-    await render(hbs`
-      <VisualizationSelector>
-        template block text
-      </VisualizationSelector>
-    `);
+    assert.deepEqual(
+      findAll('.visualization-selector__option').map(el => el.title),
+      ['Request Preview', 'Line Chart', 'Bar Chart', 'Data Table'],
+      'Each valid visualization and the request preview are included '
+    );
 
-    assert.equal(this.element.textContent.trim(), 'template block text');
+    assert
+      .dom('.visualization-selector__option--is-active')
+      .hasAttribute('title', 'Line Chart', 'The visualization type in the report is shown as the selected option');
+
+    await click('.visualization-selector__option[title="Request Preview"]');
   });
 });

--- a/packages/reports/tests/integration/components/visualization-selector-test.js
+++ b/packages/reports/tests/integration/components/visualization-selector-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | visualization-selector', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`<VisualizationSelector />`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    // Template block usage:
+    await render(hbs`
+      <VisualizationSelector>
+        template block text
+      </VisualizationSelector>
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
+});

--- a/packages/reports/tests/unit/consumers/request/dimension-test.js
+++ b/packages/reports/tests/unit/consumers/request/dimension-test.js
@@ -57,6 +57,21 @@ module('Unit | Consumer | request dimension', function(hooks) {
     assert.ok(get(CurrentModel, 'request.dimensions.length') === 0, 'The given dimension is removed from the request');
   });
 
+  test('REMOVE_DIMENSION_FRAGMENT', function(assert) {
+    assert.expect(1);
+
+    run(() => {
+      Consumer.send(RequestActions.ADD_DIMENSION, { currentModel: CurrentModel }, Age);
+      Consumer.send(
+        RequestActions.REMOVE_DIMENSION_FRAGMENT,
+        { currentModel: CurrentModel },
+        CurrentModel.request.dimensions.firstObject
+      );
+    });
+
+    assert.ok(get(CurrentModel, 'request.dimensions.length') === 0, 'The given dimension is removed from the request');
+  });
+
   test('DID_UPDATE_TIME_GRAIN', function(assert) {
     assert.expect(2);
 

--- a/packages/reports/tests/unit/consumers/request/metric-test.js
+++ b/packages/reports/tests/unit/consumers/request/metric-test.js
@@ -59,6 +59,21 @@ module('Unit | Consumer | request metric', function(hooks) {
     assert.ok(get(CurrentModel, 'request.metrics.length') === 0, 'The given metric is removed from the request');
   });
 
+  test('REMOVE_METRIC_FRAGMENT', function(assert) {
+    assert.expect(1);
+
+    run(() => {
+      Consumer.send(RequestActions.ADD_METRIC, { currentModel: CurrentModel }, AdClicks);
+      Consumer.send(
+        RequestActions.REMOVE_METRIC_FRAGMENT,
+        { currentModel: CurrentModel },
+        CurrentModel.request.metrics.firstObject
+      );
+    });
+
+    assert.ok(get(CurrentModel, 'request.metrics.length') === 0, 'The given metric is removed from the request');
+  });
+
   test('UPDATE_METRIC_PARAM', async function(assert) {
     assert.expect(3);
 

--- a/packages/reports/tests/unit/routes/reports/report/view-test.js
+++ b/packages/reports/tests/unit/routes/reports/report/view-test.js
@@ -94,12 +94,9 @@ module('Unit | Route | reports/report/view', function(hooks) {
   });
 
   test('runReport action', function(assert) {
-    assert.expect(4);
+    assert.expect(2);
 
     const route = this.owner.factoryFor('route:reports/report/view').create({
-      modelFor() {
-        return { visualization: { type: 'table' } };
-      },
       _hasRequestRun() {
         return true;
       },
@@ -107,9 +104,6 @@ module('Unit | Route | reports/report/view', function(hooks) {
         throw new Error('The route should not refresh if the request has not changed');
       }
     });
-    route.actions.onVisualizationTypeUpdate = () => {
-      assert.ok(false, 'Should not be triggered on run when visualization type is not Request Preview');
-    };
 
     /* == Request has no changes == */
     route.send('runReport');
@@ -122,21 +116,6 @@ module('Unit | Route | reports/report/view', function(hooks) {
     route.send('runReport');
 
     route._hasRequestRun = () => true;
-    route.send('forceRun');
-
-    route.actions.onVisualizationTypeUpdate = type => {
-      assert.equal(
-        type,
-        'table',
-        'Visualization type is changed to table on run for a report with request preview as its visualization'
-      );
-    };
-    route.modelFor = () => ({ visualization: { type: 'request-preview' } });
-    route._hasRequestRun = () => false;
-    route.refresh = () => null;
-
-    /* == Request has no changes and visualization is request preview == */
-    route.send('runReport');
     route.send('forceRun');
   });
 });


### PR DESCRIPTION
## Description
This PR introduces the new visualization selector for use with the request preview. It is hidden behind the `enableRequestPreview` feature flag, so if that flag is not present or false, then the old visualization toggle component will be present instead. 

## Proposed Changes

- Add visualization-selector component and add it to report view with `enableRequestPreview` enabled
- Add Data label to the visualization panel, but without collapsibility functionality for now
- Add `currentView` property to `report-view` to handle which visualization to show
- Add Acceptance test for the request preview and visualization selector

## Screenshots
![Screen Shot 2020-01-07 at 6 45 32 PM](https://user-images.githubusercontent.com/23023478/71940972-ea4fe900-317d-11ea-9739-f26794da98d8.png)
![Screen Shot 2020-01-07 at 6 45 25 PM](https://user-images.githubusercontent.com/23023478/71940973-ea4fe900-317d-11ea-9fdf-d334b7e24ce9.png)

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
