### PR TITLE
Fix: Keg adapter getById namespace behavior

### DIFF
--- a/packages/data/addon/adapters/dimensions/keg.js
+++ b/packages/data/addon/adapters/dimensions/keg.js
@@ -41,7 +41,7 @@ export default EmberObject.extend({
    * @param {String} namespace - namespace from keg
    * @returns {Object} metadata object
    */
-  _getDimensionMetadata(dimensionName, namespace=getDefaultDataSourceName()) {
+  _getDimensionMetadata(dimensionName, namespace = getDefaultDataSourceName()) {
     return this.bardMetadata.getById('dimension', dimensionName, namespace);
   },
 
@@ -141,8 +141,8 @@ export default EmberObject.extend({
    * @param {String} namespace - namespace from the keg
    * @returns {Object} - The dimension value object
    */
-  getById(dimension, value, namespace=getDefaultDataSourceName()) {
-    return this.keg.getById(`${KEG_NAMESPACE}/${namespace}.${dimension}`, value);
+  getById(dimension, value, namespace = getDefaultDataSourceName()) {
+    return this.keg.getById(`${KEG_NAMESPACE}/${namespace}.${dimension}`, value, namespace);
   },
 
   /**
@@ -152,7 +152,7 @@ export default EmberObject.extend({
    * @param {String} namespace - namespace from the keg
    * @returns {Promise} - Promise with the response
    */
-  findById(dimension, value, namespace=getDefaultDataSourceName()) {
+  findById(dimension, value, namespace = getDefaultDataSourceName()) {
     return Promise.resolve(this.getById(dimension, value, namespace));
   },
 

--- a/packages/data/tests/unit/adapters/dimensions/keg-test.js
+++ b/packages/data/tests/unit/adapters/dimensions/keg-test.js
@@ -42,9 +42,9 @@ module('Unit | Adapters | Dimensions | Keg', function(hooks) {
     Adapter = this.owner.lookup('adapter:dimensions/keg');
 
     Keg = Adapter.get('keg');
-    Keg.pushMany('dimension/dummy.dimensionOne', Records, { dataSourceName: 'dummy' });
+    Keg.pushMany('dimension/dummy.dimensionOne', Records, { namespace: 'dummy' });
     Keg.pushMany('dimension/blockhead.dimensionFour', [{ id: 1, description: 'one' }, { id: 2, description: 'two' }], {
-      dataSourceName: 'blockhead'
+      namespace: 'blockhead'
     });
 
     //Load metadata

--- a/packages/data/tests/unit/services/bard-dimensions-test.js
+++ b/packages/data/tests/unit/services/bard-dimensions-test.js
@@ -366,7 +366,8 @@ module('Unit | Service | Dimensions', function(hooks) {
 
     let keg = Service.get('_kegAdapter.keg');
     keg.pushMany('dimension/dummy.dimensionOne', Response.rows, {
-      modelFactory: Object
+      modelFactory: Object,
+      namespace: 'dummy'
     });
 
     const dimensionId = get(Service.getById(TestDimension, 'v1'), 'id');
@@ -377,7 +378,7 @@ module('Unit | Service | Dimensions', function(hooks) {
       undefined,
       'getById returnd undefined for unloaded dimension from other datasource'
     );
-    keg.pushMany('dimension/blockhead.dimensionFour', Response3.rows, { modelFactory: Object });
+    keg.pushMany('dimension/blockhead.dimensionFour', Response3.rows, { modelFactory: Object, namespace: 'blockhead' });
     const dimensionFourId = get(Service.getById('dimensionFour', 'v4', 'blockhead'), 'id');
     assert.deepEqual(dimensionFourId, 'v4', 'getById returns the expected dimension value from alternate datasource');
   });


### PR DESCRIPTION
* Bad test setup wasn't loading dimension values correctly, so this behavior was missed

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
