### PR TITLE
Update: Better styling for many filters/values

### DIFF
--- a/packages/reports/app/styles/navi-reports/components/filter-collection.less
+++ b/packages/reports/app/styles/navi-reports/components/filter-collection.less
@@ -158,5 +158,13 @@
       content: '.';
       margin: 0 5px 0 -2px;
     }
+
+    &-item {
+      display: inline-block;
+      overflow: hidden;
+      max-width: 100%;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
   }
 }


### PR DESCRIPTION
Resolves #638 

## Description
When people paste in a large number of filters and collapse the filters, they overflow into the report

## Proposed Changes
- Hide overflowing items

## Screenshots
Before:
![before](https://user-images.githubusercontent.com/12093492/73312559-9b322c80-41ee-11ea-92db-fa4274159335.png)
After:
![after](https://user-images.githubusercontent.com/12093492/73312574-a5ecc180-41ee-11ea-853b-651bbdd34db3.png)



## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
