### PR TITLE
Update: Travis wait during deploy python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ jobs:
       name: 'NPM'
       script: bash ./scripts/npm-publish.sh
     - before_script:
-        - pyenv global 3.7.1
+        - pyenv global 3.6
         - pip3 install travis-wait-improved
       script: travis-wait-improved --timeout 30m bash ./scripts/gh-pages-publish.sh
       name: 'GitHub Pages'


### PR DESCRIPTION
## Description
Fix gh-pages deploy, I tested it on my own fork this time

## Screenshots
![image](https://user-images.githubusercontent.com/12093492/75730363-4c2a5c00-5cb2-11ea-9ece-d00601311cd2.png)

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
