### PR TITLE
Update: Python 3.7.1 instead of eol

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,8 @@ jobs:
       name: 'NPM'
       script: bash ./scripts/npm-publish.sh
     - before_script:
-        - pip install travis-wait-improved
+        - pyenv global 3.7.1
+        - pip3 install travis-wait-improved
       script: travis-wait-improved --timeout 30m bash ./scripts/gh-pages-publish.sh
       name: 'GitHub Pages'
       node_js: '8'


### PR DESCRIPTION
## Description
Travis still uses eol python by default
https://travis-ci.org/yahoo/navi/jobs/657499775#L282
> File "/home/travis/.local/lib/python2.7/site-packages/travis_wait_improved/sherpa.py", line 29

## Proposed Changes
update that to 3.7.1 so travis-wait-improved will work

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
