### PR TITLE
Bulk import paste for multi-value-input

### DIFF
--- a/packages/core/app/styles/navi-core/common/dropdowns.less
+++ b/packages/core/app/styles/navi-core/common/dropdowns.less
@@ -88,8 +88,8 @@
         .clickable;
 
         &:hover {
-          background-color: @navi-form-purple;
-          color: @navi-white;
+          background-color: @navi-gray-200;
+          color: @navi-gray-800;
         }
       }
     }

--- a/packages/core/app/styles/navi-core/variables/colors.less
+++ b/packages/core/app/styles/navi-core/variables/colors.less
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 
@@ -52,11 +52,6 @@
 @navi-smoke-white: #f6f5f9;
 @navi-black: #000;
 @navi-magenta: #cc008c;
-@navi-purple-light: #6f53a1;
-@navi-purple-lighter: #8b72b3;
-@navi-purple: #400090;
-@navi-purple-dark: #5a449b;
-@navi-purple-border: #4c386f;
 @navi-teal: #00c1a5;
 @navi-gray: @navi-gray-600;
 @gray-6: @navi-gray-500;
@@ -90,7 +85,6 @@
 @navi-border-gray: @navi-gray-300;
 @navi-border-dark: @navi-gray-400;
 @navi-bottom-border-gray: @navi-gray-400;
-@navi-form-purple: #6e52a2;
 @navi-form-error-red: #fdf1f1;
 @navi-form-error-border: @navi-red;
 

--- a/packages/reports/addon/components/dimension-bulk-import-simple.js
+++ b/packages/reports/addon/components/dimension-bulk-import-simple.js
@@ -9,23 +9,13 @@
  *   />
  */
 import Component from '@ember/component';
-import { action } from '@ember/object';
+import { computed } from '@ember/object';
 import layout from '../templates/components/dimension-bulk-import-simple';
 import { layout as templateLayout, tagName } from '@ember-decorators/component';
 
 @tagName('')
 @templateLayout(layout)
 class DimensionBulkImportSimpleComponent extends Component {
-  /**
-   * @property {Array<String>} unsplitValue - empty/single value array of rawInput
-   */
-  unsplitValue = [];
-
-  /**
-   * @property {Array<String>} splitValues - array of values split by commas from rawInput
-   */
-  splitValues = [];
-
   /**
    * Filters the input list to a unique list of nonempty values
    * @param {Array<String>} list - the list to filter
@@ -38,29 +28,27 @@ class DimensionBulkImportSimpleComponent extends Component {
   }
 
   /**
-   * Sets up the split and unsplit values based on passed rawInput
-   * @param {Element} _ - The current element, unused
-   * @param {Array<String>} rawInput - the rawInput passed to the component
+   * @property {Array<String>} unsplitValue - empty/single value array of rawInput
    */
-  @action
-  setupValues(_, rawInput) {
-    let newRawInput = rawInput[0] || '';
-    this.set('unsplitValue', this.listFilter([newRawInput]));
-    this.set('splitValues', this.listFilter(newRawInput.split(',')));
+  @computed('rawInput')
+  get input() {
+    return this.rawInput || '';
   }
 
   /**
-   * Action to trigger on removing pill
-   *
-   * @method removeRecordAtIndex
-   * @param {Number} index - record to be removed from valid results
-   * @returns {Void}
+   * @property {Array<String>} unsplitValue - empty/single value array of rawInput
    */
-  @action
-  removeRecordAtIndex(index) {
-    const removed = this.splitValues.splice(index, 1);
-    this.set('splitValues', [...this.splitValues]);
-    return removed;
+  @computed('input')
+  get unsplitValue() {
+    return this.listFilter([this.input]);
+  }
+
+  /**
+   * @property {Array<String>} splitValues - array of values split by commas from rawInput
+   */
+  @computed('input')
+  get splitValues() {
+    return this.listFilter(this.input.split(','));
   }
 }
 

--- a/packages/reports/addon/components/dimension-bulk-import-simple.js
+++ b/packages/reports/addon/components/dimension-bulk-import-simple.js
@@ -16,7 +16,14 @@ import { layout as templateLayout, tagName } from '@ember-decorators/component';
 @tagName('')
 @templateLayout(layout)
 class DimensionBulkImportSimpleComponent extends Component {
+  /**
+   * @property {Array<String>} unsplitValue - empty/single value array of rawInput
+   */
   unsplitValue = [];
+
+  /**
+   * @property {Array<String>} splitValues - array of values split by commas from rawInput
+   */
   splitValues = [];
 
   /**
@@ -27,27 +34,19 @@ class DimensionBulkImportSimpleComponent extends Component {
     const filter = list
       .map(v => v.trim()) // remove surrounding space
       .filter(v => v.length > 0); // remove empty values
-    return [...new Set(filter)]; // only unique falues
+    return [...new Set(filter)]; // only unique values
   }
 
   /**
-   * @method didReceiveAttrs
-   * @override
+   * Sets up the split and unsplit values based on passed rawInput
+   * @param {Element} _ - The current element, unused
+   * @param {Array<String>} rawInput - the rawInput passed to the component
    */
-  didReceiveAttrs() {
-    super.didReceiveAttrs(...arguments);
-
-    const { previousRawInput, rawInput } = this;
-
-    if (previousRawInput !== rawInput) {
-      // new input
-      let newRawInput = rawInput || '';
-
-      this.set('unsplitValue', this.listFilter([newRawInput]));
-      this.set('splitValues', this.listFilter(newRawInput.split(',')));
-    }
-
-    this.previousRawInput = rawInput;
+  @action
+  setupValues(_, rawInput) {
+    let newRawInput = rawInput[0] || '';
+    this.set('unsplitValue', this.listFilter([newRawInput]));
+    this.set('splitValues', this.listFilter(newRawInput.split(',')));
   }
 
   /**

--- a/packages/reports/addon/components/dimension-bulk-import-simple.js
+++ b/packages/reports/addon/components/dimension-bulk-import-simple.js
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2020, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ *
+ * Usage:
+ *   <DimensionBulkImportSimple
+ *      @rawInput="list,of,ids"
+ *      @onSelectValues={{this.selectValues}}
+ *   />
+ */
+import Component from '@ember/component';
+import { action } from '@ember/object';
+import layout from '../templates/components/dimension-bulk-import-simple';
+import { layout as templateLayout, tagName } from '@ember-decorators/component';
+
+@tagName('')
+@templateLayout(layout)
+class DimensionBulkImportSimpleComponent extends Component {
+  unsplitValue = [];
+  splitValues = [];
+
+  /**
+   * Filters the input list to a unique list of nonempty values
+   * @param {Array<String>} list - the list to filter
+   */
+  listFilter(list) {
+    const filter = list
+      .map(v => v.trim()) // remove surrounding space
+      .filter(v => v.length > 0); // remove empty values
+    return [...new Set(filter)]; // only unique falues
+  }
+
+  /**
+   * @method didReceiveAttrs
+   * @override
+   */
+  didReceiveAttrs() {
+    super.didReceiveAttrs(...arguments);
+
+    const { previousRawInput, rawInput } = this;
+
+    if (previousRawInput !== rawInput) {
+      // new input
+      let newRawInput = rawInput || '';
+
+      this.set('unsplitValue', this.listFilter([newRawInput]));
+      this.set('splitValues', this.listFilter(newRawInput.split(',')));
+    }
+
+    this.previousRawInput = rawInput;
+  }
+
+  /**
+   * Action to trigger on removing pill
+   *
+   * @method removeRecordAtIndex
+   * @param {Number} index - record to be removed from valid results
+   * @returns {Void}
+   */
+  @action
+  removeRecordAtIndex(index) {
+    const removed = this.splitValues.splice(index, 1);
+    this.set('splitValues', [...this.splitValues]);
+    return removed;
+  }
+}
+
+export default DimensionBulkImportSimpleComponent;

--- a/packages/reports/addon/components/navi-tag-input.js
+++ b/packages/reports/addon/components/navi-tag-input.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  * Usage:
  *  {{#tag-input
@@ -7,6 +7,7 @@
  *    addTag=(action 'addTag')
  *    removeTagAtIndex=(action 'removeTagAtIndex')
  *    tagComponent='my-custom-tag-component'
+ *    splitOnPaste=false
  *    as |tag|
  *  }}
  *    {{tag}}
@@ -30,17 +31,79 @@ export default TagInput.extend({
   tagComponent: 'navi-tag-input/tag',
 
   /**
+   * @property {Boolean} splitOnPaste - whether or not to listen for paste input and handle importing lists
+   */
+  splitOnPaste: false,
+
+  /**
    * Ignore comma so that only 'enter' key adds new tags
    *
    * @param {InputEvent} e - The keydown input event
    * @override https://github.com/calvinlough/ember-tag-input/blob/v1.2.2/addon/components/tag-input.js#L74-L106
    */
   _onInputKeyDown(e) {
-    if (e.which === 118 || e.target.value === '') {
+    if (e.which === 188) {
       // comma input
       return;
     }
 
     return this._super(...arguments);
+  },
+
+  /**
+   * Allow simple imports of pasted lists
+   * @param {InputEvent} e - The paste event
+   */
+  _onInputPaste(e) {
+    const pastedText = e.clipboardData.getData('text/plain').trim();
+    if (this.splitOnPaste !== true || !pastedText.includes(',')) {
+      return;
+    }
+
+    e.preventDefault();
+    this.set('_showBulkImport', true);
+    this.set('_bulkImportValue', pastedText);
+  },
+
+  /**
+   * Add a listener for paste events
+   * @override https://github.com/calvinlough/ember-tag-input/blob/v1.2.2/addon/components/tag-input.js#L123-L136
+   */
+  initEvents() {
+    this._super(...arguments);
+
+    const onInputPaste = this._onInputPaste.bind(this);
+    const newTagInput = this.element.querySelector('.emberTagInput-input');
+    newTagInput.addEventListener('paste', onInputPaste);
+  },
+
+  /**
+   * Remove listener for paste events
+   * @override
+   */
+  willDestroyElement() {
+    this._super(...arguments);
+
+    const onInputPaste = this._onInputPaste.bind(this);
+    const newTagInput = this.element.querySelector('.emberTagInput-input');
+    newTagInput.removeEventListener('paste', onInputPaste);
+  },
+
+  actions: {
+    /**
+     * @action closeModal - Closes the modal and clears the pasted value
+     */
+    closeModal() {
+      this.set('_showBulkImport', false);
+      this.set('_bulkImportValue', undefined);
+    },
+
+    /**
+     * @action addTags - Imports new tags and only adds unique ones
+     * @param {Array<String>} tags - The tags to be imported
+     */
+    addTags(tags) {
+      return tags.forEach(tag => this.addNewTag(tag));
+    }
   }
 });

--- a/packages/reports/addon/components/navi-tag-input.js
+++ b/packages/reports/addon/components/navi-tag-input.js
@@ -17,6 +17,8 @@
 import layout from '../templates/components/navi-tag-input';
 import TagInput from 'ember-tag-input/components/tag-input';
 
+const COMMA_KEY_CODE = 188;
+
 export default TagInput.extend({
   layout,
 
@@ -42,8 +44,7 @@ export default TagInput.extend({
    * @override https://github.com/calvinlough/ember-tag-input/blob/v1.2.2/addon/components/tag-input.js#L74-L106
    */
   _onInputKeyDown(e) {
-    if (e.which === 188) {
-      // comma input
+    if (e.which === COMMA_KEY_CODE) {
       return;
     }
 

--- a/packages/reports/addon/templates/components/dimension-bulk-import-simple.hbs
+++ b/packages/reports/addon/templates/components/dimension-bulk-import-simple.hbs
@@ -1,9 +1,5 @@
 {{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
-<div 
-  class="dimension-bulk-import-simple" 
-  ...attributes
-  {{did-update this.setupValues @rawInput}}
->
+<div class="dimension-bulk-import-simple" ...attributes>
   <div class="navi-modal-header">
     <div class="text-capitalize primary-header">Paste Import</div>
     <div class="secondary-header">If this is a list of values, choose the split ids.</div>
@@ -14,9 +10,8 @@
     {{#paginated-scroll-list
       trim=false
       items=this.splitValues
-      as |dimVal idx|
+      as |dimVal|
     }}
-      <span role="button" class="remove-pill" {{on "click" (fn this.removeRecordAtIndex idx)}}>×</span>
       {{dimVal}}
     {{/paginated-scroll-list}}
   </div>

--- a/packages/reports/addon/templates/components/dimension-bulk-import-simple.hbs
+++ b/packages/reports/addon/templates/components/dimension-bulk-import-simple.hbs
@@ -1,5 +1,9 @@
 {{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
-<div class="dimension-bulk-import-simple" ...attributes>
+<div 
+  class="dimension-bulk-import-simple" 
+  ...attributes
+  {{did-update this.setupValues @rawInput}}
+>
   <div class="navi-modal-header">
     <div class="text-capitalize primary-header">Paste Import</div>
     <div class="secondary-header">If this is a list of values, choose the split ids.</div>

--- a/packages/reports/addon/templates/components/dimension-bulk-import-simple.hbs
+++ b/packages/reports/addon/templates/components/dimension-bulk-import-simple.hbs
@@ -1,0 +1,35 @@
+{{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+<div class="dimension-bulk-import-simple" ...attributes>
+  <div class="navi-modal-header">
+    <div class="text-capitalize primary-header">Paste Import</div>
+    <div class="secondary-header">If this is a list of values, choose the split ids.</div>
+  </div>
+
+  <div class="dimension-bulk-import-simple-row dimension-bulk-import-simple-row--split-values">
+    <span class="text-capitalize dimension-bulk-import-simple-row__header">Input split by commas ({{this.splitValues.length}})</span>
+    {{#paginated-scroll-list
+      trim=false
+      items=this.splitValues
+      as |dimVal idx|
+    }}
+      <span role="button" class="remove-pill" {{on "click" (fn this.removeRecordAtIndex idx)}}>×</span>
+      {{dimVal}}
+    {{/paginated-scroll-list}}
+  </div>
+  <div class="dimension-bulk-import-simple-row dimension-bulk-import-simple-row--raw-value">
+    <span class="text-capitalize dimension-bulk-import-simple-row__header">Raw input</span>
+    {{#paginated-scroll-list
+      trim=false
+      items=this.unsplitValue
+      as |dimVal|
+    }}
+      {{dimVal}}
+    {{/paginated-scroll-list}}
+  </div>
+
+  <div class="btn-container">
+    <button type="button" class="btn btn-primary" {{on "click" (fn @onSelectValues this.splitValues)}}>Use split input ({{this.splitValues.length}} values)</button>
+    <button type="button" class="btn btn-primary" {{on "click" (fn @onSelectValues this.unsplitValue)}}>Use raw input</button>
+    <button type="button" class="btn btn-secondary" {{on "click" @onCancel}}>Cancel</button>
+  </div>
+</div>

--- a/packages/reports/addon/templates/components/dimension-bulk-import.hbs
+++ b/packages/reports/addon/templates/components/dimension-bulk-import.hbs
@@ -1,4 +1,4 @@
-{{!-- Copyright 2019, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 {{#with (pluralize 2 dimension.longName without-count=true) as |normalizedDimensionName|}}
   <div class="navi-modal-header">
     <div class="text-capitalize primary-header">Add Multiple {{normalizedDimensionName}}</div>
@@ -19,16 +19,18 @@
     <span class="valid-id-count">{{_validDimValues.length}}</span> valid <span class="text-capitalize dimension">{{pluralize _validDimValues.length dimension.longName  without-count=true}}</span>
     {{#paginated-scroll-list
       items=_validDimValues
+      trim=false
       as |dimVal|
     }}
+      <span role="button" class="remove-pill" onclick={{action "removeRecord" dimVal}}>×</span>
       {{format-dimension dimVal}}
-      <button type="button" tabindex="-1" class="btn remove-pill" onclick={{action "removeRecord" dimVal}}>×</button>
     {{/paginated-scroll-list}}
   </div>
   <div class="id-container invalid-ids">
     <span class="invalid-id-count">{{_invalidDimValueIds.length}}</span> invalid <span class="text-capitalize dimension">{{pluralize _invalidDimValueIds.length dimension.longName  without-count=true}}</span>
     {{#paginated-scroll-list
       items=_invalidDimValueIds
+      trim=false
       as |invalidDimId|
     }}
       {{invalidDimId}}

--- a/packages/reports/addon/templates/components/filter-values/multi-value-input.hbs
+++ b/packages/reports/addon/templates/components/filter-values/multi-value-input.hbs
@@ -1,4 +1,4 @@
-{{!-- Copyright 2019, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.--}}
+{{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.--}}
 {{#if @isCollapsed}}
   {{#if @filter.validations.isInvalid}}
     <FilterValues::InvalidValue/>
@@ -16,6 +16,7 @@
     placeholder=(concat @filter.subject.longName " Values")
     removeTagAtIndex=(action "removeValueAtIndex")
     allowSpacesInTags=true
+    splitOnPaste=true
     as |tag|
   }}
     {{tag}}

--- a/packages/reports/addon/templates/components/navi-tag-input.hbs
+++ b/packages/reports/addon/templates/components/navi-tag-input.hbs
@@ -1,4 +1,4 @@
-{{!-- Copyright 2018, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.--}}
+{{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.--}}
 {{!-- This is a modification of the ember-tag-input template.
    -- Original template at https://github.com/calvinlough/ember-tag-input/blob/master/addon/templates/components/tag-input.hbs --}}
 {{#each tags as |tag index|}}
@@ -21,3 +21,12 @@
     placeholder=placeholder
   }}
 </li>
+
+{{!-- Added logic for bulk import --}}
+<NaviModal @isShown={{this._showBulkImport}}>
+  <DimensionBulkImportSimple
+    @rawInput={{this._bulkImportValue}}
+    @onSelectValues={{queue (action "addTags") (action "closeModal")}}
+    @onCancel={{action "closeModal"}}
+  />
+</NaviModal>

--- a/packages/reports/addon/templates/components/paginated-scroll-list.hbs
+++ b/packages/reports/addon/templates/components/paginated-scroll-list.hbs
@@ -7,5 +7,5 @@
   </ul>
 </div>
 {{#if _isTrimmed}}
-  <a href tabindex="-1" onclick={{action "onShowMore"}}>{{moreLabel}}</a>
+  <a tabindex="-1" onclick={{action "onShowMore"}}>{{moreLabel}}</a>
 {{/if}}

--- a/packages/reports/addon/templates/components/paginated-scroll-list.hbs
+++ b/packages/reports/addon/templates/components/paginated-scroll-list.hbs
@@ -1,8 +1,8 @@
-{{!-- Copyright 2017, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 <div class="{{_containerClass}} {{if trim "trimmed" "show-all"}}">
   <ul class={{_collectionClass}}>
-    {{#each _itemsToRender as |item|}}
-      <li class="item">{{yield item}}</li>
+    {{#each _itemsToRender as |item idx|}}
+      <li class="item">{{yield item idx}}</li>
     {{/each}}
   </ul>
 </div>

--- a/packages/reports/app/components/dimension-bulk-import-simple.js
+++ b/packages/reports/app/components/dimension-bulk-import-simple.js
@@ -1,0 +1,1 @@
+export { default } from 'navi-reports/components/dimension-bulk-import-simple';

--- a/packages/reports/app/styles/navi-reports/components/dimension-bulk-import-simple.less
+++ b/packages/reports/app/styles/navi-reports/components/dimension-bulk-import-simple.less
@@ -1,0 +1,12 @@
+/**
+ * Copyright 2020, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+
+.dimension-bulk-import-simple {
+  .dimension-bulk-import;
+
+  &-row {
+    .id-container;
+  }
+}

--- a/packages/reports/app/styles/navi-reports/components/dimension-bulk-import.less
+++ b/packages/reports/app/styles/navi-reports/components/dimension-bulk-import.less
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 
@@ -7,7 +7,7 @@
 
 .dimension-bulk-import {
   .valid-id-count {
-    color: @navi-purple-dark;
+    color: @navi-blue-500;
   }
 
   .invalid-id-count {
@@ -24,21 +24,11 @@
     .last-of-group-form-element;
 
     .item {
-      font-size: @font-size-form;
-      background: @navi-purple-lighter;
-      color: @navi-light-gray;
-      margin: 3px 5px 0 0;
-      padding: 2px 6px;
-      display: inline-block;
-      border-radius: 3px;
-      list-style: none;
+      .navi-pill;
 
       .remove-pill {
-        font-size: @font-size-mid-base;
-        margin: 0 0 0 5px;
-        color: @navi-light-gray;
-        background-color: transparent;
-        padding: 0;
+        .navi-pill-remove-button;
+        user-select: none;
       }
     }
   }

--- a/packages/reports/app/styles/navi-reports/components/index.less
+++ b/packages/reports/app/styles/navi-reports/components/index.less
@@ -18,6 +18,7 @@
 @import 'report-collection';
 @import 'show-all';
 @import 'dimension-bulk-import';
+@import 'dimension-bulk-import-simple';
 @import 'dropdown-date-picker';
 @import 'filter-collection';
 @import 'report-builder';

--- a/packages/reports/app/styles/navi-reports/components/show-all.less
+++ b/packages/reports/app/styles/navi-reports/components/show-all.less
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 
@@ -17,7 +17,7 @@
   }
 
   .items-count {
-    color: @navi-purple-lighter;
+    color: @navi-blue-500;
   }
 
   .show-all {

--- a/packages/reports/package-lock.json
+++ b/packages/reports/package-lock.json
@@ -1001,7 +1001,6 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/@ember-decorators/object/-/object-6.1.1.tgz",
       "integrity": "sha512-cb4CNR9sRoA31J3FCOFLDuR9ztM4wO9w1WlS4JeNRS7Z69SlB/XSXB/vplA3i9OOaXEy/zKWbu5ndZrHz0gvLw==",
-      "dev": true,
       "requires": {
         "@ember-decorators/utils": "^6.1.1",
         "ember-cli-babel": "^7.1.3"
@@ -1018,8 +1017,7 @@
     "@ember/edition-utils": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@ember/edition-utils/-/edition-utils-1.1.1.tgz",
-      "integrity": "sha512-GEhri78jdQp/xxPpM6z08KlB0wrHfnfrJ9dmQk7JeQ4XCiMzXsJci7yooQgg/IcTKCM/PxE/IkGCQAo80adMkw==",
-      "dev": true
+      "integrity": "sha512-GEhri78jdQp/xxPpM6z08KlB0wrHfnfrJ9dmQk7JeQ4XCiMzXsJci7yooQgg/IcTKCM/PxE/IkGCQAo80adMkw=="
     },
     "@ember/jquery": {
       "version": "0.6.1",
@@ -1205,6 +1203,15 @@
             "object-assign": "4.1.1"
           }
         }
+      }
+    },
+    "@ember/render-modifiers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@ember/render-modifiers/-/render-modifiers-1.0.2.tgz",
+      "integrity": "sha512-6tEnHl5+62NTSAG2mwhGMFPhUrJQjoVqV+slsn+rlTknm2Zik+iwxBQEbwaiQOU1FUYxkS8RWcieovRNMR8inQ==",
+      "requires": {
+        "ember-cli-babel": "^7.10.0",
+        "ember-modifier-manager-polyfill": "^1.1.0"
       }
     },
     "@ember/test-helpers": {
@@ -3883,8 +3890,7 @@
     "broccoli-node-api": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/broccoli-node-api/-/broccoli-node-api-1.7.0.tgz",
-      "integrity": "sha512-QIqLSVJWJUVOhclmkmypJJH9u9s/aWH4+FH6Q6Ju5l+Io4dtwqdPUNmDfw40o6sxhbZHhqGujDJuHTML1wG8Yw==",
-      "dev": true
+      "integrity": "sha512-QIqLSVJWJUVOhclmkmypJJH9u9s/aWH4+FH6Q6Ju5l+Io4dtwqdPUNmDfw40o6sxhbZHhqGujDJuHTML1wG8Yw=="
     },
     "broccoli-node-info": {
       "version": "2.1.0",
@@ -4571,7 +4577,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
       "integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
-      "dev": true,
       "requires": {
         "browserslist": "^4.0.0",
         "caniuse-lite": "^1.0.0",
@@ -4903,8 +4908,7 @@
     "common-tags": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
-      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
-      "dev": true
+      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -5736,8 +5740,7 @@
     "element-closest": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/element-closest/-/element-closest-2.0.2.tgz",
-      "integrity": "sha1-cqdAoQdFM4LijfnOXbtajfD5Zuw=",
-      "dev": true
+      "integrity": "sha1-cqdAoQdFM4LijfnOXbtajfD5Zuw="
     },
     "elliptic": {
       "version": "6.5.1",
@@ -5767,7 +5770,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/ember-assign-helper/-/ember-assign-helper-0.2.0.tgz",
       "integrity": "sha512-WO6K24m6Wk+G1PBOMaXUtOMkzCTtt9z67SPIcAFxOVqc95hUU62wDRUdDiPa/854T5rroq5CJ7Ey4LgxorCsgg==",
-      "dev": true,
       "requires": {
         "ember-cli-babel": "^6.6.0"
       },
@@ -5776,7 +5778,6 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz",
           "integrity": "sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==",
-          "dev": true,
           "requires": {
             "ensure-posix-path": "^1.0.1"
           }
@@ -5785,7 +5786,6 @@
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz",
           "integrity": "sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==",
-          "dev": true,
           "requires": {
             "semver": "^5.3.0"
           }
@@ -5794,7 +5794,6 @@
           "version": "6.5.1",
           "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz",
           "integrity": "sha512-w6GcnkxvHcNCte5FcLGEG1hUdQvlfvSN/6PtGWU/otg69Ugk8rUk51h41R0Ugoc+TNxyeFG1opRt2RlA87XzNw==",
-          "dev": true,
           "requires": {
             "babel-core": "^6.26.0",
             "broccoli-funnel": "^2.0.1",
@@ -5812,7 +5811,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.1.tgz",
           "integrity": "sha512-WjaexJ+I8BxP5V5RNn6um/qDRSmKoiBC/QkRi79FT9ClHfldxRyCDs9mcV7mmoaPlsshmmPaUz5jdtcKA6DClQ==",
-          "dev": true,
           "requires": {
             "broccoli-plugin": "^1.3.0",
             "merge-trees": "^1.0.1"
@@ -5822,7 +5820,6 @@
           "version": "1.4.6",
           "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.6.tgz",
           "integrity": "sha512-0RejLwoC95kv4kta8KAa+FmECJCK78Qgm8SRDEK7YyU0N9Cx6KpY3UCDy9WELl3mCXLN8TokNxc7/hp3lL4lfw==",
-          "dev": true,
           "requires": {
             "async-disk-cache": "^1.2.1",
             "async-promise-queue": "^1.0.3",
@@ -5842,8 +5839,7 @@
             "rsvp": {
               "version": "3.6.2",
               "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-              "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-              "dev": true
+              "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
             }
           }
         },
@@ -5851,7 +5847,6 @@
           "version": "6.18.0",
           "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
           "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
-          "dev": true,
           "requires": {
             "amd-name-resolver": "1.2.0",
             "babel-plugin-debug-macros": "^0.2.0-beta.6",
@@ -5872,7 +5867,6 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
           "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-          "dev": true,
           "requires": {
             "resolve": "^1.3.3",
             "semver": "^5.3.0"
@@ -5882,7 +5876,6 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-1.0.1.tgz",
           "integrity": "sha1-zL5nRWl4f53vF/1G5lJfVwC70j4=",
-          "dev": true,
           "requires": {
             "can-symlink": "^1.0.0",
             "fs-tree-diff": "^0.5.4",
@@ -5895,14 +5888,12 @@
         "rsvp": {
           "version": "4.8.5",
           "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-          "dev": true
+          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA=="
         },
         "workerpool": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.3.tgz",
           "integrity": "sha512-L1ovlYHp6UObYqElXXpbd214GgbEKDED0d3sj7pRdFXjNkb2+un/AUcCkceHizO0IVI6SOGGncrcjozruCkRgA==",
-          "dev": true,
           "requires": {
             "object-assign": "4.1.1"
           }
@@ -7326,7 +7317,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/ember-cli-element-closest-polyfill/-/ember-cli-element-closest-polyfill-0.0.1.tgz",
       "integrity": "sha512-LBYICCsG1WIhsieUoZndW5LQyuz7DtnXYgGrH9APuwR7qYsEdXJt5Uv6Pvu211GY2EnuNtJ7V24ZhFGCFu1dQg==",
-      "dev": true,
       "requires": {
         "broccoli-funnel": "^2.0.1",
         "caniuse-api": "^3.0.0",
@@ -7339,7 +7329,6 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz",
           "integrity": "sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==",
-          "dev": true,
           "requires": {
             "ensure-posix-path": "^1.0.1"
           }
@@ -7348,7 +7337,6 @@
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz",
           "integrity": "sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==",
-          "dev": true,
           "requires": {
             "semver": "^5.3.0"
           }
@@ -7357,7 +7345,6 @@
           "version": "6.5.1",
           "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz",
           "integrity": "sha512-w6GcnkxvHcNCte5FcLGEG1hUdQvlfvSN/6PtGWU/otg69Ugk8rUk51h41R0Ugoc+TNxyeFG1opRt2RlA87XzNw==",
-          "dev": true,
           "requires": {
             "babel-core": "^6.26.0",
             "broccoli-funnel": "^2.0.1",
@@ -7375,7 +7362,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.1.tgz",
           "integrity": "sha512-WjaexJ+I8BxP5V5RNn6um/qDRSmKoiBC/QkRi79FT9ClHfldxRyCDs9mcV7mmoaPlsshmmPaUz5jdtcKA6DClQ==",
-          "dev": true,
           "requires": {
             "broccoli-plugin": "^1.3.0",
             "merge-trees": "^1.0.1"
@@ -7385,7 +7371,6 @@
           "version": "1.4.6",
           "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.6.tgz",
           "integrity": "sha512-0RejLwoC95kv4kta8KAa+FmECJCK78Qgm8SRDEK7YyU0N9Cx6KpY3UCDy9WELl3mCXLN8TokNxc7/hp3lL4lfw==",
-          "dev": true,
           "requires": {
             "async-disk-cache": "^1.2.1",
             "async-promise-queue": "^1.0.3",
@@ -7405,8 +7390,7 @@
             "rsvp": {
               "version": "3.6.2",
               "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-              "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-              "dev": true
+              "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
             }
           }
         },
@@ -7414,7 +7398,6 @@
           "version": "6.18.0",
           "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
           "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
-          "dev": true,
           "requires": {
             "amd-name-resolver": "1.2.0",
             "babel-plugin-debug-macros": "^0.2.0-beta.6",
@@ -7435,7 +7418,6 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
           "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-          "dev": true,
           "requires": {
             "resolve": "^1.3.3",
             "semver": "^5.3.0"
@@ -7445,7 +7427,6 @@
           "version": "0.1.3",
           "resolved": "https://registry.npmjs.org/fastboot-transform/-/fastboot-transform-0.1.3.tgz",
           "integrity": "sha512-6otygPIJw1ARp1jJb+6KVO56iKBjhO+5x59RSC9qiZTbZRrv+HZAuP00KD3s+nWMvcFDemtdkugki9DNFTTwCQ==",
-          "dev": true,
           "requires": {
             "broccoli-stew": "^1.5.0",
             "convert-source-map": "^1.5.1"
@@ -7455,7 +7436,6 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-1.0.1.tgz",
           "integrity": "sha1-zL5nRWl4f53vF/1G5lJfVwC70j4=",
-          "dev": true,
           "requires": {
             "can-symlink": "^1.0.0",
             "fs-tree-diff": "^0.5.4",
@@ -7468,14 +7448,12 @@
         "rsvp": {
           "version": "4.8.5",
           "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-          "dev": true
+          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA=="
         },
         "workerpool": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.3.tgz",
           "integrity": "sha512-L1ovlYHp6UObYqElXXpbd214GgbEKDED0d3sj7pRdFXjNkb2+un/AUcCkceHizO0IVI6SOGGncrcjozruCkRgA==",
-          "dev": true,
           "requires": {
             "object-assign": "4.1.1"
           }
@@ -9110,7 +9088,6 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/ember-decorators/-/ember-decorators-6.1.1.tgz",
       "integrity": "sha512-63vZPntPn1aqMyeNRLoYjJD+8A8obd+c2iZkJflswpDRNVIsp2m7aQdSCtPt4G0U/TEq2251g+N10maHX3rnJQ==",
-      "dev": true,
       "requires": {
         "@ember-decorators/component": "^6.1.1",
         "@ember-decorators/object": "^6.1.1",
@@ -9127,7 +9104,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/ember-element-helper/-/ember-element-helper-0.2.0.tgz",
       "integrity": "sha512-/WV0PNLyxDvLX/YETb/8KICFTr719OYqFWXqV5XUkh9YhhBGDU/mr1OtlQaWOlsx+sHm42HD2UAICecqex8ziw==",
-      "dev": true,
       "requires": {
         "ember-cli-babel": "^6.16.0"
       },
@@ -9136,7 +9112,6 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz",
           "integrity": "sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==",
-          "dev": true,
           "requires": {
             "ensure-posix-path": "^1.0.1"
           }
@@ -9145,7 +9120,6 @@
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz",
           "integrity": "sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==",
-          "dev": true,
           "requires": {
             "semver": "^5.3.0"
           }
@@ -9154,7 +9128,6 @@
           "version": "6.5.1",
           "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz",
           "integrity": "sha512-w6GcnkxvHcNCte5FcLGEG1hUdQvlfvSN/6PtGWU/otg69Ugk8rUk51h41R0Ugoc+TNxyeFG1opRt2RlA87XzNw==",
-          "dev": true,
           "requires": {
             "babel-core": "^6.26.0",
             "broccoli-funnel": "^2.0.1",
@@ -9172,7 +9145,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.1.tgz",
           "integrity": "sha512-WjaexJ+I8BxP5V5RNn6um/qDRSmKoiBC/QkRi79FT9ClHfldxRyCDs9mcV7mmoaPlsshmmPaUz5jdtcKA6DClQ==",
-          "dev": true,
           "requires": {
             "broccoli-plugin": "^1.3.0",
             "merge-trees": "^1.0.1"
@@ -9182,7 +9154,6 @@
           "version": "1.4.6",
           "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.6.tgz",
           "integrity": "sha512-0RejLwoC95kv4kta8KAa+FmECJCK78Qgm8SRDEK7YyU0N9Cx6KpY3UCDy9WELl3mCXLN8TokNxc7/hp3lL4lfw==",
-          "dev": true,
           "requires": {
             "async-disk-cache": "^1.2.1",
             "async-promise-queue": "^1.0.3",
@@ -9202,8 +9173,7 @@
             "rsvp": {
               "version": "3.6.2",
               "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-              "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-              "dev": true
+              "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
             }
           }
         },
@@ -9211,7 +9181,6 @@
           "version": "6.18.0",
           "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
           "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
-          "dev": true,
           "requires": {
             "amd-name-resolver": "1.2.0",
             "babel-plugin-debug-macros": "^0.2.0-beta.6",
@@ -9232,7 +9201,6 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
           "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-          "dev": true,
           "requires": {
             "resolve": "^1.3.3",
             "semver": "^5.3.0"
@@ -9242,7 +9210,6 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-1.0.1.tgz",
           "integrity": "sha1-zL5nRWl4f53vF/1G5lJfVwC70j4=",
-          "dev": true,
           "requires": {
             "can-symlink": "^1.0.0",
             "fs-tree-diff": "^0.5.4",
@@ -9255,14 +9222,12 @@
         "rsvp": {
           "version": "4.8.5",
           "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-          "dev": true
+          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA=="
         },
         "workerpool": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.3.tgz",
           "integrity": "sha512-L1ovlYHp6UObYqElXXpbd214GgbEKDED0d3sj7pRdFXjNkb2+un/AUcCkceHizO0IVI6SOGGncrcjozruCkRgA==",
-          "dev": true,
           "requires": {
             "object-assign": "4.1.1"
           }
@@ -11017,7 +10982,6 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/ember-power-calendar/-/ember-power-calendar-0.14.5.tgz",
       "integrity": "sha512-SbFp8mLpoqxiGphIidZR+q4Za7aqJhMAkuw0piU/qBksC/OtQZDL0i5V1bti4yD90aI2I6IlOuHFyod9LQ7Gkg==",
-      "dev": true,
       "requires": {
         "@ember-decorators/component": "^6.0.0",
         "ember-assign-helper": "^0.2.0",
@@ -11033,7 +10997,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/ember-power-calendar-moment/-/ember-power-calendar-moment-0.1.7.tgz",
       "integrity": "sha512-tkxGrSfJJq3MkgDQXfKr3o2vJp8kTokcyZnSxwGC1KByMv/TgtDp4+74cTzaK/Di0qnj5AYeeElwEEcGIn4F3A==",
-      "dev": true,
       "requires": {
         "broccoli-funnel": "^2.0.2",
         "ember-cli-babel": "^7.7.3",
@@ -11044,7 +11007,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ember-power-calendar-selectors/-/ember-power-calendar-selectors-0.1.1.tgz",
       "integrity": "sha512-hW+GgJB6AJROKnHa20QyxTGNLCchagyq+dw+jMhLzN40RmPl+MUcs19BhSdFqG5zqtCzVjOIkfuhlejfyFgaUQ==",
-      "dev": true,
       "requires": {
         "ember-cli-babel": "^7.11.1",
         "ember-cli-htmlbars": "^4.0.0",
@@ -11055,14 +11017,12 @@
         "babel-plugin-htmlbars-inline-precompile": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-3.0.0.tgz",
-          "integrity": "sha512-dR12lOqIcBLOTwgnI5iG+bSrZhR8JIZ7zAHW43YhcD5q8G8iipvSuRo8Fah6NPPh6C8cATd827bgPikphbF09w==",
-          "dev": true
+          "integrity": "sha512-dR12lOqIcBLOTwgnI5iG+bSrZhR8JIZ7zAHW43YhcD5q8G8iipvSuRo8Fah6NPPh6C8cATd827bgPikphbF09w=="
         },
         "broccoli-plugin": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-3.0.0.tgz",
           "integrity": "sha512-aEtobBvzAlUIAaY5z+LwW2W3IJ9pruJtrT571CyfjoDFTGa8LZx0qjQG97Z7Guk5YzuxDoDNlM3hGsgBnnReTw==",
-          "dev": true,
           "requires": {
             "broccoli-node-api": "^1.6.0",
             "promise-map-series": "^0.2.1",
@@ -11075,7 +11035,6 @@
           "version": "4.0.8",
           "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-4.0.8.tgz",
           "integrity": "sha512-B6fzlqmv2E2dl8P6UIYu3bY8nZU2kKfl1VkEIgxFAINfsu9fP65kX/bKzHqGhHF8nAtWBoXZWw6tomHKfUT/Jg==",
-          "dev": true,
           "requires": {
             "@ember/edition-utils": "^1.1.1",
             "babel-plugin-htmlbars-inline-precompile": "^3.0.0",
@@ -11098,7 +11057,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
           "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
-          "dev": true,
           "requires": {
             "@types/minimatch": "^3.0.3",
             "minimatch": "^3.0.2"
@@ -11107,20 +11065,17 @@
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         },
         "strip-bom": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-          "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-          "dev": true
+          "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="
         },
         "walk-sync": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.0.2.tgz",
           "integrity": "sha512-dCZkrxfHjPn7tIvdYrX3uMD/R0beVrHpA8lROQ5wWrl8psJgR6xwCkwqTFes0dNujbS2o/ITpvSYgIFsLsf13A==",
-          "dev": true,
           "requires": {
             "@types/minimatch": "^3.0.3",
             "ensure-posix-path": "^1.1.0",
@@ -11281,7 +11236,6 @@
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/ember-prop-types/-/ember-prop-types-9.0.2.tgz",
       "integrity": "sha512-xrR2PP9xCXYbFNsKsryRZyncdUfs9izoGeY7SeMaEDQ7BSzkI99SYpSP5mGWICLfRquV9+If4PQIWXW2qwXppg==",
-      "dev": true,
       "requires": {
         "ember-cli-babel": "^6.6.0",
         "ember-get-config": "^0.2.4"
@@ -11291,7 +11245,6 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz",
           "integrity": "sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==",
-          "dev": true,
           "requires": {
             "ensure-posix-path": "^1.0.1"
           }
@@ -11300,7 +11253,6 @@
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz",
           "integrity": "sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==",
-          "dev": true,
           "requires": {
             "semver": "^5.3.0"
           }
@@ -11309,7 +11261,6 @@
           "version": "6.5.1",
           "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz",
           "integrity": "sha512-w6GcnkxvHcNCte5FcLGEG1hUdQvlfvSN/6PtGWU/otg69Ugk8rUk51h41R0Ugoc+TNxyeFG1opRt2RlA87XzNw==",
-          "dev": true,
           "requires": {
             "babel-core": "^6.26.0",
             "broccoli-funnel": "^2.0.1",
@@ -11327,7 +11278,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.1.tgz",
           "integrity": "sha512-WjaexJ+I8BxP5V5RNn6um/qDRSmKoiBC/QkRi79FT9ClHfldxRyCDs9mcV7mmoaPlsshmmPaUz5jdtcKA6DClQ==",
-          "dev": true,
           "requires": {
             "broccoli-plugin": "^1.3.0",
             "merge-trees": "^1.0.1"
@@ -11337,7 +11287,6 @@
           "version": "1.4.6",
           "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.6.tgz",
           "integrity": "sha512-0RejLwoC95kv4kta8KAa+FmECJCK78Qgm8SRDEK7YyU0N9Cx6KpY3UCDy9WELl3mCXLN8TokNxc7/hp3lL4lfw==",
-          "dev": true,
           "requires": {
             "async-disk-cache": "^1.2.1",
             "async-promise-queue": "^1.0.3",
@@ -11357,8 +11306,7 @@
             "rsvp": {
               "version": "3.6.2",
               "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-              "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-              "dev": true
+              "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
             }
           }
         },
@@ -11366,7 +11314,6 @@
           "version": "6.18.0",
           "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
           "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
-          "dev": true,
           "requires": {
             "amd-name-resolver": "1.2.0",
             "babel-plugin-debug-macros": "^0.2.0-beta.6",
@@ -11387,7 +11334,6 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
           "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-          "dev": true,
           "requires": {
             "resolve": "^1.3.3",
             "semver": "^5.3.0"
@@ -11397,7 +11343,6 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-1.0.1.tgz",
           "integrity": "sha1-zL5nRWl4f53vF/1G5lJfVwC70j4=",
-          "dev": true,
           "requires": {
             "can-symlink": "^1.0.0",
             "fs-tree-diff": "^0.5.4",
@@ -11410,14 +11355,12 @@
         "rsvp": {
           "version": "4.8.5",
           "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-          "dev": true
+          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA=="
         },
         "workerpool": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.3.tgz",
           "integrity": "sha512-L1ovlYHp6UObYqElXXpbd214GgbEKDED0d3sj7pRdFXjNkb2+un/AUcCkceHizO0IVI6SOGGncrcjozruCkRgA==",
-          "dev": true,
           "requires": {
             "object-assign": "4.1.1"
           }
@@ -14855,8 +14798,7 @@
     "fs-copy-file-sync": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/fs-copy-file-sync/-/fs-copy-file-sync-1.1.1.tgz",
-      "integrity": "sha512-2QY5eeqVv4m2PfyMiEuy9adxNP+ajf+8AR05cEi+OAzPcOj90hvFImeZhTmKLBgSd9EvG33jsD7ZRxsx9dThkQ==",
-      "dev": true
+      "integrity": "sha512-2QY5eeqVv4m2PfyMiEuy9adxNP+ajf+8AR05cEi+OAzPcOj90hvFImeZhTmKLBgSd9EvG33jsD7ZRxsx9dThkQ=="
     },
     "fs-extra": {
       "version": "5.0.0",
@@ -17722,8 +17664,7 @@
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
-      "dev": true
+      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
     },
     "lodash.merge": {
       "version": "4.6.2",
@@ -17781,8 +17722,7 @@
     "lodash.uniq": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
-      "dev": true
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
     "lodash.uniqby": {
       "version": "4.7.0",

--- a/packages/reports/package.json
+++ b/packages/reports/package.json
@@ -26,6 +26,7 @@
     "ember-decorators": "^6.1.1",
     "@ember/jquery": "^0.6.0",
     "@ember/optional-features": "^0.7.0",
+    "@ember/render-modifiers": "^1.0.2",
     "@html-next/vertical-collection": "^1.0.0",
     "ember-ajax": "^5.0.0",
     "ember-cli-babel": "^7.7.3",

--- a/packages/reports/package.json
+++ b/packages/reports/package.json
@@ -26,7 +26,6 @@
     "ember-decorators": "^6.1.1",
     "@ember/jquery": "^0.6.0",
     "@ember/optional-features": "^0.7.0",
-    "@ember/render-modifiers": "^1.0.2",
     "@html-next/vertical-collection": "^1.0.0",
     "ember-ajax": "^5.0.0",
     "ember-cli-babel": "^7.7.3",

--- a/packages/reports/tests/integration/components/common-actions/schedule-test.js
+++ b/packages/reports/tests/integration/components/common-actions/schedule-test.js
@@ -2,7 +2,7 @@ import { resolve } from 'rsvp';
 import $ from 'jquery';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, settled, click, blur, findAll, fillIn } from '@ember/test-helpers';
+import { render, click, blur, findAll, fillIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { clickTrigger, nativeMouseUp } from 'ember-power-select/test-support/helpers';
 import config from 'ember-get-config';
@@ -323,11 +323,9 @@ module('Integration | Component | common actions/schedule', function(hooks) {
       'Delete button is shown when deliveryRule is present for current user'
     );
 
-    $('.btn-container button:contains(Delete)').click();
+    await click($('.btn-container button:contains(Delete)')[0]);
 
-    return settled().then(() => {
-      $('.btn-container button:contains(Confirm)').click();
-    });
+    await click($('.btn-container button:contains(Confirm)')[0]);
   });
 
   test('frequency options - default', async function(assert) {

--- a/packages/reports/tests/integration/components/dimension-bulk-import-simple-test.js
+++ b/packages/reports/tests/integration/components/dimension-bulk-import-simple-test.js
@@ -23,9 +23,7 @@ module('Integration | Component | dimension bulk import simple', function(hooks)
   }
 
   function getSplitValues() {
-    return findAll('.dimension-bulk-import-simple-row--split-values .item').map(el =>
-      el.textContent.replace('×', '').trim()
-    );
+    return findAll('.dimension-bulk-import-simple-row--split-values .item').map(el => el.textContent.trim());
   }
 
   test('Raw inputs are filtered and split up properly', async function(assert) {
@@ -53,26 +51,6 @@ module('Integration | Component | dimension bulk import simple', function(hooks)
       'The split values will trim away weird inner spacing'
     );
     assert.dom($('.btn-primary:contains(split)')[0]).hasText('Use split input (4 values)');
-  });
-
-  test('The remove button on split values works', async function(assert) {
-    assert.expect(4);
-
-    this.set('rawInput', '1,2,3');
-    assert.deepEqual(getSplitValues(), ['1', '2', '3'], 'The input values are split on the comma');
-
-    this.set('onSelectValues', values =>
-      assert.deepEqual(values, ['1', '2', '3'], 'The selected values do not include 2 after removing it')
-    );
-    await click($('.btn-primary:contains(split)')[0]);
-
-    await click($('.dimension-bulk-import-simple-row--split-values .item:contains(2) .remove-pill')[0]);
-    assert.deepEqual(getSplitValues(), ['1', '3'], 'The 2 item was removed');
-
-    this.set('onSelectValues', values =>
-      assert.deepEqual(values, ['1', '3'], 'The selected values do not include 2 after removing it')
-    );
-    await click($('.btn-primary:contains(split)')[0]);
   });
 
   test('Selecting the raw value gives the raw array', async function(assert) {

--- a/packages/reports/tests/integration/components/dimension-bulk-import-simple-test.js
+++ b/packages/reports/tests/integration/components/dimension-bulk-import-simple-test.js
@@ -1,0 +1,101 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, findAll, click } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import $ from 'jquery';
+
+module('Integration | Component | dimension bulk import simple', function(hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(async function() {
+    this.set('onSelectValues', () => undefined);
+    this.set('onCancel', () => undefined);
+
+    await render(hbs`<DimensionBulkImportSimple
+      @rawInput={{this.rawInput}}
+      @onSelectValues={{action this.onSelectValues}}
+      @onCancel={{action this.onCancel}}
+    />`);
+  });
+
+  function getRawValue() {
+    return findAll('.dimension-bulk-import-simple-row--raw-value .item').map(el => el.textContent.trim());
+  }
+
+  function getSplitValues() {
+    return findAll('.dimension-bulk-import-simple-row--split-values .item').map(el =>
+      el.textContent.replace('×', '').trim()
+    );
+  }
+
+  test('Raw inputs are filtered and split up properly', async function(assert) {
+    assert.expect(9);
+
+    this.set('rawInput', '1,2,3');
+    assert.deepEqual(getRawValue(), ['1,2,3'], 'The raw string is 1,2,3');
+    assert.deepEqual(getSplitValues(), ['1', '2', '3'], 'The input values are split on the comma');
+    assert.dom($('.btn-primary:contains(split)')[0]).hasText('Use split input (3 values)');
+
+    this.set('rawInput', '');
+    assert.deepEqual(getRawValue(), [], 'Raw value does not include empty string');
+    assert.deepEqual(getSplitValues(), [], 'Split values do not include empty string');
+    assert.dom($('.btn-primary:contains(split)')[0]).hasText('Use split input (0 values)');
+
+    this.set('rawInput', ' some weird,  spacing,going ,on');
+    assert.deepEqual(
+      getRawValue(),
+      ['some weird,  spacing,going ,on'],
+      'The raw value string is trimmed, but retains innner spacing'
+    );
+    assert.deepEqual(
+      getSplitValues(),
+      ['some weird', 'spacing', 'going', 'on'],
+      'The split values will trim away weird inner spacing'
+    );
+    assert.dom($('.btn-primary:contains(split)')[0]).hasText('Use split input (4 values)');
+  });
+
+  test('The remove button on split values works', async function(assert) {
+    assert.expect(4);
+
+    this.set('rawInput', '1,2,3');
+    assert.deepEqual(getSplitValues(), ['1', '2', '3'], 'The input values are split on the comma');
+
+    this.set('onSelectValues', values =>
+      assert.deepEqual(values, ['1', '2', '3'], 'The selected values do not include 2 after removing it')
+    );
+    await click($('.btn-primary:contains(split)')[0]);
+
+    await click($('.dimension-bulk-import-simple-row--split-values .item:contains(2) .remove-pill')[0]);
+    assert.deepEqual(getSplitValues(), ['1', '3'], 'The 2 item was removed');
+
+    this.set('onSelectValues', values =>
+      assert.deepEqual(values, ['1', '3'], 'The selected values do not include 2 after removing it')
+    );
+    await click($('.btn-primary:contains(split)')[0]);
+  });
+
+  test('Selecting the raw value gives the raw array', async function(assert) {
+    assert.expect(2);
+
+    const raw = ['some weird,  spacing,going ,on'];
+    this.set('rawInput', ' some weird,  spacing,going ,on');
+    assert.deepEqual(getRawValue(), raw, 'The raw value string is trimmed, but retains innner spacing');
+    this.set('onSelectValues', values =>
+      assert.deepEqual(values, raw, 'The selected value is the raw string as an array')
+    );
+    await click($('.btn-primary:contains(raw)')[0]);
+  });
+
+  test('Selecting the split values gives the filtered split array', async function(assert) {
+    assert.expect(2);
+
+    const split = ['some weird', 'spacing', 'going', 'on'];
+    this.set('rawInput', ' some weird,  spacing,going ,on,,, ,,,');
+    assert.deepEqual(getSplitValues(), split, 'The split values will trim away weird inner spacing');
+    this.set('onSelectValues', values =>
+      assert.deepEqual(values, split, 'The selected values are just the split string array')
+    );
+    await click($('.btn-primary:contains(split)')[0]);
+  });
+});

--- a/packages/reports/tests/integration/components/dimension-bulk-import-test.js
+++ b/packages/reports/tests/integration/components/dimension-bulk-import-test.js
@@ -1,4 +1,3 @@
-import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, settled, findAll, waitFor, click } from '@ember/test-helpers';
@@ -236,9 +235,7 @@ module('Integration | Component | Dimension Bulk Import', function(hooks) {
     );
 
     //Remove First Valid Pill, item removed depends on the ordering
-    run(() => {
-      $('.items-list:first .item:first .remove-pill').click();
-    });
+    await click('.items-list:first-of-type .item:first-of-type .remove-pill');
 
     assert.equal(
       $('.valid-id-count')

--- a/packages/reports/tests/integration/components/dimension-bulk-import-test.js
+++ b/packages/reports/tests/integration/components/dimension-bulk-import-test.js
@@ -126,7 +126,7 @@ module('Integration | Component | Dimension Bulk Import', function(hooks) {
     assert.deepEqual(
       validPills
         .map(function() {
-          return this.childNodes[0].wholeText.trim();
+          return this.childNodes[3].wholeText.trim();
         })
         .get(),
       ['Property 1 (114)', 'Property 2 (100001)', 'Property 3 (100002)', 'Property 4 (100003)'],
@@ -217,7 +217,7 @@ module('Integration | Component | Dimension Bulk Import', function(hooks) {
     assert.deepEqual(
       validPills
         .map(function() {
-          return this.childNodes[0].wholeText.trim();
+          return this.childNodes[3].wholeText.trim();
         })
         .get(),
       ['Property 1 (114)', 'Property 2 (100001)', 'Property 3 (100002)', 'Property 4 (100003)'],
@@ -237,7 +237,7 @@ module('Integration | Component | Dimension Bulk Import', function(hooks) {
 
     //Remove First Valid Pill, item removed depends on the ordering
     run(() => {
-      $('.items-list:first .item:first button').click();
+      $('.items-list:first .item:first .remove-pill').click();
     });
 
     assert.equal(
@@ -252,7 +252,7 @@ module('Integration | Component | Dimension Bulk Import', function(hooks) {
     assert.deepEqual(
       validPills
         .map(function() {
-          return this.childNodes[0].wholeText.trim();
+          return this.childNodes[3].wholeText.trim();
         })
         .get(),
       ['Property 2 (100001)', 'Property 3 (100002)', 'Property 4 (100003)'],
@@ -312,7 +312,7 @@ module('Integration | Component | Dimension Bulk Import', function(hooks) {
       assert.deepEqual(
         validPills
           .map(function() {
-            return this.childNodes[0].wholeText.trim();
+            return this.childNodes[3].wholeText.trim();
           })
           .get(),
         ['System ID 1 (6)', 'System ID 2 (7)'],

--- a/packages/reports/tests/integration/components/paginated-scroll-list-test.js
+++ b/packages/reports/tests/integration/components/paginated-scroll-list-test.js
@@ -2,7 +2,7 @@ import { A } from '@ember/array';
 import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, settled, triggerEvent } from '@ember/test-helpers';
+import { render, settled, triggerEvent, click } from '@ember/test-helpers';
 import $ from 'jquery';
 import hbs from 'htmlbars-inline-precompile';
 
@@ -28,7 +28,7 @@ const COMMON_TEMPLATE = hbs`
         items=items
         trim=trim
         perPage=perPage
-        showMore= (action showMoreAction)
+        showMore=(action showMoreAction)
         as |item|
     }}
         <div class='mock-item'>{{item.foo}}</div>
@@ -93,9 +93,7 @@ module('Integration | Component | paginated scroll list', function(hooks) {
       assert.ok(true, 'show more action is triggered');
     });
 
-    run(() => {
-      $('a:contains("Show more")').click();
-    });
+    await click($('a:contains("Show more")')[0]);
 
     assert.equal($('a:contains("Show more")').length, 0, 'Show more link is not visible after clicking show more link');
 

--- a/packages/reports/tests/integration/components/power-select-bulk-import-trigger-test.js
+++ b/packages/reports/tests/integration/components/power-select-bulk-import-trigger-test.js
@@ -79,7 +79,7 @@ module('Integration | Component | power select bulk import trigger', function(ho
     assert.deepEqual(
       validPills
         .map(function() {
-          return this.childNodes[0].wholeText.trim();
+          return this.childNodes[3].wholeText.trim();
         })
         .get(),
       ['Property 1 (114)', 'Property 4 (101272)'],


### PR DESCRIPTION
## Description
When we have a dimension with `storageStrategy === 'none'`, we fall back to multi-value-input which means we don't support dimension bulk import on (pasting a list of ids)

https://github.com/yahoo/navi/blob/842719c9c2b074aa1d04d6982cc1a0fca4c4e210/packages/reports/addon/components/filter-builders/dimension.js#L31-L34

## Proposed Changes
- Add a simple dimension importer for multi-value-input
  - detect if the users pastes something in with a `','`
  - let user choose whole string value or split values into array
- clean up some styling on dimension importing
- fix key code from `118` to `188` for commas 👀 

## Screenshots
Updated styles:
![normal dimension bulk importer](https://user-images.githubusercontent.com/12093492/73311295-b6e80380-41eb-11ea-9a67-ac6c64e401bb.png)
New simple importer:
![simple dimension bulk importer](https://user-images.githubusercontent.com/12093492/73311397-f31b6400-41eb-11ea-91af-469721e62bcc.png)


## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
