### PR TITLE
Update: Add datasource to dimension metadata

### DIFF
--- a/packages/data/addon/adapters/dimensions/bard.js
+++ b/packages/data/addon/adapters/dimensions/bard.js
@@ -9,7 +9,7 @@ import { assert, warn } from '@ember/debug';
 import { inject as service } from '@ember/service';
 import { assign } from '@ember/polyfills';
 import EmberObject, { get } from '@ember/object';
-import { configHost } from '../../utils/adapter';
+import { configHost, getDefaultDataSourceName } from '../../utils/adapter';
 import { serializeFilters } from '../bard-facts';
 
 const SUPPORTED_FILTER_OPERATORS = ['in', 'notin', 'startswith', 'contains'];
@@ -52,10 +52,12 @@ export default EmberObject.extend({
    * @method _getDimensionMetadata
    * @private
    * @param {String} dimensionName - name of dimension
+   * @param {String} namespace - namespace of keg.
    * @returns {Object} metadata object
    */
-  _getDimensionMetadata(dimensionName) {
-    return get(this, 'bardMetadata').getById('dimension', dimensionName);
+  _getDimensionMetadata(dimensionName, namespace) {
+    namespace = namespace || getDefaultDataSourceName();
+    return get(this, 'bardMetadata').getById('dimension', dimensionName, namespace);
   },
 
   /**
@@ -84,9 +86,10 @@ export default EmberObject.extend({
    * @param {String} query.field - field used to query
    * @param {String} query.operator - valid operators 'contains', 'in'
    * @param {Array<String|number>} query.values
+   * @param {Object} options - adapter options
    * @returns {String} filter query string
    */
-  _buildFilterQuery(dimension, andQueries) {
+  _buildFilterQuery(dimension, andQueries, options = {}) {
     if (!Array.isArray(andQueries)) {
       warn('_buildFilterQuery() was not passed an array of AND queries, wrapping as single query array', {
         id: 'bard-_buildFilterQuery-query-as-array'
@@ -96,7 +99,9 @@ export default EmberObject.extend({
     assert("You must pass an 'Array' of queries to be ANDed together", Array.isArray(andQueries));
     let defaultQueryOptions = {
       dimension,
-      field: this._getDimensionMetadata(dimension).get('primaryKeyFieldName'),
+      field: this._getDimensionMetadata(dimension, options.dataSourceName || getDefaultDataSourceName()).get(
+        'primaryKeyFieldName'
+      ),
       operator: 'in',
       values: []
     };
@@ -260,7 +265,7 @@ export default EmberObject.extend({
 
     // If filter query is present, build query having the filter
     if (andQueries) {
-      data = this._buildFilterQuery(dimension, andQueries);
+      data = this._buildFilterQuery(dimension, andQueries, options);
     }
 
     return this._find(url, data, options);
@@ -285,7 +290,7 @@ export default EmberObject.extend({
       data = {};
 
     if (andQueries) {
-      data = this._buildSearchQuery(dimension, andQueries);
+      data = this._buildSearchQuery(dimension, andQueries, options);
     }
 
     return this._find(url, data, options);

--- a/packages/data/addon/adapters/dimensions/bard.js
+++ b/packages/data/addon/adapters/dimensions/bard.js
@@ -55,9 +55,8 @@ export default EmberObject.extend({
    * @param {String} namespace - namespace of keg.
    * @returns {Object} metadata object
    */
-  _getDimensionMetadata(dimensionName, namespace) {
-    namespace = namespace || getDefaultDataSourceName();
-    return get(this, 'bardMetadata').getById('dimension', dimensionName, namespace);
+  _getDimensionMetadata(dimensionName, namespace=getDefaultDataSourceName()) {
+  return this.bardMetadata.getById('dimension', dimensionName, namespace);
   },
 
   /**

--- a/packages/data/addon/adapters/dimensions/keg.js
+++ b/packages/data/addon/adapters/dimensions/keg.js
@@ -230,7 +230,7 @@ export default EmberObject.extend({
    * @returns {Array} records that were pushed to the keg
    */
   pushMany(dimension, payload, options = {}) {
-    const namespace = options.dataSourceName || getDefaultDataSourceName(),
+    const namespace = options.dataSourceName || getDefaultDataSourceName();
     const modelFactory = this.bardDimensions.getFactoryFor(dimension, namespace);
 
     return get(this, 'keg').pushMany(

--- a/packages/data/addon/adapters/dimensions/keg.js
+++ b/packages/data/addon/adapters/dimensions/keg.js
@@ -12,6 +12,7 @@ import { assign } from '@ember/polyfills';
 import EmberObject, { get } from '@ember/object';
 import { getOwner } from '@ember/application';
 import { intersection } from 'lodash-es';
+import { getDefaultDataSourceName } from '../../utils/adapter';
 
 const KEG_NAMESPACE = 'dimension';
 
@@ -37,10 +38,12 @@ export default EmberObject.extend({
    * @method _getDimensionMetadata
    * @private
    * @param {String} dimensionName - name of dimension
+   * @param {String} namespace - namespace from keg
    * @returns {Object} metadata object
    */
-  _getDimensionMetadata(dimensionName) {
-    return get(this, 'bardMetadata').getById('dimension', dimensionName);
+  _getDimensionMetadata(dimensionName, namespace) {
+    namespace = namespace || getDefaultDataSourceName();
+    return get(this, 'bardMetadata').getById('dimension', dimensionName, namespace);
   },
 
   /**
@@ -123,30 +126,37 @@ export default EmberObject.extend({
    *      }
    * @returns {Promise} - Promise with the response
    */
-  all(dimension, options) {
-    let keg = get(this, 'keg');
+  all(dimension, options = {}) {
+    let keg = get(this, 'keg'),
+      namespace = options.dataSourceName || getDefaultDataSourceName();
 
-    return Promise.resolve(this._buildResponse(keg.all(`${KEG_NAMESPACE}/${dimension}`), options));
+    return Promise.resolve(
+      this._buildResponse(keg.all(`${KEG_NAMESPACE}/${namespace}.${dimension}`, { namespace }), options)
+    );
   },
 
   /**
    * @method getById - Finds a dimension value object by its id
    * @param {String} dimension - dimension name
    * @param {String} value - the value to be looked up
+   * @param {String} namespace - namespace from the keg
    * @returns {Object} - The dimension value object
    */
-  getById(dimension, value) {
-    return get(this, 'keg').getById(`${KEG_NAMESPACE}/${dimension}`, value);
+  getById(dimension, value, namespace) {
+    namespace = namespace || getDefaultDataSourceName();
+    return get(this, 'keg').getById(`${KEG_NAMESPACE}/${namespace}.${dimension}`, value);
   },
 
   /**
    * @method findById - Finds a dimension value object by its id
    * @param {String} dimension - dimension name
    * @param {String} value - the value to be looked up
+   * @param {String} namespace - namespace from the keg
    * @returns {Promise} - Promise with the response
    */
-  findById(dimension, value) {
-    return Promise.resolve(this.getById(dimension, value));
+  findById(dimension, value, namespace) {
+    namespace = namespace || getDefaultDataSourceName();
+    return Promise.resolve(this.getById(dimension, value, namespace));
   },
 
   /**
@@ -160,7 +170,8 @@ export default EmberObject.extend({
    *      }
    * @returns {Promise} - Promise with the response
    */
-  find(dimension, andQueries, options) {
+  find(dimension, andQueries, options = {}) {
+    const namespace = options.dataSourceName || getDefaultDataSourceName();
     if (!Array.isArray(andQueries)) {
       // if not array
       warn('find() was not passed an array of queries, wrapping as single query array', {
@@ -187,7 +198,7 @@ export default EmberObject.extend({
     let keg = get(this, 'keg');
 
     let defaultQueryOptions = {
-      field: this._getDimensionMetadata(dimension).get('primaryKeyFieldName'),
+      field: this._getDimensionMetadata(dimension, namespace).get('primaryKeyFieldName'),
       values: []
     };
 
@@ -207,7 +218,9 @@ export default EmberObject.extend({
       return all;
     }, {});
 
-    return Promise.resolve(this._buildResponse(keg.getBy(`${KEG_NAMESPACE}/${dimension}`, query), options));
+    return Promise.resolve(
+      this._buildResponse(keg.getBy(`${KEG_NAMESPACE}/${namespace}.${dimension}`, query), options)
+    );
   },
 
   /**
@@ -219,15 +232,17 @@ export default EmberObject.extend({
    * @param {Object} [options] - keg.pushMany options object
    * @returns {Array} records that were pushed to the keg
    */
-  pushMany(dimension, payload, options) {
-    let modelFactory = get(this, 'bardDimensions').getFactoryFor(dimension);
+  pushMany(dimension, payload, options = {}) {
+    let namespace = options.dataSourceName || getDefaultDataSourceName(),
+      modelFactory = get(this, 'bardDimensions').getFactoryFor(dimension, namespace);
 
     return get(this, 'keg').pushMany(
-      `${KEG_NAMESPACE}/${dimension}`,
+      `${KEG_NAMESPACE}/${namespace}.${dimension}`,
       payload,
       assign(
         {
-          modelFactory
+          modelFactory,
+          namespace
         },
         options
       )

--- a/packages/data/addon/adapters/dimensions/keg.js
+++ b/packages/data/addon/adapters/dimensions/keg.js
@@ -41,9 +41,8 @@ export default EmberObject.extend({
    * @param {String} namespace - namespace from keg
    * @returns {Object} metadata object
    */
-  _getDimensionMetadata(dimensionName, namespace) {
-    namespace = namespace || getDefaultDataSourceName();
-    return get(this, 'bardMetadata').getById('dimension', dimensionName, namespace);
+  _getDimensionMetadata(dimensionName, namespace=getDefaultDataSourceName()) {
+    return this.bardMetadata.getById('dimension', dimensionName, namespace);
   },
 
   /**
@@ -127,8 +126,8 @@ export default EmberObject.extend({
    * @returns {Promise} - Promise with the response
    */
   all(dimension, options = {}) {
-    let keg = get(this, 'keg'),
-      namespace = options.dataSourceName || getDefaultDataSourceName();
+    const { keg } = this;
+    const namespace = options.dataSourceName || getDefaultDataSourceName();
 
     return Promise.resolve(
       this._buildResponse(keg.all(`${KEG_NAMESPACE}/${namespace}.${dimension}`, { namespace }), options)
@@ -142,9 +141,8 @@ export default EmberObject.extend({
    * @param {String} namespace - namespace from the keg
    * @returns {Object} - The dimension value object
    */
-  getById(dimension, value, namespace) {
-    namespace = namespace || getDefaultDataSourceName();
-    return get(this, 'keg').getById(`${KEG_NAMESPACE}/${namespace}.${dimension}`, value);
+  getById(dimension, value, namespace=getDefaultDataSourceName()) {
+    return this.keg.getById(`${KEG_NAMESPACE}/${namespace}.${dimension}`, value);
   },
 
   /**
@@ -154,8 +152,7 @@ export default EmberObject.extend({
    * @param {String} namespace - namespace from the keg
    * @returns {Promise} - Promise with the response
    */
-  findById(dimension, value, namespace) {
-    namespace = namespace || getDefaultDataSourceName();
+  findById(dimension, value, namespace=getDefaultDataSourceName()) {
     return Promise.resolve(this.getById(dimension, value, namespace));
   },
 
@@ -233,8 +230,8 @@ export default EmberObject.extend({
    * @returns {Array} records that were pushed to the keg
    */
   pushMany(dimension, payload, options = {}) {
-    let namespace = options.dataSourceName || getDefaultDataSourceName(),
-      modelFactory = get(this, 'bardDimensions').getFactoryFor(dimension, namespace);
+    const namespace = options.dataSourceName || getDefaultDataSourceName(),
+    const modelFactory = this.bardDimensions.getFactoryFor(dimension, namespace);
 
     return get(this, 'keg').pushMany(
       `${KEG_NAMESPACE}/${namespace}.${dimension}`,

--- a/packages/data/addon/models/metadata/dimension.js
+++ b/packages/data/addon/models/metadata/dimension.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import { A as array } from '@ember/array';
@@ -65,6 +65,11 @@ let Model = EmberObject.extend({
   idTag: 'id',
 
   /**
+   * @property {String} source - name of the data source this dimension is from.
+   */
+  source: undefined,
+
+  /**
    * Fetches tags for a given field name
    *
    * @method getTagsForField
@@ -125,9 +130,9 @@ let Model = EmberObject.extend({
    * @property {Promise} extended
    */
   extended: computed(function() {
-    const { metadata, name, type } = this;
+    const { metadata, name, type, source } = this;
     return ObjectProxy.extend(PromiseProxyMixin).create({
-      promise: metadata.fetchById(type, name)
+      promise: metadata.fetchById(type, name, source)
     });
   })
 });

--- a/packages/data/addon/models/metadata/dimension.js
+++ b/packages/data/addon/models/metadata/dimension.js
@@ -132,7 +132,7 @@ let Model = EmberObject.extend({
   extended: computed(function() {
     const { metadata, name, type, source } = this;
     return ObjectProxy.extend(PromiseProxyMixin).create({
-      promise: metadata.fetchById(type, name, source)
+      promise: metadata.findById(type, name, source)
     });
   })
 });

--- a/packages/data/addon/services/bard-dimensions.js
+++ b/packages/data/addon/services/bard-dimensions.js
@@ -16,6 +16,7 @@ import BardDimensionArray from 'navi-data/models/bard-dimension-array';
 import SearchUtils from 'navi-data/utils/search';
 import config from 'ember-get-config';
 import { intersection } from 'lodash-es';
+import { getDefaultDataSourceName } from '../utils/adapter';
 
 const LOAD_CARDINALITY = config.navi.searchThresholds.contains;
 
@@ -109,7 +110,7 @@ export default Service.extend({
    * @param {Object} [options] - options object
    * @returns {Promise} - Promise with the bard dimension model object
    */
-  all(dimension, options) {
+  all(dimension, options = {}) {
     let kegAdapter = get(this, '_kegAdapter');
 
     // fetch all from keg if all records are loaded in keg
@@ -123,7 +124,7 @@ export default Service.extend({
       .all(dimension, options)
       .then(recordsFromBard => {
         let serialized = get(this, '_serializer').normalize(dimension, recordsFromBard),
-          dimensions = kegAdapter.pushMany(dimension, serialized);
+          dimensions = kegAdapter.pushMany(dimension, serialized, options);
 
         // Fili provides pagination metadata only when data is partially fetched
         let isPartiallyLoaded = get(recordsFromBard, 'meta.pagination');
@@ -181,7 +182,7 @@ export default Service.extend({
       .find(dimension, andQueries, options)
       .then(recordsFromBard => {
         let serialized = get(this, '_serializer').normalize(dimension, recordsFromBard),
-          dimensions = kegAdapter.pushMany(dimension, serialized);
+          dimensions = kegAdapter.pushMany(dimension, serialized, options);
         return this._createBardDimensionsArray(recordsFromBard, dimensions, dimension);
       });
   },
@@ -190,10 +191,12 @@ export default Service.extend({
    * @method getById - Returns the dimension value object for a bard dimension where identifierField value matches value
    * @param {String} dimension - dimension name
    * @param {Object} value - the value to be looked up
+   * @param {String} namespace - namespace to the keg
    * @returns {Object} - The bard dimension model object
    */
-  getById(dimension, value) {
-    return get(this, '_kegAdapter').getById(dimension, value);
+  getById(dimension, value, namespace) {
+    namespace = namespace || getDefaultDataSourceName();
+    return get(this, '_kegAdapter').getById(dimension, value, namespace);
   },
 
   /**
@@ -203,10 +206,11 @@ export default Service.extend({
    * @param {Object} [options] - options object
    * @returns {Promise} - Promise with the bard dimension model object
    */
-  findById(dimension, value, options) {
-    let kegAdapter = get(this, '_kegAdapter');
+  findById(dimension, value, options = {}) {
+    let kegAdapter = get(this, '_kegAdapter'),
+      namespace = options.dataSourceName || getDefaultDataSourceName();
 
-    return kegAdapter.findById(dimension, value).then(recordFromKeg => {
+    return kegAdapter.findById(dimension, value, namespace).then(recordFromKeg => {
       if (!isEmpty(recordFromKeg)) {
         return recordFromKeg;
       } else {
@@ -214,7 +218,7 @@ export default Service.extend({
           .findById(dimension, value, options)
           .then(recordFromBard => {
             let serialized = get(this, '_serializer').normalize(dimension, recordFromBard);
-            return kegAdapter.pushMany(dimension, serialized).get('firstObject');
+            return kegAdapter.pushMany(dimension, serialized, options).get('firstObject');
           });
       }
     });
@@ -268,16 +272,18 @@ export default Service.extend({
    * @param {String} dimension - name of dimension
    * @param {String} field - dimension record/value field
    * @param {String} query - search query
+   * @param {Object} options - adapter options
    * @returns {Promise} - Array Promise containing the search result
    */
-  searchValueField(dimension, field, query) {
+  searchValueField(dimension, field, query, options = {}) {
     assert('search query must be defined', query);
     assert('dimension must be defined', dimension);
 
     let metadataService = get(this, 'metadataService'),
+      source = options.dataSourceName || getDefaultDataSourceName(),
       operator = this._getSearchOperator(dimension);
 
-    if (get(metadataService.getById('dimension', dimension), 'cardinality') > MAX_LOAD_CARDINALITY) {
+    if (get(metadataService.getById('dimension', dimension, source), 'cardinality') > MAX_LOAD_CARDINALITY) {
       operator = 'in';
     }
 
@@ -287,7 +293,7 @@ export default Service.extend({
       operator,
       values: [v]
     }));
-    return get(this, '_bardAdapter').find(dimension, andFilters);
+    return get(this, '_bardAdapter').find(dimension, andFilters, options);
   },
 
   /**
@@ -296,12 +302,13 @@ export default Service.extend({
    * @method searchValue
    * @param {String} dimension - name of dimension
    * @param {String} query - search query
+   * @param {Object} options - adapter options
    * @returns {Promise} - Array Promise containing the search result
    */
-  searchValue(dimension, query) {
+  searchValue(dimension, query, options = {}) {
     let values = query.split(/,\s+|\s+/).map(v => v.trim());
 
-    return get(this, '_bardAdapter').search(dimension, { values });
+    return get(this, '_bardAdapter').search(dimension, { values }, options);
   },
 
   /**
@@ -327,12 +334,13 @@ export default Service.extend({
     }
 
     let metadataService = get(this, 'metadataService'),
+      source = options.dataSourceName || getDefaultDataSourceName(),
       query = options.term.trim(),
       promise,
       dimensionRecords;
 
-    if (get(metadataService.getById('dimension', dimension), 'cardinality') <= LOAD_CARDINALITY) {
-      promise = this.all(dimension).then(dimValues => {
+    if (get(metadataService.getById('dimension', dimension, source), 'cardinality') <= LOAD_CARDINALITY) {
+      promise = this.all(dimension, options).then(dimValues => {
         dimensionRecords = A(dimValues);
 
         return A(
@@ -345,15 +353,15 @@ export default Service.extend({
         ).mapBy('record');
       });
     } else if (options.useNewSearchAPI) {
-      promise = this.searchValue(dimension, query).then(dimValues => {
+      promise = this.searchValue(dimension, query, options).then(dimValues => {
         dimensionRecords = A(getWithDefault(dimValues, 'rows', []));
 
         return A(SearchUtils.searchDimensionRecords(dimensionRecords, query, MAX_SEARCH_RESULT_COUNT)).mapBy('record');
       });
     } else {
       let promises = {
-        searchById: this.searchValueField(dimension, 'id', query),
-        searchByDescription: this.searchValueField(dimension, 'description', query)
+        searchById: this.searchValueField(dimension, 'id', query, options),
+        searchByDescription: this.searchValueField(dimension, 'description', query, options)
       };
 
       promise = hashSettled(promises).then(({ searchById, searchByDescription }) => {
@@ -371,13 +379,16 @@ export default Service.extend({
   /**
    * @method getFactoryFor - fetches a dimension model for a dimension type
    * @param dimensionName {String} - name of the dimension
+   * @param namespace {String} - namespace of dimension
    * @returns {Object} dimension model factory
    */
-  getFactoryFor(dimensionName) {
-    if (MODEL_FACTORY_CACHE[dimensionName]) {
-      return MODEL_FACTORY_CACHE[dimensionName];
+  getFactoryFor(dimensionName, namespace) {
+    namespace = namespace || getDefaultDataSourceName();
+    const key = `${namespace}.${dimensionName}`;
+    if (MODEL_FACTORY_CACHE[key]) {
+      return MODEL_FACTORY_CACHE[key];
     }
-    return (MODEL_FACTORY_CACHE[dimensionName] = this._createDimensionModelFactory(dimensionName));
+    return (MODEL_FACTORY_CACHE[key] = this._createDimensionModelFactory(dimensionName, namespace));
   },
 
   /**
@@ -385,8 +396,9 @@ export default Service.extend({
    * @param dimensionName {String} - name of the dimension
    * @returns {Object} dimension model factory
    */
-  _createDimensionModelFactory(dimensionName) {
-    let metadata = get(this, 'metadataService').getById('dimension', dimensionName),
+  _createDimensionModelFactory(dimensionName, namespace) {
+    namespace = namespace || getDefaultDataSourceName();
+    let metadata = get(this, 'metadataService').getById('dimension', dimensionName, namespace),
       dimensionModel = getOwner(this).factoryFor('model:bard-dimension').class,
       identifierField = metadata.get('primaryKeyFieldName');
 

--- a/packages/data/addon/services/bard-dimensions.js
+++ b/packages/data/addon/services/bard-dimensions.js
@@ -194,9 +194,8 @@ export default Service.extend({
    * @param {String} namespace - namespace to the keg
    * @returns {Object} - The bard dimension model object
    */
-  getById(dimension, value, namespace) {
-    namespace = namespace || getDefaultDataSourceName();
-    return get(this, '_kegAdapter').getById(dimension, value, namespace);
+  getById(dimension, value, namespace=getDefaultDataSourceName()) {
+    return this._kegAdapter.getById(dimension, value, namespace);
   },
 
   /**
@@ -207,8 +206,8 @@ export default Service.extend({
    * @returns {Promise} - Promise with the bard dimension model object
    */
   findById(dimension, value, options = {}) {
-    let kegAdapter = get(this, '_kegAdapter'),
-      namespace = options.dataSourceName || getDefaultDataSourceName();
+    const { _kegAdapter: kegAdapter } = this;
+    const namespace = options.dataSourceName || getDefaultDataSourceName();
 
     return kegAdapter.findById(dimension, value, namespace).then(recordFromKeg => {
       if (!isEmpty(recordFromKeg)) {
@@ -293,7 +292,7 @@ export default Service.extend({
       operator,
       values: [v]
     }));
-    return get(this, '_bardAdapter').find(dimension, andFilters, options);
+    return this._bardAdapter.find(dimension, andFilters, options);
   },
 
   /**
@@ -308,7 +307,7 @@ export default Service.extend({
   searchValue(dimension, query, options = {}) {
     let values = query.split(/,\s+|\s+/).map(v => v.trim());
 
-    return get(this, '_bardAdapter').search(dimension, { values }, options);
+    return this._bardAdapter.search(dimension, { values }, options);
   },
 
   /**
@@ -339,7 +338,8 @@ export default Service.extend({
       promise,
       dimensionRecords;
 
-    if (get(metadataService.getById('dimension', dimension, source), 'cardinality') <= LOAD_CARDINALITY) {
+    const { cardinality } = metadataService.getById('dimension', dimension, source);
+    if (cardinality <= LOAD_CARDINALITY) {
       promise = this.all(dimension, options).then(dimValues => {
         dimensionRecords = A(dimValues);
 
@@ -382,8 +382,7 @@ export default Service.extend({
    * @param namespace {String} - namespace of dimension
    * @returns {Object} dimension model factory
    */
-  getFactoryFor(dimensionName, namespace) {
-    namespace = namespace || getDefaultDataSourceName();
+  getFactoryFor(dimensionName, namespace=getDefaultDataSourceName()) {
     const key = `${namespace}.${dimensionName}`;
     if (MODEL_FACTORY_CACHE[key]) {
       return MODEL_FACTORY_CACHE[key];
@@ -396,9 +395,8 @@ export default Service.extend({
    * @param dimensionName {String} - name of the dimension
    * @returns {Object} dimension model factory
    */
-  _createDimensionModelFactory(dimensionName, namespace) {
-    namespace = namespace || getDefaultDataSourceName();
-    let metadata = get(this, 'metadataService').getById('dimension', dimensionName, namespace),
+  _createDimensionModelFactory(dimensionName, namespace=getDefaultDataSourceName()) {
+    const metadata = this.metadataService.getById('dimension', dimensionName, namespace),
       dimensionModel = getOwner(this).factoryFor('model:bard-dimension').class,
       identifierField = metadata.get('primaryKeyFieldName');
 

--- a/packages/data/addon/services/bard-metadata.js
+++ b/packages/data/addon/services/bard-metadata.js
@@ -226,9 +226,8 @@ export default Service.extend({
    * @returns {string} - namespace
    */
   getTableNamespace(table) {
-    const tableIndex = this._keg.idIndexes['metadata/table'];
-    const metaKey = Object.keys(tableIndex).find(metaTable => metaTable.endsWith(table));
+    const items = this._keg.getBy('metadata/table', recordTable => (recordTable.name = table));
 
-    return metaKey ? metaKey.split('.')[0] : getDefaultDataSourceName();
+    return items.length ? items[0].source : getDefaultDataSourceName();
   }
 });

--- a/packages/data/addon/services/bard-metadata.js
+++ b/packages/data/addon/services/bard-metadata.js
@@ -218,5 +218,17 @@ export default Service.extend({
       return defaultIfNone;
     }
     return getWithDefault(meta, field, defaultIfNone);
+  },
+
+  /**
+   * Convenience method to get namespace of a table
+   * @param {String} table
+   * @returns {string} - namespace
+   */
+  getTableNamespace(table) {
+    const tableIndex = this._keg.idIndexes['metadata/table'];
+    const metaKey = Object.keys(tableIndex).find(metaTable => metaTable.endsWith(table));
+
+    return metaKey ? metaKey.split('.')[0] : getDefaultDataSourceName();
   }
 });

--- a/packages/data/addon/services/keg.js
+++ b/packages/data/addon/services/keg.js
@@ -160,7 +160,7 @@ export default class KegService extends Service {
    */
   all(type, namespace) {
     const all = this._getRecordKegForType(type);
-    if (namespace) {
+    if (namespace && all.any(item => !!item.source)) {
       return A(all.filter(item => item.source === namespace));
     }
     return all;

--- a/packages/data/test-support/helpers/metadata-routes.js
+++ b/packages/data/test-support/helpers/metadata-routes.js
@@ -91,6 +91,25 @@ export const DimensionFour = {
   ]
 };
 
+export const DimensionFive = {
+  category: 'categoryTwo',
+  name: 'dimensionFive',
+  longName: 'Dimension Five',
+  cardinality: 6000000000,
+  fields: [
+    {
+      name: 'id',
+      description: 'description',
+      tags: ['primaryKey', 'display']
+    },
+    {
+      name: 'description',
+      description: 'description',
+      tags: ['description', 'display']
+    }
+  ]
+};
+
 export const TableOne = {
   description: 'Table1 Description',
   longName: 'table1LongName',
@@ -173,7 +192,7 @@ export const Tables2 = [
         metrics: [MetricThree],
         retention: 'P24M',
         longName: 'Day',
-        dimensions: [DimensionFour]
+        dimensions: [DimensionFour, DimensionFive]
       }
     ]
   },
@@ -189,7 +208,7 @@ export const Tables2 = [
         metrics: [MetricFour],
         retention: 'P24M',
         longName: 'Day',
-        dimensions: [DimensionFour]
+        dimensions: [DimensionFour, DimensionFive]
       }
     ]
   }

--- a/packages/data/tests/unit/adapters/dimensions/bard-test.js
+++ b/packages/data/tests/unit/adapters/dimensions/bard-test.js
@@ -4,7 +4,6 @@ import Pretender from 'pretender';
 import config from 'ember-get-config';
 import metadataRoutes from '../../../helpers/metadata-routes';
 import { assign } from '@ember/polyfills';
-import { all } from 'rsvp';
 
 const HOST = config.navi.dataSources[0].uri;
 
@@ -68,7 +67,7 @@ module('Unit | Adapter | Dimensions | Bard', function(hooks) {
     //Load metadata
     Server.map(metadataRoutes);
     metadataRoutes.bind(Server)(1);
-    return all([
+    return Promise.all([
       this.owner.lookup('service:bard-metadata').loadMetadata(),
       this.owner.lookup('service:bard-metadata').loadMetadata({ dataSourceName: 'blockhead' })
     ]);

--- a/packages/data/tests/unit/adapters/dimensions/keg-test.js
+++ b/packages/data/tests/unit/adapters/dimensions/keg-test.js
@@ -154,7 +154,7 @@ module('Unit | Adapters | Dimensions | Keg', function(hooks) {
 
     const result = await Adapter.findById('dimensionOne', '1');
     assert.deepEqual(
-      result.get('id'),
+      result.id,
       1,
       'findById() returns the expected response object for Test dimension, identifierField and query'
     );

--- a/packages/data/tests/unit/adapters/dimensions/keg-test.js
+++ b/packages/data/tests/unit/adapters/dimensions/keg-test.js
@@ -1,6 +1,5 @@
 import EmberObject from '@ember/object';
 import { assign } from '@ember/polyfills';
-import { all } from 'rsvp';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import metadataRoutes from '../../../helpers/metadata-routes';
@@ -52,7 +51,7 @@ module('Unit | Adapters | Dimensions | Keg', function(hooks) {
     Server = new Pretender(metadataRoutes);
     metadataRoutes.bind(Server)(1);
 
-    return all([
+    return Promise.all([
       this.owner.lookup('service:bard-metadata').loadMetadata(),
       this.owner.lookup('service:bard-metadata').loadMetadata({ dataSourceName: 'blockhead' })
     ]);
@@ -96,7 +95,7 @@ module('Unit | Adapters | Dimensions | Keg', function(hooks) {
     );
 
     const nonFoundResult = await Adapter.all('dimensionFour');
-    assert.deepEqual(nonFoundResult.rows.mapBy('id'), [], "all() returns empy array when dimension can't be found");
+    assert.deepEqual(nonFoundResult.rows.mapBy('id'), [], "all() returns empty array when dimension can't be found");
   });
 
   test('find', async function(assert) {

--- a/packages/data/tests/unit/adapters/dimensions/keg-test.js
+++ b/packages/data/tests/unit/adapters/dimensions/keg-test.js
@@ -161,7 +161,7 @@ module('Unit | Adapters | Dimensions | Keg', function(hooks) {
 
     const blockheadResult = await Adapter.findById('dimensionFour', '1', 'blockhead');
     assert.deepEqual(
-      blockheadResult.get('description'),
+      blockheadResult.description,
       'one',
       'findById() returns the expected response object for the blockhead sourced dimension'
     );
@@ -189,7 +189,7 @@ module('Unit | Adapters | Dimensions | Keg', function(hooks) {
     );
 
     assert.deepEqual(
-      Adapter.getById('dimensionFour', '1', 'blockhead').get('description'),
+      Adapter.getById('dimensionFour', '1', 'blockhead').description,
       'one',
       'getById() returns the expected response object from a dimension in another namespace'
     );

--- a/packages/data/tests/unit/adapters/dimensions/keg-test.js
+++ b/packages/data/tests/unit/adapters/dimensions/keg-test.js
@@ -1,5 +1,6 @@
 import EmberObject from '@ember/object';
 import { assign } from '@ember/polyfills';
+import { all } from 'rsvp';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import metadataRoutes from '../../../helpers/metadata-routes';
@@ -36,16 +37,25 @@ module('Unit | Adapters | Dimensions | Keg', function(hooks) {
   setupTest(hooks);
 
   hooks.beforeEach(function() {
-    this.owner.register('model:dimension/dimensionOne', EmberObject.extend({ name: 'dimensionOne' }));
+    this.owner.register('model:dimension/dummy.dimensionOne', EmberObject.extend({ name: 'dimensionOne' }));
+    this.owner.register('model:dimension/blockhead.dimensionFour', EmberObject.extend({ name: 'dimensionFour' }));
 
     Adapter = this.owner.lookup('adapter:dimensions/keg');
 
     Keg = Adapter.get('keg');
-    Keg.pushMany('dimension/dimensionOne', Records);
+    Keg.pushMany('dimension/dummy.dimensionOne', Records, { dataSourceName: 'dummy' });
+    Keg.pushMany('dimension/blockhead.dimensionFour', [{ id: 1, description: 'one' }, { id: 2, description: 'two' }], {
+      dataSourceName: 'blockhead'
+    });
 
     //Load metadata
     Server = new Pretender(metadataRoutes);
-    return this.owner.lookup('service:bard-metadata').loadMetadata();
+    metadataRoutes.bind(Server)(1);
+
+    return all([
+      this.owner.lookup('service:bard-metadata').loadMetadata(),
+      this.owner.lookup('service:bard-metadata').loadMetadata({ dataSourceName: 'blockhead' })
+    ]);
   });
 
   hooks.afterEach(function() {
@@ -68,20 +78,29 @@ module('Unit | Adapters | Dimensions | Keg', function(hooks) {
     );
   });
 
-  test('all', function(assert) {
-    assert.expect(1);
+  test('all', async function(assert) {
+    assert.expect(3);
 
-    return Adapter.all('dimensionOne').then(result => {
-      assert.deepEqual(
-        result.rows.mapBy('id'),
-        [1, 2, 3],
-        'all() contains the expected response object for Test dimension without any filters'
-      );
-    });
+    const result = await Adapter.all('dimensionOne');
+    assert.deepEqual(
+      result.rows.mapBy('id'),
+      [1, 2, 3],
+      'all() contains the expected response object for Test dimension without any filters'
+    );
+
+    const blockheadResult = await Adapter.all('dimensionFour', { dataSourceName: 'blockhead' });
+    assert.deepEqual(
+      blockheadResult.rows.mapBy('id'),
+      [1, 2],
+      'all() contains the expected response object for blockhead dimension without any filters'
+    );
+
+    const nonFoundResult = await Adapter.all('dimensionFour');
+    assert.deepEqual(nonFoundResult.rows.mapBy('id'), [], "all() returns empy array when dimension can't be found");
   });
 
   test('find', async function(assert) {
-    assert.expect(8);
+    assert.expect(9);
 
     const assertThrowOperator = query => {
       assert.throws(
@@ -125,22 +144,32 @@ module('Unit | Adapters | Dimensions | Keg', function(hooks) {
       { field: 'id', values: [3, 4] },
       { field: 'description', values: ['bar', 'gar'] }
     ]).then(assertEquals([3], 'find() returns expected when passed multiple overlapping filters'));
+
+    await Adapter.find('dimensionFour', [{ field: 'description', values: ['two'] }], {
+      dataSourceName: 'blockhead'
+    }).then(assertEquals([2], 'find() returns expected when using a dimension from a different data source'));
   });
 
-  test('findById', function(assert) {
-    assert.expect(1);
+  test('findById', async function(assert) {
+    assert.expect(2);
 
-    return Adapter.findById('dimensionOne', '1').then(result => {
-      assert.deepEqual(
-        result.get('id'),
-        1,
-        'findById() returns the expected response object for Test dimension, identifierField and query'
-      );
-    });
+    const result = await Adapter.findById('dimensionOne', '1');
+    assert.deepEqual(
+      result.get('id'),
+      1,
+      'findById() returns the expected response object for Test dimension, identifierField and query'
+    );
+
+    const blockheadResult = await Adapter.findById('dimensionFour', '1', 'blockhead');
+    assert.deepEqual(
+      blockheadResult.get('description'),
+      'one',
+      'findById() returns the expected response object for the blockhead sourced dimension'
+    );
   });
 
   test('getById', function(assert) {
-    assert.expect(3);
+    assert.expect(4);
 
     assert.deepEqual(
       Adapter.getById('unknownDimensionName', '1'),
@@ -159,16 +188,31 @@ module('Unit | Adapters | Dimensions | Keg', function(hooks) {
       1,
       'getById() returns the expected response object for Test dimension, identifierField and query'
     );
+
+    assert.deepEqual(
+      Adapter.getById('dimensionFour', '1', 'blockhead').get('description'),
+      'one',
+      'getById() returns the expected response object from a dimension in another namespace'
+    );
   });
 
   test('pushMany', function(assert) {
-    assert.expect(2);
+    assert.expect(4);
     Adapter.pushMany('dimensionOne', [{ id: 22, foo: 'bar' }, { id: 44, foo: 'baz' }]);
+    Adapter.pushMany('dimensionFour', [{ id: 77, foo: 'quux' }, { id: 99, foo: 'plugh' }], {
+      dataSourceName: 'blockhead'
+    });
 
-    let { foo: bar } = Keg.getById('dimension/dimensionOne', 22);
+    let { foo: bar } = Keg.getById('dimension/dummy.dimensionOne', 22, 'dummy');
     assert.deepEqual(bar, 'bar', 'pushMany stores records into the keg');
 
-    let { foo: baz } = Keg.getById('dimension/dimensionOne', 44);
+    let { foo: baz } = Keg.getById('dimension/dummy.dimensionOne', 44, 'dummy');
     assert.deepEqual(baz, 'baz', 'pushMany stores records into the keg');
+
+    let { foo: quux } = Keg.getById('dimension/blockhead.dimensionFour', 77, 'blockhead');
+    assert.deepEqual(quux, 'quux', 'pushMany stores records into the keg from different datasource');
+
+    let { foo: plugh } = Keg.getById('dimension/blockhead.dimensionFour', 99, 'blockhead');
+    assert.deepEqual(plugh, 'plugh', 'pushMany stores records into the keg from different datasource');
   });
 });

--- a/packages/data/tests/unit/services/bard-dimensions-test.js
+++ b/packages/data/tests/unit/services/bard-dimensions-test.js
@@ -8,6 +8,7 @@ import Pretender from 'pretender';
 import config from 'ember-get-config';
 import metadataRoutes from '../../helpers/metadata-routes';
 import { parseFilters } from 'navi-data/mirage/routes/bard-lite-parsers';
+import { all } from 'rsvp';
 
 let Service, Server, MetadataService;
 
@@ -28,7 +29,13 @@ const Response2 = {
   meta: { test: true }
 };
 
+const Response3 = {
+  rows: [{ id: 'v4', description: 'value4' }],
+  meta: { test: true }
+};
+
 const HOST = config.navi.dataSources[0].uri;
+const HOST2 = config.navi.dataSources[1].uri;
 
 module('Unit | Service | Dimensions', function(hooks) {
   setupTest(hooks);
@@ -61,6 +68,10 @@ module('Unit | Service | Dimensions', function(hooks) {
         return [200, { 'Content-Type': 'application/json' }, JSON.stringify({ rows })];
       });
 
+      this.get(`${HOST2}/v1/dimensions/dimensionFour/values`, () => {
+        return [200, { 'Content-Type': 'application/json ' }, JSON.stringify(Response3)];
+      });
+
       this.get(`${HOST}/v1/dimensions/dimensionOne/search/`, request => {
         let rows = request.queryParams.query === 'v1' ? Response2.rows : Response.rows;
         if (request.queryParams.page && request.queryParams.perPage) {
@@ -85,7 +96,8 @@ module('Unit | Service | Dimensions', function(hooks) {
     });
 
     Server.map(metadataRoutes);
-    return MetadataService.loadMetadata();
+    metadataRoutes.bind(Server)(1);
+    return all([MetadataService.loadMetadata(), MetadataService.loadMetadata({ dataSourceName: 'blockhead' })]);
   });
 
   hooks.afterEach(function() {
@@ -134,7 +146,7 @@ module('Unit | Service | Dimensions', function(hooks) {
     assert.expect(3);
 
     let keg = Service.get('_kegAdapter.keg');
-    keg.pushMany('dimension/dimensionOne', KegResponse.rows, {
+    keg.pushMany('dimension/dummy.dimensionOne', KegResponse.rows, {
       modelFactory: Object
     });
 
@@ -164,7 +176,7 @@ module('Unit | Service | Dimensions', function(hooks) {
     assert.expect(1);
 
     let keg = Service.get('_kegAdapter').get('keg');
-    keg.pushMany('dimension/dimensionOne', KegResponse.rows, {
+    keg.pushMany('dimension/dummy.dimensionOne', KegResponse.rows, {
       modelFactory: Object
     });
 
@@ -213,6 +225,31 @@ module('Unit | Service | Dimensions', function(hooks) {
     });
   });
 
+  test('find from bard from other datasource', function(assert) {
+    assert.expect(3);
+
+    //Mock service - dimensions are loaded in keg
+    Service.set('_loadedAllDimensions', {
+      dimensionFour: false
+    });
+
+    return Service.find('dimensionFour', { values: ['v4'] }, { dataSourceName: 'blockhead' }).then(function(model) {
+      assert.deepEqual(
+        get(model, 'dimension'),
+        'dimensionFour',
+        'find returns a bard dimension array model with the requested dimension'
+      );
+
+      assert.deepEqual(
+        get(model, '_dimensionsService'),
+        Service,
+        'find returns a bard dimension array model object with the service instance'
+      );
+
+      assert.deepEqual(get(model, 'content').mapBy('id'), ['v4'], 'find returns requested dimension rows');
+    });
+  });
+
   test('find from keg with pagination', function(assert) {
     assert.expect(1);
 
@@ -240,7 +277,7 @@ module('Unit | Service | Dimensions', function(hooks) {
     assert.expect(1);
 
     let keg = Service.get('_kegAdapter').get('keg');
-    keg.pushMany('dimension/dimensionOne', KegResponse.rows, {
+    keg.pushMany('dimension/dummy.dimensionOne', KegResponse.rows, {
       modelFactory: Object
     });
 
@@ -273,6 +310,25 @@ module('Unit | Service | Dimensions', function(hooks) {
     });
   });
 
+  test('all from bard alternate datasource', function(assert) {
+    assert.expect(2);
+
+    //Mock service - dimensions are loaded in keg
+    Service.set('_loadedAllDimensions', {
+      dimensionFour: false
+    });
+
+    return Service.all('dimensionFour', { dataSourceName: 'blockhead' }).then(model => {
+      assert.deepEqual(get(model, 'content').mapBy('id'), ['v4'], '`all` returns all records for a dimension');
+
+      assert.equal(
+        Service.getLoadedStatus('dimensionFour'),
+        true,
+        'loadedAllDimension for dimensionFour is set to true after fetching from bard'
+      );
+    });
+  });
+
   test('all from bard - partial load', function(assert) {
     assert.expect(1);
 
@@ -286,16 +342,22 @@ module('Unit | Service | Dimensions', function(hooks) {
     });
   });
 
-  test('findById', function(assert) {
-    assert.expect(1);
+  test('findById', async function(assert) {
+    assert.expect(2);
 
-    return Service.findById(TestDimension, 'v1').then(model => {
-      assert.deepEqual(get(model, 'id'), 'v1', 'findByid returns the expected dimension value');
-    });
+    const model = await Service.findById(TestDimension, 'v1');
+    assert.deepEqual(get(model, 'id'), 'v1', 'findByid returns the expected dimension value');
+
+    const blockheadModel = await Service.findById('dimensionFour', 'v4', { dataSourceName: 'blockhead' });
+    assert.deepEqual(
+      get(blockheadModel, 'id'),
+      'v4',
+      'findByid returns the expected dimension value in a differetn datasource'
+    );
   });
 
   test('getById', function(assert) {
-    assert.expect(2);
+    assert.expect(4);
 
     assert.deepEqual(
       Service.getById(TestDimension, 'v1'),
@@ -304,12 +366,21 @@ module('Unit | Service | Dimensions', function(hooks) {
     );
 
     let keg = Service.get('_kegAdapter.keg');
-    keg.pushMany('dimension/dimensionOne', Response.rows, {
+    keg.pushMany('dimension/dummy.dimensionOne', Response.rows, {
       modelFactory: Object
     });
 
     const dimensionId = get(Service.getById(TestDimension, 'v1'), 'id');
     assert.deepEqual(dimensionId, 'v1', 'getById returns the expected dimension value');
+
+    assert.deepEqual(
+      Service.getById('dimensionFour', 'v4', 'blockhead'),
+      undefined,
+      'getById returnd undefined for unloaded dimension from other datasource'
+    );
+    keg.pushMany('dimension/blockhead.dimensionFour', Response3.rows, { modelFactory: Object });
+    const dimensionFourId = get(Service.getById('dimensionFour', 'v4', 'blockhead'), 'id');
+    assert.deepEqual(dimensionFourId, 'v4', 'getById returns the expected dimension value from alternate datasource');
   });
 
   test('all and catch error', function(assert) {
@@ -379,6 +450,7 @@ module('Unit | Service | Dimensions', function(hooks) {
     });
   });
 
+  //TODO: Copy this
   test('searchValue', async function(assert) {
     assert.expect(2);
 
@@ -411,6 +483,42 @@ module('Unit | Service | Dimensions', function(hooks) {
 
     res = await Service.searchValue('dimensionThree', 'value1, value2');
     A(res.rows).mapBy('id'), ['value1', 'value2'], 'searchValue returns dimensions when comma separated spaced value';
+  });
+
+  test('searchValue alternate datasource', async function(assert) {
+    assert.expect(2);
+
+    const options = { dataSourceName: 'blockhead' };
+
+    let response3 = {
+      rows: [{ id: 'v4', desc: 'value4' }, { id: 'v5', desc: 'value5' }],
+      meta: { test: true }
+    };
+
+    Server.get(`${HOST2}/v1/dimensions/dimensionFive/search/`, req => {
+      let { query } = req.queryParams,
+        rows = response3.rows.filter(row => `${row.id} ${row.description}`.includes(query));
+
+      return [200, { 'Content-Type': 'application/json' }, JSON.stringify({ rows })];
+    });
+
+    await settled();
+
+    let res = await Service.searchValue('dimensionFive', 'v5', options);
+
+    assert.deepEqual(
+      A(res.rows).mapBy('desc'),
+      ['value5'],
+      'searchValue returns expected dimension values when searched for "v5"'
+    );
+
+    /* == no results == */
+    res = await Service.searchValue('dimensionFive', 'foo', options);
+
+    assert.deepEqual(A(res.rows), [], 'searchValue returns no dimension values as expected when searched for "foo"');
+
+    res = await Service.searchValue('dimensionFive', 'value4, value5', options);
+    A(res.rows).mapBy('id'), ['value4', 'value5'], 'searchValue returns dimensions when comma separated spaced value';
   });
 
   test('searchValueField: contains search', async function(assert) {
@@ -567,6 +675,40 @@ module('Unit | Service | Dimensions', function(hooks) {
     });
   });
 
+  test('search: low dimension cardinality alternate datasource', function(assert) {
+    assert.expect(3);
+
+    return settled().then(() => {
+      let options = { term: 'v4', dataSourceName: 'blockhead' };
+      return Service.search('dimensionFour', options).then(res => {
+        assert.deepEqual(
+          A(res).mapBy('id'),
+          ['v4'],
+          'search returns dimension values as expected when searched for "v4"'
+        );
+
+        options.term = 'value4';
+        return Service.search('dimensionFour', options).then(res => {
+          assert.deepEqual(
+            A(res).mapBy('description'),
+            ['value4'],
+            'search returns dimension values as expected when searched for "value4"'
+          );
+
+          /* == no results == */
+          options.term = 'foo';
+          return Service.search('dimensionFour', options).then(res => {
+            assert.deepEqual(
+              A(res).mapBy('id'),
+              [],
+              'search returns no dimension values as expected when searched for "foo"'
+            );
+          });
+        });
+      });
+    });
+  });
+
   test('search: high dimension cardinality', function(assert) {
     assert.expect(2);
 
@@ -608,6 +750,57 @@ module('Unit | Service | Dimensions', function(hooks) {
         /* == no results == */
         options = { term: 'foo' };
         return Service.search('dimensionTwo', options).then(res => {
+          assert.deepEqual(
+            A(res).mapBy('id'),
+            [],
+            'search returns no dimension values as expected when searched for "foo"'
+          );
+        });
+      });
+    });
+  });
+
+  test('search: high dimension cardinality with alternate datasource', function(assert) {
+    assert.expect(2);
+
+    let response3 = {
+      rows: [
+        {
+          id: 'v1',
+          description: 'value1'
+        },
+        {
+          id: 'v4',
+          description: 'value4'
+        }
+      ],
+      meta: {
+        test: true
+      }
+    };
+
+    Server.get(`${HOST2}/v1/dimensions/dimensionFive/values/`, req => {
+      let { field, values } = parseFilters(req.queryParams.filters)[0],
+        rows = A(response3.rows).filterBy(field, values[0]);
+
+      return [200, { 'Content-Type': 'application/json' }, JSON.stringify({ rows })];
+    });
+
+    return settled().then(() => {
+      //Set dimension cardinality above threshold & supportedFilterOperators for point lookup
+      set(Service, '_bardAdapter.supportedFilterOperators', ['in']);
+
+      let options = { term: 'v4', dataSourceName: 'blockhead' };
+      return Service.search('dimensionFive', options).then(res => {
+        assert.deepEqual(
+          A(res).mapBy('id'),
+          ['v4'],
+          'search returns expected dimension values when searched for "EMEA Region"'
+        );
+
+        /* == no results == */
+        options = { term: 'foo', dataSourceName: 'blockhead' };
+        return Service.search('dimensionFive', options).then(res => {
           assert.deepEqual(
             A(res).mapBy('id'),
             [],
@@ -759,6 +952,50 @@ module('Unit | Service | Dimensions', function(hooks) {
     });
   });
 
+  test('search: high dimension cardinality with useNewSearchAPI=true and different datasource', function(assert) {
+    assert.expect(2);
+
+    let response3 = {
+      rows: [
+        {
+          id: 'v1',
+          description: 'value1'
+        },
+        {
+          id: 'v4',
+          description: 'value4'
+        }
+      ],
+      meta: {
+        test: true
+      }
+    };
+
+    Server.get(`${HOST2}/v1/dimensions/dimensionFive/search/`, req => {
+      let { query } = req.queryParams,
+        rows = response3.rows.filter(row => `${row.id} ${row.description}`.includes(query));
+
+      return [200, { 'Content-Type': 'application/json' }, JSON.stringify({ rows })];
+    });
+
+    return settled().then(() => {
+      let options = { term: 'v4', useNewSearchAPI: true, dataSourceName: 'blockhead' };
+      return Service.search('dimensionFive', options).then(res => {
+        assert.deepEqual(
+          A(res).mapBy('id'),
+          ['v4'],
+          'search returns expected dimension values when searched for "EMEA Region"'
+        );
+
+        /* == no results == */
+        options = { term: 'foo', useNewSearchAPI: true, dataSourceName: 'blockhead' };
+        return Service.search('dimensionFive', options).then(res => {
+          assert.deepEqual(A(res), [], 'search returns no dimension values as expected when searched for "foo"');
+        });
+      });
+    });
+  });
+
   test('search: pagination with useNewSearchAPI=true', function(assert) {
     assert.expect(2);
 
@@ -780,7 +1017,7 @@ module('Unit | Service | Dimensions', function(hooks) {
   });
 
   test('getFactoryFor', function(assert) {
-    assert.expect(5);
+    assert.expect(6);
 
     assert.equal(
       Service.getFactoryFor('dimensionOne').dimensionName,
@@ -810,6 +1047,12 @@ module('Unit | Service | Dimensions', function(hooks) {
       Service.getFactoryFor('dimensionTwo'),
       Service.getFactoryFor('dimensionTwo'),
       'getFactoryFor returned the same factory for the same dimension'
+    );
+
+    assert.equal(
+      Service.getFactoryFor('dimensionFour', 'blockhead').dimensionName,
+      'dimensionFour',
+      'getFactoryFor returns factory for dimension from alternative datasource'
     );
   });
 

--- a/packages/data/tests/unit/services/bard-dimensions-test.js
+++ b/packages/data/tests/unit/services/bard-dimensions-test.js
@@ -8,7 +8,6 @@ import Pretender from 'pretender';
 import config from 'ember-get-config';
 import metadataRoutes from '../../helpers/metadata-routes';
 import { parseFilters } from 'navi-data/mirage/routes/bard-lite-parsers';
-import { all } from 'rsvp';
 
 let Service, Server, MetadataService;
 
@@ -97,7 +96,7 @@ module('Unit | Service | Dimensions', function(hooks) {
 
     Server.map(metadataRoutes);
     metadataRoutes.bind(Server)(1);
-    return all([MetadataService.loadMetadata(), MetadataService.loadMetadata({ dataSourceName: 'blockhead' })]);
+    return Promise.all([MetadataService.loadMetadata(), MetadataService.loadMetadata({ dataSourceName: 'blockhead' })]);
   });
 
   hooks.afterEach(function() {

--- a/packages/data/tests/unit/services/bard-dimensions-test.js
+++ b/packages/data/tests/unit/services/bard-dimensions-test.js
@@ -449,7 +449,6 @@ module('Unit | Service | Dimensions', function(hooks) {
     });
   });
 
-  //TODO: Copy this
   test('searchValue', async function(assert) {
     assert.expect(2);
 

--- a/packages/reports/addon/components/filter-values/dimension-select.js
+++ b/packages/reports/addon/components/filter-values/dimension-select.js
@@ -67,9 +67,7 @@ class DimensionSelectComponent extends Component {
       dimensionName &&
       get(metadataService.getById('dimension', dimensionName, source), 'cardinality') <= LOAD_CARDINALITY
     ) {
-      return dimensionService.all(dimensionName, { dataSourceName: source }).then(results => {
-        return results;
-      });
+      return dimensionService.all(dimensionName, { dataSourceName: source });
     }
 
     return undefined;

--- a/packages/reports/tests/integration/components/filter-values/dimension-select-test.js
+++ b/packages/reports/tests/integration/components/filter-values/dimension-select-test.js
@@ -70,7 +70,7 @@ module('Integration | Component | filter values/dimension select', function(hook
     assert.dom().hasText('under 13 (1) 13-17 (2) 18-20 (3)', 'Selected values are rendered correctly when collapsed');
   });
 
-  test('it works from dimension from other datasource', async function(assert) {
+  test('it works for dimensions from other datasources', async function(assert) {
     assert.expect(3);
     await this.owner.lookup('service:bard-metadata').loadMetadata({ dataSourceName: 'blockhead' });
 


### PR DESCRIPTION
Resolves #667 

<!-- The above line will close the issue upon merge -->

## Description

Adds multi datasource support to dimension metadata services

## Proposed Changes

- Add namespace and datasource options to service methods.
- Add namespace to dimension value kegs
- Make sure options get passed down to keg lookups and bard/dimension adapters correctly
- wire up the new changes to dimension-select component so that dimension values can be searched.
- Make sure defaults are set up so all calls are backwards compatible.

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
