### PR TITLE
Update: Before deploy didn't run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,6 @@ script:
     else
     npx lerna run test --scope ${PACKAGE} --stream;
     fi
-before_deploy:
-  - pip install travis-wait-improved
 jobs:
   fast_finish: true
   include:
@@ -57,7 +55,9 @@ jobs:
       node_js: '8'
       name: 'NPM'
       script: bash ./scripts/npm-publish.sh
-    - script: travis-wait-improved --timeout 30m bash ./scripts/gh-pages-publish.sh
+    - before_script:
+        - pip install travis-wait-improved
+      script: travis-wait-improved --timeout 30m bash ./scripts/gh-pages-publish.sh
       name: 'GitHub Pages'
       node_js: '8'
       if: branch = master AND repo = yahoo/navi AND type = push


### PR DESCRIPTION
Resolves #692 

## Description
`before_deploy` didn't run, so `travis-wait-improved` didn't exist

## Proposed Changes
install right before script

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
