### PR TITLE
Update: Remove `show selected` toggle from selectors (feature flagged)

### DIFF
--- a/packages/reports/addon/components/navi-list-selector.js
+++ b/packages/reports/addon/components/navi-list-selector.js
@@ -1,86 +1,84 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Usage:
- *   {{#navi-list-selector
- *      title=title
- *      items=items
- *      searchField=field
- *      selected=selected
+ *   <NaviListSelector
+ *      @title={{title}}
+ *      @items={{items}}
+ *      @searchField={{searchField}}
+ *      @selected={{selected}}
+ *      @contentClass={{contentClass}}
  *      as | items |
- *   }}
+ *   >
  *      {{yield items}}
- *   {{/navi-list-selector}}
+ *   </NaviListSelector>
  */
 
 import Component from '@ember/component';
-import { set, get, computed } from '@ember/object';
+import { set, computed } from '@ember/object';
 import layout from '../templates/components/navi-list-selector';
 import { searchRecords } from 'navi-core/utils/search';
+import { layout as templateLayout, tagName } from '@ember-decorators/component';
 
-export default Component.extend({
-  layout,
-
-  /*
-   * @property {Array} classNames
-   */
-  classNames: ['navi-list-selector'],
-
+@templateLayout(layout)
+@tagName('')
+class NaviListSelector extends Component {
   /*
    * @property {Boolean} showSelected
    */
-  showSelected: false,
+  showSelected = false;
 
   /*
    * @property {String} errorMessage
    */
-  errorMessage: computed('query', 'showSelected', 'title', function() {
-    if (get(this, 'query.length') > 0) {
-      return `No ${get(this, 'title').toLowerCase()} found`;
-    } else if (get(this, 'showSelected')) {
-      return `No ${get(this, 'title').toLowerCase()} selected`;
+  @computed('query', 'showSelected', 'title')
+  get errorMessage() {
+    if (this.query?.length > 0) {
+      return `No ${this.title?.toLowerCase()} found`;
+    } else if (this.showSelected) {
+      return `No ${this.title?.toLowerCase()} selected`;
     }
-  }),
+    return '';
+  }
 
   /**
    * @property {Boolean} areItemsFiltered - true if items are filtered by selected state or a search query
    */
-  areItemsFiltered: computed('showSelected', 'query', function() {
+  @computed('showSelected', 'query')
+  get areItemsFiltered() {
     return !!this.showSelected || !!this.query;
-  }),
+  }
 
   /*
    * @property {Array} filteredItems - items filtered either by selected and by searchQuery
    */
-  filteredItems: computed('items', 'query', 'searchField', 'selected', 'showSelected', function() {
-    let query = get(this, 'query'),
-      items;
-
-    //set items to selected or all items based on showSelected
-    if (get(this, 'showSelected')) {
-      items = get(this, 'selected');
-    } else {
-      items = get(this, 'items');
-    }
+  @computed('items', 'query', 'searchField', 'selected', 'showSelected')
+  get filteredItems() {
+    const { query, showSelected } = this,
+      //set items to selected or all items based on showSelected
+      items = showSelected ? this.selected : this.items;
 
     //filter items by searchQuery
     if (query) {
-      return searchRecords(items, query, get(this, 'searchField'));
+      return searchRecords(items, query, this.searchField);
     }
 
     return items;
-  }),
+  }
 
   /**
    * Called when the attributes passed into the component have been changed
-   *
-   * @event didUpdateAttrs
+   * @method didUpdateAttrs
    */
   didUpdateAttrs() {
+    this._super(...arguments);
+
     // For convenience, automatically take user to "Show All" when nothing is selected
-    if (!get(this, 'selected.length')) {
+    if (!this.selected?.length) {
       set(this, 'showSelected', false);
     }
   }
-});
+}
+
+export default NaviListSelector;

--- a/packages/reports/addon/components/navi-list-selector.js
+++ b/packages/reports/addon/components/navi-list-selector.js
@@ -1,84 +1,86 @@
 /**
- * Copyright 2020, Yahoo Holdings Inc.
+ * Copyright 2017, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Usage:
- *   <NaviListSelector
- *      @title={{title}}
- *      @items={{items}}
- *      @searchField={{searchField}}
- *      @selected={{selected}}
- *      @contentClass={{contentClass}}
+ *   {{#navi-list-selector
+ *      title=title
+ *      items=items
+ *      searchField=field
+ *      selected=selected
  *      as | items |
- *   >
+ *   }}
  *      {{yield items}}
- *   </NaviListSelector>
+ *   {{/navi-list-selector}}
  */
 
 import Component from '@ember/component';
-import { set, computed } from '@ember/object';
+import { set, get, computed } from '@ember/object';
 import layout from '../templates/components/navi-list-selector';
 import { searchRecords } from 'navi-core/utils/search';
-import { layout as templateLayout, tagName } from '@ember-decorators/component';
 
-@templateLayout(layout)
-@tagName('')
-class NaviListSelector extends Component {
+export default Component.extend({
+  layout,
+
+  /*
+   * @property {Array} classNames
+   */
+  classNames: ['navi-list-selector'],
+
   /*
    * @property {Boolean} showSelected
    */
-  showSelected = false;
+  showSelected: false,
 
   /*
    * @property {String} errorMessage
    */
-  @computed('query', 'showSelected', 'title')
-  get errorMessage() {
-    if (this.query?.length > 0) {
-      return `No ${this.title?.toLowerCase()} found`;
-    } else if (this.showSelected) {
-      return `No ${this.title?.toLowerCase()} selected`;
+  errorMessage: computed('query', 'showSelected', 'title', function() {
+    if (get(this, 'query.length') > 0) {
+      return `No ${get(this, 'title').toLowerCase()} found`;
+    } else if (get(this, 'showSelected')) {
+      return `No ${get(this, 'title').toLowerCase()} selected`;
     }
-    return '';
-  }
+  }),
 
   /**
    * @property {Boolean} areItemsFiltered - true if items are filtered by selected state or a search query
    */
-  @computed('showSelected', 'query')
-  get areItemsFiltered() {
+  areItemsFiltered: computed('showSelected', 'query', function() {
     return !!this.showSelected || !!this.query;
-  }
+  }),
 
   /*
    * @property {Array} filteredItems - items filtered either by selected and by searchQuery
    */
-  @computed('items', 'query', 'searchField', 'selected', 'showSelected')
-  get filteredItems() {
-    const { query, showSelected } = this,
-      //set items to selected or all items based on showSelected
-      items = showSelected ? this.selected : this.items;
+  filteredItems: computed('items', 'query', 'searchField', 'selected', 'showSelected', function() {
+    let query = get(this, 'query'),
+      items;
+
+    //set items to selected or all items based on showSelected
+    if (get(this, 'showSelected')) {
+      items = get(this, 'selected');
+    } else {
+      items = get(this, 'items');
+    }
 
     //filter items by searchQuery
     if (query) {
-      return searchRecords(items, query, this.searchField);
+      return searchRecords(items, query, get(this, 'searchField'));
     }
 
     return items;
-  }
+  }),
 
   /**
    * Called when the attributes passed into the component have been changed
-   * @method didUpdateAttrs
+   *
+   * @event didUpdateAttrs
    */
   didUpdateAttrs() {
-    this._super(...arguments);
-
     // For convenience, automatically take user to "Show All" when nothing is selected
-    if (!this.selected?.length) {
+    if (!get(this, 'selected.length')) {
       set(this, 'showSelected', false);
     }
   }
-}
-
-export default NaviListSelector;
+});

--- a/packages/reports/addon/templates/components/navi-list-selector.hbs
+++ b/packages/reports/addon/templates/components/navi-list-selector.hbs
@@ -1,36 +1,34 @@
 {{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
-<div class="navi-list-selector" ...attributes>
-  <div class="navi-list-selector__header">
-    <h3 class="navi-list-selector__title" title="{{@title}}">{{@title}}</h3>
-    {{#unless (feature-flag "enableRequestPreview")}}
-      <button type="button" class="navi-list-selector__show-link" {{on "click" (toggle "showSelected" this)}}>
-        {{#if this.showSelected}}
-          Show All
-        {{else}}
-          Show Selected ({{@selected.length}})
-        {{/if}}
-      </button>
-    {{/unless}}
-  </div>
-  <div class="navi-list-selector__search">
-    <NaviIcon @icon="search" class="navi-list-selector__search-icon" />
-    <Input
-      placeholder={{concat "Search " (capitalize @title)}}
-      @value={{this.query}}
-      autocomplete="false"
-      spellcheck="false"
-      class="navi-list-selector__search-input"
-    />
-    <NaviIcon @icon="times-circle"
-      class="navi-list-selector__search-input-clear"
-      {{on "click" (fn (mut this.query) undefined)}}
-    />
-  </div>
-  <div class="navi-list-selector__content {{@contentClass}}">
-    {{#if (eq this.filteredItems.length 0)}}
-      <span class="navi-list-selector__content navi-list-selector__content--error">{{this.errorMessage}}</span>
-    {{else}}
-      {{yield this.filteredItems this.areItemsFiltered}}
-    {{/if}}
-  </div>
+<div class="navi-list-selector__header">
+  <h3 class="navi-list-selector__title" title="{{@title}}">{{@title}}</h3>
+  {{#unless (feature-flag "enableRequestPreview")}}
+    <button type="button" class="navi-list-selector__show-link" {{on "click" (toggle "showSelected" this)}}>
+      {{#if this.showSelected}}
+        Show All
+      {{else}}
+        Show Selected ({{@selected.length}})
+      {{/if}}
+    </button>
+  {{/unless}}
+</div>
+<div class="navi-list-selector__search">
+  <NaviIcon @icon="search" class="navi-list-selector__search-icon" />
+  <Input
+    placeholder={{concat "Search " (capitalize @title)}}
+    @value={{this.query}}
+    autocomplete="false"
+    spellcheck="false"
+    class="navi-list-selector__search-input"
+  />
+  <NaviIcon @icon="times-circle"
+    class="navi-list-selector__search-input-clear"
+    {{on "click" (fn (mut this.query) undefined)}}
+  />
+</div>
+<div class="navi-list-selector__content {{@contentClass}}">
+  {{#if (eq this.filteredItems.length 0)}}
+    <span class="navi-list-selector__content navi-list-selector__content--error">{{this.errorMessage}}</span>
+  {{else}}
+    {{yield this.filteredItems this.areItemsFiltered}}
+  {{/if}}
 </div>

--- a/packages/reports/addon/templates/components/navi-list-selector.hbs
+++ b/packages/reports/addon/templates/components/navi-list-selector.hbs
@@ -1,29 +1,36 @@
 {{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
-<div class="navi-list-selector__header">
-  <h3 class="navi-list-selector__title" title={{title}}>{{title}}</h3>
-  <button type="button" class="navi-list-selector__show-link" {{on "click" (toggle "showSelected" this)}}>
-    {{#if showSelected}}
-      Show All
+<div class="navi-list-selector" ...attributes>
+  <div class="navi-list-selector__header">
+    <h3 class="navi-list-selector__title" title="{{@title}}">{{@title}}</h3>
+    {{#unless (feature-flag "enableRequestPreview")}}
+      <button type="button" class="navi-list-selector__show-link" {{on "click" (toggle "showSelected" this)}}>
+        {{#if this.showSelected}}
+          Show All
+        {{else}}
+          Show Selected ({{@selected.length}})
+        {{/if}}
+      </button>
+    {{/unless}}
+  </div>
+  <div class="navi-list-selector__search">
+    <NaviIcon @icon="search" class="navi-list-selector__search-icon" />
+    <Input
+      placeholder={{concat "Search " (capitalize @title)}}
+      @value={{this.query}}
+      autocomplete="false"
+      spellcheck="false"
+      class="navi-list-selector__search-input"
+    />
+    <NaviIcon @icon="times-circle"
+      class="navi-list-selector__search-input-clear"
+      {{on "click" (fn (mut this.query) undefined)}}
+    />
+  </div>
+  <div class="navi-list-selector__content {{@contentClass}}">
+    {{#if (eq this.filteredItems.length 0)}}
+      <span class="navi-list-selector__content navi-list-selector__content--error">{{this.errorMessage}}</span>
     {{else}}
-      Show Selected ({{selected.length}})
+      {{yield this.filteredItems this.areItemsFiltered}}
     {{/if}}
-  </button>
-</div>
-<div class="navi-list-selector__search">
-  {{navi-icon "search" class="navi-list-selector__search-icon"}}
-  {{input
-    placeholder=(concat "Search " (capitalize title))
-    value=query
-    autocomplete=false
-    spellcheck=false
-    class="navi-list-selector__search-input"
-  }}
-  {{navi-icon "times-circle" class="navi-list-selector__search-input-clear" click=(action (set this "query" undefined))}}
-</div>
-<div class="navi-list-selector__content {{@contentClass}}">
-  {{#if (eq filteredItems.length 0)}}
-    <span class="navi-list-selector__content navi-list-selector__content--error">{{errorMessage}}</span>
-  {{else}}
-    {{yield filteredItems areItemsFiltered}}
-  {{/if}}
+  </div>
 </div>

--- a/packages/reports/app/styles/navi-reports/components/grouped-list.less
+++ b/packages/reports/app/styles/navi-reports/components/grouped-list.less
@@ -36,6 +36,7 @@
       align-items: center;
       display: flex;
       flex: 1;
+      transition: background-color 0.2s ease-out;
 
       &--selected {
         background-color: @denali-brand-100;

--- a/packages/reports/tests/integration/components/dimension-selector-test.js
+++ b/packages/reports/tests/integration/components/dimension-selector-test.js
@@ -18,6 +18,15 @@ import {
 
 let Store, MetadataService, Age;
 
+const TEMPLATE = hbs`<DimensionSelector
+  @request={{this.request}}
+  @onAddTimeGrain={{this.addTimeGrain}}
+  @onRemoveTimeGrain={{this.removeTimeGrain}}
+  @onAddDimension={{this.addDimension}}
+  @onRemoveDimension={{this.removeDimension}}
+  @onToggleDimFilter={{this.addDimFilter}}
+/>`;
+
 module('Integration | Component | dimension selector', function(hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
@@ -49,14 +58,7 @@ module('Integration | Component | dimension selector', function(hooks) {
         })
       );
 
-      await render(hbs`{{dimension-selector
-            request=request
-            onAddTimeGrain=(action addTimeGrain)
-            onRemoveTimeGrain=(action removeTimeGrain)
-            onAddDimension=(action addDimension)
-            onRemoveDimension=(action removeDimension)
-            onToggleDimFilter=(action addDimFilter)
-          }}`);
+      await render(TEMPLATE);
     });
   });
 
@@ -96,14 +98,7 @@ module('Integration | Component | dimension selector', function(hooks) {
 
     config.navi.FEATURES.enableRequestPreview = false;
 
-    await render(hbs`{{dimension-selector
-      request=request
-      onAddTimeGrain=(action addTimeGrain)
-      onRemoveTimeGrain=(action removeTimeGrain)
-      onAddDimension=(action addDimension)
-      onRemoveDimension=(action removeDimension)
-      onToggleDimFilter=(action addDimFilter)
-    }}`);
+    await render(TEMPLATE);
 
     const allDimensions = await getAll('dimension');
     assert.ok(
@@ -129,14 +124,7 @@ module('Integration | Component | dimension selector', function(hooks) {
 
     config.navi.FEATURES.enableRequestPreview = true;
 
-    await render(hbs`{{dimension-selector
-      request=request
-      onAddTimeGrain=(action addTimeGrain)
-      onRemoveTimeGrain=(action removeTimeGrain)
-      onAddDimension=(action addDimension)
-      onRemoveDimension=(action removeDimension)
-      onToggleDimFilter=(action addDimFilter)
-    }}`);
+    await render(TEMPLATE);
 
     assert
       .dom('.navi-list-selector__show-link')

--- a/packages/reports/tests/integration/components/dimension-selector-test.js
+++ b/packages/reports/tests/integration/components/dimension-selector-test.js
@@ -92,24 +92,39 @@ module('Integration | Component | dimension selector', function(hooks) {
   test('show selected', async function(assert) {
     assert.expect(4);
 
+    const originalFeatureFlag = config.navi.FEATURES.enableRequestPreview;
+
+    config.navi.FEATURES.enableRequestPreview = false;
+
+    await render(hbs`{{dimension-selector
+      request=request
+      onAddTimeGrain=(action addTimeGrain)
+      onRemoveTimeGrain=(action removeTimeGrain)
+      onAddDimension=(action addDimension)
+      onRemoveDimension=(action removeDimension)
+      onToggleDimFilter=(action addDimFilter)
+    }}`);
+
     const allDimensions = await getAll('dimension');
     assert.ok(
       allDimensions.length > this.get('request.dimensions.length') + 1 /*for timegrain*/,
       'Initially all the dimensions are shown in the dimension-selector'
     );
 
+    await clickShowSelected('dimension');
+
     const selectedDimensions = await getAllSelected('dimension');
     assert.deepEqual(
       selectedDimensions,
       ['Day', 'Age'],
-      'When show selected is clicked only the selected age dimension and the selected timegrain are shown'
+      'When show selected is clicked the selected age dimension and the selected timegrain are still shown'
     );
 
     assert.notOk(
       findAll('.grouped-list__item-checkbox')
         .filter(el => !el.checked)
         .concat(findAll('.grouped-list__add-icon--deselected')).length,
-      'No items are marked as unselected'
+      'No unselected dimensions are shown'
     );
 
     config.navi.FEATURES.enableRequestPreview = true;
@@ -123,17 +138,11 @@ module('Integration | Component | dimension selector', function(hooks) {
       onToggleDimFilter=(action addDimFilter)
     }}`);
 
-    await clickShowSelected('dimension');
+    assert
+      .dom('.navi-list-selector__show-link')
+      .doesNotExist('Show Selected toggle is hidden if enableRequestPreview flag is turned on');
 
-    assert.equal(
-      findAll('.grouped-list__item-checkbox')
-        .filter(el => el.checked)
-        .concat(findAll('.grouped-list__item-container--selected')).length,
-      2,
-      'The selected items are marked as added or selected when enableRequestPreview is on'
-    );
-
-    config.navi.FEATURES.enableRequestPreview = false;
+    config.navi.FEATURES.enableRequestPreview = originalFeatureFlag;
   });
 
   test('actions', async function(assert) {

--- a/packages/reports/tests/integration/components/metric-config-test.js
+++ b/packages/reports/tests/integration/components/metric-config-test.js
@@ -12,8 +12,7 @@ import {
   clickItemFilter,
   getItem,
   getAll,
-  clickShowSelected,
-  renderAll
+  clickShowSelected
 } from 'navi-reports/test-support/report-builder';
 import config from 'ember-get-config';
 

--- a/packages/reports/tests/integration/components/metric-config-test.js
+++ b/packages/reports/tests/integration/components/metric-config-test.js
@@ -18,6 +18,15 @@ import config from 'ember-get-config';
 
 let MockRequest, MockMetric, MetadataService;
 
+const TEMPLATE = hbs`<MetricConfig
+  @metric={{this.metric}}
+  @request={{this.request}}
+  @onAddParameterizedMetric={{this.addParameterizedMetric}}
+  @onRemoveParameterizedMetric={{this.removeParameterizedMetric}}
+  @onToggleParameterizedMetricFilter={{this.toggleParameterizedMetricFilter}}
+  @parametersPromise={{this.parametersPromise}}
+/>`;
+
 module('Integration | Component | metric config', function(hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
@@ -78,15 +87,7 @@ module('Integration | Component | metric config', function(hooks) {
     await MetadataService.loadMetadata();
     set(this, 'metric', MockMetric);
     set(this, 'request', MockRequest);
-    await render(hbs`
-      {{metric-config
-        metric=metric
-        request=request
-        onAddParameterizedMetric=(action addParameterizedMetric)
-        onRemoveParameterizedMetric=(action removeParameterizedMetric)
-        onToggleParameterizedMetricFilter=(action toggleParameterizedMetricFilter)
-        parametersPromise=parametersPromise
-      }}`);
+    await render(TEMPLATE);
   });
 
   test('it renders', async function(assert) {
@@ -138,15 +139,7 @@ module('Integration | Component | metric config', function(hooks) {
 
     config.navi.FEATURES.enableRequestPreview = false;
 
-    await render(hbs`
-      {{metric-config
-        metric=metric
-        request=request
-        onAddParameterizedMetric=(action addParameterizedMetric)
-        onRemoveParameterizedMetric=(action removeParameterizedMetric)
-        onToggleParameterizedMetricFilter=(action toggleParameterizedMetricFilter)
-        parametersPromise=parametersPromise
-      }}`);
+    await render(TEMPLATE);
 
     await clickTrigger('.metric-config__dropdown-trigger');
 
@@ -167,15 +160,7 @@ module('Integration | Component | metric config', function(hooks) {
 
     config.navi.FEATURES.enableRequestPreview = true;
 
-    await render(hbs`
-      {{metric-config
-        metric=metric
-        request=request
-        onAddParameterizedMetric=(action addParameterizedMetric)
-        onRemoveParameterizedMetric=(action removeParameterizedMetric)
-        onToggleParameterizedMetricFilter=(action toggleParameterizedMetricFilter)
-        parametersPromise=parametersPromise
-      }}`);
+    await render(TEMPLATE);
 
     assert
       .dom('.navi-list-selector__show-link')

--- a/packages/reports/tests/integration/components/metric-selector-test.js
+++ b/packages/reports/tests/integration/components/metric-selector-test.js
@@ -21,6 +21,13 @@ import {
 
 let Store, MetadataService, AdClicks, PageViews;
 
+const TEMPLATE = hbs`<MetricSelector
+  @request={{this.request}}
+  @onAddMetric={{this.addMetric}}
+  @onRemoveMetric={{this.removeMetric}}
+  @onToggleMetricFilter={{this.addMetricFilter}}
+/>`;
+
 module('Integration | Component | metric selector', function(hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
@@ -72,12 +79,7 @@ module('Integration | Component | metric selector', function(hooks) {
         })
       );
 
-      await render(hbs`{{metric-selector
-            request=request
-            onAddMetric=(action addMetric)
-            onRemoveMetric=(action removeMetric)
-            onToggleMetricFilter=(action addMetricFilter)
-          }}`);
+      await render(TEMPLATE);
     });
   });
 
@@ -100,12 +102,7 @@ module('Integration | Component | metric selector', function(hooks) {
 
     config.navi.FEATURES.enableRequestPreview = false;
 
-    await render(hbs`{{metric-selector
-      request=request
-      onAddMetric=(action addMetric)
-      onRemoveMetric=(action removeMetric)
-      onToggleMetricFilter=(action addMetricFilter)
-    }}`);
+    await render(TEMPLATE);
 
     await renderAll('metric');
 
@@ -126,7 +123,7 @@ module('Integration | Component | metric selector', function(hooks) {
       'When show selected is clicked the selected adClicks base metric is still shown'
     );
 
-    assert.notOk(findAll('.grouped-list__add-icon--deselected').length, 'No unselected metrics are shown');
+    assert.dom('.grouped-list__add-icon--deselected').doesNotExist('No unselected metrics are shown');
 
     let metrics = get(this, 'request.metrics');
     metrics.removeFragment(metrics.toArray()[0]);
@@ -168,16 +165,11 @@ module('Integration | Component | metric selector', function(hooks) {
       'Adding a new metric will show its base metric as selected'
     );
 
-    assert.notOk(findAll('.grouped-list__add-icon--deselected').length, 'No unselected metrics are shown');
+    assert.dom('.grouped-list__add-icon--deselected').doesNotExist('No unselected metrics are shown');
 
     config.navi.FEATURES.enableRequestPreview = true;
 
-    await render(hbs`{{metric-selector
-      request=request
-      onAddMetric=(action addMetric)
-      onRemoveMetric=(action removeMetric)
-      onToggleMetricFilter=(action addMetricFilter)
-    }}`);
+    await render(TEMPLATE);
 
     assert
       .dom('.navi-list-selector__show-link')

--- a/packages/reports/tests/integration/components/navi-list-selector-test.js
+++ b/packages/reports/tests/integration/components/navi-list-selector-test.js
@@ -4,6 +4,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, click, findAll } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { fillInSync } from '../../helpers/fill-in-sync';
+import config from 'ember-get-config';
 
 module('Integration | Component | navi list selector', function(hooks) {
   setupRenderingTest(hooks);
@@ -71,7 +72,27 @@ module('Integration | Component | navi list selector', function(hooks) {
   });
 
   test('show all/show selected', async function(assert) {
-    assert.expect(8);
+    assert.expect(9);
+
+    const originalFeatureFlag = config.navi.FEATURES.enableRequestPreview;
+
+    config.navi.FEATURES.enableRequestPreview = false;
+
+    await render(hbs`
+          {{#navi-list-selector
+              title='Items'
+              items=items
+              searchField='field'
+              selected=selected
+              as | items areItemsFiltered |
+          }}
+              {{#each items as | item |}}
+                  <li class='test-item {{if areItemsFiltered 'test-item__filtered'}}'>
+                    {{item.field}}
+                  </li>
+              {{/each}}
+          {{/navi-list-selector}}
+      `);
 
     assert
       .dom('.navi-list-selector__show-link')
@@ -114,6 +135,30 @@ module('Integration | Component | navi list selector', function(hooks) {
     assert
       .dom('.navi-list-selector__content--error')
       .hasText('No items selected', 'No items selected error message is displayed when no items are selected');
+
+    config.navi.FEATURES.enableRequestPreview = true;
+
+    await render(hbs`
+          {{#navi-list-selector
+              title='Items'
+              items=items
+              searchField='field'
+              selected=selected
+              as | items areItemsFiltered |
+          }}
+              {{#each items as | item |}}
+                  <li class='test-item {{if areItemsFiltered 'test-item__filtered'}}'>
+                    {{item.field}}
+                  </li>
+              {{/each}}
+          {{/navi-list-selector}}
+      `);
+
+    assert
+      .dom('.navi-list-selector__show-link')
+      .doesNotExist('Show Selected toggle is hidden if enableRequestPreview flag is turned on');
+
+    config.navi.FEATURES.enableRequestPreview = originalFeatureFlag;
   });
 
   test('search', async function(assert) {

--- a/packages/reports/tests/integration/components/navi-list-selector-test.js
+++ b/packages/reports/tests/integration/components/navi-list-selector-test.js
@@ -6,6 +6,21 @@ import hbs from 'htmlbars-inline-precompile';
 import { fillInSync } from '../../helpers/fill-in-sync';
 import config from 'ember-get-config';
 
+const TEMPLATE = hbs`
+  <NaviListSelector
+    @title="Items"
+    @items={{this.items}}
+    @searchField="field"
+    @selected={{this.selected}}
+    as | items areItemsFiltered |
+  >
+    {{#each items as | item |}}
+      <li class="test-item {{if areItemsFiltered "test-item__filtered"}}">
+        {{item.field}}
+      </li>
+    {{/each}}
+  </NaviListSelector>`;
+
 module('Integration | Component | navi list selector', function(hooks) {
   setupRenderingTest(hooks);
 
@@ -32,21 +47,7 @@ module('Integration | Component | navi list selector', function(hooks) {
       }
     ]);
 
-    await render(hbs`
-          {{#navi-list-selector
-              title='Items'
-              items=items
-              searchField='field'
-              selected=selected
-              as | items areItemsFiltered |
-          }}
-              {{#each items as | item |}}
-                  <li class='test-item {{if areItemsFiltered 'test-item__filtered'}}'>
-                    {{item.field}}
-                  </li>
-              {{/each}}
-          {{/navi-list-selector}}
-      `);
+    await render(TEMPLATE);
   });
 
   test('it renders', async function(assert) {
@@ -78,21 +79,7 @@ module('Integration | Component | navi list selector', function(hooks) {
 
     config.navi.FEATURES.enableRequestPreview = false;
 
-    await render(hbs`
-          {{#navi-list-selector
-              title='Items'
-              items=items
-              searchField='field'
-              selected=selected
-              as | items areItemsFiltered |
-          }}
-              {{#each items as | item |}}
-                  <li class='test-item {{if areItemsFiltered 'test-item__filtered'}}'>
-                    {{item.field}}
-                  </li>
-              {{/each}}
-          {{/navi-list-selector}}
-      `);
+    await render(TEMPLATE);
 
     assert
       .dom('.navi-list-selector__show-link')
@@ -138,21 +125,7 @@ module('Integration | Component | navi list selector', function(hooks) {
 
     config.navi.FEATURES.enableRequestPreview = true;
 
-    await render(hbs`
-          {{#navi-list-selector
-              title='Items'
-              items=items
-              searchField='field'
-              selected=selected
-              as | items areItemsFiltered |
-          }}
-              {{#each items as | item |}}
-                  <li class='test-item {{if areItemsFiltered 'test-item__filtered'}}'>
-                    {{item.field}}
-                  </li>
-              {{/each}}
-          {{/navi-list-selector}}
-      `);
+    await render(TEMPLATE);
 
     assert
       .dom('.navi-list-selector__show-link')


### PR DESCRIPTION
Only if `enableRequestPreview` is turned on.

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
