### PR TITLE
Update: Add search for raw query input during import

### DIFF
--- a/packages/core/app/styles/navi-core/utils/mixins.less
+++ b/packages/core/app/styles/navi-core/utils/mixins.less
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 
@@ -89,4 +89,12 @@
   padding: 10px @report-selector-padding-left;
   resize: none;
   width: 100%;
+}
+
+.ellipsed-text {
+  display: inline-block;
+  overflow: hidden;
+  max-width: 100%;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }

--- a/packages/reports/addon/components/dimension-bulk-import.js
+++ b/packages/reports/addon/components/dimension-bulk-import.js
@@ -3,88 +3,93 @@
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Usage:
- *   {{dimension-bulk-import
- *      dimension=dimensionToImport - {Object} dimension to import, with name and longName
- *      queryIds=queryIds - {Array} list of id strings
- *      onSelectValues= (action selectValues) - {String} name of action to trigger on select
- *      onCancel= (action cancel) - {String} name of action to trigger on cancel
- *   }}
+ *   <DimensionBulkImport
+ *      @dimension={{@dimensionToImport}}
+ *      @queryIds={{@queryIds}}
+ *      @rawQuery={{@rawQuery}}
+ *      @onSelectValues={{this.selectValues}}
+ *      @onCancel={{this.cancel}}
+ *   />
  */
 import { not } from '@ember/object/computed';
 import Component from '@ember/component';
-import { get, set, computed } from '@ember/object';
+import { get, set, computed, action } from '@ember/object';
 import { A as arr } from '@ember/array';
 import { isEmpty } from '@ember/utils';
 import { inject as service } from '@ember/service';
 import layout from '../templates/components/dimension-bulk-import';
 import DS from 'ember-data';
+import { layout as templateLayout, tagName } from '@ember-decorators/component';
 
-export default Component.extend({
-  layout,
-
-  /**
-   * @property {Array} classNames - list of class names to be applied to the component
-   */
-  classNames: ['dimension-bulk-import'],
-
+@templateLayout(layout)
+@tagName('')
+class DimensionBulkImportComponent extends Component {
   /**
    * @property {Object} - dimension - dimension metadata containing name and longName properties
    */
-  dimension: undefined,
+  dimension = undefined;
 
   /**
    * @private
    * @property {Array} _trimmedQueryIds - unique list of non-empty dimension ids to search for
    */
-  _trimmedQueryIds: computed('queryIds', function() {
-    let queryIds = get(this, 'queryIds') || [];
+  @computed('queryIds')
+  get _trimmedQueryIds() {
+    const queryIds = get(this, 'queryIds') || [];
 
     //Remove preceding and trailing white spaces, empty strings and duplicates
     return arr(queryIds.map(key => key.trim()).filter(Boolean)).uniq();
-  }),
+  }
 
   /**
    * @private
    * @property {Promise} _loadingPromise - loading spinner promise
    */
-  _loadingPromise: undefined,
+  _loadingPromise = undefined;
 
   /**
    * @private
    * @property {Array} _validDimValues - Array of DS.Model Dimension Value Records
    */
-  _validDimValues: undefined,
+  _validDimValues = undefined;
+
+  /**
+   * @private
+   * @property {Object} _validRawInputDimValue - the single value array with the dim value for raw input
+   */
+  _validRawInputDimValue = undefined;
 
   /**
    * @private
    * @property {Array} _invalidDimValueIds - array of invalid dimension value Ids
    */
-  _invalidDimValueIds: computed('_trimmedQueryIds', '_validDimValues', function() {
-    let validDimVals = get(this, '_validDimValues');
+  @computed('_trimmedQueryIds', '_validDimValues')
+  get _invalidDimValueIds() {
+    const validDimVals = get(this, '_validDimValues');
     return arr(
       get(this, '_trimmedQueryIds').reject(queryId =>
         validDimVals.any(validDimVal => get(validDimVal, 'id') === queryId)
       )
     );
-  }),
+  }
 
   /**
    * @private
    * @property {Boolean} _disableButton - if true button is disabled else not
    */
-  _disableButton: not('_loadingPromise.isSettled'),
+  @not('_loadingPromise.isSettled') _disableButton;
 
   /**
    * @private
    * @property {Ember.Service} dimensionService
    */
-  _dimensionService: service('bard-dimensions'),
+  @service('bard-dimensions') _dimensionService;
 
   /**
    * @private
    * @property {Ember.Service} bardMetadata
    */
-  _bardMetadata: service('bard-metadata'),
+  @service('bard-metadata') _bardMetadata;
 
   /**
    * @method didInsertElement
@@ -93,7 +98,7 @@ export default Component.extend({
   didInsertElement() {
     this._super(...arguments);
     this._search();
-  },
+  }
 
   /**
    * Queries dimension service for the given list of dimension value IDs
@@ -108,7 +113,7 @@ export default Component.extend({
       return;
     }
 
-    let promise = get(this, '_dimensionService')
+    const splitValuesPromise = get(this, '_dimensionService')
       .find(get(this, 'dimension.name'), [
         {
           values: get(this, '_trimmedQueryIds'),
@@ -119,28 +124,46 @@ export default Component.extend({
         set(this, '_validDimValues', dimValues.toArray());
       });
 
+    set(this, '_validRawInputDimValue', undefined);
+    const rawInputPromise = get(this, '_dimensionService')
+      .find(get(this, 'dimension.name'), [
+        {
+          field: get(this, 'searchableIdField'),
+          values: [this.rawQuery]
+        }
+      ])
+      .then(dimValue => set(this, '_validRawInputDimValue', dimValue.toArray()));
+
     //set loading promise
-    set(this, '_loadingPromise', DS.PromiseObject.create({ promise }));
-  },
+    set(
+      this,
+      '_loadingPromise',
+      DS.PromiseObject.create({
+        promise: Promise.all([splitValuesPromise, rawInputPromise])
+      })
+    );
+  }
 
   /**
    * @property {String} - which id field that we would want to search values against
    */
-  searchableIdField: computed('dimension.name', function() {
-    const meta = get(this, '_bardMetadata').getById('dimension', get(this, 'dimension.name'));
+  @computed('dimension.name')
+  get searchableIdField() {
+    const meta = this._bardMetadata.getById('dimension', get(this, 'dimension.name'));
     return get(meta, 'idFieldName');
-  }),
-
-  actions: {
-    /**
-     * Action to trigger on removing pill
-     *
-     * @method removeRecord
-     * @param {DS.Record} record - record to be removed from valid results
-     * @returns {Void}
-     */
-    removeRecord(record) {
-      get(this, '_validDimValues').removeObject(record);
-    }
   }
-});
+
+  /**
+   * Action to trigger on removing pill
+   *
+   * @method removeRecord
+   * @param {DS.Record} record - record to be removed from valid results
+   * @returns {Void}
+   */
+  @action
+  removeRecord(record) {
+    return this._validDimValues.removeObject(record);
+  }
+}
+
+export default DimensionBulkImportComponent;

--- a/packages/reports/addon/components/power-select-bulk-import-trigger.js
+++ b/packages/reports/addon/components/power-select-bulk-import-trigger.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * An ember-power-select trigger component that can import a list of comma separated values on paste
@@ -21,10 +21,16 @@ export default Trigger.extend({
   _showBulkImport: false,
 
   /**
-   * @param {Array} bulkImportQueryIds - list of ids that were pasted into search input
+   * @param {Array} _bulkImportQueryIds - list of ids that were pasted into search input
    * @private
    */
   _bulkImportQueryIds: undefined,
+
+  /**
+   * @param {String} _bulkImportRawValue - String that was pasted into search input
+   * @private
+   */
+  _bulkImportRawValue: undefined,
 
   /**
    * @method init
@@ -63,7 +69,8 @@ export default Trigger.extend({
       if (isBulkImportRequest) {
         setProperties(this, {
           _showBulkImport: true,
-          _bulkImportQueryIds: queryIds
+          _bulkImportQueryIds: queryIds,
+          _bulkImportRawValue: pastedData
         });
       }
     }

--- a/packages/reports/addon/templates/components/dimension-bulk-import.hbs
+++ b/packages/reports/addon/templates/components/dimension-bulk-import.hbs
@@ -1,44 +1,41 @@
 {{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
-{{#with (pluralize 2 dimension.longName without-count=true) as |normalizedDimensionName|}}
-  <div class="navi-modal-header">
-    <div class="text-capitalize primary-header">Add Multiple {{normalizedDimensionName}}</div>
-    {{#if (is-pending _loadingPromise)}}
-      <div class="secondary-header">Hold tight! We are searching for valid {{normalizedDimensionName}}.</div>
-    {{else}}
-      <div class="secondary-header">Search Results.</div>
+<div class="dimension-bulk-import" ...attributes>
+  {{#with (pluralize 2 this.dimension.longName without-count=true) as |normalizedDimensionName|}}
+    <div class="navi-modal-header">
+      <div class="text-capitalize primary-header">Add Multiple {{normalizedDimensionName}}</div>
+      {{#if (is-pending this._loadingPromise)}}
+        <div class="secondary-header">Hold tight! We are searching for valid {{normalizedDimensionName}}.</div>
+      {{else}}
+        <div class="secondary-header">Search Results.</div>
+      {{/if}}
+    </div>
+  {{/with}}
+
+  {{#if (is-pending this._loadingPromise)}}
+    <NaviLoadingMessage>
+      Searching
+    </NaviLoadingMessage>
+  {{else}}
+    <div class="id-container valid-ids">
+      <span class="valid-id-count">{{this._validDimValues.length}}</span> valid <span class="text-capitalize dimension">{{pluralize this._validDimValues.length this.dimension.longName without-count=true}}</span>
+      <PaginatedScrollList @items={{this._validDimValues}} @trim={{false}} as |dimVal|>
+        <span role="button" class="remove-pill" {{on "click" (fn this.removeRecord dimVal)}}>×</span>
+        {{format-dimension dimVal}}
+      </PaginatedScrollList>
+    </div>
+    <div class="id-container invalid-ids">
+      <span class="invalid-id-count">{{this._invalidDimValueIds.length}}</span> invalid <span class="text-capitalize dimension">{{pluralize this._invalidDimValueIds.length this.dimension.longName without-count=true}}</span>
+      <PaginatedScrollList @items={{this._invalidDimValueIds}} @trim={{false}} as |invalidDimId|>
+        {{invalidDimId}}
+      </PaginatedScrollList>
+    </div>
+  {{/if}}
+
+  <div class="btn-container">
+    <button type="button" class="btn btn-primary" {{on "click" (fn @onSelectValues this._validDimValues)}} disabled={{this._disableButton}}>Include Valid IDs</button>
+    {{#if this._validRawInputDimValue}}
+      <button type="button" class="btn btn-primary" {{on "click" (fn @onSelectValues this._validRawInputDimValue)}}>Include Raw Input</button>
     {{/if}}
+    <button type="button" class="btn btn-secondary" {{on "click" @onCancel}}>Cancel</button>
   </div>
-{{/with}}
-
-{{#if (is-pending _loadingPromise)}}
-  {{#navi-loading-message}}
-    Searching
-  {{/navi-loading-message}}
-{{else}}
-  <div class="id-container valid-ids">
-    <span class="valid-id-count">{{_validDimValues.length}}</span> valid <span class="text-capitalize dimension">{{pluralize _validDimValues.length dimension.longName  without-count=true}}</span>
-    {{#paginated-scroll-list
-      items=_validDimValues
-      trim=false
-      as |dimVal|
-    }}
-      <span role="button" class="remove-pill" onclick={{action "removeRecord" dimVal}}>×</span>
-      {{format-dimension dimVal}}
-    {{/paginated-scroll-list}}
-  </div>
-  <div class="id-container invalid-ids">
-    <span class="invalid-id-count">{{_invalidDimValueIds.length}}</span> invalid <span class="text-capitalize dimension">{{pluralize _invalidDimValueIds.length dimension.longName  without-count=true}}</span>
-    {{#paginated-scroll-list
-      items=_invalidDimValueIds
-      trim=false
-      as |invalidDimId|
-    }}
-      {{invalidDimId}}
-    {{/paginated-scroll-list}}
-  </div>
-{{/if}}
-
-<div class="btn-container">
-  <button type="button" class="btn btn-primary" onclick={{action onSelectValues _validDimValues}} disabled={{_disableButton}}>Include Valid IDs</button>
-  <button type="button" class="btn btn-secondary" onclick={{action onCancel}}>Cancel</button>
 </div>

--- a/packages/reports/addon/templates/components/dimension-bulk-import.hbs
+++ b/packages/reports/addon/templates/components/dimension-bulk-import.hbs
@@ -6,7 +6,7 @@
       {{#if (is-pending this._loadingPromise)}}
         <div class="secondary-header">Hold tight! We are searching for valid {{normalizedDimensionName}}.</div>
       {{else}}
-        <div class="secondary-header">Search Results.</div>
+        <div class="secondary-header">Search Results for <span class="pasted-input">{{@rawQuery}}</span></div>
       {{/if}}
     </div>
   {{/with}}

--- a/packages/reports/addon/templates/components/power-select-bulk-import-trigger.hbs
+++ b/packages/reports/addon/templates/components/power-select-bulk-import-trigger.hbs
@@ -44,13 +44,12 @@
 <span class="ember-power-select-status-icon"></span>
 
 {{!-- Added logic for bulk import --}}
-{{#navi-modal
-    isShown=_showBulkImport
-}}
-  {{dimension-bulk-import
-    dimension=extra.filter.subject
-    queryIds=_bulkImportQueryIds
-    onSelectValues=(pipe (action "importValues") (action (set this "_showBulkImport" false)))
-    onCancel=(action (set this "_showBulkImport" false))
-  }}
-{{/navi-modal}}
+<NaviModal @isShown={{this._showBulkImport}}>
+  <DimensionBulkImport
+    @dimension={{@extra.filter.subject}}
+    @queryIds={{this._bulkImportQueryIds}}
+    @rawQuery={{this._bulkImportRawValue}}
+    @onSelectValues={{pipe (action "importValues") (set this._showBulkImport false)}}
+    @onCancel={{set this._showBulkImport false}}
+  />
+</NaviModal>

--- a/packages/reports/addon/templates/components/power-select-bulk-import-trigger.hbs
+++ b/packages/reports/addon/templates/components/power-select-bulk-import-trigger.hbs
@@ -49,7 +49,7 @@
     @dimension={{@extra.filter.subject}}
     @queryIds={{this._bulkImportQueryIds}}
     @rawQuery={{this._bulkImportRawValue}}
-    @onSelectValues={{pipe (action "importValues") (set this._showBulkImport false)}}
+    @onSelectValues={{queue (action "importValues") (set this._showBulkImport false)}}
     @onCancel={{set this._showBulkImport false}}
   />
 </NaviModal>

--- a/packages/reports/app/styles/navi-reports/components/dimension-bulk-import.less
+++ b/packages/reports/app/styles/navi-reports/components/dimension-bulk-import.less
@@ -48,4 +48,14 @@
       overflow: auto;
     }
   }
+
+  .secondary-header {
+    .ellipsed-text;
+  }
+
+  .pasted-input {
+    padding: 3px 8px;
+    background-color: @navi-gray-300;
+    border-radius: 3px;
+  }
 }

--- a/packages/reports/app/styles/navi-reports/components/filter-collection.less
+++ b/packages/reports/app/styles/navi-reports/components/filter-collection.less
@@ -160,11 +160,7 @@
     }
 
     &-item {
-      display: inline-block;
-      overflow: hidden;
-      max-width: 100%;
-      text-overflow: ellipsis;
-      white-space: nowrap;
+      .ellipsed-text;
     }
   }
 }

--- a/packages/reports/tests/integration/components/dimension-bulk-import-test.js
+++ b/packages/reports/tests/integration/components/dimension-bulk-import-test.js
@@ -8,14 +8,13 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 const HOST = config.navi.dataSources[0].uri;
 
-const COMMON_TEMPLATE = hbs`
-        {{dimension-bulk-import
-           dimension=dimension
-           queryIds=queryIds
-           onSelectValues= (action onSelectValues)
-           onCancel= (action onCancel)
-        }}
-    `,
+const COMMON_TEMPLATE = hbs`<DimensionBulkImport
+    @rawQuery={{this.rawQuery}}
+    @dimension={{this.dimension}}
+    @queryIds={{this.queryIds}}
+    @onSelectValues={{action this.onSelectValues}}
+    @onCancel={{action this.onCancel}}
+  />`,
   PROPERTY_MOCK_DATA = {
     rows: [
       {
@@ -101,9 +100,8 @@ module('Integration | Component | Dimension Bulk Import', function(hooks) {
 
     assert.dom('.dimension-bulk-import').isVisible('Component renders');
 
-    let buttons = findAll('.btn-container button');
     assert.deepEqual(
-      buttons.map(el => el.textContent.trim()),
+      findAll('.btn-container button').map(el => el.textContent.trim()),
       ['Include Valid IDs', 'Cancel'],
       'Include and Cancel buttons are rendered in input mode as expected'
     );
@@ -316,5 +314,26 @@ module('Integration | Component | Dimension Bulk Import', function(hooks) {
         'Search returns valid IDs as expected'
       );
     });
+  });
+
+  test('Raw input is searched', async function(assert) {
+    assert.expect(1);
+    const rawQuery = 'yes, comma';
+    this.setProperties({
+      dimension: { name: 'commaDim', longName: 'Dimension With Comma' },
+      onSelectValues: () => {},
+      onCancel: () => {},
+      rawQuery,
+      queryIds: rawQuery.split(',').map(s => s.trim())
+    });
+
+    await render(COMMON_TEMPLATE);
+
+    await settled();
+    assert.deepEqual(
+      findAll('.btn-container button').map(el => el.textContent.trim()),
+      ['Include Valid IDs', 'Include Raw Input', 'Cancel'],
+      'The Include Raw Input button shows up for valid rawQuery'
+    );
   });
 });

--- a/packages/reports/tests/integration/components/dimension-bulk-import-test.js
+++ b/packages/reports/tests/integration/components/dimension-bulk-import-test.js
@@ -94,8 +94,10 @@ module('Integration | Component | Dimension Bulk Import', function(hooks) {
   });
 
   test('bulk import Component renders', async function(assert) {
-    assert.expect(2);
+    assert.expect(3);
 
+    const rawQuery = this.queryIds.join(',');
+    this.set('rawQuery', rawQuery);
     await render(COMMON_TEMPLATE);
 
     assert.dom('.dimension-bulk-import').isVisible('Component renders');
@@ -105,6 +107,9 @@ module('Integration | Component | Dimension Bulk Import', function(hooks) {
       ['Include Valid IDs', 'Cancel'],
       'Include and Cancel buttons are rendered in input mode as expected'
     );
+
+    await settled();
+    assert.dom('.pasted-input').hasText(rawQuery, 'pasted text is visible');
   });
 
   test('search dimension IDs', async function(assert) {
@@ -288,7 +293,7 @@ module('Integration | Component | Dimension Bulk Import', function(hooks) {
 
     assert
       .dom('.secondary-header')
-      .hasText('Search Results.', 'Secondary header has expected result text after searching');
+      .hasText('Search Results for', 'Secondary header has expected result text after searching');
   });
 
   test('Search dimension with smart key', async function(assert) {


### PR DESCRIPTION
## Description
During the dimension bulk import, if a user pasted a dimension id containing a comma ('yes, comma'), then it will.
- paste 'yes, comma'
- bring up bulk import
- show 2 invalid values

## Proposed Changes
Add a search for the raw input in the bulk import
- paste 'yes, comma'
- bring up bulk import
- show 2 invalid values _and_ button allowing import of raw value

## Screenshots
![bulk-import-raw-value-search](https://user-images.githubusercontent.com/12093492/74461708-9e672280-4e54-11ea-9ef9-51f211e6d963.png)


## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
