### PR TITLE
Update: Merge matrix and jobs config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: java
 jdk:
   - openjdk8
 
-sudo: true
 git:
   depth: false
 addons:
@@ -33,8 +32,6 @@ env:
 branches:
   only:
     - master
-matrix:
-  fast_finish: true
 install:
   - if [[ "${PACKAGE}" == "navi-webservice" ]]; then
     pushd packages/webservice && ./gradlew assemble && popd;
@@ -50,6 +47,7 @@ script:
     npx lerna run test --scope ${PACKAGE} --stream;
     fi
 jobs:
+  fast_finish: true
   include:
     - stage: 'Publish'
       if: branch = master AND repo = yahoo/navi AND type = push


### PR DESCRIPTION
Partially address #635 

## Description
Travis is now warning that our build config is invalid because we have both a `matrix` and `jobs` field, with the `matrix` field overwriting the jobs and stopping our builds from publishing

## Proposed Changes
- Merge `matrix` and `jobs`
- Remove deprecated `sudo` field

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
