### PR TITLE
Fix: Send credentials with requests

### DIFF
--- a/packages/core/addon/adapters/base-json-adapter.js
+++ b/packages/core/addon/adapters/base-json-adapter.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 

--- a/packages/core/addon/adapters/base-json-adapter.js
+++ b/packages/core/addon/adapters/base-json-adapter.js
@@ -31,7 +31,10 @@ export default DS.JSONAPIAdapter.extend({
    */
   ajaxOptions() {
     let hash = this._super(...arguments);
-    hash.credentials = 'include';
+    hash.xhrFields = {
+      withCredentials: true
+    };
+    hash.crossDomain = true;
     hash.headers = {
       Accept: 'application/vnd.api+json',
       'Content-Type': 'application/vnd.api+json'

--- a/packages/core/tests/unit/adapters/base-json-adapter-test.js
+++ b/packages/core/tests/unit/adapters/base-json-adapter-test.js
@@ -1,0 +1,22 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Adapter | Base Json Adapter', function(hooks) {
+  setupTest(hooks);
+
+  test('ajaxOptions', function(assert) {
+    assert.expect(3);
+
+    const adapter = this.owner.lookup('adapter:base-json-adapter');
+    const options = adapter.ajaxOptions();
+
+    assert.deepEqual(
+      options.headers,
+      { Accept: 'application/vnd.api+json', 'Content-Type': 'application/vnd.api+json' },
+      'The headers must specify jsonapi'
+    );
+
+    assert.deepEqual(options.crossDomain, true, 'Crossdomain is enabled');
+    assert.deepEqual(options.xhrFields, { withCredentials: true }, 'xhrFields includes withCredentials');
+  });
+});


### PR DESCRIPTION
## Description
The #619 PR removed the fetch adapter, which caused Cookies to not be included in requests and resulted in 401s when fetching resources

## Proposed Changes
Send credentials to persistence api host

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
