### PR TITLE
Fix: Metric filter input

### DIFF
--- a/packages/reports/addon/components/filter-values/range-input.js
+++ b/packages/reports/addon/components/filter-values/range-input.js
@@ -1,57 +1,55 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Usage:
- *   {{filter-values/range-input
- *       filter=filter
- *       onUpdateFilter=(action 'update')
- *       lowPlaceholder=lowPlaceholder
- *       highPlaceholder=highPlaceholder
- *   }}
+ *   <FilterValues::RangeInput
+ *     @filter={{filter}}
+ *     @onUpdateFilter={{action "update"}}
+ *     @lowPlaceholder={{lowPlaceholder}}
+ *     @highPlaceholder={{highPlaceholder}}
+ *   />
  */
 
 import Component from '@ember/component';
-import { get } from '@ember/object';
+import { action, get } from '@ember/object';
 import layout from '../../templates/components/filter-values/range-input';
+import { layout as templateLayout, tagName } from '@ember-decorators/component';
 
-export default Component.extend({
-  layout,
-
-  /**
-   * @property {Array} classNames
-   */
-  classNames: ['filter-values--range-input'],
-
+@tagName('')
+@templateLayout(layout)
+class RangeInput extends Component {
   /**
    * @property {String} lowPlaceholder
    */
-  lowPlaceholder: 'Low value',
+  lowPlaceholder = 'Low value';
 
   /**
    * @property {String} highPlaceholder
    */
-  highPlaceholder: 'High value',
+  highPlaceholder = 'High value';
 
-  actions: {
-    /**
-     * @action setLowValue
-     * @param {String} value - first value to be set in filter
-     */
-    setLowValue(value) {
-      this.onUpdateFilter({
-        values: [value, get(this, 'filter.values.lastObject')]
-      });
-    },
-
-    /**
-     * @action setHighValue
-     * @param {String} value - last value to be set in filter
-     */
-    setHighValue(value) {
-      this.onUpdateFilter({
-        values: [get(this, 'filter.values.firstObject'), value]
-      });
-    }
+  /**
+   * @action setLowValue
+   * @param {String} value - first value to be set in filter
+   */
+  @action
+  setLowValue(value) {
+    this.onUpdateFilter({
+      values: [value, get(this, 'filter.values.lastObject')]
+    });
   }
-});
+
+  /**
+   * @action setHighValue
+   * @param {String} value - last value to be set in filter
+   */
+  @action
+  setHighValue(value) {
+    this.onUpdateFilter({
+      values: [get(this, 'filter.values.firstObject'), value]
+    });
+  }
+}
+
+export default RangeInput;

--- a/packages/reports/addon/components/filter-values/range-input.js
+++ b/packages/reports/addon/components/filter-values/range-input.js
@@ -31,10 +31,10 @@ class RangeInput extends Component {
 
   /**
    * @action setLowValue
-   * @param {String} value - first value to be set in filter
+   * @param {InputEvent} event
    */
   @action
-  setLowValue(value) {
+  setLowValue({ target: { value } }) {
     this.onUpdateFilter({
       values: [value, get(this, 'filter.values.lastObject')]
     });
@@ -42,10 +42,10 @@ class RangeInput extends Component {
 
   /**
    * @action setHighValue
-   * @param {String} value - last value to be set in filter
+   * @param {InputEvent} event
    */
   @action
-  setHighValue(value) {
+  setHighValue({ target: { value } }) {
     this.onUpdateFilter({
       values: [get(this, 'filter.values.firstObject'), value]
     });

--- a/packages/reports/addon/components/filter-values/value-input.js
+++ b/packages/reports/addon/components/filter-values/value-input.js
@@ -18,10 +18,10 @@ import { layout as templateLayout, tagName } from '@ember-decorators/component';
 class ValueInput extends Component {
   /**
    * @action setValue
-   * @param {String} value - single value to be set in filter
+   * @param {InputEvent} event
    */
   @action
-  setValue(value) {
+  setValue({ target: { value } }) {
     this.onUpdateFilter({
       values: [value]
     });

--- a/packages/reports/addon/components/filter-values/value-input.js
+++ b/packages/reports/addon/components/filter-values/value-input.js
@@ -17,7 +17,7 @@ import { layout as templateLayout, tagName } from '@ember-decorators/component';
 @templateLayout(layout)
 class ValueInput extends Component {
   /**
-   * @action setValues
+   * @action setValue
    * @param {String} value - single value to be set in filter
    */
   @action

--- a/packages/reports/addon/components/filter-values/value-input.js
+++ b/packages/reports/addon/components/filter-values/value-input.js
@@ -1,34 +1,31 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Usage:
- *   {{filter-values/value-input
- *       filter=filter
- *       onUpdateFilter=(action 'update')
- *   }}
+ *   <FilterValues::ValueInput
+ *     @filter={{filter}}
+ *     @onUpdateFilter={{action "update"}}
+ *   />
  */
 import Component from '@ember/component';
+import { action } from '@ember/object';
 import layout from '../../templates/components/filter-values/value-input';
+import { layout as templateLayout, tagName } from '@ember-decorators/component';
 
-export default Component.extend({
-  layout,
-
+@tagName('')
+@templateLayout(layout)
+class ValueInput extends Component {
   /**
-   * @property {String} tagName
-   * @override
+   * @action setValues
+   * @param {String} value - single value to be set in filter
    */
-  tagName: '',
-
-  actions: {
-    /**
-     * @action setValues
-     * @param {String} value - single value to be set in filter
-     */
-    setValue(value) {
-      this.onUpdateFilter({
-        values: [value]
-      });
-    }
+  @action
+  setValue(value) {
+    this.onUpdateFilter({
+      values: [value]
+    });
   }
-});
+}
+
+export default ValueInput;

--- a/packages/reports/addon/templates/components/filter-values/range-input.hbs
+++ b/packages/reports/addon/templates/components/filter-values/range-input.hbs
@@ -20,7 +20,7 @@
       @value={{@filter.values.lastObject}}
       @placeholder={{this.highPlaceholder}}
       class="filter-values--range-input__input {{if @filter.validations.attrs.values.isInvalid "filter-values--range-input__input--error"}}"
-      {{on "input" (action "setHighValue" value="target.value")}}
+      {{on "input" (action this.setHighValue value="target.value")}}
     />
   </div>
 {{/if}}

--- a/packages/reports/addon/templates/components/filter-values/range-input.hbs
+++ b/packages/reports/addon/templates/components/filter-values/range-input.hbs
@@ -1,4 +1,4 @@
-{{!-- Copyright 2019, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 {{#if @isCollapsed}}
   {{#if @filter.validations.attrs.values.isInvalid}}
     <FilterValues::InvalidValue/>
@@ -6,19 +6,21 @@
     {{concat @filter.values.firstObject " and " @filter.values.lastObject}}
   {{/if}}
 {{else}}
-  <Input
-    @value={{readonly @filter.values.firstObject}}
-    @placeholder={{this.lowPlaceholder}}
-    class="filter-values--range-input__input {{if @filter.validations.attrs.values.isInvalid "filter-values--range-input__input--error"}}"
-    @key-up={{action "setLowValue"}}
-  />
+  <div class="filter-values--range-input">
+    <Input
+      @value={{@filter.values.firstObject}}
+      @placeholder={{this.lowPlaceholder}}
+      class="filter-values--range-input__input {{if @filter.validations.attrs.values.isInvalid "filter-values--range-input__input--error"}}"
+      {{on "input" (action "setLowValue" value="target.value")}}
+    />
 
-  <span class="filter-values--range-input__separator">and</span>
+    <span class="filter-values--range-input__separator">and</span>
 
-  <Input
-    @value={{readonly @filter.values.lastObject}}
-    @placeholder={{this.highPlaceholder}}
-    class="filter-values--range-input__input {{if @filter.validations.attrs.values.isInvalid "filter-values--range-input__input--error"}}"
-    @key-up={{action "setHighValue"}}
-  />
+    <Input
+      @value={{@filter.values.lastObject}}
+      @placeholder={{this.highPlaceholder}}
+      class="filter-values--range-input__input {{if @filter.validations.attrs.values.isInvalid "filter-values--range-input__input--error"}}"
+      {{on "input" (action "setHighValue" value="target.value")}}
+    />
+  </div>
 {{/if}}

--- a/packages/reports/addon/templates/components/filter-values/range-input.hbs
+++ b/packages/reports/addon/templates/components/filter-values/range-input.hbs
@@ -11,8 +11,7 @@
       value={{@filter.values.firstObject}}
       placeholder={{this.lowPlaceholder}}
       class="filter-values--range-input__input {{if @filter.validations.attrs.values.isInvalid "filter-values--range-input__input--error"}}"
-      {{on "input" (action this.setLowValue value="target.value")}}
-    />
+      {{on "input" (action this.setLowValue value="target.value")}}>
 
     <span class="filter-values--range-input__separator">and</span>
 
@@ -20,7 +19,6 @@
       value={{@filter.values.lastObject}}
       placeholder={{this.highPlaceholder}}
       class="filter-values--range-input__input {{if @filter.validations.attrs.values.isInvalid "filter-values--range-input__input--error"}}"
-      {{on "input" (action this.setHighValue value="target.value")}}
-    />
+      {{on "input" (action this.setHighValue value="target.value")}}>
   </div>
 {{/if}}

--- a/packages/reports/addon/templates/components/filter-values/range-input.hbs
+++ b/packages/reports/addon/templates/components/filter-values/range-input.hbs
@@ -6,7 +6,7 @@
     {{concat @filter.values.firstObject " and " @filter.values.lastObject}}
   {{/if}}
 {{else}}
-  <div class="filter-values--range-input">
+  <div class="filter-values--range-input" ...attributes>
     <Input
       @value={{@filter.values.firstObject}}
       @placeholder={{this.lowPlaceholder}}

--- a/packages/reports/addon/templates/components/filter-values/range-input.hbs
+++ b/packages/reports/addon/templates/components/filter-values/range-input.hbs
@@ -7,18 +7,18 @@
   {{/if}}
 {{else}}
   <div class="filter-values--range-input" ...attributes>
-    <Input
-      @value={{@filter.values.firstObject}}
-      @placeholder={{this.lowPlaceholder}}
+    <input
+      value={{@filter.values.firstObject}}
+      placeholder={{this.lowPlaceholder}}
       class="filter-values--range-input__input {{if @filter.validations.attrs.values.isInvalid "filter-values--range-input__input--error"}}"
       {{on "input" (action this.setLowValue value="target.value")}}
     />
 
     <span class="filter-values--range-input__separator">and</span>
 
-    <Input
-      @value={{@filter.values.lastObject}}
-      @placeholder={{this.highPlaceholder}}
+    <input
+      value={{@filter.values.lastObject}}
+      placeholder={{this.highPlaceholder}}
       class="filter-values--range-input__input {{if @filter.validations.attrs.values.isInvalid "filter-values--range-input__input--error"}}"
       {{on "input" (action this.setHighValue value="target.value")}}
     />

--- a/packages/reports/addon/templates/components/filter-values/range-input.hbs
+++ b/packages/reports/addon/templates/components/filter-values/range-input.hbs
@@ -11,7 +11,7 @@
       value={{@filter.values.firstObject}}
       placeholder={{this.lowPlaceholder}}
       class="filter-values--range-input__input {{if @filter.validations.attrs.values.isInvalid "filter-values--range-input__input--error"}}"
-      {{on "input" (action this.setLowValue value="target.value")}}>
+      {{on "input" this.setLowValue}}>
 
     <span class="filter-values--range-input__separator">and</span>
 
@@ -19,6 +19,6 @@
       value={{@filter.values.lastObject}}
       placeholder={{this.highPlaceholder}}
       class="filter-values--range-input__input {{if @filter.validations.attrs.values.isInvalid "filter-values--range-input__input--error"}}"
-      {{on "input" (action this.setHighValue value="target.value")}}>
+      {{on "input" this.setHighValue}}>
   </div>
 {{/if}}

--- a/packages/reports/addon/templates/components/filter-values/range-input.hbs
+++ b/packages/reports/addon/templates/components/filter-values/range-input.hbs
@@ -11,7 +11,7 @@
       @value={{@filter.values.firstObject}}
       @placeholder={{this.lowPlaceholder}}
       class="filter-values--range-input__input {{if @filter.validations.attrs.values.isInvalid "filter-values--range-input__input--error"}}"
-      {{on "input" (action "setLowValue" value="target.value")}}
+      {{on "input" (action this.setLowValue value="target.value")}}
     />
 
     <span class="filter-values--range-input__separator">and</span>

--- a/packages/reports/addon/templates/components/filter-values/value-input.hbs
+++ b/packages/reports/addon/templates/components/filter-values/value-input.hbs
@@ -10,6 +10,5 @@
     value={{@filter.values.firstObject}}
     placeholder="Value"
     class="filter-values--value-input {{if @filter.validations.attrs.values.isInvalid "filter-values--value-input--error"}}"
-    {{on "input" (action this.setValue value="target.value")}}
-  />
+    {{on "input" (action this.setValue value="target.value")}}>
 {{/if}}

--- a/packages/reports/addon/templates/components/filter-values/value-input.hbs
+++ b/packages/reports/addon/templates/components/filter-values/value-input.hbs
@@ -6,9 +6,9 @@
     {{@filter.values.firstObject}}
   {{/if}}
 {{else}}
-  <Input
-    @value={{@filter.values.firstObject}}
-    @placeholder="Value"
+  <input
+    value={{@filter.values.firstObject}}
+    placeholder="Value"
     class="filter-values--value-input {{if @filter.validations.attrs.values.isInvalid "filter-values--value-input--error"}}"
     {{on "input" (action this.setValue value="target.value")}}
   />

--- a/packages/reports/addon/templates/components/filter-values/value-input.hbs
+++ b/packages/reports/addon/templates/components/filter-values/value-input.hbs
@@ -10,6 +10,6 @@
     @value={{@filter.values.firstObject}}
     @placeholder="Value"
     class="filter-values--value-input {{if @filter.validations.attrs.values.isInvalid "filter-values--value-input--error"}}"
-    {{on "input" (action "setValue" value="target.value")}}
+    {{on "input" (action this.setValue value="target.value")}}
   />
 {{/if}}

--- a/packages/reports/addon/templates/components/filter-values/value-input.hbs
+++ b/packages/reports/addon/templates/components/filter-values/value-input.hbs
@@ -1,4 +1,4 @@
-{{!-- Copyright 2019, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 {{#if @isCollapsed}}
   {{#if @filter.validations.attrs.values.isInvalid}}
     <FilterValues::InvalidValue/>
@@ -7,9 +7,9 @@
   {{/if}}
 {{else}}
   <Input
-    @value={{readonly @filter.values.firstObject}}
+    @value={{@filter.values.firstObject}}
     @placeholder="Value"
     class="filter-values--value-input {{if @filter.validations.attrs.values.isInvalid "filter-values--value-input--error"}}"
-    @key-up={{action "setValue"}}
+    {{on "input" (action "setValue" value="target.value")}}
   />
 {{/if}}

--- a/packages/reports/addon/templates/components/filter-values/value-input.hbs
+++ b/packages/reports/addon/templates/components/filter-values/value-input.hbs
@@ -10,5 +10,5 @@
     value={{@filter.values.firstObject}}
     placeholder="Value"
     class="filter-values--value-input {{if @filter.validations.attrs.values.isInvalid "filter-values--value-input--error"}}"
-    {{on "input" (action this.setValue value="target.value")}}>
+    {{on "input" this.setValue}}>
 {{/if}}

--- a/packages/reports/tests/integration/components/filter-values/range-input-test.js
+++ b/packages/reports/tests/integration/components/filter-values/range-input-test.js
@@ -2,7 +2,7 @@ import { A } from '@ember/array';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import $ from 'jquery';
-import { render } from '@ember/test-helpers';
+import { render, fillIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | filter values/range input', function(hooks) {
@@ -12,11 +12,12 @@ module('Integration | Component | filter values/range input', function(hooks) {
     this.filter = { values: A([1000, 2000]) };
     this.onUpdateFilter = () => null;
 
-    await render(hbs`{{filter-values/range-input
-            filter=filter
-            onUpdateFilter=(action onUpdateFilter)
-            isCollapsed=isCollapsed
-        }}`);
+    await render(hbs`
+      <FilterValues::RangeInput
+        @filter={{this.filter}}
+        @onUpdateFilter={{this.onUpdateFilter}}
+        @isCollapsed={{this.isCollapsed}}
+      />`);
   });
 
   test('it renders', function(assert) {
@@ -40,30 +41,20 @@ module('Integration | Component | filter values/range input', function(hooks) {
     assert.dom().hasText('1000 and 2000', 'Selected values are rendered correctly when collapsed');
   });
 
-  test('changing values', function(assert) {
+  test('changing values', async function(assert) {
     assert.expect(2);
 
     this.set('onUpdateFilter', changeSet => {
       assert.deepEqual(changeSet, { values: ['aaa', 2000] }, 'User inputted number is given to update action');
     });
 
-    $('.filter-values--range-input__input')
-      .eq(0)
-      .val('aaa');
-    $('.filter-values--range-input__input')
-      .eq(0)
-      .trigger('keyup');
+    await fillIn('.filter-values--range-input__input:first-child', 'aaa');
 
     this.set('onUpdateFilter', changeSet => {
       assert.deepEqual(changeSet, { values: [1000, 'bbb'] }, 'User inputted number is given to update action');
     });
 
-    $('.filter-values--range-input__input')
-      .eq(1)
-      .val('bbb');
-    $('.filter-values--range-input__input')
-      .eq(1)
-      .trigger('keyup');
+    await fillIn('.filter-values--range-input__input:last-child', 'bbb');
   });
 
   test('error state', function(assert) {
@@ -79,19 +70,18 @@ module('Integration | Component | filter values/range input', function(hooks) {
     assert.ok($('.filter-values--range-input__input--error').is(':visible'), 'The input should have error state');
 
     this.set('isCollapsed', true);
-    assert
-      .dom('.filter-values--range-input .filter-values--selected-error')
-      .exists('Error is rendered correctly when collapsed');
+    assert.dom('.filter-values--selected-error').exists('Error is rendered correctly when collapsed');
   });
 
   test('config placeholders', async function(assert) {
     assert.expect(1);
-    await render(hbs`{{filter-values/range-input
-          filter=filter
-          onUpdateFilter=(action onUpdateFilter)
-          lowPlaceholder='start'
-          highPlaceholder='end'
-      }}`);
+    await render(hbs`
+      <FilterValues::RangeInput
+        @filter={{this.filter}}
+        @onUpdateFilter={{this.onUpdateFilter}}
+        @lowPlaceholder="start"
+        @highPlaceholder="end"
+      />`);
 
     assert.deepEqual(
       $('.filter-values--range-input__input')

--- a/packages/reports/tests/integration/components/filter-values/value-input-test.js
+++ b/packages/reports/tests/integration/components/filter-values/value-input-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import $ from 'jquery';
-import { render, fillIn, triggerEvent } from '@ember/test-helpers';
+import { render, fillIn } from '@ember/test-helpers';
 import { A as arr } from '@ember/array';
 import hbs from 'htmlbars-inline-precompile';
 
@@ -12,11 +12,12 @@ module('Integration | Component | filter values/value input', function(hooks) {
     this.filter = { values: arr([1000]) };
     this.onUpdateFilter = () => null;
 
-    await render(hbs`{{filter-values/value-input
-            filter=filter
-            onUpdateFilter=(action onUpdateFilter)
-            isCollapsed=isCollapsed
-        }}`);
+    await render(hbs`
+      <FilterValues::ValueInput
+        @filter={{this.filter}}
+        @onUpdateFilter={{this.onUpdateFilter}}
+        @isCollapsed={{this.isCollapsed}}
+      />`);
   });
 
   test('it renders', function(assert) {
@@ -47,7 +48,6 @@ module('Integration | Component | filter values/value input', function(hooks) {
     });
 
     await fillIn('.filter-values--value-input', 'aaa');
-    await triggerEvent('.filter-values--value-input', 'keyup');
   });
 
   test('error state', function(assert) {


### PR DESCRIPTION
## Description

Fix the input for metric filters.

## Proposed Changes

For one-way binding we should use `<input>` with the `value` property and the `input` event, i.e.:
<strike>`<Input @value={{...}} @key-up={{action "setValue"}} />`</strike>
`<input value={{...}} {{on "input" (action this.setValue value="target.value")}}>`.

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
