### PR TITLE
Fix: Table metric formatting and add tests

### DIFF
--- a/packages/core/addon/components/number-format-dropdown.js
+++ b/packages/core/addon/components/number-format-dropdown.js
@@ -13,10 +13,11 @@ import Component from '@ember/component';
 import layout from '../templates/components/number-format-dropdown';
 import { oneWay } from '@ember/object/computed';
 import { get, set, getWithDefault, action } from '@ember/object';
-import { layout as templateLayout } from '@ember-decorators/component';
+import { layout as templateLayout, tagName } from '@ember-decorators/component';
 import { merge } from 'lodash-es';
 
 @templateLayout(layout)
+@tagName('')
 class NumberFormatDropdownComponent extends Component {
   /**
    * @property {String} format

--- a/packages/core/addon/components/number-format-dropdown.js
+++ b/packages/core/addon/components/number-format-dropdown.js
@@ -1,43 +1,48 @@
 /**
- * Copyright 2018, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Usage:
- *  {{number-format-dropdown
- *    column=column
- *    onUpdateFormat = (action 'onUpdateFormat')
- *  }}
+ *  <NumberFormatDropdown
+ *    @column={{@column}}
+ *    @onUpdateFormat{{action @onUpdateFormat}}
+ *  />
  */
 
 import Component from '@ember/component';
 import layout from '../templates/components/number-format-dropdown';
 import { oneWay } from '@ember/object/computed';
-import { get, getWithDefault } from '@ember/object';
+import { get, set, getWithDefault, action } from '@ember/object';
+import { layout as templateLayout } from '@ember-decorators/component';
 import { merge } from 'lodash-es';
 
-export default Component.extend({
-  layout,
-
-  /**
-   * @property {Array} classNames
-   */
-  classNames: ['number-format-dropdown'],
-
+@templateLayout(layout)
+class NumberFormatDropdownComponent extends Component {
   /**
    * @property {String} format
    */
-  format: oneWay('column.attributes.format'),
+  @oneWay('column.attributes.format') format;
 
-  actions: {
-    /**
-     * @action updateColumnNumberFormat
-     */
-    updateColumnNumberFormat() {
-      let { onUpdateReport, column } = this,
-        format = getWithDefault(this, 'format', get(column, 'attributes.format')),
-        updatedColumn = merge({}, column, { attributes: { format } });
+  /**
+   * @action updateColumnNumberFormat
+   */
+  @action
+  updateColumnNumberFormat() {
+    const { onUpdateReport, column } = this;
+    const format = getWithDefault(this, 'format', get(column, 'attributes.format'));
+    const updatedColumn = merge({}, column, { attributes: { format } });
 
-      onUpdateReport('updateColumn', updatedColumn);
-    }
+    onUpdateReport('updateColumn', updatedColumn);
   }
-});
+
+  /**
+   *
+   * @param {String} format - The new format for the number
+   */
+  @action
+  setFormat(format) {
+    set(this, 'format', format);
+  }
+}
+
+export default NumberFormatDropdownComponent;

--- a/packages/core/addon/templates/components/number-format-dropdown.hbs
+++ b/packages/core/addon/templates/components/number-format-dropdown.hbs
@@ -1,11 +1,12 @@
-{{!-- Copyright 2018, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for
-terms. --}}
-{{#basic-dropdown horizontalPosition="right" onClose=(action "updateColumnNumberFormat") renderInPlace=true as |dd| }}
-  {{#dd.trigger class="number-format-dropdown__trigger"}}
-    {{navi-icon "ellipsis-v"}}
-  {{/dd.trigger}}
+{{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+<div class="number-format-dropdown" ...attributes>
+  <BasicDropdown @horizontalPosition="right" @onClose={{this.updateColumnNumberFormat}} @renderInPlace={{true}} as |dd|>
+    <dd.trigger @class="number-format-dropdown__trigger">
+      <NaviIcon @icon="ellipsis-v" />
+    </dd.trigger>
 
-  {{#dd.content class="number-format-dropdown__container"}}
-    {{number-format-selector format=format onUpdateFormat=(action (set this "format" _))}}
-  {{/dd.content}}
-{{/basic-dropdown}}
+    <dd.content @class="number-format-dropdown__container">
+      <NumberFormatSelector @format={{this.format}} @onUpdateFormat={{this.setFormat}} />
+    </dd.content>
+  </BasicDropdown>
+</div>

--- a/packages/core/tests/integration/components/number-format-dropdown-test.js
+++ b/packages/core/tests/integration/components/number-format-dropdown-test.js
@@ -1,0 +1,64 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click, triggerEvent, find } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { clickTrigger } from 'ember-basic-dropdown/test-support/helpers';
+
+let Template = hbs`
+  <NumberFormatDropdown
+    @column={{this.column}}
+    @onUpdateReport={{this.onUpdateReport}}
+  />`;
+
+module('Integration | Component | number format dropdown', function(hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.set('column', {
+      type: 'metric',
+      displayName: 'Coins',
+      attributes: {
+        name: 'coins',
+        parameters: {},
+        format: '$0,0[.]00'
+      },
+      hasCustomDisplayName: false,
+      sortDirection: 'none'
+    });
+  });
+
+  test('updating format', async function(assert) {
+    assert.expect(3);
+
+    this.set('onUpdateReport', (action, updatedColumn) => {
+      assert.deepEqual(
+        updatedColumn,
+        {
+          type: 'metric',
+          displayName: 'Coins',
+          attributes: {
+            name: 'coins',
+            parameters: {},
+            format: '0.0a'
+          },
+          hasCustomDisplayName: false,
+          sortDirection: 'none'
+        },
+        'onUpdateFormat is called on close with a deeply merged updated column'
+      );
+    });
+
+    await render(Template);
+
+    await clickTrigger('.number-format-dropdown'); // open dropdown
+
+    assert.dom('.number-format-selector__radio-money input').isChecked('The money input is selected');
+
+    find('.number-format-selector__radio-nice-number input').checked = true; // change format to nice number
+    await triggerEvent('.number-format-selector__radio-nice-number input', 'change');
+
+    assert.dom('.number-format-selector__radio-nice-number input').isChecked('The format changes to nice number');
+
+    await click('.number-format-dropdown');
+  });
+});

--- a/packages/reports/tests/acceptance/navi-report-test.js
+++ b/packages/reports/tests/acceptance/navi-report-test.js
@@ -1994,4 +1994,26 @@ module('Acceptance | Navi Report', function(hooks) {
       'Report changed and ran successfully'
     );
   });
+
+  test('Table number formatting works', async function(assert) {
+    assert.expect(4);
+    await visit('/reports/2/view');
+
+    await click($('.visualization-toggle__option:contains(Data Table)')[0]);
+    await click('.report-view__visualization-edit-btn');
+
+    await click(findAll('.number-format-dropdown__trigger')[1]); // open nav clicks dropdown
+
+    const navClicksCell = () => find('.table-row-vc').querySelectorAll('.table-cell-content.metric')[1];
+    assert.dom(navClicksCell()).hasText('718', 'The original metric value has no formatting');
+    assert.dom('.number-format-selector__radio-custom input').isChecked('The custom input is selected');
+
+    find('.number-format-selector__radio-money input').checked = true; // change format to money
+    await triggerEvent('.number-format-selector__radio-money input', 'change');
+
+    assert.dom('.number-format-selector__radio-money input').isChecked('The money input is selected');
+
+    await click('.number-format-dropdown');
+    assert.dom(navClicksCell()).hasText('$718', 'The metric is re-rendered in the money format');
+  });
 });


### PR DESCRIPTION
## Description
The table metric formatting is currently not working
1. Make a [new report](https://yahoo.github.io/navi/#/reports/new)
2. Add a metric 'coins'
3. Click Run
4. Click Edit Table
5. Click Number format dropdown
6. Click money format

Nothing happens, formatting still works on existing saved reports but new reports can no longer modify formatting

## Proposed Changes
- Fix modifying format
- add tests

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
