### PR TITLE
Update: Include ember-intl config in dummy apps

### DIFF
--- a/packages/app/config/ember-intl.js
+++ b/packages/app/config/ember-intl.js
@@ -1,0 +1,5 @@
+module.exports = function() {
+  return {
+    locales: ['en-us']
+  };
+};

--- a/packages/dashboards/tests/dummy/config/ember-intl.js
+++ b/packages/dashboards/tests/dummy/config/ember-intl.js
@@ -1,0 +1,5 @@
+module.exports = function() {
+  return {
+    locales: ['en-us']
+  };
+};

--- a/packages/directory/tests/dummy/config/ember-intl.js
+++ b/packages/directory/tests/dummy/config/ember-intl.js
@@ -1,0 +1,5 @@
+module.exports = function() {
+  return {
+    locales: ['en-us']
+  };
+};

--- a/packages/notifications/tests/dummy/config/ember-intl.js
+++ b/packages/notifications/tests/dummy/config/ember-intl.js
@@ -1,0 +1,5 @@
+module.exports = function() {
+  return {
+    locales: ['en-us']
+  };
+};

--- a/packages/reports/tests/dummy/config/ember-intl.js
+++ b/packages/reports/tests/dummy/config/ember-intl.js
@@ -1,0 +1,5 @@
+module.exports = function() {
+  return {
+    locales: ['en-us']
+  };
+};


### PR DESCRIPTION
## Description
`ember-intl` makes a _lot_ of noise during tests

## Proposed Changes
stop it


## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
