### PR TITLE
Fix: Update visualizations with multi-datasource support

### DIFF
--- a/packages/app/app/initializers/config.js
+++ b/packages/app/app/initializers/config.js
@@ -16,7 +16,6 @@ export function initialize() {
      *dataEpoch: NAVI_APP.appSettings.dataEpoch,
      */
     dataSources: [{ name: 'default', uri: config.appSettings.factApiHost }],
-    defaultDataSource: 'default',
     appPersistence: {
       type: 'webservice',
       uri: config.appSettings.persistenceApiHost,

--- a/packages/app/config/environment.js
+++ b/packages/app/config/environment.js
@@ -25,6 +25,7 @@ module.exports = function(environment) {
     },
 
     navi: {
+      defaultDataSource: 'default',
       FEATURES: {
         enableDashboardFilters: true,
         enableMultipleExport: false,

--- a/packages/core/addon/chart-builders/metric.js
+++ b/packages/core/addon/chart-builders/metric.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Logic for grouping chart data by many metrics
@@ -77,7 +77,7 @@ export default EmberObject.extend({
       return Object.assign(
         { x },
         ...metrics.map(metric => {
-          let metricDisplayName = get(this, 'metricName').getDisplayName(metric),
+          let metricDisplayName = get(this, 'metricName').getDisplayName(metric, request.dataSource),
             canonicalName = canonicalizeMetric(metric);
 
           return {

--- a/packages/core/addon/components/navi-vis-c3-chart.js
+++ b/packages/core/addon/components/navi-vis-c3-chart.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Extend c3 to listen to incoming resize events
@@ -14,6 +14,7 @@
  *   point=pointConfig
  *   tooltip=tooltipConfig
  *   containerComponent=container
+ *   metaNamespace=namespace
  *  }}
  */
 import { next, scheduleOnce } from '@ember/runloop';
@@ -121,7 +122,9 @@ export default C3Chart.extend({
     if (dataSelection) {
       dataSelection.then(insightsData => {
         let metricName = get(this, 'metricName'),
-          metrics = get(this, 'axis.y.series.config.metrics').map(metric => metricName.getDisplayName(metric)),
+          metrics = get(this, 'axis.y.series.config.metrics').map(metric =>
+            metricName.getDisplayName(metric, this.metaNamespace)
+          ),
           dataSelectionIndices = insightsData.mapBy('index');
         get(this, 'chart').select(metrics, dataSelectionIndices);
       });

--- a/packages/core/addon/components/navi-visualizations/goal-gauge.js
+++ b/packages/core/addon/components/navi-visualizations/goal-gauge.js
@@ -71,13 +71,18 @@ export default class NaviVisualizationsGoalGaugeComponent extends Component {
   legend = { hide: true };
 
   /**
+   * @property {String} - which meta data namespace to use
+   */
+  @alias('model.firstObject.request.dataSource') namespace;
+
+  /**
    * @property {String} formatted default metric
    */
-  @computed('metricModel')
+  @computed('metricModel', 'namespace')
   get defaultMetricTitle() {
-    const { metricModel } = this;
+    const { metricModel, namespace } = this;
     const { metric: baseMetric } = metricModel;
-    const longName = this.bardMetadata.getMetaField('metric', baseMetric, 'longName');
+    const longName = this.bardMetadata.getMetaField('metric', baseMetric, 'longName', null, namespace);
 
     return metricFormat(metricModel, longName);
   }

--- a/packages/core/addon/components/navi-visualizations/pie-chart.js
+++ b/packages/core/addon/components/navi-visualizations/pie-chart.js
@@ -104,7 +104,7 @@ class NaviVisualizationsPieChartComponent extends Component.extend(hasChartBuild
   get metricDisplayName() {
     let metric = get(this, 'seriesConfig.metric');
 
-    return metric && get(this, 'metricName').getDisplayName(metric, this.namespace);
+    return metric && this.metricName.getDisplayName(metric, this.namespace);
   }
 
   /**

--- a/packages/core/addon/components/navi-visualizations/pie-chart.js
+++ b/packages/core/addon/components/navi-visualizations/pie-chart.js
@@ -56,14 +56,16 @@ class NaviVisualizationsPieChartComponent extends Component.extend(hasChartBuild
   @alias('model.firstObject.request') request;
 
   /**
+   * @property {String} namespace - meta data namespace to use
+   */
+  @alias('request.dataSource') namespace;
+
+  /**
    * @property {Object} builder - builder based on series type
    */
   @computed('seriesType')
   get builder() {
-    const {
-      seriesType: type,
-      chartBuilders: builders
-    } = this;
+    const { seriesType: type, chartBuilders: builders } = this;
 
     return builders[type];
   }
@@ -98,11 +100,11 @@ class NaviVisualizationsPieChartComponent extends Component.extend(hasChartBuild
   /**
    * @property {String} metricDisplayName - display name for metric
    */
-  @computed('options')
+  @computed('options', 'namespace')
   get metricDisplayName() {
     let metric = get(this, 'seriesConfig.metric');
 
-    return metric && get(this, 'metricName').getDisplayName(metric);
+    return metric && get(this, 'metricName').getDisplayName(metric, this.namespace);
   }
 
   /**

--- a/packages/core/addon/components/navi-visualizations/table.js
+++ b/packages/core/addon/components/navi-visualizations/table.js
@@ -179,12 +179,12 @@ class Table extends Component {
    * @private
    * @returns {Boolean}
    */
-  _hasCustomDisplayName(column) {
+  _hasCustomDisplayName(column, namespace) {
     if (isBlank(column.displayName)) {
       return false;
     }
 
-    let defaultName = getColumnDefaultName(column, get(this, 'bardMetadata'));
+    let defaultName = getColumnDefaultName(column, get(this, 'bardMetadata'), namespace);
     return column.displayName !== defaultName;
   }
 
@@ -249,7 +249,7 @@ class Table extends Component {
   /**
    * @property {Object} columns
    */
-  @computed('options.columns', 'request.sort')
+  @computed('options.columns', 'request.{sort,dataSource}')
   get columns() {
     let sorts = this._mapAlias(get(this, 'request')),
       columns = cloneDeep(get(this, 'options.columns') || []);
@@ -258,7 +258,7 @@ class Table extends Component {
       let { attributes, type } = column,
         canonicalName = type === 'dateTime' ? type : canonicalizeColumnAttributes(attributes),
         sort = arr(sorts).findBy('metric', canonicalName) || {},
-        hasCustomDisplayName = this._hasCustomDisplayName(column),
+        hasCustomDisplayName = this._hasCustomDisplayName(column, this.request.dataSource),
         sortDirection;
 
       if (column.type === 'dateTime') {

--- a/packages/core/addon/components/navi-visualizations/table.js
+++ b/packages/core/addon/components/navi-visualizations/table.js
@@ -177,6 +177,8 @@ class Table extends Component {
    * Determines if column has a custom display name
    *
    * @private
+   * @param {Object} column - column object
+   * @param {String} namespace - metadata namespace
    * @returns {Boolean}
    */
   _hasCustomDisplayName(column, namespace) {

--- a/packages/core/addon/components/navi-visualizations/table.js
+++ b/packages/core/addon/components/navi-visualizations/table.js
@@ -186,7 +186,7 @@ class Table extends Component {
       return false;
     }
 
-    let defaultName = getColumnDefaultName(column, get(this, 'bardMetadata'), namespace);
+    const defaultName = getColumnDefaultName(column, this.bardMetadata, namespace);
     return column.displayName !== defaultName;
   }
 

--- a/packages/core/addon/helpers/default-column-name.js
+++ b/packages/core/addon/helpers/default-column-name.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  */
@@ -9,6 +9,7 @@ import { inject as service } from '@ember/service';
 import { metricFormat } from 'navi-data/helpers/metric-format';
 import { mapColumnAttributes } from 'navi-data/utils/metric';
 import { formatDimensionName } from 'navi-data/utils/dimension';
+import { getDefaultDataSourceName } from 'navi-data/utils/adapter';
 
 /**
  * Get column default display name
@@ -16,9 +17,10 @@ import { formatDimensionName } from 'navi-data/utils/dimension';
  * @method chartToolTipFormat
  * @param {Object} column - table column object
  * @param {Object} bardMetadata - bard metadata service
+ * @param {String} namespace - meta data namespace
  * @return {String} - default display name
  */
-export function getColumnDefaultName({ type, attributes }, bardMetadata) {
+export function getColumnDefaultName({ type, attributes }, bardMetadata, namespace = getDefaultDataSourceName()) {
   if (type === 'dateTime') {
     return 'Date';
   }
@@ -28,7 +30,7 @@ export function getColumnDefaultName({ type, attributes }, bardMetadata) {
   }
 
   let { name, field } = attributes,
-    model = bardMetadata.getById(type, name);
+    model = bardMetadata.getById(type, name, namespace);
 
   if (type === 'metric') {
     return metricFormat(mapColumnAttributes(attributes), model.longName);
@@ -47,7 +49,7 @@ export function getColumnDefaultName({ type, attributes }, bardMetadata) {
 export default Helper.extend({
   bardMetadata: service(),
 
-  compute([column]) {
-    return getColumnDefaultName(column, get(this, 'bardMetadata'));
+  compute([column, namespace]) {
+    return getColumnDefaultName(column, get(this, 'bardMetadata'), namespace);
   }
 });

--- a/packages/core/addon/helpers/default-column-name.js
+++ b/packages/core/addon/helpers/default-column-name.js
@@ -50,6 +50,6 @@ export default Helper.extend({
   bardMetadata: service(),
 
   compute([column, namespace]) {
-    return getColumnDefaultName(column, get(this, 'bardMetadata'), namespace);
+    return getColumnDefaultName(column, this.bardMetadata, namespace);
   }
 });

--- a/packages/core/addon/helpers/default-column-name.js
+++ b/packages/core/addon/helpers/default-column-name.js
@@ -4,7 +4,6 @@
  *
  */
 import Helper from '@ember/component/helper';
-import { get } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { metricFormat } from 'navi-data/helpers/metric-format';
 import { mapColumnAttributes } from 'navi-data/utils/metric';

--- a/packages/core/addon/templates/chart-tooltips/date.hbs
+++ b/packages/core/addon/templates/chart-tooltips/date.hbs
@@ -1,6 +1,6 @@
 {{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 <div class="title">{{this.request.logicalTable.timeGrain}} {{this.x}}</div>
-<div class="sub-title">{{metric-format (get this.seriesConfig "metric")}}</div>
+<div class="sub-title">{{metric-format (get this.seriesConfig "metric") this.request.dataSource}}</div>
 <ol class="hover-metrics">
   {{#each this.tooltipData as |series|}}
     <li class="metric-val">

--- a/packages/core/addon/templates/chart-tooltips/dimension.hbs
+++ b/packages/core/addon/templates/chart-tooltips/dimension.hbs
@@ -1,6 +1,6 @@
 {{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 <div class="title">{{format-chart-tooltip-date this.request this.x}}</div>
-<div class="sub-title">{{metric-format (get this.seriesConfig "metric")}}</div>
+<div class="sub-title">{{metric-format (get this.seriesConfig "metric") this.request.dataSource}}</div>
 <ol class="hover-dimensions">
   {{#each this.tooltipData as |series|}}
     <li class="metric-val">

--- a/packages/core/addon/templates/components/chart-series-config.hbs
+++ b/packages/core/addon/templates/components/chart-series-config.hbs
@@ -15,7 +15,7 @@
           as |item|
         >
           <div class="line-chart-config__series-config__item__content">
-            {{if (eq @seriesType "dimension") seriesDataItem.name (metric-format seriesDataItem)}}
+            {{if (eq @seriesType "dimension") seriesDataItem.name (metric-format seriesDataItem @request.dataSource)}}
           </div>
           <item.handle>
             <div class="line-chart-config__series-config__item__handler">

--- a/packages/core/addon/templates/components/navi-visualization-config/goal-gauge.hbs
+++ b/packages/core/addon/templates/components/navi-visualization-config/goal-gauge.hbs
@@ -12,7 +12,7 @@
       @value={{readonly @options.metricTitle}}
       @focus-out={{fn this.updateConfig "metricTitle"}}
       @key-up={{fn this.updateConfig "metricTitle"}}
-      @placeholder={{metric-format (serialize @request.metrics.firstObject)}}
+      @placeholder={{metric-format (serialize @request.metrics.firstObject @request.dataSource)}}
     />
   </div>
   <div class="goal-gauge-config__section-header">

--- a/packages/core/addon/templates/components/navi-visualization-config/line-chart.hbs
+++ b/packages/core/addon/templates/components/navi-visualization-config/line-chart.hbs
@@ -53,6 +53,7 @@
         @seriesConfig={{this.seriesConfig}}
         @seriesType={{this.seriesType}}
         @onUpdateConfig={{this.onUpdateSeriesConfig}}
+        @request={{@request}}
       />
     {{/if}}
   {{else if (not (eq this.seriesType "dimension"))}}

--- a/packages/core/addon/templates/components/navi-visualization-config/series-chart.hbs
+++ b/packages/core/addon/templates/components/navi-visualization-config/series-chart.hbs
@@ -16,7 +16,7 @@
           @renderInPlace={{true}}
           as |metric|
         >
-          {{metric-format metric}}
+          {{metric-format metric @request.dataSource}}
         </PowerSelect>
       </div>
     </div>

--- a/packages/core/addon/templates/components/navi-visualizations/goal-gauge.hbs
+++ b/packages/core/addon/templates/components/navi-visualizations/goal-gauge.hbs
@@ -7,4 +7,5 @@
   @color={{this.color}}
   @legend={{this.legend}}
   @containerComponent={{@containerComponent}}
+  @metaNamespace={{@request.dataSource}}
 />

--- a/packages/core/addon/templates/components/navi-visualizations/line-chart.hbs
+++ b/packages/core/addon/templates/components/navi-visualizations/line-chart.hbs
@@ -9,4 +9,5 @@
   @point={{this.config.point}}
   @tooltip={{this.config.tooltip}}
   @containerComponent={{@containerComponent}}
+  @metaNamespace={{@request.dataSource}}
 />

--- a/packages/core/addon/templates/components/navi-visualizations/pie-chart.hbs
+++ b/packages/core/addon/templates/components/navi-visualizations/pie-chart.hbs
@@ -7,4 +7,5 @@
   @pie={{this.config.pie}}
   @containerComponent={{@containerComponent}}
   @onrendered={{this.redrawMetricLabel}}
+  @metaNamespace={{@request.dataSource}}
 />

--- a/packages/core/addon/templates/components/table-renderer-vertical-collection.hbs
+++ b/packages/core/addon/templates/components/table-renderer-vertical-collection.hbs
@@ -21,7 +21,7 @@
             class="table-header-cell__title {{if column.hasCustomDisplayName "table-header-cell__title--custom-name"}}"
             title="Drag column header to reorder"
           >
-            {{or column.displayName (default-column-name column)}}
+            {{or column.displayName (default-column-name column @request.dataSource)}}
           </span>
           {{#if column.sortDirection}}
             <NaviTableSortIcon
@@ -53,7 +53,7 @@
                 <Input
                   class="table-header-cell__input"
                   @value={{readonly column.displayName}}
-                  @placeholder={{default-column-name column}}
+                  @placeholder={{default-column-name column @request.dataSource}}
                   @focus-out={{fn @updateColumnDisplayName column}}
                 />
                 {{#if (or (eq column.type "metric") (eq column.type "threshold"))}}
@@ -65,7 +65,7 @@
                 {{/if}}
               {{else}}
                 <span class="table-header-cell__title">
-                  {{or column.displayName (default-column-name column)}}
+                  {{or column.displayName (default-column-name column @request.dataSource)}}
                 </span>
                 {{#if column.sortDirection}}
                   <NaviTableSortIcon

--- a/packages/core/addon/templates/components/table-renderer.hbs
+++ b/packages/core/addon/templates/components/table-renderer.hbs
@@ -8,7 +8,7 @@
             <Input
               class="table-header-cell__input"
               @value={{readonly column.displayName}}
-              @placeholder={{default-column-name column}}
+              @placeholder={{default-column-name column @request.dataSource}}
               @focus-out={{fn @updateColumnDisplayName column}}
             />
             {{#if (or (eq column.type "metric") (eq column.type "threshold"))}}

--- a/packages/core/addon/templates/components/table-renderer.hbs
+++ b/packages/core/addon/templates/components/table-renderer.hbs
@@ -36,7 +36,7 @@
               class="table-header-cell__title {{if column.hasCustomDisplayName "table-header-cell__title--custom-name"}}"
               title="Drag column header to reorder"
             >
-              {{or column.displayName (default-column-name column)}}
+              {{or column.displayName (default-column-name column @request.dataSource)}}
             </span>
             {{#if column.sortDirection}}
               <NaviTableSortIcon

--- a/packages/core/addon/utils/chart-data.js
+++ b/packages/core/addon/utils/chart-data.js
@@ -5,7 +5,7 @@
 import { A as arr } from '@ember/array';
 import { get } from '@ember/object';
 import DataGroup from 'navi-core/utils/classes/data-group';
-import { bestDimensionField } from 'navi-core/utils/data';
+import { getDimensionGroupingField } from 'navi-core/utils/data';
 
 export const METRIC_SERIES = 'metric';
 export const DIMENSION_SERIES = 'dimension';
@@ -22,7 +22,7 @@ export const DATE_TIME_SERIES = 'dateTime';
 export function groupDataByDimensions(rows, config) {
   let dimensionOrder = config.dimensionOrder,
     byDimensions = new DataGroup(rows, row =>
-      dimensionOrder.map(dimension => row[bestDimensionField([row], dimension)]).join('|')
+      dimensionOrder.map(dimension => row[getDimensionGroupingField([row], dimension)]).join('|')
     );
 
   return byDimensions;
@@ -121,10 +121,10 @@ export function buildDimensionSeriesValues(request, rows) {
     let values = {},
       dimensionLabels = [];
     requestDimensions.forEach(dimension => {
-      let id = get(row, `${dimension}|id`),
+      let id = get(row, getDimensionGroupingField([row], dimension)),
         desc = get(row, `${dimension}|desc`);
 
-      values[dimension] = id || desc;
+      values[dimension] = id;
       dimensionLabels.push(desc || id);
     });
 

--- a/packages/core/addon/utils/chart-data.js
+++ b/packages/core/addon/utils/chart-data.js
@@ -1,10 +1,11 @@
 /**
- * Copyright 2018, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import { A as arr } from '@ember/array';
 import { get } from '@ember/object';
 import DataGroup from 'navi-core/utils/classes/data-group';
+import { bestDimensionField } from 'navi-core/utils/data';
 
 export const METRIC_SERIES = 'metric';
 export const DIMENSION_SERIES = 'dimension';
@@ -20,7 +21,9 @@ export const DATE_TIME_SERIES = 'dateTime';
  */
 export function groupDataByDimensions(rows, config) {
   let dimensionOrder = config.dimensionOrder,
-    byDimensions = new DataGroup(rows, row => dimensionOrder.map(dimension => row[`${dimension}|id`]).join('|'));
+    byDimensions = new DataGroup(rows, row =>
+      dimensionOrder.map(dimension => row[bestDimensionField([row], dimension)]).join('|')
+    );
 
   return byDimensions;
 }
@@ -121,7 +124,7 @@ export function buildDimensionSeriesValues(request, rows) {
       let id = get(row, `${dimension}|id`),
         desc = get(row, `${dimension}|desc`);
 
-      values[dimension] = id;
+      values[dimension] = id || desc;
       dimensionLabels.push(desc || id);
     });
 

--- a/packages/core/addon/utils/data.js
+++ b/packages/core/addon/utils/data.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import { get } from '@ember/object';
@@ -47,7 +47,36 @@ export function mostRecentData(rows) {
  * @returns {DataGroup}
  */
 export function dataByDimensions(rows, dimensionOrder) {
-  return new DataGroup(rows, row => dimensionOrder.map(dimension => row[`${dimension}|id`]).join('|'));
+  return new DataGroup(rows, row =>
+    dimensionOrder
+      .map(dimension => {
+        const field = bestDimensionField([row], dimension);
+        return row[field];
+      })
+      .join('|')
+  );
+}
+
+/**
+ * Selects best available dimension field to group on.
+ *
+ * @param {Array} rows
+ * @param {String} dimension
+ * @returns {String} field
+ */
+export function bestDimensionField(rows, dimension) {
+  const fields = Object.keys(rows[0]).filter(field => field.startsWith(dimension + '|'));
+  if (fields.length === 1) {
+    return fields[0];
+  }
+  //TODO: add meta dataservice to get dimension meta data id field, need to get namespace down here consistently though
+  const preferredFields = ['key', 'id', 'desc'];
+  for (const field of preferredFields) {
+    if (fields.includes(`${dimension}|${field}`)) {
+      return `${dimension}|${field}`;
+    }
+  }
+  return `${dimension}|id`;
 }
 
 /**

--- a/packages/core/addon/utils/data.js
+++ b/packages/core/addon/utils/data.js
@@ -59,13 +59,16 @@ export function dataByDimensions(rows, dimensionOrder) {
 
 /**
  * Selects best available dimension field to group on.
+ * Given a response rowSet, tries to find the best identifier field for the given dimension to use.
+ * If there is only one available use that. otherwise it will try to find key in preference order:
+ * key > id > desc
  *
  * @param {Array} rows
  * @param {String} dimension
  * @returns {String} field
  */
 export function bestDimensionField(rows, dimension) {
-  const fields = Object.keys(rows[0]).filter(field => field.startsWith(dimension + '|'));
+  const fields = Object.keys(rows[0]).filter(field => field.startsWith(`${dimension}|`));
   if (fields.length === 1) {
     return fields[0];
   }

--- a/packages/core/addon/utils/data.js
+++ b/packages/core/addon/utils/data.js
@@ -50,7 +50,7 @@ export function dataByDimensions(rows, dimensionOrder) {
   return new DataGroup(rows, row =>
     dimensionOrder
       .map(dimension => {
-        const field = bestDimensionField([row], dimension);
+        const field = getDimensionGroupingField([row], dimension);
         return row[field];
       })
       .join('|')
@@ -67,7 +67,7 @@ export function dataByDimensions(rows, dimensionOrder) {
  * @param {String} dimension
  * @returns {String} field
  */
-export function bestDimensionField(rows, dimension) {
+export function getDimensionGroupingField(rows, dimension) {
   const fields = Object.keys(rows[0]).filter(field => field.startsWith(`${dimension}|`));
   if (fields.length === 1) {
     return fields[0];
@@ -79,7 +79,7 @@ export function bestDimensionField(rows, dimension) {
       return `${dimension}|${field}`;
     }
   }
-  return `${dimension}|id`;
+  return fields[0];
 }
 
 /**

--- a/packages/core/tests/integration/components/navi-visualizations/goal-gauge-test.js
+++ b/packages/core/tests/integration/components/navi-visualizations/goal-gauge-test.js
@@ -55,7 +55,7 @@ module('Integration | Component | goal gauge ', function(hooks) {
     set(this, 'metric', { metric: 'pageViews', paramters: {} });
     await render(hbs`
     <NaviVisualizations::GoalGauge
-       @model={{this.model}}
+        @model={{this.model}}
         @options={{hash
           baselineValue=290000000
           goalValue=310000000

--- a/packages/core/tests/integration/components/navi-visualizations/goal-gauge-test.js
+++ b/packages/core/tests/integration/components/navi-visualizations/goal-gauge-test.js
@@ -54,14 +54,14 @@ module('Integration | Component | goal gauge ', function(hooks) {
     _setModel(this, 'pageViews', 3030000000, 'blockhead');
     set(this, 'metric', { metric: 'pageViews', paramters: {} });
     await render(hbs`
-    {{navi-visualizations/goal-gauge
-        model=model
-        options=(hash
+    <NaviVisualizations::GoalGauge
+       @model={{this.model}}
+        @options={{hash
           baselineValue=290000000
           goalValue=310000000
           metric=metric
-        )
-      }}
+        }}
+      />
     `);
 
     assert.dom('.metric-title').hasText('Page Views', 'the default metric title is correctly displayed');

--- a/packages/core/tests/integration/components/navi-visualizations/goal-gauge-test.js
+++ b/packages/core/tests/integration/components/navi-visualizations/goal-gauge-test.js
@@ -45,6 +45,29 @@ module('Integration | Component | goal gauge ', function(hooks) {
     assert.dom('.goal-title').hasText('310M Goal', 'goal title is correctly displayed');
   });
 
+  test('goal-gauge renders correctly with multi datasource', async function(assert) {
+    assert.expect(1);
+    const metaData = this.owner.lookup('service:bard-metadata');
+    metaData._keg.reset();
+    await metaData.loadMetadata({ dataSourceName: 'blockhead' });
+
+    _setModel(this, 'pageViews', 3030000000, 'blockhead');
+    set(this, 'metric', { metric: 'pageViews', paramters: {} });
+    await render(hbs`
+    {{navi-visualizations/goal-gauge
+        model=model
+        options=(hash
+          baselineValue=290000000
+          goalValue=310000000
+          metric=metric
+        )
+      }}
+    `);
+
+    assert.dom('.metric-title').hasText('Page Views', 'the default metric title is correctly displayed');
+    metaData._keg.reset();
+  });
+
   test('goal-gauge renders correctly with unit', async function(assert) {
     assert.expect(6);
 
@@ -303,13 +326,13 @@ module('Integration | Component | goal gauge ', function(hooks) {
    * @param {Number} value - value of metric
    * @return {Void}
    */
-  function _setModel(context, metric, value) {
+  function _setModel(context, metric, value, dataSource = 'dummy') {
     context.set(
       'model',
       arr([
         {
           response: { rows: [{ [metric]: value }] },
-          request: { metrics: [{ metric }] }
+          request: { metrics: [{ metric }], dataSource }
         }
       ])
     );

--- a/packages/core/tests/integration/components/navi-visualizations/pie-chart-test.js
+++ b/packages/core/tests/integration/components/navi-visualizations/pie-chart-test.js
@@ -410,8 +410,6 @@ module('Integration | Component | pie chart', function(hooks) {
     await render(TEMPLATE);
 
     assert.dom('.c3-title').hasText('Total Page Views', 'The metric name is displayed in the metric label correctly');
-
-    this.set('model', Model);
   });
 
   test('parameterized metric renders correctly for metric series', async function(assert) {

--- a/packages/core/tests/integration/components/navi-visualizations/pie-chart-test.js
+++ b/packages/core/tests/integration/components/navi-visualizations/pie-chart-test.js
@@ -8,6 +8,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import $ from 'jquery';
 import { next } from '@ember/runloop';
 import { getTranslation } from 'navi-core/utils/chart';
+import { cloneDeep } from 'lodash-es';
 
 const TEMPLATE = hbs`
     {{navi-visualizations/pie-chart
@@ -115,6 +116,10 @@ module('Integration | Component | pie chart', function(hooks) {
     this.set('model', Model);
     MetadataService = this.owner.lookup('service:bard-metadata');
     return MetadataService.loadMetadata();
+  });
+
+  hooks.afterEach(function() {
+    MetadataService._keg.reset();
   });
 
   test('it renders for a dimension series', async function(assert) {
@@ -368,6 +373,45 @@ module('Integration | Component | pie chart', function(hooks) {
     assert
       .dom('.c3-target-Under-13 text')
       .hasText('60%', 'Percentage label shown on slice is formatted properly for `Under 13`');
+  });
+
+  test('renders correctly with multi datasource', async function(assert) {
+    assert.expect(1);
+    MetadataService._keg.reset();
+    await MetadataService.loadMetadata({ dataSourceName: 'blockhead' });
+    const blockheadModel = cloneDeep(Model[0]);
+    blockheadModel.request.dataSource = 'blockhead';
+    this.set('model', A([blockheadModel]));
+
+    this.set('options', {
+      series: {
+        type: 'dimension',
+        config: {
+          metric: {
+            metric: 'totalPageViews',
+            parameters: {},
+            canonicalName: 'totalPageViews'
+          },
+          dimensionOrder: ['age'],
+          dimensions: [
+            {
+              name: 'All Other',
+              values: { age: '-3' }
+            },
+            {
+              name: 'Under 13',
+              values: { age: '1' }
+            }
+          ]
+        }
+      }
+    });
+
+    await render(TEMPLATE);
+
+    assert.dom('.c3-title').hasText('Total Page Views', 'The metric name is displayed in the metric label correctly');
+
+    this.set('model', Model);
   });
 
   test('parameterized metric renders correctly for metric series', async function(assert) {

--- a/packages/core/tests/integration/components/navi-visualizations/table-test.js
+++ b/packages/core/tests/integration/components/navi-visualizations/table-test.js
@@ -131,6 +131,8 @@ const Options = {
   ]
 };
 
+let MetadataService;
+
 module('Integration | Component | table', function(hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
@@ -142,12 +144,14 @@ module('Integration | Component | table', function(hooks) {
     this.set('options', Options);
     this.set('onUpdateReport', () => {});
 
-    return this.owner.lookup('service:bard-metadata').loadMetadata();
+    MetadataService = this.owner.lookup('service:bard-metadata');
+
+    return MetadataService.loadMetadata();
   });
 
   hooks.afterEach(function() {
     config.navi.FEATURES.enableVerticalCollectionTableIterator = false;
-    return this.owner.lookup('service:bard-metadata')._keg.reset();
+    return MetadataService._keg.reset();
   });
 
   test('it renders', async function(assert) {
@@ -186,9 +190,8 @@ module('Integration | Component | table', function(hooks) {
 
   test('render alternative datasource', async function(assert) {
     assert.expect(2);
-    const bardMeta = this.owner.lookup('service:bard-metadata');
-    bardMeta._keg.reset();
-    await bardMeta.loadMetadata({ dataSourceName: 'blockhead' });
+    MetadataService._keg.reset();
+    await MetadataService.loadMetadata({ dataSourceName: 'blockhead' });
     const blockheadModel = cloneDeep(Model[0]);
     blockheadModel.request.dataSource = 'blockhead';
     this.set('model', arr([blockheadModel]));

--- a/packages/core/tests/unit/chart-builders/dimension-test.js
+++ b/packages/core/tests/unit/chart-builders/dimension-test.js
@@ -142,6 +142,68 @@ const DATA2 = [
       totalPageViews: 289431575
     }
   ],
+  DATA3 = [
+    {
+      dateTime: '2016-01-01 00:00:00.000',
+      'age|desc': 'Not Available',
+      totalPageViews: 176267792438
+    },
+    {
+      dateTime: '2016-01-01 00:00:00.000',
+      'age|desc': 'Not Available',
+      totalPageViews: 76735188
+    },
+    {
+      dateTime: '2016-01-01 00:00:00.000',
+      'age|desc': 'Not Available',
+      totalPageViews: 74621538
+    },
+    {
+      dateTime: '2016-01-01 00:00:00.000',
+      'age|desc': 'under 13',
+      totalPageViews: 2306935
+    },
+    {
+      dateTime: '2016-01-01 00:00:00.000',
+      'age|desc': 'under 13',
+      totalPageViews: 158591335
+    },
+    {
+      dateTime: '2016-01-01 00:00:00.000',
+      'age|desc': 'under 13',
+      totalPageViews: 293462742
+    },
+    {
+      dateTime: '2016-01-02 00:00:00.000',
+      'age|desc': 'Not Available',
+      totalPageViews: 163354994741
+    },
+    {
+      dateTime: '2016-01-02 00:00:00.000',
+      'age|desc': 'Not Available',
+      totalPageViews: 74006011
+    },
+    {
+      dateTime: '2016-01-02 00:00:00.000',
+      'age|desc': 'Not Available',
+      totalPageViews: 72011227
+    },
+    {
+      dateTime: '2016-01-02 00:00:00.000',
+      'age|desc': 'under 13',
+      totalPageViews: 5630202
+    },
+    {
+      dateTime: '2016-01-02 00:00:00.000',
+      'age|desc': 'under 13',
+      totalPageViews: 156664890
+    },
+    {
+      dateTime: '2016-01-02 00:00:00.000',
+      'age|desc': 'under 13',
+      totalPageViews: 289431575
+    }
+  ],
   REQUEST = {
     logicalTable: {
       timeGrain: 'day'
@@ -151,7 +213,8 @@ const DATA2 = [
         start: '2016-05-30 00:00:00.000',
         end: '2016-06-02 00:00:00.000'
       }
-    ]
+    ],
+    dataSource: 'dummy'
   },
   REQUEST2 = {
     logicalTable: {
@@ -162,7 +225,20 @@ const DATA2 = [
         start: 'P2D',
         end: '2016-01-03 00:00:00.000'
       }
-    ]
+    ],
+    dataSource: 'dummy'
+  },
+  REQUEST3 = {
+    logicalTable: {
+      timeGrain: 'day'
+    },
+    intervals: [
+      {
+        start: 'P2D',
+        end: '2016-01-03 00:00:00.000'
+      }
+    ],
+    dataSource: 'blockhead'
   };
 
 module('Unit | Chart Builders | Dimension', function() {
@@ -638,5 +714,48 @@ module('Unit | Chart Builders | Dimension', function() {
     assert.equal(get(tooltip, 'layout'), TooltipTemplate, 'Tooltip uses dimension tooltip template');
 
     assert.deepEqual(get(tooltip, 'rowData'), [DATA[1]], 'The correct response row is given to the tooltip');
+  });
+
+  test('group by dimension with when id is not present', function(assert) {
+    let config = {
+      metric: {
+        metric: 'totalPageViews',
+        parameters: {},
+        canonicalName: 'totalPageViews'
+      },
+      dimensionOrder: ['age'],
+      dimensions: [
+        {
+          name: 'Not Available',
+          values: { age: 'Not Available' }
+        },
+        {
+          name: 'Under 13',
+          values: { age: 'under 13' }
+        }
+      ]
+    };
+    assert.deepEqual(
+      DimensionChartBuilder.buildData(DATA3, config, REQUEST3),
+      [
+        {
+          'Not Available': 176267792438,
+          'Under 13': 2306935,
+          x: {
+            displayValue: 'Jan 1',
+            rawValue: '2016-01-01 00:00:00.000'
+          }
+        },
+        {
+          'Not Available': 163354994741,
+          'Under 13': 5630202,
+          x: {
+            displayValue: 'Jan 2',
+            rawValue: '2016-01-02 00:00:00.000'
+          }
+        }
+      ],
+      'Data is built correctly when dimension has no id field'
+    );
   });
 });

--- a/packages/core/tests/unit/components/navi-visualizations/table-test.js
+++ b/packages/core/tests/unit/components/navi-visualizations/table-test.js
@@ -64,6 +64,7 @@ module('Unit | Component | table', function(hooks) {
   const MODEL = A([
     {
       request: {
+        dataSource: 'dummy',
         metrics: [
           {
             metric: 'uniqueIdentifier',
@@ -280,7 +281,7 @@ module('Unit | Component | table', function(hooks) {
     let options = merge({}, OPTIONS, { showTotals: { subtotal: 'dimension' } }),
       component = this.owner.factoryFor('component:navi-visualizations/table').create({
         options,
-        model: A([{ response: { rows: ROWS } }])
+        model: A([{ response: { rows: ROWS }, request: { dataSource: 'dummy' } }])
       });
 
     assert.deepEqual(
@@ -343,7 +344,7 @@ module('Unit | Component | table', function(hooks) {
     let options = merge({}, OPTIONS, { showTotals: { subtotal: 'dimension' } }),
       component = this.owner.factoryFor('component:navi-visualizations/table').create({
         options,
-        model: A([{ response: { rows: ROWS } }]),
+        model: A([{ response: { rows: ROWS }, request: { dataSource: 'dummy' } }]),
         computeColumnTotal
       });
 

--- a/packages/core/tests/unit/utils/chart-data-test.js
+++ b/packages/core/tests/unit/utils/chart-data-test.js
@@ -198,7 +198,7 @@ module('Unit | Utils | Chart Data', function() {
   });
 
   test('buildDimensionSeriesValues', function(assert) {
-    assert.expect(1);
+    assert.expect(2);
 
     let request = {
         metrics: [{ metric: { name: 'totalPageViews' } }],
@@ -267,6 +267,51 @@ module('Unit | Utils | Chart Data', function() {
         }
       ],
       'buildDimensionSeriesValues retuns expected series object'
+    );
+
+    assert.deepEqual(
+      buildDimensionSeriesValues(
+        request,
+        rows.map(row => ({
+          dateTime: row.dateTime,
+          'age|desc': row['age|desc'],
+          uniqueIdentifier: row.uniqueIdentifier,
+          totalPageViews: row.totalPageViews
+        }))
+      ),
+      [
+        {
+          name: 'All Other',
+          values: {
+            age: 'All Other'
+          }
+        },
+        {
+          name: 'under 13',
+          values: {
+            age: 'under 13'
+          }
+        },
+        {
+          name: '13 - 25',
+          values: {
+            age: '13 - 25'
+          }
+        },
+        {
+          name: '25 - 35',
+          values: {
+            age: '25 - 35'
+          }
+        },
+        {
+          name: '35 - 45',
+          values: {
+            age: '35 - 45'
+          }
+        }
+      ],
+      'Builds series when id is not available'
     );
   });
 });

--- a/packages/core/tests/unit/utils/chart-data-test.js
+++ b/packages/core/tests/unit/utils/chart-data-test.js
@@ -12,7 +12,7 @@ import { buildTestRequest } from '../../helpers/request';
 
 module('Unit | Utils | Chart Data', function() {
   test('groupDataByDimensions', function(assert) {
-    assert.expect(1);
+    assert.expect(2);
 
     let rows = [
         {
@@ -56,6 +56,42 @@ module('Unit | Utils | Chart Data', function() {
       dataGroup = groupDataByDimensions(rows, config);
 
     assert.deepEqual(dataGroup.getDataForKey('1'), expectedDataGroup, 'groupDataByDimensions groups data as expected');
+
+    assert.deepEqual(
+      groupDataByDimensions(
+        [
+          {
+            'foo|desc': 'foo',
+            metricName: 123
+          },
+          {
+            'foo|desc': 'bar',
+            metricName: 321
+          }
+        ],
+        {
+          metric: 'metricName',
+          dimensionOrder: ['foo'],
+          dimensions: [
+            {
+              name: 'foo',
+              values: { foo: 'foo' }
+            },
+            {
+              name: 'bar',
+              values: { foo: 'bar' }
+            }
+          ]
+        }
+      ).getDataForKey('bar'),
+      [
+        {
+          'foo|desc': 'bar',
+          metricName: 321
+        }
+      ],
+      "Still can group even if identifier field isn't present"
+    );
   });
 
   test('buildSeriesKey', function(assert) {

--- a/packages/core/tests/unit/utils/data-test.js
+++ b/packages/core/tests/unit/utils/data-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { topN, mostRecentData, dataByDimensions, maxDataByDimensions } from 'navi-core/utils/data';
+import { topN, mostRecentData, dataByDimensions, maxDataByDimensions, bestDimensionField } from 'navi-core/utils/data';
 
 module('Unit | Utils | Data', function() {
   test('top n values', function(assert) {
@@ -185,6 +185,50 @@ module('Unit | Utils | Data', function() {
         }
       ],
       'All data rows for max value based on dimensions are returned'
+    );
+  });
+
+  test('best dimension field', function(assert) {
+    assert.equal(
+      bestDimensionField(
+        [
+          {
+            'dim|key': 'foo',
+            'dim|id': 'foo',
+            'dim|desc': 'foo'
+          }
+        ],
+        'dim'
+      ),
+      'dim|key',
+      'key is best field to use when it is available'
+    );
+
+    assert.equal(
+      bestDimensionField(
+        [
+          {
+            'dim|id': 'foo',
+            'dim|desc': 'foo'
+          }
+        ],
+        'dim'
+      ),
+      'dim|id',
+      'id is next field to use when it is available'
+    );
+
+    assert.equal(
+      bestDimensionField(
+        [
+          {
+            'dim|desc': 'foo'
+          }
+        ],
+        'dim'
+      ),
+      'dim|desc',
+      'desc is prefferred when it is the only field available'
     );
   });
 });

--- a/packages/core/tests/unit/utils/data-test.js
+++ b/packages/core/tests/unit/utils/data-test.js
@@ -228,7 +228,7 @@ module('Unit | Utils | Data', function() {
         'dim'
       ),
       'dim|desc',
-      'desc is prefferred when it is the only field available'
+      'desc is preferred when it is the only field available'
     );
   });
 });

--- a/packages/core/tests/unit/utils/data-test.js
+++ b/packages/core/tests/unit/utils/data-test.js
@@ -1,5 +1,11 @@
 import { module, test } from 'qunit';
-import { topN, mostRecentData, dataByDimensions, maxDataByDimensions, bestDimensionField } from 'navi-core/utils/data';
+import {
+  topN,
+  mostRecentData,
+  dataByDimensions,
+  maxDataByDimensions,
+  getDimensionGroupingField
+} from 'navi-core/utils/data';
 
 module('Unit | Utils | Data', function() {
   test('top n values', function(assert) {
@@ -190,7 +196,7 @@ module('Unit | Utils | Data', function() {
 
   test('best dimension field', function(assert) {
     assert.equal(
-      bestDimensionField(
+      getDimensionGroupingField(
         [
           {
             'dim|key': 'foo',
@@ -205,7 +211,7 @@ module('Unit | Utils | Data', function() {
     );
 
     assert.equal(
-      bestDimensionField(
+      getDimensionGroupingField(
         [
           {
             'dim|id': 'foo',
@@ -219,7 +225,7 @@ module('Unit | Utils | Data', function() {
     );
 
     assert.equal(
-      bestDimensionField(
+      getDimensionGroupingField(
         [
           {
             'dim|desc': 'foo'

--- a/packages/data/addon/helpers/metric-format.js
+++ b/packages/data/addon/helpers/metric-format.js
@@ -13,6 +13,7 @@ import { hasParameters } from '../utils/metric';
 import { get } from '@ember/object';
 import { isPresent } from '@ember/utils';
 import Helper from '@ember/component/helper';
+import { getDefaultDataSourceName } from 'navi-data/utils/adapter';
 
 export default Helper.extend({
   /**
@@ -25,7 +26,7 @@ export default Helper.extend({
    * @param metric - serialized bard-request metric fragment
    * @returns {string} - formatted metric
    */
-  compute([metric /*...rest*/]) {
+  compute([metric, namespace = getDefaultDataSourceName() /*...rest*/]) {
     let longName = '--';
     if (!metric) {
       return longName;
@@ -33,7 +34,7 @@ export default Helper.extend({
 
     let metricId = get(metric, 'metric');
     if (isPresent(metricId)) {
-      longName = get(this, 'metricName').getLongName(metricId);
+      longName = get(this, 'metricName').getLongName(metricId, namespace);
     }
     return metricFormat(metric, longName);
   }

--- a/packages/data/addon/helpers/metric-format.js
+++ b/packages/data/addon/helpers/metric-format.js
@@ -34,7 +34,7 @@ export default Helper.extend({
 
     let metricId = get(metric, 'metric');
     if (isPresent(metricId)) {
-      longName = get(this, 'metricName').getLongName(metricId, namespace);
+      longName = this.metricName.getLongName(metricId, namespace);
     }
     return metricFormat(metric, longName);
   }

--- a/packages/data/addon/services/metric-name.js
+++ b/packages/data/addon/services/metric-name.js
@@ -18,8 +18,8 @@ export default Service.extend({
    * @param {String} metricId - base metric name for a metric
    * @returns {String} - long name for the metric from the metadata
    */
-  getLongName(metricId) {
-    return get(this, 'metricMeta').getMetaField('metric', metricId, 'longName', metricId);
+  getLongName(metricId, namespace) {
+    return get(this, 'metricMeta').getMetaField('metric', metricId, 'longName', metricId, namespace);
   },
 
   /**
@@ -27,9 +27,9 @@ export default Service.extend({
    * @param {Object} metricObject - object with metric and parameter properties
    * @returns {String} formatted metric display name
    */
-  getDisplayName(metricObject) {
+  getDisplayName(metricObject, namespace) {
     let metricId = get(metricObject, 'metric'),
-      longName = this.getLongName(metricId);
+      longName = this.getLongName(metricId, namespace);
 
     return metricFormat(metricObject, longName);
   }

--- a/packages/data/addon/services/metric-name.js
+++ b/packages/data/addon/services/metric-name.js
@@ -19,7 +19,7 @@ export default Service.extend({
    * @returns {String} - long name for the metric from the metadata
    */
   getLongName(metricId, namespace) {
-    return get(this, 'metricMeta').getMetaField('metric', metricId, 'longName', metricId, namespace);
+    return this.metricMeta.getMetaField('metric', metricId, 'longName', metricId, namespace);
   },
 
   /**

--- a/packages/data/tests/integration/helpers/metric-format-test.js
+++ b/packages/data/tests/integration/helpers/metric-format-test.js
@@ -43,4 +43,21 @@ module('helper:metric-format', function(hooks) {
     this.set('metric', { metric: 'foo' });
     assert.dom().hasText('foo');
   });
+
+  test('multi-datasource support', async function(assert) {
+    assert.expect(1);
+    const metaData = this.owner.lookup('service:bard-metadata');
+    metaData._keg.reset();
+    await metaData.loadMetadata({ dataSourceName: 'blockhead' });
+
+    this.set('metric', {
+      metric: 'revenue',
+      parameters: { currency: 'USD', as: 'revenueUSD' }
+    });
+
+    await render(hbs`{{metric-format metric 'blockhead'}}`);
+    assert.dom().hasText('Revenue (USD)');
+
+    metaData._keg.reset();
+  });
 });

--- a/packages/data/tests/integration/helpers/metric-format-test.js
+++ b/packages/data/tests/integration/helpers/metric-format-test.js
@@ -45,7 +45,7 @@ module('helper:metric-format', function(hooks) {
   });
 
   test('multi-datasource support', async function(assert) {
-    assert.expect(1);
+    assert.expect(3);
     const metaData = this.owner.lookup('service:bard-metadata');
     metaData._keg.reset();
     await metaData.loadMetadata({ dataSourceName: 'blockhead' });
@@ -55,8 +55,19 @@ module('helper:metric-format', function(hooks) {
       parameters: { currency: 'USD', as: 'revenueUSD' }
     });
 
-    await render(hbs`{{metric-format metric 'blockhead'}}`);
+    this.set('namespace', 'blockhead');
+
+    await render(hbs`{{metric-format metric namespace}}`);
     assert.dom().hasText('Revenue (USD)');
+
+    this.set('metric', {
+      metric: 'navClicks',
+      parameters: {}
+    });
+    assert.dom().hasText('Nav Link Clicks', 'Fall back works');
+
+    this.set('namespace', undefined);
+    assert.dom().hasText('navClicks', 'default works if datasource is not loaded');
 
     metaData._keg.reset();
   });

--- a/packages/data/tests/unit/services/metric-name-test.js
+++ b/packages/data/tests/unit/services/metric-name-test.js
@@ -42,4 +42,27 @@ module('Unit | Service | metric long name', function(hooks) {
       'Service returns a correctly formatted metric name for a parameterized metric'
     );
   });
+
+  test('multi-data source support', async function(assert) {
+    assert.expect(2);
+    const metaData = this.owner.lookup('service:bard-metadata');
+    metaData._keg.reset();
+    await metaData.loadMetadata({ dataSourceName: 'blockhead' });
+
+    let service = this.owner.lookup('service:metric-name');
+
+    assert.equal(
+      service.getDisplayName({ metric: 'adClicks', parameters: {} }, 'blockhead'),
+      'Ad Clicks',
+      'Service returns the long name for a non parameterized metric'
+    );
+
+    assert.equal(
+      service.getLongName('revenue', 'blockhead'),
+      'Revenue',
+      'Service can succesfully retrieve the long name for a valid metric'
+    );
+
+    metaData._keg.reset();
+  });
 });


### PR DESCRIPTION
Resolves #691 

<!-- The above line will close the issue upon merge -->

## Description

make sure visualizations get the right namespace to pull namespaced stuff out of metadata services.

## Proposed Changes

- Add metaNamespace field to navi-viz-c3-chart
- Add namespace support to metric name service and metric name helpers
- Make sure all metadata calls in visualizations get a namespace passed in.
- chart-data/data utils can now group on more fields besides id.
- moved defaultDataSource in navi-app to prevent  error message.

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
