### PR TITLE
Update: Bard dimension adapter multiple filters

### DIFF
--- a/packages/data/addon/adapters/dimensions/bard.js
+++ b/packages/data/addon/adapters/dimensions/bard.js
@@ -109,7 +109,7 @@ export default EmberObject.extend({
       });
       stringQueries.forEach(query => (query.values = query.values.split(',')));
     }
-    assert("Only 'Array' query values are currently supported in Keg", andQueries.every(q => Array.isArray(q.values)));
+    assert("Only 'Array' query values are currently supported in the Bard adapter", andQueries.every(q => Array.isArray(q.values)));
 
     const filters = andQueries.map(query => {
       const queryField = get(query, 'field'),
@@ -147,7 +147,7 @@ export default EmberObject.extend({
     );
 
     const defaultQueryOptions = { values: [] };
-    let query = andQueries[0];
+    const query = assign({}, defaultQueryOptions, andQueries[0]);
 
     query = assign({}, defaultQueryOptions, query);
 

--- a/packages/data/addon/adapters/dimensions/bard.js
+++ b/packages/data/addon/adapters/dimensions/bard.js
@@ -109,7 +109,10 @@ export default EmberObject.extend({
       });
       stringQueries.forEach(query => (query.values = query.values.split(',')));
     }
-    assert("Only 'Array' query values are currently supported in the Bard adapter", andQueries.every(q => Array.isArray(q.values)));
+    assert(
+      "Only 'Array' query values are currently supported in the Bard adapter",
+      andQueries.every(q => Array.isArray(q.values))
+    );
 
     const filters = andQueries.map(query => {
       const queryField = get(query, 'field'),
@@ -148,8 +151,6 @@ export default EmberObject.extend({
 
     const defaultQueryOptions = { values: [] };
     const query = assign({}, defaultQueryOptions, andQueries[0]);
-
-    query = assign({}, defaultQueryOptions, query);
 
     if (typeof query.values === 'string') {
       warn('_buildFilterQuery() was passed query.values as a string, must be an array', {

--- a/packages/data/addon/adapters/dimensions/bard.js
+++ b/packages/data/addon/adapters/dimensions/bard.js
@@ -5,8 +5,7 @@
  * Description: The adapter for the Bard dimension model.
  */
 
-import { assert } from '@ember/debug';
-import { makeArray } from '@ember/array';
+import { assert, warn } from '@ember/debug';
 import { inject as service } from '@ember/service';
 import { assign } from '@ember/polyfills';
 import EmberObject, { get } from '@ember/object';
@@ -80,13 +79,20 @@ export default EmberObject.extend({
    * @method _buildFilterQuery
    * @private
    * @param {String} dimension
-   * @param {Object} query - filter query object
+   * @param {Array<Query>} andQueries - filter query object
    * @param {String} query.field - field used to query
    * @param {String} query.operator - valid operators 'contains', 'in'
-   * @param {String} query.values
+   * @param {Array<String|number>} query.values
    * @returns {String} filter query string
    */
-  _buildFilterQuery(dimension, query) {
+  _buildFilterQuery(dimension, andQueries) {
+    if (!Array.isArray(andQueries)) {
+      warn('_buildFilterQuery() was not passed an array of AND queries, wrapping as single query array', {
+        id: 'bard-_buildFilterQuery-query-as-array'
+      });
+      andQueries = [andQueries]; // if not array, wrap
+    }
+    assert("You must pass an 'Array' of queries to be ANDed together", Array.isArray(andQueries));
     let defaultQueryOptions = {
       field: this._getDimensionMetadata(dimension).get('primaryKeyFieldName'),
       operator: 'in',
@@ -94,13 +100,25 @@ export default EmberObject.extend({
       values: []
     };
 
-    query = assign({}, defaultQueryOptions, query);
+    andQueries = andQueries.map(query => assign({}, defaultQueryOptions, query));
 
-    let queryField = get(query, 'field'),
-      field = URL_FIELD_NAMES[queryField] || queryField,
-      operator = get(query, 'operator'),
+    const stringQueries = andQueries.filter(q => typeof q.values === 'string');
+    if (stringQueries.length) {
+      warn('_buildFilterQuery() was passed query.values as a string, falling back to splitting by commas', {
+        id: 'bard-_buildFilterQuery-query-values-as-array'
+      });
+      stringQueries.forEach(query => (query.values = query.values.split(',')));
+    }
+    assert("Only 'Array' query values are currently supported in Keg", andQueries.every(q => Array.isArray(q.values)));
+
+    const filters = andQueries.map(query => {
+      const queryField = get(query, 'field'),
+        field = URL_FIELD_NAMES[queryField] || queryField,
+        operator = get(query, 'operator'),
+        values = query.values.join(',');
       // Build the filters as expected by bard api
-      filters = makeArray(get(query, 'values')).map(value => `${dimension}|${field}-${operator}[${value}]`);
+      return `${dimension}|${field}-${operator}[${values}]`;
+    });
 
     return {
       filters: filters.join(',')
@@ -113,19 +131,36 @@ export default EmberObject.extend({
    * @method _buildSearchQuery
    * @private
    * @param {String} dimension
-   * @param {Object} query - filter query object
-   * @param {String} query.values
+   * @param {[{values: Array<String|number>}]} andQueries - filter query object
    * @returns {String} filter query string
    */
-  _buildSearchQuery(dimension, query) {
-    let defaultQueryOptions = { values: [] };
+  _buildSearchQuery(dimension, andQueries) {
+    if (!Array.isArray(andQueries)) {
+      warn('_buildSearchQuery() was not passed an array of queries, wrapping as single query array', {
+        id: 'bard-_buildSearchQuery-query-as-array'
+      });
+      andQueries = [andQueries]; // if not array, wrap
+    }
+    assert(
+      "You must pass an 'Array' of queries, but searching only supports one query",
+      Array.isArray(andQueries) && andQueries.length === 1
+    );
+
+    const defaultQueryOptions = { values: [] };
+    let query = andQueries[0];
 
     query = assign({}, defaultQueryOptions, query);
 
-    let values = makeArray(get(query, 'values'));
+    if (typeof query.values === 'string') {
+      warn('_buildFilterQuery() was passed query.values as a string, must be an array', {
+        id: 'bard-_buildFilterQuery-query-values-as-array'
+      });
+      query.values = query.values.split(' ');
+    }
+    assert("Only 'Array' query values are currently supported in Bard", Array.isArray(query.values));
 
     return {
-      query: values.join(' ')
+      query: query.values.join(' ')
     };
   },
 
@@ -209,7 +244,7 @@ export default EmberObject.extend({
   /**
    * @method find - makes a request to /values api to find dimensions by query term
    * @param {String} dimension - dimension name
-   * @param {Object} [query] - the filter query object
+   * @param {Array<Query>} andQueries - the filter query object
    * @param {Object} [options] - options object
    *      Ex: {
    *        page: 1,
@@ -220,13 +255,13 @@ export default EmberObject.extend({
    *      }
    * @returns {Promise} - Promise with the response
    */
-  find(dimension, query, options) {
+  find(dimension, andQueries, options) {
     let url = this._buildUrl(dimension, undefined, options),
       data = {};
 
     // If filter query is present, build query having the filter
-    if (query) {
-      data = this._buildFilterQuery(dimension, query);
+    if (andQueries) {
+      data = this._buildFilterQuery(dimension, andQueries);
     }
 
     return this._find(url, data, options);
@@ -246,12 +281,12 @@ export default EmberObject.extend({
    *      }
    * @returns {Promise} - Promise with the response
    */
-  search(dimension, query, options) {
+  search(dimension, andQueries, options) {
     let url = this._buildUrl(dimension, 'search', options),
       data = {};
 
-    if (query) {
-      data = this._buildSearchQuery(dimension, query);
+    if (andQueries) {
+      data = this._buildSearchQuery(dimension, andQueries);
     }
 
     return this._find(url, data, options);

--- a/packages/data/addon/services/bard-dimensions.js
+++ b/packages/data/addon/services/bard-dimensions.js
@@ -177,7 +177,7 @@ export default Service.extend({
     }
 
     return get(this, '_bardAdapter')
-      .find(dimension, query, options)
+      .find(dimension, [query], options)
       .then(recordsFromBard => {
         let serialized = get(this, '_serializer').normalize(dimension, recordsFromBard),
           dimensions = kegAdapter.pushMany(dimension, serialized);
@@ -280,17 +280,13 @@ export default Service.extend({
       operator = 'in';
     }
 
-    return get(this, '_bardAdapter').find(dimension, {
+    const andValues = operator === 'contains' ? query.split(/,\s+|\s+/).map(s => s.trim()) : [query];
+    const andFilters = andValues.map(v => ({
       field,
       operator,
-      values:
-        operator === 'contains'
-          ? query
-              .split(/,\s+|\s+/)
-              .map(s => s.trim())
-              .filter(_ => _)
-          : [query]
-    });
+      values: [v]
+    }));
+    return get(this, '_bardAdapter').find(dimension, andFilters);
   },
 
   /**
@@ -302,10 +298,7 @@ export default Service.extend({
    * @returns {Promise} - Array Promise containing the search result
    */
   searchValue(dimension, query) {
-    let values = query
-      .split(/,\s+|\s+/)
-      .map(v => v.trim())
-      .filter(_ => _);
+    let values = query.split(/,\s+|\s+/).map(v => v.trim());
 
     return get(this, '_bardAdapter').search(dimension, { values });
   },

--- a/packages/data/tests/unit/adapters/dimensions/bard-test.js
+++ b/packages/data/tests/unit/adapters/dimensions/bard-test.js
@@ -91,22 +91,33 @@ module('Unit | Adapter | Dimensions | Bard', function(hooks) {
   });
 
   test('_buildFilterQuery', function(assert) {
-    assert.expect(3);
+    assert.expect(5);
 
     assert.deepEqual(
       Adapter._buildFilterQuery('dimensionOne', { values: 'v1' }),
       { filters: 'dimensionOne|id-in[v1]' },
-      '_buildFilterQuery correctly built the query object for the provided dimension filters'
+      'correctly built filters for object with one string value'
     );
 
     assert.deepEqual(
-      Adapter._buildFilterQuery('dimensionOne', {
-        field: 'id',
-        operator: 'contains',
-        values: [1, 2]
-      }),
-      { filters: 'dimensionOne|id-contains[1],dimensionOne|id-contains[2]' },
-      'AND filter query is generated given a query with "and" booleanOperation and an array of ids'
+      Adapter._buildFilterQuery('dimensionOne', { values: 'v1,v2,v3' }),
+      { filters: 'dimensionOne|id-in[v1,v2,v3]' },
+      'correctly built the query for object with csv string values'
+    );
+
+    assert.deepEqual(
+      Adapter._buildFilterQuery('dimensionOne', { values: ['v1', 'v2', 'v3'] }),
+      { filters: 'dimensionOne|id-in[v1,v2,v3]' },
+      'correctly built the query for object with array of values'
+    );
+
+    assert.deepEqual(
+      Adapter._buildFilterQuery('dimensionOne', [
+        { field: 'id', operator: 'contains', values: [1, 3] },
+        { field: 'id', operator: 'contains', values: [2] }
+      ]),
+      { filters: 'dimensionOne|id-contains[1,3],dimensionOne|id-contains[2]' },
+      'AND filter is generated given a query with multiple filters and OR filter for multiple values'
     );
 
     assert.deepEqual(


### PR DESCRIPTION
## Description
The bard dimension adapter currently takes in
```js
{
   field: 'id',
   operation: 'in',
   values: '1,2,3' // or [1, 2, 3]
}
```
When given
- `'1,2,3'` -> `filters=dim|id-in[1,2,3]`
- `[1, 2, 3]` -> `filters=dim|id-in[1],dim|id-in[2],dim|id-in[3]`

which is confusing since we think of multiple filter objects being ANDed together and filter values being ORed

## Proposed Changes
Update the interface to take in an array of filters which will be ANDed together, and in a single filter the values are ORed
```js
[
  {
     field: 'id',
     operation: 'in',
     values: [1, 2, 3]
  }
]
```

Now
- `[{values: '1,2,3'}]` -> `filters=dim|id-in[1,2,3]` *(same as before)*
-  `[{values: [1, 2, 3]}]` -> `filters=dim|id-in[1,2,3]`
-  `[{values: [1]}, {values: [2]}, {values: [3]}]` -> `filters=dim|id-in[1],dim|id-in[2],dim|id-in[3]`

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
