### PR TITLE
Update: Hide chart overflow so it resizes to visible area

### DIFF
--- a/packages/dashboards/app/styles/navi-dashboards/components/navi-widget.less
+++ b/packages/dashboards/app/styles/navi-dashboards/components/navi-widget.less
@@ -55,5 +55,6 @@
     .flex-1;
     flex-flow: column;
     justify-content: center;
+    overflow: hidden;
   }
 }


### PR DESCRIPTION
## Description
Resizing widgets would work horizontally, but resizing vertically would only expand the height and not shrink it

## Proposed Changes
- Hide the overflow of the widget content so that when we shrink it and set `max-height` to `100%` that it will resize to the visible area instead of the actual height including the overflow

## Screenshots
### Before:
![before](https://user-images.githubusercontent.com/12093492/74599101-6a515480-5042-11ea-923c-37e9b9890492.gif)

### After:
![after](https://user-images.githubusercontent.com/12093492/74599100-66253700-5042-11ea-8017-008d967290c3.gif)


## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
