### PR TITLE
Update: Use andQueries in keg dimension adapter

### DIFF
--- a/packages/data/addon/adapters/dimensions/keg.js
+++ b/packages/data/addon/adapters/dimensions/keg.js
@@ -161,7 +161,7 @@ export default EmberObject.extend({
    * @returns {Promise} - Promise with the response
    */
   find(dimension, andQueries, options) {
-    if (andQueries.length === undefined) {
+    if (!Array.isArray(andQueries)) {
       // if not array
       warn('find() was not passed an array of queries, wrapping as single query array', {
         id: 'keg-find-query-as-array'

--- a/packages/data/addon/adapters/dimensions/keg.js
+++ b/packages/data/addon/adapters/dimensions/keg.js
@@ -1,16 +1,17 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Description: The adapter for Keg.
  */
 import { Promise } from 'rsvp';
 import { A } from '@ember/array';
-import { assert } from '@ember/debug';
+import { assert, warn } from '@ember/debug';
 import { inject as service } from '@ember/service';
 import { assign } from '@ember/polyfills';
 import EmberObject, { get } from '@ember/object';
 import { getOwner } from '@ember/application';
+import intersection from 'lodash/intersection';
 
 const KEG_NAMESPACE = 'dimension';
 
@@ -151,7 +152,7 @@ export default EmberObject.extend({
   /**
    * @method find - Find dimension values matching the query
    * @param {String} dimension - dimension name
-   * @param {Object} query - the query object
+   * @param {Array<Object>} andQueries - the array query objects to be ANDed together
    * @param {Object} [options] - options object
    *      Ex: {
    *        page: 1,
@@ -159,12 +160,29 @@ export default EmberObject.extend({
    *      }
    * @returns {Promise} - Promise with the response
    */
-  find(dimension, query, options) {
+  find(dimension, andQueries, options) {
+    if (andQueries.length === undefined) {
+      // if not array
+      warn('find() was not passed an array of queries, wrapping as single query array', {
+        id: 'keg-find-query-as-array'
+      });
+      andQueries = [andQueries]; // wrap
+    }
+    assert("You must pass an 'Array' of queries to be ANDed together", andQueries.length);
     // defaults to 'in' operation if operator is not specified
-    assert("Only 'in' operation is currently supported in Keg", query.operator ? query.operator === 'in' : true);
+    assert(
+      "Only 'in' operation is currently supported in Keg",
+      andQueries.filter(q => q.operator).every(q => q.operator === 'in')
+    );
 
-    // TODO: might need to redfine or investigate the find interface, string of comma seperated values or array of values
-    assert("Only 'string' query values is currently supported in Keg", typeof query.values === 'string');
+    const stringQueries = andQueries.filter(q => typeof q.values === 'string');
+    if (stringQueries.length) {
+      warn('find() was passed query.values as a string, falling back to splitting by commas', {
+        id: 'keg-find-query-values-as-array'
+      });
+      stringQueries.forEach(query => (query.values = query.values.split(',')));
+    }
+    assert("Only 'Array' query values is currently supported in Keg", andQueries.every(q => !!q.values.length));
 
     let keg = get(this, 'keg');
 
@@ -173,12 +191,21 @@ export default EmberObject.extend({
       values: []
     };
 
-    query = assign({}, defaultQueryOptions, query);
-
-    query.values = query.values.split(',');
+    andQueries = andQueries.map(query => assign({}, defaultQueryOptions, query));
 
     //convert navi-data query object interface to keg query object interface
-    query = { [query.field]: query.values };
+    const query = andQueries.reduce((all, query) => {
+      let values;
+      if (all.hasOwnProperty(query.field)) {
+        // if it already exists, we AND it by intersecting the values
+        values = intersection(all[query.field], query.values);
+      } else {
+        values = query.values;
+      }
+      all[query.field] = values;
+
+      return all;
+    }, {});
 
     return Promise.resolve(this._buildResponse(keg.getBy(`${KEG_NAMESPACE}/${dimension}`, query), options));
   },

--- a/packages/data/addon/adapters/dimensions/keg.js
+++ b/packages/data/addon/adapters/dimensions/keg.js
@@ -168,7 +168,7 @@ export default EmberObject.extend({
       });
       andQueries = [andQueries]; // wrap
     }
-    assert("You must pass an 'Array' of queries to be ANDed together", andQueries.length);
+    assert("You must pass an 'Array' of queries to be ANDed together", Array.isArray(andQueries));
     // defaults to 'in' operation if operator is not specified
     assert(
       "Only 'in' operation is currently supported in Keg",
@@ -182,7 +182,7 @@ export default EmberObject.extend({
       });
       stringQueries.forEach(query => (query.values = query.values.split(',')));
     }
-    assert("Only 'Array' query values is currently supported in Keg", andQueries.every(q => !!q.values.length));
+    assert("Only 'Array' query values is currently supported in Keg", andQueries.every(q => Array.isArray(q.values)));
 
     let keg = get(this, 'keg');
 

--- a/packages/data/addon/adapters/dimensions/keg.js
+++ b/packages/data/addon/adapters/dimensions/keg.js
@@ -182,7 +182,7 @@ export default EmberObject.extend({
       });
       stringQueries.forEach(query => (query.values = query.values.split(',')));
     }
-    assert("Only 'Array' query values is currently supported in Keg", andQueries.every(q => Array.isArray(q.values)));
+    assert("Only 'Array' query values are currently supported in Keg", andQueries.every(q => Array.isArray(q.values)));
 
     let keg = get(this, 'keg');
 

--- a/packages/data/addon/services/bard-dimensions.js
+++ b/packages/data/addon/services/bard-dimensions.js
@@ -171,7 +171,7 @@ export default Service.extend({
 
     // fetch from keg if all records are loaded in keg
     if (this.getLoadedStatus(dimension)) {
-      return kegAdapter.find(dimension, query, options).then(recordsFromKeg => {
+      return kegAdapter.find(dimension, [query], options).then(recordsFromKeg => {
         return this._createBardDimensionsArray(recordsFromKeg, recordsFromKeg.rows, dimension);
       });
     }

--- a/packages/data/addon/services/bard-dimensions.js
+++ b/packages/data/addon/services/bard-dimensions.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Description: Bard dimensions service that fetches dimension values

--- a/packages/data/tests/unit/adapters/dimensions/keg-test.js
+++ b/packages/data/tests/unit/adapters/dimensions/keg-test.js
@@ -96,26 +96,35 @@ module('Unit | Adapters | Dimensions | Keg', function(hooks) {
     assertThrowOperator([{ operator: 'contains' }]);
     assertThrowOperator([{}, { operator: 'in' }, { operator: 'contains' }]);
 
-    const assertPromise = expected => result => {
-      assert.deepEqual(
-        result.rows.mapBy('id'),
-        expected,
-        'find() returns expected response using navi-data query object interface.'
-      );
+    const assertEquals = (expected, message) => result => {
+      assert.deepEqual(result.rows.mapBy('id'), expected, message);
     };
 
-    await Adapter.find('dimensionOne', { field: 'description', values: 'bar,gar' }).then(assertPromise([2, 3]));
-    await Adapter.find('dimensionOne', [{ field: 'description', values: 'bar,gar' }]).then(assertPromise([2, 3]));
-    await Adapter.find('dimensionOne', [{ field: 'description', values: ['bar', 'gar'] }]).then(assertPromise([2, 3]));
+    await Adapter.find('dimensionOne', {
+      field: 'description',
+      values: 'bar,gar'
+    }).then(assertEquals([2, 3], 'find() returns expected when values is a string'));
+    await Adapter.find('dimensionOne', [
+      {
+        field: 'description',
+        values: 'bar,gar'
+      }
+    ]).then(assertEquals([2, 3], 'find() returns expected when passed an array of queries'));
+    await Adapter.find('dimensionOne', [
+      {
+        field: 'description',
+        values: ['bar', 'gar']
+      }
+    ]).then(assertEquals([2, 3], 'find() returns expected when values is an array'));
     await Adapter.find('dimensionOne', [
       { field: 'id', values: [1, 2, 3] },
       { field: 'description', values: ['bar'] }
-    ]).then(assertPromise([2]));
+    ]).then(assertEquals([2], 'find() returns expected when passed multiple filters'));
     await Adapter.find('dimensionOne', [
       { field: 'id', values: [1, 2, 3] },
       { field: 'id', values: [3, 4] },
       { field: 'description', values: ['bar', 'gar'] }
-    ]).then(assertPromise([3]));
+    ]).then(assertEquals([3], 'find() returns expected when passed multiple overlapping filters'));
   });
 
   test('findById', function(assert) {


### PR DESCRIPTION
## Description
The keg dimension adapter currently only supports passing in a single query in the given format (string list of values)
```js
{
  field: 'id',
  operator: 'in', // optional
  values: 'my,list,of,values'
}
```

## Proposed Changes
- Add support for multiple filters
- Directly pass an array of filter values instead of a string (supports values like `"Thing, Small"`)
```js
[
  {
    field: 'id',
    values: ['my', 'list', 'of', 'values']
  },
  {
    field: 'id',
    values: ['my', 'list']
  },
  {
    field: 'description',
    values: ['yay']
  }
]
```

We then merge all filters to be a keg-compatible filter
```js
{
  id: ['my', 'list'],
  description: ['yay']
}
```

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
