### PR TITLE
Update: Tooltip position behavior near edge

### DIFF
--- a/packages/core/addon/initializers/inject-c3-enhancements.js
+++ b/packages/core/addon/initializers/inject-c3-enhancements.js
@@ -173,7 +173,7 @@ export function initialize() {
    * Overrides the defaults tooltipPosition to allow moving the tooltip to the left of the cursor
    * if it would go past the right side of the chart
    *
-   * https://github.com/c3js/c3/blob/f339e290a7ddd73221e9ffe01cba6356951e22d7/src/tooltip.js#L175-L215
+   * https://github.com/c3js/c3/blob/v0.7.9/src/tooltip.js#L175-L215
    * @method tooltipPosition
    * @override
    * @returns {Object} - the top and left offset positions for the tooltip

--- a/packages/core/addon/initializers/inject-c3-enhancements.js
+++ b/packages/core/addon/initializers/inject-c3-enhancements.js
@@ -168,6 +168,58 @@ export function initialize() {
   c3infn.isCustomX = function() {
     return false;
   };
+
+  /**
+   * Overrides the defaults tooltipPosition to allow moving the tooltip to the left of the cursor
+   * if it would go past the right side of the chart
+   *
+   * https://github.com/c3js/c3/blob/f339e290a7ddd73221e9ffe01cba6356951e22d7/src/tooltip.js#L175-L215
+   * @method tooltipPosition
+   * @override
+   * @returns {Object} - the top and left offset positions for the tooltip
+   *
+   */
+  c3infn.tooltipPosition = function(dataToShow, tWidth, tHeight, element) {
+    const { config, d3 } = this;
+    const forArc = this.hasArcType();
+    const [mouseX, mouseY] = d3.mouse(element);
+    let tooltipLeft, tooltipTop;
+
+    if (forArc) {
+      tooltipLeft = this.width / 2 + mouseX;
+      tooltipTop = this.height / 2 + mouseY + 20;
+    } else {
+      const svgLeft = this.getSvgLeft(true);
+      // position of verticalBar on chart
+      const verticalBarX = svgLeft + this.getCurrentPaddingLeft(true) + this.x(dataToShow[0].x);
+
+      let tooltipRight, chartRight;
+      if (config.axis_rotated) {
+        tooltipLeft = svgLeft + mouseX + 100;
+        tooltipRight = tooltipLeft + tWidth;
+        chartRight = this.currentWidth - this.getCurrentPaddingRight();
+        tooltipTop = this.x(dataToShow[0].x) + 20;
+      } else {
+        tooltipLeft = verticalBarX + 20; // defaults to 20px after
+        tooltipRight = tooltipLeft + tWidth;
+        chartRight = svgLeft + this.currentWidth - this.getCurrentPaddingRight();
+        tooltipTop = mouseY + 15;
+      }
+
+      // override here to move the tooltip an equal amount to the left of the vertical bar
+      if (tooltipRight > chartRight) {
+        tooltipLeft = verticalBarX - tWidth - 20;
+      }
+      if (tooltipTop + tHeight > this.currentHeight) {
+        tooltipTop -= tHeight + 30;
+      }
+    }
+    if (tooltipTop < 0) {
+      tooltipTop = 0;
+    }
+
+    return { top: tooltipTop, left: tooltipLeft };
+  };
 }
 
 export default {

--- a/packages/core/addon/initializers/inject-c3-enhancements.js
+++ b/packages/core/addon/initializers/inject-c3-enhancements.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import { set } from '@ember/object';


### PR DESCRIPTION
## Description
If the tooltip gets too close to the right edge of the chart it will just stay snapped to the right side. This can be an issue because it will cover the data the user wants to look at

## Proposed Changes
- Mirror the tooltip over the vertical bar to the left side of the data instead of blocking the right side of the data

## Screenshots
### Before:
![before](https://user-images.githubusercontent.com/12093492/74572912-7c010200-4f45-11ea-924b-5fd07b3afff7.gif)
### After:
![after](https://user-images.githubusercontent.com/12093492/74572911-7b686b80-4f45-11ea-875c-06f24e3d7e07.gif)


## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
