### PR TITLE
Update: Replace navi-collection ember-pick filter selector with power select

### DIFF
--- a/packages/dashboards/tests/acceptance/dashboards-test.js
+++ b/packages/dashboards/tests/acceptance/dashboards-test.js
@@ -289,7 +289,7 @@ module('Acceptance | Dashboards', function(hooks) {
 
     // Filter by favorites
     await visit('/dashboards');
-    await click($('.pick-form li:contains(Favorites)')[0]);
+    await selectChoose('.navi-collection__filter-trigger', 'Favorites');
 
     const dashboardBefore = findAll('tbody tr td:first-of-type').map(el => el.textContent.trim());
 
@@ -299,7 +299,7 @@ module('Acceptance | Dashboards', function(hooks) {
     await click($('tbody tr td a:contains(Tumblr Goals Dashboard)')[0]);
     await click('.navi-dashboard__fav-icon');
     await visit('/dashboards');
-    await click($('.pick-form li:contains(Favorites)')[0]);
+    await selectChoose('.navi-collection__filter-trigger', 'Favorites');
 
     const dashboardsAfter = findAll('tbody tr td:first-of-type').map(el => el.textContent.trim());
 
@@ -318,7 +318,7 @@ module('Acceptance | Dashboards', function(hooks) {
 
     /* == list favorites in list view == */
     await visit('/dashboards');
-    await click($('.pick-form li:contains(Favorites)')[0]);
+    await selectChoose('.navi-collection__filter-trigger', 'Favorites');
 
     const listedDashboards = findAll('tbody tr td:first-of-type').map(el => el.textContent.trim());
 

--- a/packages/reports/addon/components/navi-collection.js
+++ b/packages/reports/addon/components/navi-collection.js
@@ -1,79 +1,79 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Usage:
- *   {{navi-collection
- *      items=items
- *      itemType='item type'
- *      config=(hash
+ *   <NaviCollection
+ *      @items={{items}}
+ *      @itemType="item type"
+ *      @config={{hash
  *          actions='actions-component'
  *          itemRoute='route for item link'
  *          itemNewRoute='route for new item link'
  *          emptyMsg='error message when items is empty'
  *          filterable='boolean flag for a filterable table'
- *       )
- *   }}
+ *      }}
+ *   />
  */
 import { oneWay, or } from '@ember/object/computed';
-import { A } from '@ember/array';
+import { A as arr } from '@ember/array';
 import Component from '@ember/component';
 import { get, computed } from '@ember/object';
 import { isEmpty } from '@ember/utils';
 import layout from '../templates/components/navi-collection';
+import { layout as templateLayout, tagName } from '@ember-decorators/component';
 
-export default Component.extend({
-  layout,
-
+@templateLayout(layout)
+@tagName('')
+class NaviCollection extends Component {
   /**
-   * @property {Array} classNames
+   * @property {DS.ArrayPromise} items - array of assets
    */
-  classNames: ['navi-collection'],
-
-  /**
-   * @property {DS.ArrayPromise} reports - array of reports
-   */
-  items: undefined,
+  items = undefined;
 
   /**
    * @param {Object} filter - current report table filter
    */
-  filter: oneWay('filterOptions.firstObject'),
+  @oneWay('filterOptions.firstObject')
+  filter;
 
   /**
    *
    * @property {Array} filteredReports -  array of reports filtered by user selected filter
    */
-  filteredItems: computed('items.[]', 'filter', function() {
+  @computed('items.[]', 'filter')
+  get filteredItems() {
     let { items, filter } = this.getProperties('items', 'filter');
 
     return isEmpty(items) ? undefined : filter.filterFn(items);
-  }),
+  }
 
   /**
    * @property {String} itemRoute - routes to ${itemType}.${item} by default
    */
-  itemRoute: computed('config.itemRoute', function() {
+  @computed('config.itemRoute')
+  get itemRoute() {
     let itemType = get(this, 'itemType'),
       itemRoute = get(this, 'config.itemRoute') || `${itemType}s.${itemType}`;
 
     return itemRoute;
-  }),
+  }
 
   /**
    * @property {String} itemNewRoute - routes to ${itemType}.new by default
    */
-  itemNewRoute: computed('config.itemNewRoute', function() {
+  @computed('config.itemNewRoute')
+  get itemNewRoute() {
     let itemType = get(this, 'itemType'),
       itemNewRoute = get(this, 'config.itemNewRoute') || `${itemType}s.new`;
 
     return itemNewRoute;
-  }),
+  }
 
   /**
    * @param {Array} filterOptions - list of filters for the report table
    */
-  filterOptions: A([
+  filterOptions = arr([
     {
       filterFn: item => item,
       name: 'All'
@@ -82,10 +82,12 @@ export default Component.extend({
       filterFn: items => items.filterBy('isFavorite'),
       name: 'Favorites'
     }
-  ]),
+  ]);
 
   /**
    * @property {Boolean} hasTableLoaded - indicates if table has loaded
    */
-  hasTableLoaded: or('items.isSettled', 'items.isLoaded')
-});
+  @or('items.isSettled', 'items.isLoaded') hasTableLoaded;
+}
+
+export default NaviCollection;

--- a/packages/reports/addon/components/navi-collection.js
+++ b/packages/reports/addon/components/navi-collection.js
@@ -43,7 +43,7 @@ class NaviCollection extends Component {
    */
   @computed('items.[]', 'filter')
   get filteredItems() {
-    let { items, filter } = this.getProperties('items', 'filter');
+    const { items, filter } = this;
 
     return isEmpty(items) ? undefined : filter.filterFn(items);
   }

--- a/packages/reports/addon/templates/components/navi-collection.hbs
+++ b/packages/reports/addon/templates/components/navi-collection.hbs
@@ -1,79 +1,87 @@
-{{!-- Copyright 2019, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
-{{#if config.filterable}}
-  {{pick-single
-    selection=filter
-    options=filterOptions
-    onUpdateSelection=(action (set this "filter" _))
-    idField="filterKey"
-    displayField="name"
-  }}
-{{/if}}
-<table class="table">
-  <thead>
-    <tr>
-      <th class="align left">Name</th>
-      {{#if config.actions}}
-        <th class="align left navi-collection__actions"></th>
-      {{/if}}
-      <th class="align left">Author</th>
-      <th class="align left">Last Updated</th>
-    </tr>
-  </thead>
-  <tbody>
-    {{#unless hasTableLoaded}}
-      <tr class="is-loading">
-        <td colspan="4">
-          {{navi-loader}}
-        </td>
+{{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+<div class="navi-collection" ...attributes>
+  {{#if config.filterable}}
+    <div class="navi-collection__filter-selector">
+      <PowerSelect
+        @triggerClass="navi-collection__filter-trigger"
+        @dropdownClass="navi-collection__filter-dropdown"
+        @options={{this.filterOptions}}
+        @selected={{this.filter}}
+        @onchange={{set this "filter" _}}
+        @searchEnabled={{false}}
+        as |filter|
+      >
+        {{filter.name}}
+      </PowerSelect>
+    </div>
+  {{/if}}
+  <table class="table">
+    <thead>
+      <tr>
+        <th class="align left">Name</th>
+        {{#if config.actions}}
+          <th class="align left navi-collection__actions"></th>
+        {{/if}}
+        <th class="align left">Author</th>
+        <th class="align left">Last Updated</th>
       </tr>
-    {{else}}
-      {{#each filteredItems as |item index|}}
-        <tr class="navi-collection__row {{concat "navi-collection__row" index}}">
-          <td class="align left">
-            {{#if item.tempId}}
-              {{#link-to itemRoute item.tempId}}
-                {{item.title}}
-              {{/link-to}}
-              <span class="navi-collection__unsaved-label">Unsaved</span>
-            {{else}}
-              {{#link-to itemRoute item.id}}
-                {{item.title}}
-              {{/link-to}}
-            {{/if}}
-            {{#if item.isFavorite}}
-              {{navi-icon "star" class="favorite-item--active"}}
-            {{/if}}
-          </td>
-          {{#if config.actions}}
-            <td class="align left navi-collection__actions">
-              {{#lazy-render target=(concat ".navi-collection__row" index)}}
-                {{component config.actions
-                  item=item
-                  index=index
-                }}
-              {{/lazy-render}}
-            </td>
-          {{/if}}
-          <td class="align left">{{item.author.id}}</td>
-          <td class="align left">
-            {{moment-format
-              item.updatedOn
-              "MM/DD/YYYY - hh:mm:ss a z"
-              timeZone=(guess-timezone)
-            }}
+    </thead>
+    <tbody>
+      {{#unless hasTableLoaded}}
+        <tr class="is-loading">
+          <td colspan="4">
+            <NaviLoader/>
           </td>
         </tr>
       {{else}}
-        <tr class="no-results">
-          <td colspan="4">
-            {{#if config.emptyMsg}}
-              {{config.emptyMsg}}
-            {{else}}
-              You don't have any {{itemType}} yet. Go ahead and {{#link-to itemNewRoute}}create one{{/link-to}} now?
+        {{#each filteredItems as |item index|}}
+          <tr class="navi-collection__row {{concat "navi-collection__row" index}}">
+            <td class="align left">
+              {{#if item.tempId}}
+                {{#link-to itemRoute item.tempId}}
+                  {{item.title}}
+                {{/link-to}}
+                <span class="navi-collection__unsaved-label">Unsaved</span>
+              {{else}}
+                {{#link-to itemRoute item.id}}
+                  {{item.title}}
+                {{/link-to}}
+              {{/if}}
+              {{#if item.isFavorite}}
+                <NaviIcon @icon="star" class="favorite-item--active"/>
+              {{/if}}
+            </td>
+            {{#if config.actions}}
+              <td class="align left navi-collection__actions">
+                {{#lazy-render target=(concat ".navi-collection__row" index)}}
+                  {{component config.actions
+                    item=item
+                    index=index
+                  }}
+                {{/lazy-render}}
+              </td>
             {{/if}}
-          </td>
-        </tr>
-      {{/each}}
-    {{/unless}}
-  </tbody>
-</table>
+            <td class="align left">{{item.author.id}}</td>
+            <td class="align left">
+              {{moment-format
+                item.updatedOn
+                "MM/DD/YYYY - hh:mm:ss a z"
+                timeZone=(guess-timezone)
+              }}
+            </td>
+          </tr>
+        {{else}}
+          <tr class="no-results">
+            <td colspan="4">
+              {{#if config.emptyMsg}}
+                {{config.emptyMsg}}
+              {{else}}
+                You don't have any {{itemType}} yet. Go ahead and {{#link-to itemNewRoute}}create one{{/link-to}} now?
+              {{/if}}
+            </td>
+          </tr>
+        {{/each}}
+      {{/unless}}
+    </tbody>
+  </table>
+</div>

--- a/packages/reports/addon/templates/components/navi-collection.hbs
+++ b/packages/reports/addon/templates/components/navi-collection.hbs
@@ -53,12 +53,12 @@
             </td>
             {{#if config.actions}}
               <td class="align left navi-collection__actions">
-                {{#lazy-render target=(concat ".navi-collection__row" index)}}
+                <LazyRender @target={{concat ".navi-collection__row" index}}>
                   {{component config.actions
                     item=item
                     index=index
                   }}
-                {{/lazy-render}}
+                </LazyRender>
               </td>
             {{/if}}
             <td class="align left">{{item.author.id}}</td>

--- a/packages/reports/addon/templates/components/navi-collection.hbs
+++ b/packages/reports/addon/templates/components/navi-collection.hbs
@@ -7,7 +7,7 @@
         @dropdownClass="navi-collection__filter-dropdown"
         @options={{this.filterOptions}}
         @selected={{this.filter}}
-        @onchange={{set this "filter" _}}
+        @onchange={{set this.filter _}}
         @searchEnabled={{false}}
         as |filter|
       >
@@ -38,14 +38,14 @@
           <tr class="navi-collection__row {{concat "navi-collection__row" index}}">
             <td class="align left">
               {{#if item.tempId}}
-                {{#link-to itemRoute item.tempId}}
+                <LinkTo @route={{itemRoute}} @model={{item.tempId}}>
                   {{item.title}}
-                {{/link-to}}
+                </LinkTo>
                 <span class="navi-collection__unsaved-label">Unsaved</span>
               {{else}}
-                {{#link-to itemRoute item.id}}
+                <LinkTo @route={{itemRoute}} @model={{item.id}}>
                   {{item.title}}
-                {{/link-to}}
+                </LinkTo>
               {{/if}}
               {{#if item.isFavorite}}
                 <NaviIcon @icon="star" class="favorite-item--active"/>
@@ -76,7 +76,7 @@
               {{#if config.emptyMsg}}
                 {{config.emptyMsg}}
               {{else}}
-                You don't have any {{itemType}} yet. Go ahead and {{#link-to itemNewRoute}}create one{{/link-to}} now?
+                You don't have any {{itemType}} yet. Go ahead and <LinkTo @route={{itemNewRoute}}>create one</LinkTo> now?
               {{/if}}
             </td>
           </tr>

--- a/packages/reports/app/styles/navi-reports/components/navi-collection.less
+++ b/packages/reports/app/styles/navi-reports/components/navi-collection.less
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 
@@ -59,20 +59,24 @@
     margin-right: 15px;
   }
 
-  .pick-value {
-    text-align: right;
-    font-size: @font-size-base;
-    .value {
-      padding-right: 6px;
+  &__filter-selector {
+    display: flex;
+    justify-content: flex-end;
+
+    .navi-collection__filter-trigger.ember-power-select-trigger {
+      border: 1px solid @navi-white;
+      display: inline-block;
+      min-width: 108px;
+      text-align: right;
+
+      &[aria-expanded='true'] {
+        border-bottom: 1px solid @navi-gray-500;
+      }
+
+      .ember-power-select-status-icon {
+        display: inline;
+      }
     }
-  }
-
-  .pick-form {
-    .dropdown-list;
-    .dropdown-list .list;
-
-    min-width: 110px;
-    right: 0;
   }
 
   &__unsaved-label {

--- a/packages/reports/app/styles/navi-reports/components/navi-collection.less
+++ b/packages/reports/app/styles/navi-reports/components/navi-collection.less
@@ -61,6 +61,7 @@
 
   &__filter-selector {
     display: flex;
+    font-size: @font-size-base;
     justify-content: flex-end;
 
     .navi-collection__filter-trigger.ember-power-select-trigger {
@@ -83,5 +84,13 @@
     color: @disabled-gray;
     font-size: @font-size-mid;
     margin-left: 8px;
+  }
+}
+
+.navi-collection__filter-dropdown {
+  font-size: @font-size-base;
+
+  li.ember-power-select-option {
+    text-align: right;
   }
 }

--- a/packages/reports/tests/acceptance/navi-report-test.js
+++ b/packages/reports/tests/acceptance/navi-report-test.js
@@ -1264,7 +1264,7 @@ module('Acceptance | Navi Report', function(hooks) {
 
     // Filter by favorites
     await visit('/reports');
-    await click($('.pick-form li:contains(Favorites)')[0]);
+    await selectChoose('.navi-collection__filter-trigger', 'Favorites');
 
     let listedReports = findAll('tbody tr td:first-of-type').map(el => el.innerText.trim());
 
@@ -1276,7 +1276,7 @@ module('Acceptance | Navi Report', function(hooks) {
 
     // Filter by favorites
     await visit('/reports');
-    await click($('.pick-form li:contains(Favorites)')[0]);
+    await selectChoose('.navi-collection__filter-trigger', 'Favorites');
 
     listedReports = findAll('tbody tr td:first-of-type').map(el => el.innerText.trim());
 
@@ -1286,7 +1286,7 @@ module('Acceptance | Navi Report', function(hooks) {
     await click($('tbody tr td a:contains(Hyrule Ad&Nav Clicks)')[0]);
     await click('.favorite-item');
     await visit('/reports');
-    await click($('.pick-form li:contains(Favorites)')[0]);
+    await selectChoose('.navi-collection__filter-trigger', 'Favorites');
 
     listedReports = findAll('tbody tr td:first-of-type').map(el => el.innerText.trim());
 
@@ -1302,7 +1302,7 @@ module('Acceptance | Navi Report', function(hooks) {
 
     // Filter by favorites
     await visit('/reports');
-    await click($('.pick-form li:contains(Favorites)')[0]);
+    await selectChoose('.navi-collection__filter-trigger', 'Favorites');
 
     let listedReports = findAll('tbody tr td:first-of-type').map(el => el.innerText.trim());
 
@@ -1314,7 +1314,7 @@ module('Acceptance | Navi Report', function(hooks) {
 
     await visit('/reports');
 
-    await click($('.pick-form li:contains(Favorites)')[0]);
+    await selectChoose('.navi-collection__filter-trigger', 'Favorites');
 
     listedReports = findAll('tbody tr td:first-of-type').map(el => el.innerText.trim());
 

--- a/packages/reports/tests/integration/components/navi-collection-test.js
+++ b/packages/reports/tests/integration/components/navi-collection-test.js
@@ -4,7 +4,8 @@ import ArrayProxy from '@ember/array/proxy';
 import $ from 'jquery';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, find, click, findAll } from '@ember/test-helpers';
+import { render, find, findAll } from '@ember/test-helpers';
+import { selectChoose } from 'ember-power-select/test-support';
 import hbs from 'htmlbars-inline-precompile';
 
 const REPORTS = ArrayProxy.create({
@@ -60,7 +61,7 @@ module('Integration | Component | navi collection', function(hooks) {
     await render(TEMPLATE);
 
     // Click "Favorites" filter option
-    await click($('.pick-form li:contains(All)')[0]);
+    await selectChoose('.navi-collection__filter-trigger', 'All');
 
     let listedReports = findAll('tbody tr td:first-of-type').map(el => el.textContent.trim());
 
@@ -71,7 +72,7 @@ module('Integration | Component | navi collection', function(hooks) {
     );
 
     // Click "Favorites" filter option
-    await click($('.pick-form li:contains(Favorites)')[0]);
+    await selectChoose('.navi-collection__filter-trigger', 'Favorites');
     listedReports = findAll('tbody tr td:first-of-type').map(el => el.textContent.trim());
 
     assert.deepEqual(
@@ -89,7 +90,7 @@ module('Integration | Component | navi collection', function(hooks) {
     await render(TEMPLATE);
 
     //Reset to all filter
-    await click($('.pick-form li:contains(All)')[0]);
+    await selectChoose('.navi-collection__filter-trigger', 'All');
 
     assert
       .dom($('tbody tr:eq(0) td:first-of-type i')[0])
@@ -111,10 +112,9 @@ module('Integration | Component | navi collection', function(hooks) {
           }}
       `);
 
-    assert.notOk(
-      $('.navi-collection .pick-container').is(':visible'),
-      'Filter dropdown is not shown when `filterable` flag is not set to true in collection config'
-    );
+    assert
+      .dom('.navi-collection__filter-selector')
+      .isNotVisible('Filter dropdown is not shown when `filterable` flag is not set to true in collection config');
 
     await render(hbs`
           {{navi-collection
@@ -125,10 +125,9 @@ module('Integration | Component | navi collection', function(hooks) {
           }}
       `);
 
-    assert.ok(
-      $('.navi-collection .pick-container').is(':visible'),
-      'Filter dropdown is shown when `filterable` flag is set to true in collection config'
-    );
+    assert
+      .dom('.navi-collection__filter-selector')
+      .isVisible('Filter dropdown is shown when `filterable` flag is set to true in collection config');
   });
 
   test('Actions in Table', async function(assert) {


### PR DESCRIPTION
Partially addresses #40 

## Description
We want to use ember-power-select in place of ember-pick. Navi collection is the only place besides the date picker components that uses ember-pick. @kevinhinterlong is working on replacing the dropdown date picker so once that is complete, we will be able to remove ember-pick components from Navi.

## Proposed Changes

- Replace the navi-collection table filter dropdown with ember-power-select
- Use Angle Brackets and Native Class syntax in the applicable files

## Screenshots
Before: 
![Screen Shot 2020-01-09 at 6 36 51 PM](https://user-images.githubusercontent.com/23023478/72116177-06cf5b00-330f-11ea-9257-5dbf85738292.png)
![Screen Shot 2020-01-09 at 6 35 43 PM](https://user-images.githubusercontent.com/23023478/72116191-1189f000-330f-11ea-979a-9b0266201756.png)

After: 
![Screen Shot 2020-01-09 at 6 36 09 PM](https://user-images.githubusercontent.com/23023478/72116199-1b135800-330f-11ea-85d7-9e8b19c0431c.png)
![Screen Shot 2020-01-09 at 6 35 38 PM](https://user-images.githubusercontent.com/23023478/72116205-2070a280-330f-11ea-9ae7-247bb3c0fc39.png)




## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
