### PR TITLE
Update: Fix dimension select search behavior

### DIFF
--- a/packages/reports/addon/components/filter-values/dimension-select.js
+++ b/packages/reports/addon/components/filter-values/dimension-select.js
@@ -6,7 +6,7 @@
  *   <FilterValues::DimensionSelect
  *       @filter={{filter}}
  *       @onUpdateFilter={{action "update"}}
- *   }}
+ *   />
  */
 import config from 'ember-get-config';
 import { featureFlag } from 'navi-core/helpers/feature-flag';
@@ -34,7 +34,8 @@ class DimensionSelectComponent extends Component {
   @service('bard-dimensions') _dimensionService;
 
   /**
-   * @property _metadataService
+   * @private
+   * @property {Ember.Service} _metadataService
    */
   @service('bard-metadata') _metadataService;
 

--- a/packages/reports/addon/components/filter-values/dimension-select.js
+++ b/packages/reports/addon/components/filter-values/dimension-select.js
@@ -1,58 +1,62 @@
 /**
- * Copyright 2019, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Usage:
- *   {{filter-values/dimension-select
- *       filter=filter
- *       onUpdateFilter=(action 'update')
+ *   <FilterValues::DimensionSelect
+ *       @filter={{filter}}
+ *       @onUpdateFilter={{action "update"}}
  *   }}
  */
 import config from 'ember-get-config';
 import { featureFlag } from 'navi-core/helpers/feature-flag';
-import { readOnly } from '@ember/object/computed';
 import { debounce } from '@ember/runloop';
 import { A } from '@ember/array';
 import { resolve, Promise } from 'rsvp';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
-import { get, computed } from '@ember/object';
+import { get, set, computed, action } from '@ember/object';
+import { readOnly } from '@ember/object/computed';
 import layout from '../../templates/components/filter-values/dimension-select';
+import { layout as templateLayout, tagName } from '@ember-decorators/component';
 
 const SEARCH_DEBOUNCE_TIME = 200;
 
 const LOAD_CARDINALITY = config.navi.searchThresholds.contains;
 
-export default Component.extend({
-  layout,
-
-  tagName: '',
-
+@templateLayout(layout)
+@tagName('')
+class DimensionSelectComponent extends Component {
   /**
    * @private
    * @property {Ember.Service} _dimensionService
    */
-  _dimensionService: service('bard-dimensions'),
+  @service('bard-dimensions') _dimensionService;
 
   /**
    * @property _metadataService
    */
-  _metadataService: service('bard-metadata'),
+  @service('bard-metadata') _metadataService;
 
   /**
    * @property {String} dimensionName - name of dimension to be filtered
    */
-  dimensionName: readOnly('filter.subject.name'),
+  @readOnly('filter.subject.name') dimensionName;
 
   /**
    * @property {String} primaryKey - primary key for this dimension
    */
-  primaryKey: readOnly('filter.subject.primaryKeyFieldName'),
+  @readOnly('filter.subject.primaryKeyFieldName') primaryKey;
 
   /**
    * @property {BardDimensionArray} dimensionOptions - list of all dimension values
    */
-  dimensionOptions: computed('filter.subject', function() {
+  @computed('dimensionName', 'searchTerm')
+  get dimensionOptions() {
+    if (this.searchTerm !== undefined) {
+      return undefined; // we are searching, so only show search results
+    }
+
     const dimensionName = get(this, 'dimensionName'),
       dimensionService = get(this, '_dimensionService'),
       metadataService = get(this, '_metadataService');
@@ -62,12 +66,13 @@ export default Component.extend({
     }
 
     return undefined;
-  }),
+  }
 
   /**
    * @property {BardDimensionArray} selectedDimensions - list of currently selected dimension values
    */
-  selectedDimensions: computed('filter.values', function() {
+  @computed('filter.values')
+  get selectedDimensions() {
     let dimensionIds = get(this, 'filter.values'),
       dimensionName = get(this, 'dimensionName'),
       primaryKey = get(this, 'primaryKey'),
@@ -82,25 +87,27 @@ export default Component.extend({
     } else {
       return resolve(A());
     }
-  }),
+  }
 
   /**
    * @property {String} filterValueFieldId - which id field to use as ID display.
    */
-  filterValueFieldId: computed('dimensionName', 'filter.field', function() {
+  @computed('dimensionName', 'filter.field')
+  get filterValueFieldId() {
     const { dimensionName } = this,
       metadataService = this._metadataService,
       meta = metadataService.getById('dimension', dimensionName);
 
     return meta ? meta.idFieldName : this.filter.field;
-  }),
+  }
 
   /**
    * @property {Boolean} useNewSearchAPI - whether to use /search endpoint instead of /values
    */
-  useNewSearchAPI: computed(function() {
+  @computed
+  get useNewSearchAPI() {
     return featureFlag('newDimensionsSearchAPI');
-  }),
+  }
 
   /**
    * Executes a dimension search for a given term and executes the
@@ -120,34 +127,36 @@ export default Component.extend({
     get(this, '_dimensionService')
       .search(dimension, { term, useNewSearchAPI })
       .then(resolve, reject);
-  },
+  }
 
-  actions: {
-    /**
-     * @action setValues
-     * @param {Array} values
-     */
-    setValues(values) {
-      let primaryKey = get(this, 'primaryKey');
-      this.onUpdateFilter({
-        rawValues: A(values).mapBy(primaryKey)
+  /**
+   * @action setValues
+   * @param {Array} values
+   */
+  @action
+  setValues(values) {
+    this.onUpdateFilter({
+      rawValues: A(values).mapBy(this.primaryKey)
+    });
+  }
+
+  /**
+   * Searches dimension service for the given query
+   *
+   * @action searchDimensionValues
+   * @param {String} searchTerm - Search query
+   */
+  @action
+  searchDimensionValues(searchTerm) {
+    let term = searchTerm.trim();
+    set(this, 'searchTerm', term);
+
+    if (term) {
+      return new Promise((resolve, reject) => {
+        return debounce(this, this._performSearch, term, resolve, reject, SEARCH_DEBOUNCE_TIME);
       });
-    },
-
-    /**
-     * Searches dimension service for the given query
-     *
-     * @action searchDimensionValues
-     * @param {String} query - Search query
-     */
-    searchDimensionValues(query) {
-      let term = query.trim();
-
-      if (term) {
-        return new Promise((resolve, reject) => {
-          return debounce(this, this._performSearch, term, resolve, reject, SEARCH_DEBOUNCE_TIME);
-        });
-      }
     }
   }
-});
+}
+
+export default DimensionSelectComponent;

--- a/packages/reports/addon/templates/components/filter-values/dimension-select.hbs
+++ b/packages/reports/addon/templates/components/filter-values/dimension-select.hbs
@@ -1,4 +1,4 @@
-{{!-- Copyright 2019, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 {{#if @isCollapsed}}
   {{#if (is-fulfilled this.selectedDimensions)}}
     {{#if @filter.validations.attrs.rawValues.isInvalid}}
@@ -16,8 +16,9 @@
     @extra={{hash filter=@filter}}
     @triggerComponent="power-select-bulk-import-trigger"
     @optionsComponent="power-select-collection-options"
-    @onchange={{action "setValues"}}
-    @search={{action "searchDimensionValues"}}
+    @onchange={{action this.setValues}}
+    @onclose={{set this.searchTerm undefined}}
+    @search={{action this.searchDimensionValues}}
     @closeOnSelect={{false}}
     @placeholder={{concat @filter.subject.longName " Values"}}
     @loadingMessage="Loading..."

--- a/packages/reports/addon/templates/components/filter-values/dimension-select.hbs
+++ b/packages/reports/addon/templates/components/filter-values/dimension-select.hbs
@@ -16,9 +16,9 @@
     @extra={{hash filter=@filter}}
     @triggerComponent="power-select-bulk-import-trigger"
     @optionsComponent="power-select-collection-options"
-    @onchange={{action this.setValues}}
+    @onchange={{this.setValues}}
     @onclose={{set this.searchTerm undefined}}
-    @search={{action this.searchDimensionValues}}
+    @search={{this.searchDimensionValues}}
     @closeOnSelect={{false}}
     @placeholder={{concat @filter.subject.longName " Values"}}
     @loadingMessage="Loading..."

--- a/packages/reports/package-lock.json
+++ b/packages/reports/package-lock.json
@@ -10816,28 +10816,6 @@
         "ember-concurrency": "^0.8.27 || ^0.9.0 || ^0.10.0 || ^1.0.0",
         "ember-text-measurer": "^0.5.0",
         "ember-truth-helpers": "^2.1.0"
-      },
-      "dependencies": {
-        "ember-basic-dropdown": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/ember-basic-dropdown/-/ember-basic-dropdown-1.1.3.tgz",
-          "integrity": "sha512-zIFk5yzu31L4E5lz3DfXF1IGGMcMAGYssh7hCoemjB7iqkL7Sf1UhUg/yEHcr5aEdfyGc1V3G2s740cRY+VLiQ==",
-          "dev": true,
-          "requires": {
-            "ember-cli-babel": "^7.2.0",
-            "ember-cli-htmlbars": "^3.0.1",
-            "ember-maybe-in-element": "^0.2.0"
-          }
-        },
-        "ember-maybe-in-element": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/ember-maybe-in-element/-/ember-maybe-in-element-0.2.0.tgz",
-          "integrity": "sha512-R5e6N8yDbfNbA/3lMZsFs2KEzv/jt80TsATiKMCqdqKuSG82KrD25cRdU5VkaE8dTQbziyBeuJs90bBiqOnakQ==",
-          "dev": true,
-          "requires": {
-            "ember-cli-babel": "^7.1.0"
-          }
-        }
       }
     },
     "ember-promise-helpers": {

--- a/packages/reports/tests/integration/components/filter-values/dimension-select-test.js
+++ b/packages/reports/tests/integration/components/filter-values/dimension-select-test.js
@@ -105,7 +105,7 @@ module('Integration | Component | filter values/dimension select', function(hook
     };
 
     await render(
-      hbs`<FilterValues::DimensionSelect @filter={{this.filter}} @onUpdateFilter={{action this.onUpdateFilter}} />`
+      hbs`<FilterValues::DimensionSelect @filter={{this.filter}} @onUpdateFilter={{this.onUpdateFilter}} />`
     );
 
     // Select a new value
@@ -164,7 +164,7 @@ module('Integration | Component | filter values/dimension select', function(hook
     };
 
     await render(
-      hbs`<FilterValues::DimensionSelect @filter={{this.filter}} @onUpdateFilter={{action this.onUpdateFilter}} />`
+      hbs`<FilterValues::DimensionSelect @filter={{this.filter}} @onUpdateFilter={{this.onUpdateFilter}} />`
     );
 
     await clickTrigger();

--- a/packages/reports/tests/integration/components/filter-values/dimension-select-test.js
+++ b/packages/reports/tests/integration/components/filter-values/dimension-select-test.js
@@ -1,13 +1,13 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, findAll } from '@ember/test-helpers';
+import { render, findAll, fillIn, triggerEvent } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { clickTrigger, nativeMouseUp } from 'ember-power-select/test-support/helpers';
 import AgeValues from 'navi-data/mirage/bard-lite/dimensions/age';
 import config from 'ember-get-config';
 import $ from 'jquery';
-import { run } from '@ember/runloop';
+import { set } from '@ember/object';
 
 const MockFilter = {
   subject: {
@@ -86,7 +86,7 @@ module('Integration | Component | filter values/dimension select', function(hook
       values: []
     };
 
-    await render(hbs`{{filter-values/dimension-select filter=filter}}`);
+    await render(hbs`<FilterValues::DimensionSelect @filter={{this.filter}} />`);
 
     assert
       .dom('input')
@@ -104,7 +104,9 @@ module('Integration | Component | filter values/dimension select', function(hook
       );
     };
 
-    await render(hbs`{{filter-values/dimension-select filter=filter onUpdateFilter=(action onUpdateFilter)}}`);
+    await render(
+      hbs`<FilterValues::DimensionSelect @filter={{this.filter}} @onUpdateFilter={{action this.onUpdateFilter}} />`
+    );
 
     // Select a new value
     await clickTrigger();
@@ -118,9 +120,7 @@ module('Integration | Component | filter values/dimension select', function(hook
     await render(hbs`<FilterValues::DimensionSelect @filter={{this.filter}} @isCollapsed={{this.isCollapsed}} />`);
     assert.dom('.filter-values--dimension-select--error').isNotVisible('The input should not have error state');
 
-    await run(() => {
-      this.set('filter.validations', { attrs: { rawValues: { isInvalid: true } } });
-    });
+    this.set('filter.validations', { attrs: { rawValues: { isInvalid: true } } });
     assert.dom('.filter-values--dimension-select--error').isVisible('The input should have error state');
 
     this.set('isCollapsed', true);
@@ -139,7 +139,7 @@ module('Integration | Component | filter values/dimension select', function(hook
       validations: {}
     };
 
-    await render(hbs`{{filter-values/dimension-select filter=filter}}`);
+    await render(hbs`<FilterValues::DimensionSelect @filter={{this.filter}} />`);
 
     let selectedValueText = findAll('.ember-power-select-multiple-option span:nth-of-type(2)').map(el => {
       let text = el.textContent.trim();
@@ -147,5 +147,47 @@ module('Integration | Component | filter values/dimension select', function(hook
     });
 
     assert.deepEqual(selectedValueText, ['(1)', '(3)'], 'Select values by key instead of id');
+  });
+
+  test('filters stay applied while selecting', async function(assert) {
+    assert.expect(2);
+    this.filter = {
+      ...MockFilter,
+      values: []
+    };
+
+    const searchTerm = '5';
+    const selectedId = '5';
+
+    this.onUpdateFilter = changeSet => {
+      set(this, 'filter', { ...this.filter, values: changeSet.rawValues });
+    };
+
+    await render(
+      hbs`<FilterValues::DimensionSelect @filter={{this.filter}} @onUpdateFilter={{action this.onUpdateFilter}} />`
+    );
+
+    await clickTrigger();
+    await fillIn('.ember-power-select-trigger-multiple-input', searchTerm);
+    await triggerEvent('.ember-power-select-trigger-multiple-input', 'keyup');
+
+    let visibleOptions = () =>
+      findAll('.ember-power-select-option')
+        .filter(el => el.offsetParent !== null) // only visible elements
+        .map(el => el.textContent.trim());
+
+    const expectedValueDimensions = AgeValues.map(age => `${age.description} (${age.id})`).filter(str =>
+      str.includes(searchTerm)
+    );
+
+    assert.deepEqual(visibleOptions(), expectedValueDimensions, `Only values containing '${searchTerm}' are displayed`);
+
+    await nativeMouseUp($(`.ember-power-select-option:contains("(${selectedId})")`)[0]);
+
+    assert.deepEqual(
+      visibleOptions(),
+      expectedValueDimensions,
+      `Only values containing ${searchTerm} are displayed, even after changing selection`
+    );
   });
 });


### PR DESCRIPTION
Resolves #344 

## Description
The dimension search had inconsistent behavior depending on the cardinality of the dimension being search
- for low cardinality dimensions, when searching, if you clicked an option the list would be recomputed and override the actual search results
- for high cardinality dimensions, when searching, if you clicked an option the list would stay filtered as expected

## Proposed Changes
Only show dimension options if there is no search filter for low cardinality dimensions

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
