### PR TITLE
Update: Jobs param for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ cache:
 env:
   global:
     - NODE_VERSION=8.16.0
+    - JOBS=1 # See https://git.io/vdao3 for details.
   jobs:
     - PACKAGE=navi-app
     - PACKAGE=navi-core

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ cache:
     - '$HOME/.gradle/wrapper/'
 env:
   global:
-    - NODE_VERSION=8.16.0
+    - NODE_VERSION=12.16.0
     - JOBS=1 # See https://git.io/vdao3 for details.
   jobs:
     - PACKAGE=navi-app


### PR DESCRIPTION
## Description
Running into out of memory during gh-pages deploy

## Proposed Changes
Try setting `JOBS=1` like in ember-cli [.travis.yml blueprint](https://github.com/ember-cli/ember-cli/blob/b05d47e3d9fd60d075cdfcc5afdb57a03421f3e4/blueprints/addon/files/.travis.yml)

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
