### PR TITLE
New: Calendar presets

### DIFF
--- a/packages/core/app/styles/navi-core/vendor/index.less
+++ b/packages/core/app/styles/navi-core/vendor/index.less
@@ -1,6 +1,7 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 
 @import 'navi-ember-power-select';
+@import 'navi-ember-basic-dropdown';

--- a/packages/core/app/styles/navi-core/vendor/navi-ember-basic-dropdown.less
+++ b/packages/core/app/styles/navi-core/vendor/navi-ember-basic-dropdown.less
@@ -20,6 +20,6 @@
 
   &-option {
     .ember-power-select-option;
-    font-size: 13px;
+    font-size: @font-size-mid-base;
   }
 }

--- a/packages/core/app/styles/navi-core/vendor/navi-ember-basic-dropdown.less
+++ b/packages/core/app/styles/navi-core/vendor/navi-ember-basic-dropdown.less
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2020, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ *
+ * Navi specific styles for ember-basic-dropdown
+ */
+
+@import 'ember-basic-dropdown';
+
+.ember-basic-dropdown-content {
+  z-index: 10;
+}
+
+.navi-basic-dropdown {
+  &-content {
+    .ember-power-select-options;
+    .ember-power-select-dropdown;
+    .ember-power-select-dropdown.ember-basic-dropdown-content--below;
+  }
+
+  &-option {
+    .ember-power-select-option;
+    font-size: 13px;
+  }
+}

--- a/packages/core/app/styles/navi-core/vendor/navi-ember-power-select.less
+++ b/packages/core/app/styles/navi-core/vendor/navi-ember-power-select.less
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Navi specific styles for ember-power-select
@@ -29,15 +29,12 @@
     color: @navi-blue-300;
   }
 
+  &[aria-selected='false']:hover,
   &[aria-selected='false'][aria-current='true'],
   &:not([aria-selected=''])[aria-current=''] {
     background-color: @navi-lightest-gray;
     color: @navi-gray-800;
   }
-}
-
-.ember-basic-dropdown-content {
-  z-index: 10;
 }
 
 .ember-power-select-group {

--- a/packages/core/config/environment.js
+++ b/packages/core/config/environment.js
@@ -16,10 +16,10 @@ module.exports = function(/* environment, appConfig */) {
       },
       predefinedIntervalRanges: {
         day: ['P1D', 'P7D', 'P14D', 'P30D', 'P60D', 'P90D', 'P180D', 'P400D'],
-        week: ['current/next', 'P1W', 'P4W', 'P8W', 'P13W', 'P26W', 'P52W', 'P78W', 'P104W'],
-        month: ['current/next', 'P1M', 'P3M', 'P6M', 'P12M', 'P18M', 'P24M'],
-        quarter: ['current/next', 'P3M', 'P6M', 'P12M', 'P24M'],
-        year: ['current/next', 'P1Y', 'P2Y']
+        week: ['P1W', 'P4W', 'P8W', 'P13W', 'P26W', 'P52W', 'P78W', 'P104W'],
+        month: ['P1M', 'P3M', 'P6M', 'P12M', 'P18M', 'P24M'],
+        quarter: ['P3M', 'P6M', 'P12M', 'P24M'],
+        year: ['P1Y', 'P2Y']
       },
       notifications: {
         short: 3000,

--- a/packages/core/tests/dummy/config/environment.js
+++ b/packages/core/tests/dummy/config/environment.js
@@ -34,10 +34,10 @@ module.exports = function(environment) {
       },
       predefinedIntervalRanges: {
         day: ['P1D', 'P7D', 'P14D', 'P30D', 'P60D', 'P90D', 'P180D', 'P400D'],
-        week: ['current/next', 'P1W', 'P4W', 'P8W', 'P13W', 'P26W', 'P52W', 'P78W', 'P104W'],
-        month: ['current/next', 'P1M', 'P3M', 'P6M', 'P12M', 'P18M', 'P24M'],
-        quarter: ['current/next', 'P3M', 'P6M', 'P12M', 'P24M'],
-        year: ['current/next', 'P1Y', 'P2Y']
+        week: ['P1W', 'P4W', 'P8W', 'P13W', 'P26W', 'P52W', 'P78W', 'P104W'],
+        month: ['P1M', 'P3M', 'P6M', 'P12M', 'P18M', 'P24M'],
+        quarter: ['P3M', 'P6M', 'P12M', 'P24M'],
+        year: ['P1Y', 'P2Y']
       },
       notifications: {
         short: 3000,

--- a/packages/reports/addon/components/filter-values/lookback-input.js
+++ b/packages/reports/addon/components/filter-values/lookback-input.js
@@ -18,6 +18,8 @@ import Interval from 'navi-core/utils/classes/interval';
 import { isEmpty } from '@ember/utils';
 import { MONTHS_IN_QUARTER } from '../filter-builders/date-time';
 import config from 'ember-get-config';
+import { warn } from '@ember/debug';
+import { capitalize } from '@ember/string';
 
 @templateLayout(layout)
 @tagName('')
@@ -50,20 +52,54 @@ class LookbackInput extends BaseIntervalComponent {
   }
 
   /**
-   * @property {Array} predefinedRanges - list of ranges based on time grain supported look backs
+   * @property {Array} ranges - list of ranges based on time grain supported look backs
    */
   @computed('dateTimePeriod', 'interval')
   get ranges() {
     const { dateTimePeriod } = this;
     const predefinedRanges = get(config, `navi.predefinedIntervalRanges.${dateTimePeriod}`) || [];
 
-    return predefinedRanges.map(lookBack => {
-      const interval = new Interval(new Duration(lookBack), 'current');
-      return {
-        isActive: interval.isEqual(this.interval),
-        interval
-      };
-    });
+    return predefinedRanges
+      .map(lookBack => {
+        if (lookBack === 'current/next') {
+          warn('current/next is not supported as a predefined lookback interval', {
+            id: 'no-current-next-predefined-interval'
+          });
+          return undefined;
+        }
+        const duration = new Duration(lookBack);
+        const interval = new Interval(duration, 'current');
+        return {
+          isActive: interval.isEqual(this.interval),
+          interval,
+          text: this.formatDurationFromCurrent(duration, dateTimePeriod)
+        };
+      })
+      .filter(i => !!i);
+  }
+
+  /**
+   * Converts a duration into string representing how long ago duration is from today
+   *
+   * @method formatDurationFromCurrent
+   * @param {Duration} duration - object to format
+   * @param {String} timePeriod - time period dates should align to
+   * @returns {String} formatted string
+   */
+  formatDurationFromCurrent(duration, timePeriod) {
+    let durationValue = duration.getValue();
+    let durationUnit = duration.getUnit();
+
+    if (timePeriod === 'quarter') {
+      durationValue = durationValue / MONTHS_IN_QUARTER;
+      durationUnit = 'quarter';
+    }
+
+    if (durationValue === 1) {
+      return `1 ${capitalize(durationUnit)}`;
+    }
+
+    return `${durationValue} ${capitalize(durationUnit)}s`;
   }
 
   /**
@@ -79,6 +115,13 @@ class LookbackInput extends BaseIntervalComponent {
     return this.setInterval(lookbackDuration, 'current');
   }
 
+  /**
+   * Sets an interval exactly as it was defined (does not make it inclusive)
+   * @action
+   * @method setPresetInterval
+   * @param {Interval} interval - The exact interval to set
+   * @returns {Interval} - the interval that was set
+   */
   @action
   setPresetInterval(interval) {
     return this.setInterval(interval._start, interval._end, false);

--- a/packages/reports/addon/templates/components/filter-values/lookback-input.hbs
+++ b/packages/reports/addon/templates/components/filter-values/lookback-input.hbs
@@ -8,15 +8,33 @@
     {{/if}}
   {{else}}
     <div class="filter-values--lookback-input" ...attributes>
-      <input
-        class="filter-values--lookback-input__value
-          {{if filter.validations.attrs.values.isInvalid "filter-values--lookback-input--error"}}"
-        value={{this.lookback}}
-        placeholder={{capitalize (concat this.calendarDateTimePeriod "s")}}
-        type="number"
-        min="1"
-        {{on "input" this.setLookback}}
-      >
+      <BasicDropdown @matchTriggerWidth={{true}} as |dd|>
+        <dd.trigger>
+          <input
+            class="filter-values--lookback-input__value
+              {{if filter.validations.attrs.values.isInvalid "filter-values--lookback-input--error"}}"
+            value={{this.lookback}}
+            placeholder={{capitalize (concat this.calendarDateTimePeriod "s")}}
+            type="number"
+            min="1"
+            {{on "input" this.setLookback}}
+          >
+        </dd.trigger>
+        <dd.content @class="navi-basic-dropdown-content">
+          <ul>
+            {{#each this.ranges as |range|}}
+              <li
+                role="button"
+                class="navi-basic-dropdown-option"
+                aria-selected="{{if range.isActive "true" "false"}}"
+                {{on "click" (queue (fn this.setPresetInterval range.interval) dd.actions.close)}}
+              >
+                {{format-interval-inclusive-inclusive range.interval this.dateTimePeriod}}
+              </li>
+            {{/each}}
+          </ul>
+        </dd.content>
+      </BasicDropdown>
       <span class="filter-values--lookback-input__label">{{dateDescription}}</span>
     </div>
   {{/if}}

--- a/packages/reports/addon/templates/components/filter-values/lookback-input.hbs
+++ b/packages/reports/addon/templates/components/filter-values/lookback-input.hbs
@@ -29,7 +29,7 @@
                 aria-selected="{{if range.isActive "true" "false"}}"
                 {{on "click" (queue (fn this.setPresetInterval range.interval) dd.actions.close)}}
               >
-                {{format-interval-inclusive-inclusive range.interval this.dateTimePeriod}}
+                {{range.text}}
               </li>
             {{/each}}
           </ul>

--- a/packages/reports/config/environment.js
+++ b/packages/reports/config/environment.js
@@ -16,10 +16,10 @@ module.exports = function(/* environment, appConfig */) {
       },
       predefinedIntervalRanges: {
         day: ['P1D', 'P7D', 'P14D', 'P30D', 'P60D', 'P90D', 'P180D', 'P400D'],
-        week: ['current/next', 'P1W', 'P4W', 'P8W', 'P13W', 'P26W', 'P52W', 'P78W', 'P104W'],
-        month: ['current/next', 'P1M', 'P3M', 'P6M', 'P12M', 'P18M', 'P24M'],
-        quarter: ['current/next', 'P3M', 'P6M', 'P12M', 'P24M'],
-        year: ['current/next', 'P1Y', 'P2Y']
+        week: ['P1W', 'P4W', 'P8W', 'P13W', 'P26W', 'P52W', 'P78W', 'P104W'],
+        month: ['P1M', 'P3M', 'P6M', 'P12M', 'P18M', 'P24M'],
+        quarter: ['P3M', 'P6M', 'P12M', 'P24M'],
+        year: ['P1Y', 'P2Y']
       },
       notifications: {
         short: 3000,

--- a/packages/reports/tests/integration/components/filter-values/lookback-input-test.js
+++ b/packages/reports/tests/integration/components/filter-values/lookback-input-test.js
@@ -1,10 +1,12 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, fillIn, triggerEvent } from '@ember/test-helpers';
+import { render, fillIn, triggerEvent, click } from '@ember/test-helpers';
 import { A as arr } from '@ember/array';
 import hbs from 'htmlbars-inline-precompile';
 import Interval from 'navi-core/utils/classes/interval';
 import { getDateRangeFormat } from './date-range-test';
+import { clickTrigger } from 'ember-basic-dropdown/test-support/helpers';
+import $ from 'jquery';
 
 module('Integration | Component | filter values/lookback input', function(hooks) {
   setupRenderingTest(hooks);
@@ -59,5 +61,60 @@ module('Integration | Component | filter values/lookback input', function(hooks)
 
     assert.dom('.filter-values--lookback-input').doesNotExist('The lookback input does not display when collapsed');
     assert.dom().hasText(`4 days (${getDateRangeFormat(this)})`, 'The lookback is rendered correctly when collapsed');
+  });
+
+  test('selecting preset values', async function(assert) {
+    assert.expect(9);
+
+    this.set('onUpdateFilter', filter => {
+      this.set('filter', { values: arr([filter.interval]) });
+    });
+
+    // Set to 7
+    await clickTrigger('.filter-values--lookback-input');
+    await click($('.navi-basic-dropdown-option:contains(7)')[0]);
+    assert.dom('.filter-values--lookback-input__value').hasValue('7', 'Clicking last 7 days changes input value to 7');
+
+    // Only 7 is selected
+    await clickTrigger('.filter-values--lookback-input');
+    assert
+      .dom($('.navi-basic-dropdown-option:contains(7)')[0])
+      .hasAttribute('aria-selected', 'true', '7 is selected after being clicked');
+    assert
+      .dom($('.navi-basic-dropdown-option:contains(30)')[0])
+      .hasAttribute('aria-selected', 'false', 'only 7 is selected');
+    await clickTrigger('.filter-values--lookback-input');
+
+    // Set to 30
+    await clickTrigger('.filter-values--lookback-input');
+    await click($('.navi-basic-dropdown-option:contains(30)')[0]);
+    assert
+      .dom('.filter-values--lookback-input__value')
+      .hasValue('30', 'Clicking last 30 days changes input value to 30');
+
+    // Only 30 is selected
+    await clickTrigger('.filter-values--lookback-input');
+    assert
+      .dom($('.navi-basic-dropdown-option:contains(30)')[0])
+      .hasAttribute('aria-selected', 'true', '30 is selected after being clicked');
+    assert
+      .dom($('.navi-basic-dropdown-option:contains(7)')[0])
+      .hasAttribute('aria-selected', 'false', '7 is not selected after switching away');
+    await clickTrigger('.filter-values--lookback-input');
+
+    // type in 14
+    await fillIn('.filter-values--lookback-input__value', 14);
+    await blur('.filter-values--lookback-input__value');
+    assert.dom('.filter-values--lookback-input__value').hasValue('14', 'typing in 14 works');
+
+    // Only 14 is selected
+    await clickTrigger('.filter-values--lookback-input');
+    assert
+      .dom($('.navi-basic-dropdown-option:contains(14)')[0])
+      .hasAttribute('aria-selected', 'true', '14 is selected in the dropdown after being typed in');
+    assert
+      .dom($('.navi-basic-dropdown-option:contains(30)')[0])
+      .hasAttribute('aria-selected', 'false', '30 is not selected after switching away');
+    await clickTrigger('.filter-values--lookback-input');
   });
 });

--- a/packages/reports/tests/integration/components/filter-values/lookback-input-test.js
+++ b/packages/reports/tests/integration/components/filter-values/lookback-input-test.js
@@ -77,7 +77,7 @@ module('Integration | Component | filter values/lookback input', function(hooks)
 
     // Only 7 is selected
     await clickTrigger('.filter-values--lookback-input');
-    assert.deepEqual(getSelectedOptions(), ['Last 7 Days'], '7 is the only selected option after being clicked');
+    assert.deepEqual(getSelectedOptions(), ['7 Days'], '7 is the only selected option after being clicked');
     await clickTrigger('.filter-values--lookback-input');
 
     // Set to 30
@@ -89,7 +89,7 @@ module('Integration | Component | filter values/lookback input', function(hooks)
 
     // Only 30 is selected
     await clickTrigger('.filter-values--lookback-input');
-    assert.deepEqual(getSelectedOptions(), ['Last 30 Days'], '30 is the only selected option after being clicked');
+    assert.deepEqual(getSelectedOptions(), ['30 Days'], '30 is the only selected option after being clicked');
     await clickTrigger('.filter-values--lookback-input');
   });
 
@@ -107,19 +107,25 @@ module('Integration | Component | filter values/lookback input', function(hooks)
 
     // Only 14 is selected
     await clickTrigger('.filter-values--lookback-input');
-    assert.deepEqual(
-      getSelectedOptions(),
-      ['Last 14 Days'],
-      '14 is the only selected in the dropdown after being typed in'
-    );
+    assert.deepEqual(getSelectedOptions(), ['14 Days'], '14 is the only selected in the dropdown after being typed in');
     await clickTrigger('.filter-values--lookback-input');
   });
 
   test('typing in a not predefined lookback value', async function(assert) {
-    assert.expect(2);
+    assert.expect(4);
+
+    this.set('onUpdateFilter', filter => {
+      this.set('filter', { values: arr([filter.interval]) });
+    });
+
+    await clickTrigger('.filter-values--lookback-input');
+    await click($('.navi-basic-dropdown-option:contains(7)')[0]);
+    assert.dom('.filter-values--lookback-input__value').hasValue('7', 'Clicking last 7 days changes input value to 7');
+
+    await clickTrigger('.filter-values--lookback-input');
+    assert.deepEqual(getSelectedOptions(), ['7 Days'], '7 is the only selected option after being clicked');
 
     // type 22
-    await clickTrigger('.filter-values--lookback-input');
     await fillIn('.filter-values--lookback-input__value', '22');
     await blur('.filter-values--lookback-input__value');
 


### PR DESCRIPTION
Fixes some of #550 

## Description
Using the new calendar picker, trying to select an interval like `P7D/current` will require you to click in the input box, clear what was in there, then type 7

## Proposed Changes
- Add back functionality for presets such as `P7D/current`, `P30D/current`, so all you have to do is another click

## Screenshots

![navi-calendar-presets](https://user-images.githubusercontent.com/12093492/75591848-78da3b80-5a46-11ea-8e26-c63207462a47.gif)

Here it is side by side `Power Select Styles | Basic Dropdown Styles`
<img src="https://user-images.githubusercontent.com/12093492/75591944-af17bb00-5a46-11ea-8db2-3f743de7604e.png" width="400" alt="power select styles" /> <img src="https://user-images.githubusercontent.com/12093492/75591904-99a29100-5a46-11ea-9d88-617b572f7d71.png" width="200" alt="basic dropdown styles" />



## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
