### PR TITLE
Update: Travis wait during gh-pages deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,8 @@ script:
     else
     npx lerna run test --scope ${PACKAGE} --stream;
     fi
+before_deploy:
+  - pip install travis-wait-improved
 jobs:
   fast_finish: true
   include:
@@ -55,7 +57,7 @@ jobs:
       node_js: '8'
       name: 'NPM'
       script: bash ./scripts/npm-publish.sh
-    - script: bash ./scripts/gh-pages-publish.sh
+    - script: travis-wait-improved --timeout 30m bash ./scripts/gh-pages-publish.sh
       name: 'GitHub Pages'
       node_js: '8'
       if: branch = master AND repo = yahoo/navi AND type = push


### PR DESCRIPTION
Resolves #508 (never resolved see #518)

## Description
The `gh-pages` deploy step is taking too long and has failed for the last several builds
- https://travis-ci.org/yahoo/navi/jobs/657423046
- https://travis-ci.org/yahoo/navi/jobs/657371616
- https://travis-ci.org/yahoo/navi/jobs/656024170

## Proposed Changes
We tried using `travis_wait` before, but that didn't exist during deploy so I'm adding [travis-wait-improved](https://github.com/cisagov/travis-wait-improved) so that it no longer times out

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
