### PR TITLE
Fixing dashboard widget bug with cloned dashboards

### DIFF
--- a/packages/dashboards/addon/routes/dashboards/dashboard/clone.js
+++ b/packages/dashboards/addon/routes/dashboards/dashboard/clone.js
@@ -58,11 +58,15 @@ export default Route.extend({
       this._cloneWidgets(dashboardModel, cloneDashboardModel).then(widgetPromiseArray =>
         all(widgetPromiseArray).then(newWidgets => {
           let layout = cloneDashboardModel.get('presentation.layout');
+          console.log('Layout before clone:');
+          console.log(layout);
 
           //Replace original widget IDs with newly cloned widget IDs
           newWidgets.forEach((widget, idx) => {
             set(layout.objectAt(idx), 'widgetId', Number(widget.id));
           });
+          console.log('Cloned layout:');
+          console.log(layout);
           return cloneDashboardModel.save();
         })
       )

--- a/packages/dashboards/addon/routes/dashboards/dashboard/clone.js
+++ b/packages/dashboards/addon/routes/dashboards/dashboard/clone.js
@@ -58,15 +58,11 @@ export default Route.extend({
       this._cloneWidgets(dashboardModel, cloneDashboardModel).then(widgetPromiseArray =>
         all(widgetPromiseArray).then(newWidgets => {
           let layout = cloneDashboardModel.get('presentation.layout');
-          console.log('Layout before clone:');
-          console.log(layout);
 
           //Replace original widget IDs with newly cloned widget IDs
           newWidgets.forEach((widget, idx) => {
             set(layout.objectAt(idx), 'widgetId', Number(widget.id));
           });
-          console.log('Cloned layout:');
-          console.log(layout);
           return cloneDashboardModel.save();
         })
       )

--- a/packages/dashboards/addon/routes/dashboards/dashboard/widgets/add.js
+++ b/packages/dashboards/addon/routes/dashboards/dashboard/widgets/add.js
@@ -6,7 +6,7 @@
 import { reject } from 'rsvp';
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
-import { set, get } from '@ember/object';
+import { get } from '@ember/object';
 
 export default Route.extend({
   /**
@@ -32,23 +32,7 @@ export default Route.extend({
 
         return widget.save().then(({ id }) => {
           let layout = get(dashboard, 'presentation.layout');
-          console.log('Old layout:');
-          console.log(layout);
-          console.log(layout.toArray());
-          let newLayout = this._addToLayout(layout, Number(id));
-          console.log('New layout:');
-          console.log(newLayout);
-          console.log(newLayout.toArray());
-          console.log('Get dashboard layout:');
-          console.log(get(dashboard, 'presentation.layout').toArray());
-          debugger;
-
-          // set(dashboard, 'presentation.layout', newLayout);
-          console.log('Dashboard layout after set:');
-          console.log(newLayout.toArray());
-          console.log('Get dashboard layout:');
-          console.log(get(dashboard, 'presentation.layout').toArray());
-          debugger;
+          this._addToLayout(layout, Number(id));
         });
       } else {
         return reject('Unable to find unsaved widget');

--- a/packages/dashboards/addon/routes/dashboards/dashboard/widgets/add.js
+++ b/packages/dashboards/addon/routes/dashboards/dashboard/widgets/add.js
@@ -31,10 +31,24 @@ export default Route.extend({
         widget.set('dashboard', dashboard);
 
         return widget.save().then(({ id }) => {
-          let layout = get(dashboard, 'presentation.layout'),
-            newLayout = this._addToLayout(layout, Number(id));
+          let layout = get(dashboard, 'presentation.layout');
+          console.log('Old layout:');
+          console.log(layout);
+          console.log(layout.toArray());
+          let newLayout = this._addToLayout(layout, Number(id));
+          console.log('New layout:');
+          console.log(newLayout);
+          console.log(newLayout.toArray());
+          console.log('Get dashboard layout:');
+          console.log(get(dashboard, 'presentation.layout').toArray());
+          debugger;
 
-          set(dashboard, 'presentation.layout', newLayout);
+          // set(dashboard, 'presentation.layout', newLayout);
+          console.log('Dashboard layout after set:');
+          console.log(newLayout.toArray());
+          console.log('Get dashboard layout:');
+          console.log(get(dashboard, 'presentation.layout').toArray());
+          debugger;
         });
       } else {
         return reject('Unable to find unsaved widget');

--- a/packages/dashboards/tests/acceptance/dashboards-test.js
+++ b/packages/dashboards/tests/acceptance/dashboards-test.js
@@ -664,7 +664,7 @@ module('Acceptance | Dashboards', function(hooks) {
   });
 
   test('New widget after clone', async function(assert) {
-    assert.expect(15);
+    assert.expect(18);
 
     let originalDashboardTitle, originalWidgetTitles;
 
@@ -710,7 +710,7 @@ module('Acceptance | Dashboards', function(hooks) {
     // Save without running
     await click('.navi-report-widget__save-btn');
     assert.ok(
-      currentURL().endsWith('/dashboards/1/view'),
+      currentURL().endsWith('/dashboards/6/view'),
       'After saving without running, user is brought back to dashboard view'
     );
 
@@ -748,7 +748,7 @@ module('Acceptance | Dashboards', function(hooks) {
 
     // Save
     await click('.navi-report-widget__save-btn');
-    assert.ok(currentURL().endsWith('/dashboards/1/view'), 'After saving, user is brought back to dashboard view');
+    assert.ok(currentURL().endsWith('/dashboards/6/view'), 'After saving, user is brought back to dashboard view');
 
     widgetsAfter = findAll('.navi-widget__title').map(el => el.textContent.trim());
 
@@ -770,11 +770,11 @@ module('Acceptance | Dashboards', function(hooks) {
     find('.navi-widget__actions').style.visibility = 'visible';
     await click('.navi-widget__explore-btn');
 
-    assert.equal(currentURL(), '/dashboards/1/widgets/1/view', 'Taken to explore widget page');
+    assert.equal(currentURL(), '/dashboards/6/widgets/7/view', 'Taken to explore widget page');
 
     await click(findAll('.navi-report-widget__breadcrumb-link')[1]);
 
-    assert.equal(currentURL(), '/dashboards/1/view', 'Taken back to dashboard page');
+    assert.equal(currentURL(), '/dashboards/6/view', 'Taken back to dashboard page');
 
     assert.deepEqual(
       widgetsAfter,
@@ -789,7 +789,7 @@ module('Acceptance | Dashboards', function(hooks) {
 
     await click('.navi-dashboard__breadcrumb-link');
 
-    assert.equal(currentURL(), '/dashboards/1/view', 'We are still on the dashboard route');
+    assert.equal(currentURL(), '/dashboards/6/view', 'We are still on the dashboard route');
 
     await click('.navi-dashboard__save-button');
     await click('.navi-dashboard__breadcrumb-link');

--- a/packages/dashboards/tests/acceptance/dashboards-test.js
+++ b/packages/dashboards/tests/acceptance/dashboards-test.js
@@ -664,41 +664,13 @@ module('Acceptance | Dashboards', function(hooks) {
   });
 
   test('New widget after clone', async function(assert) {
-    assert.expect(18);
-
-    let originalDashboardTitle, originalWidgetTitles;
+    assert.expect(4);
 
     await visit('/dashboards/1');
-
-    originalDashboardTitle = find('.page-title .clickable').textContent.trim();
-
-    originalWidgetTitles = findAll('.navi-widget__title').map(el => el.textContent.trim());
 
     await click('.navi-icon__copy');
 
     assert.equal(currentURL(), '/dashboards/6/view', 'Cloning a dashboard transitions to newly made dashboard');
-
-    assert
-      .dom('.page-title .clickable')
-      .hasText(
-        `Copy of ${originalDashboardTitle}`,
-        'Cloned dashboard has the same title as Original dashboard with `copy of` prefix title'
-      );
-
-    assert.deepEqual(
-      findAll('.navi-widget__title').map(el => el.textContent.trim()),
-      originalWidgetTitles,
-      'Cloned widgets are present in the dashboard '
-    );
-
-    // Check original set of widgets
-    const widgetsBefore = findAll('.navi-widget__title').map(el => el.textContent.trim());
-
-    assert.deepEqual(
-      widgetsBefore,
-      ['Mobile DAU Goal', 'Mobile DAU Graph', 'Mobile DAU Table'],
-      '"Untitled Widget" is not initially present on dashboard'
-    );
 
     // Create new widget
     await click('.add-widget .btn');
@@ -729,73 +701,5 @@ module('Acceptance | Dashboards', function(hooks) {
       ['Date', 'Total Clicks'],
       'Table columns for the new widget are rendered correctly'
     );
-
-    // Create another new widget
-    await click('.add-widget .btn');
-    await click('.add-widget-modal .add-to-dashboard');
-
-    // Fill out request
-    await click(
-      $('.checkbox-selector--metric .grouped-list__item:contains(Total Page Views) .grouped-list__add-icon')[0]
-    );
-
-    // Run request
-    await click('.navi-report-widget__run-btn');
-    // Regex to check that a string ends with "{uuid}/view"
-    const TempIdRegex = /\/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\/view$/;
-
-    assert.ok(TempIdRegex.test(currentURL()), 'Creating a widget brings user to /view route with a temp id');
-
-    // Save
-    await click('.navi-report-widget__save-btn');
-    assert.ok(currentURL().endsWith('/dashboards/6/view'), 'After saving, user is brought back to dashboard view');
-
-    widgetsAfter = findAll('.navi-widget__title').map(el => el.textContent.trim());
-
-    assert.deepEqual(
-      widgetsAfter,
-      ['Mobile DAU Goal', 'Mobile DAU Graph', 'Mobile DAU Table', 'Untitled Widget', 'Untitled Widget'],
-      'Another "Untitled Widget" has been added to dashboard'
-    );
-
-    widgetColumns = findAll('.navi-widget:nth-child(5) .table-header-cell').map(el => el.textContent.trim());
-
-    assert.deepEqual(
-      widgetColumns,
-      ['Date', 'Total Page Views'],
-      'Table columns for the second new widget are rendered correctly'
-    );
-
-    // hover css events are hard
-    find('.navi-widget__actions').style.visibility = 'visible';
-    await click('.navi-widget__explore-btn');
-
-    assert.equal(currentURL(), '/dashboards/6/widgets/7/view', 'Taken to explore widget page');
-
-    await click(findAll('.navi-report-widget__breadcrumb-link')[1]);
-
-    assert.equal(currentURL(), '/dashboards/6/view', 'Taken back to dashboard page');
-
-    assert.deepEqual(
-      widgetsAfter,
-      ['Mobile DAU Goal', 'Mobile DAU Graph', 'Mobile DAU Table', 'Untitled Widget', 'Untitled Widget'],
-      '"Untitled Widget"s are still on dashboard after navigating to subroute'
-    );
-
-    window.confirm = () => {
-      assert.step('navigation confirmation denied');
-      return false;
-    };
-
-    await click('.navi-dashboard__breadcrumb-link');
-
-    assert.equal(currentURL(), '/dashboards/6/view', 'We are still on the dashboard route');
-
-    await click('.navi-dashboard__save-button');
-    await click('.navi-dashboard__breadcrumb-link');
-
-    assert.equal(currentURL(), '/dashboards', 'successfully navigated away with no unsaved changes');
-
-    assert.verifySteps(['navigation confirmation denied']);
   });
 });

--- a/packages/dashboards/tests/acceptance/dashboards-test.js
+++ b/packages/dashboards/tests/acceptance/dashboards-test.js
@@ -662,4 +662,140 @@ module('Acceptance | Dashboards', function(hooks) {
       'the filters reflect the dashboards modified filters'
     );
   });
+
+  test('New widget after clone', async function(assert) {
+    assert.expect(15);
+
+    let originalDashboardTitle, originalWidgetTitles;
+
+    await visit('/dashboards/1');
+
+    originalDashboardTitle = find('.page-title .clickable').textContent.trim();
+
+    originalWidgetTitles = findAll('.navi-widget__title').map(el => el.textContent.trim());
+
+    await click('.navi-icon__copy');
+
+    assert.equal(currentURL(), '/dashboards/6/view', 'Cloning a dashboard transitions to newly made dashboard');
+
+    assert
+      .dom('.page-title .clickable')
+      .hasText(
+        `Copy of ${originalDashboardTitle}`,
+        'Cloned dashboard has the same title as Original dashboard with `copy of` prefix title'
+      );
+
+    assert.deepEqual(
+      findAll('.navi-widget__title').map(el => el.textContent.trim()),
+      originalWidgetTitles,
+      'Cloned widgets are present in the dashboard '
+    );
+
+    // Check original set of widgets
+    const widgetsBefore = findAll('.navi-widget__title').map(el => el.textContent.trim());
+
+    assert.deepEqual(
+      widgetsBefore,
+      ['Mobile DAU Goal', 'Mobile DAU Graph', 'Mobile DAU Table'],
+      '"Untitled Widget" is not initially present on dashboard'
+    );
+
+    // Create new widget
+    await click('.add-widget .btn');
+    await click('.add-widget-modal .add-to-dashboard');
+
+    // Fill out request
+    await click($('.checkbox-selector--metric .grouped-list__item:contains(Total Clicks) .grouped-list__add-icon')[0]);
+
+    // Save without running
+    await click('.navi-report-widget__save-btn');
+    assert.ok(
+      currentURL().endsWith('/dashboards/1/view'),
+      'After saving without running, user is brought back to dashboard view'
+    );
+
+    let widgetsAfter = findAll('.navi-widget__title').map(el => el.textContent.trim());
+
+    assert.deepEqual(
+      widgetsAfter,
+      ['Mobile DAU Goal', 'Mobile DAU Graph', 'Mobile DAU Table', 'Untitled Widget'],
+      '"Untitled Widget" has been added to dashboard'
+    );
+
+    let widgetColumns = findAll('.navi-widget:nth-child(4) .table-header-cell').map(el => el.textContent.trim());
+
+    assert.deepEqual(
+      widgetColumns,
+      ['Date', 'Total Clicks'],
+      'Table columns for the new widget are rendered correctly'
+    );
+
+    // Create another new widget
+    await click('.add-widget .btn');
+    await click('.add-widget-modal .add-to-dashboard');
+
+    // Fill out request
+    await click(
+      $('.checkbox-selector--metric .grouped-list__item:contains(Total Page Views) .grouped-list__add-icon')[0]
+    );
+
+    // Run request
+    await click('.navi-report-widget__run-btn');
+    // Regex to check that a string ends with "{uuid}/view"
+    const TempIdRegex = /\/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\/view$/;
+
+    assert.ok(TempIdRegex.test(currentURL()), 'Creating a widget brings user to /view route with a temp id');
+
+    // Save
+    await click('.navi-report-widget__save-btn');
+    assert.ok(currentURL().endsWith('/dashboards/1/view'), 'After saving, user is brought back to dashboard view');
+
+    widgetsAfter = findAll('.navi-widget__title').map(el => el.textContent.trim());
+
+    assert.deepEqual(
+      widgetsAfter,
+      ['Mobile DAU Goal', 'Mobile DAU Graph', 'Mobile DAU Table', 'Untitled Widget', 'Untitled Widget'],
+      'Another "Untitled Widget" has been added to dashboard'
+    );
+
+    widgetColumns = findAll('.navi-widget:nth-child(5) .table-header-cell').map(el => el.textContent.trim());
+
+    assert.deepEqual(
+      widgetColumns,
+      ['Date', 'Total Page Views'],
+      'Table columns for the second new widget are rendered correctly'
+    );
+
+    // hover css events are hard
+    find('.navi-widget__actions').style.visibility = 'visible';
+    await click('.navi-widget__explore-btn');
+
+    assert.equal(currentURL(), '/dashboards/1/widgets/1/view', 'Taken to explore widget page');
+
+    await click(findAll('.navi-report-widget__breadcrumb-link')[1]);
+
+    assert.equal(currentURL(), '/dashboards/1/view', 'Taken back to dashboard page');
+
+    assert.deepEqual(
+      widgetsAfter,
+      ['Mobile DAU Goal', 'Mobile DAU Graph', 'Mobile DAU Table', 'Untitled Widget', 'Untitled Widget'],
+      '"Untitled Widget"s are still on dashboard after navigating to subroute'
+    );
+
+    window.confirm = () => {
+      assert.step('navigation confirmation denied');
+      return false;
+    };
+
+    await click('.navi-dashboard__breadcrumb-link');
+
+    assert.equal(currentURL(), '/dashboards/1/view', 'We are still on the dashboard route');
+
+    await click('.navi-dashboard__save-button');
+    await click('.navi-dashboard__breadcrumb-link');
+
+    assert.equal(currentURL(), '/dashboards', 'successfully navigated away with no unsaved changes');
+
+    assert.verifySteps(['navigation confirmation denied']);
+  });
 });


### PR DESCRIPTION
Resolves #674

<!-- The above line will close the issue upon merge -->

## Description
Adding a new widget to a freshly cloned report redirects you to a dashboard with all but the first widget.
The bug appears when we set the new layout back to the dashboard, but this set was not necessary. 

## Proposed Changes

- Remove set statement and add a corresponding acceptance test.

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
