### PR TITLE
Fix: Fetch extended data properly

### DIFF
--- a/packages/data/addon/models/metadata/metric.js
+++ b/packages/data/addon/models/metadata/metric.js
@@ -94,7 +94,7 @@ const Model = EmberObject.extend({
   extended: computed(function() {
     const { metadata, name, type } = this;
     return ObjectProxy.extend(PromiseProxyMixin).create({
-      promise: metadata.fetchById(type, name)
+      promise: metadata.findById(type, name)
     });
   })
 });

--- a/packages/data/addon/serializers/bard-metadata.js
+++ b/packages/data/addon/serializers/bard-metadata.js
@@ -21,7 +21,7 @@ export default EmberObject.extend({
       tables = rawTables.map(table => {
         let timeGrains = table.timeGrains.map(timegrain => {
           dimensions = dimensions.concat(
-            timegrain.dimensions.map(dimension => Object.assign({}, dimension, { source, partial: true }))
+            timegrain.dimensions.map(dimension => Object.assign({}, dimension, { source, partialData: true }))
           );
 
           /*
@@ -33,7 +33,7 @@ export default EmberObject.extend({
               Object.assign({ valueType: metric.type }, metric, {
                 type: 'metric',
                 source,
-                partial: true
+                partialData: true
               })
             )
           );

--- a/packages/data/addon/serializers/bard-metadata.js
+++ b/packages/data/addon/serializers/bard-metadata.js
@@ -21,7 +21,7 @@ export default EmberObject.extend({
       tables = rawTables.map(table => {
         let timeGrains = table.timeGrains.map(timegrain => {
           dimensions = dimensions.concat(
-            timegrain.dimensions.map(dimension => Object.assign({}, dimension, { source }))
+            timegrain.dimensions.map(dimension => Object.assign({}, dimension, { source, partial: true }))
           );
 
           /*
@@ -32,7 +32,8 @@ export default EmberObject.extend({
             timegrain.metrics.map(metric =>
               Object.assign({ valueType: metric.type }, metric, {
                 type: 'metric',
-                source
+                source,
+                partial: true
               })
             )
           );

--- a/packages/data/addon/services/bard-metadata.js
+++ b/packages/data/addon/services/bard-metadata.js
@@ -182,7 +182,7 @@ export default Service.extend({
     //Get entity if already present in the keg
     let dataSourceName = namespace || getDefaultDataSourceName();
     const kegRecord = get(this, '_keg').getById(`metadata/${type}`, id, dataSourceName);
-    if (kegRecord && !kegRecord.partial) {
+    if (kegRecord && !kegRecord.partialData) {
       return resolve(this.getById(type, id, dataSourceName));
     }
 

--- a/packages/data/addon/services/bard-metadata.js
+++ b/packages/data/addon/services/bard-metadata.js
@@ -182,7 +182,8 @@ export default Service.extend({
   findById(type, id, namespace) {
     //Get entity if already present in the keg
     let dataSourceName = namespace || getDefaultDataSourceName();
-    if (get(this, '_keg').getById(`metadata/${type}`, id, dataSourceName)) {
+    const kegRecord = get(this, '_keg').getById(`metadata/${type}`, id, dataSourceName);
+    if (kegRecord && !kegRecord.partial) {
       return resolve(this.getById(type, id, dataSourceName));
     }
 

--- a/packages/data/addon/services/bard-metadata.js
+++ b/packages/data/addon/services/bard-metadata.js
@@ -109,7 +109,7 @@ export default Service.extend({
       return owner.factoryFor(`model:metadata/${type}`).create(payload);
     });
 
-    get(this, '_keg').pushMany(`metadata/${type}`, metadata, { namespace });
+    return get(this, '_keg').pushMany(`metadata/${type}`, metadata, { namespace });
   },
 
   /**
@@ -165,8 +165,7 @@ export default Service.extend({
       .fetchMetadata(type, id, { dataSourceName })
       .then(meta => {
         //load into keg if not already present
-        this._loadMetadataForType(type, [meta], dataSourceName);
-        return meta;
+        return this._loadMetadataForType(type, [meta], dataSourceName)?.[0];
       });
   },
 

--- a/packages/data/addon/services/keg.js
+++ b/packages/data/addon/services/keg.js
@@ -92,6 +92,9 @@ export default class KegService extends Service {
       const existingRecord = this.getById(type, id, namespace);
 
       if (existingRecord) {
+        if (existingRecord.partial && !rawRecords[i].partial) {
+          delete existingRecord.partial;
+        }
         setProperties(existingRecord, rawRecords[i]);
         returnedRecords.pushObject(existingRecord);
       } else {

--- a/packages/data/addon/services/keg.js
+++ b/packages/data/addon/services/keg.js
@@ -92,8 +92,8 @@ export default class KegService extends Service {
       const existingRecord = this.getById(type, id, namespace);
 
       if (existingRecord) {
-        if (existingRecord.partial && !rawRecords[i].partial) {
-          delete existingRecord.partial;
+        if (existingRecord.partialData && !rawRecords[i].partialData) {
+          delete existingRecord.partialData;
         }
         setProperties(existingRecord, rawRecords[i]);
         returnedRecords.pushObject(existingRecord);

--- a/packages/data/test-support/helpers/metadata-routes.js
+++ b/packages/data/test-support/helpers/metadata-routes.js
@@ -220,17 +220,18 @@ export default function(index = 0) {
     return [200, { 'Content-Type': 'application/json' }, JSON.stringify({ tables: index > 0 ? Tables2 : Tables })];
   });
 
-  this.get(`${host}/v1/metrics/metricOne`, function() {
-    return [200, { 'Content-Type': 'application/json' }, JSON.stringify(MetricOne)];
+  this.get(`${host}/v1/metrics/:id`, function({ params: { id } }) {
+    return [200, { 'Content-Type': 'application/json' }, JSON.stringify(METRIC_MAP[id])];
   });
-
-  if (index === 1) {
-    this.get(`${host}/v1/metrics/metricThree`, function() {
-      return [200, { 'Content-Type': 'application/json' }, JSON.stringify(MetricThree)];
-    });
-  }
 
   this.get(`${host}/v1/dimensions/dimensionOne`, function() {
     return [200, { 'Content-Type': 'application/json' }, JSON.stringify(DimensionOne)];
   });
 }
+
+const METRIC_MAP = {
+  metricOne: MetricOne,
+  metricTwo: MetricTwo,
+  metricThree: MetricThree,
+  metricFour: MetricFour
+};

--- a/packages/data/tests/unit/models/metadata/dimension-test.js
+++ b/packages/data/tests/unit/models/metadata/dimension-test.js
@@ -204,14 +204,21 @@ module('Unit | Metadata Model | Dimension', function(hooks) {
       name: 'dimensionOne'
     });
     const server = new Pretender(metadataRoutes);
+    const originalDataSources = dimensionOne.metadata.loadedDataSources;
+    dimensionOne.metadata.set('loadedDataSources', ['dummy']);
 
+    const expected = {
+      cardinality: 60,
+      category: 'categoryOne',
+      longName: 'Dimension One',
+      name: 'dimensionOne'
+    };
     const result = await dimensionOne.get('extended');
-    assert.deepEqual(result, {
-      'cardinality': 60,
-      'category': 'categoryOne',
-      'longName': 'Dimension One',
-      'name': 'dimensionOne'
-    }, 'dimension model can fetch extended attributes');
+    assert.ok(
+      Object.keys(expected).every(key => result[key] === expected[key]),
+      'dimension model can fetch extended attributes'
+    );
     server.shutdown();
+    dimensionOne.metadata.set('loadedDataSources', originalDataSources);
   });
 });

--- a/packages/data/tests/unit/models/metadata/metric-test.js
+++ b/packages/data/tests/unit/models/metadata/metric-test.js
@@ -148,13 +148,21 @@ module('Unit | Metadata Model | Metric', function(hooks) {
       name: 'metricOne'
     });
     const server = new Pretender(metadataRoutes);
+    const originalDataSources = metricOne.metadata.loadedDataSources;
+    metricOne.metadata.set('loadedDataSources', ['dummy']);
+
+    const expected = {
+      category: 'category',
+      longName: 'Metric One',
+      name: 'metricOne'
+    };
 
     const result = await metricOne.get('extended');
-    assert.deepEqual(result, 	{
-      'category': 'category',
-      'longName': 'Metric One',
-      'name': 'metricOne'
-    }, 'metric model can fetch extended attributes');
+    assert.ok(
+      Object.keys(expected).every(key => result[key] === expected[key]),
+      'metric model can fetch extended attributes'
+    );
     server.shutdown();
+    metricOne.metadata.set('loadedDataSources', originalDataSources);
   });
 });

--- a/packages/data/tests/unit/serializers/bard-metadata-test.js
+++ b/packages/data/tests/unit/serializers/bard-metadata-test.js
@@ -125,6 +125,7 @@ const Payload = {
       longName: 'Dimension One',
       uri: 'https://host:port/namespace/dimensions/dimensionOne',
       cardinality: '10',
+      partial: true,
       source: 'dummy'
     },
     {
@@ -133,6 +134,7 @@ const Payload = {
       longName: 'Dimension Two',
       uri: 'https://host:port/namespace/dimensions/dimensionTwo',
       cardinality: '5',
+      partial: true,
       source: 'dummy'
     },
     {
@@ -141,6 +143,7 @@ const Payload = {
       longName: 'Dimension One',
       uri: 'https://host:port/namespace/dimensions/dimensionOne',
       cardinality: '10',
+      partial: true,
       source: 'dummy'
     },
     {
@@ -149,6 +152,7 @@ const Payload = {
       longName: 'Dimension Two',
       uri: 'https://host:port/namespace/dimensions/dimensionTwo',
       cardinality: '5',
+      partial: true,
       source: 'dummy'
     }
   ],
@@ -160,6 +164,7 @@ const Payload = {
       type: 'metric',
       uri: 'https://metric-one-url',
       valueType: 'number',
+      partial: true,
       source: 'dummy'
     },
     {
@@ -169,6 +174,7 @@ const Payload = {
       type: 'metric',
       uri: 'https://metric-two-url',
       valueType: 'money',
+      partial: true,
       source: 'dummy'
     },
     {
@@ -178,6 +184,7 @@ const Payload = {
       type: 'metric',
       uri: 'https://metric-one-url',
       valueType: 'number',
+      partial: true,
       source: 'dummy'
     },
     {
@@ -187,6 +194,7 @@ const Payload = {
       type: 'metric',
       uri: 'https://metric-two-url',
       valueType: 'money',
+      partial: true,
       source: 'dummy'
     }
   ];

--- a/packages/data/tests/unit/serializers/bard-metadata-test.js
+++ b/packages/data/tests/unit/serializers/bard-metadata-test.js
@@ -125,7 +125,7 @@ const Payload = {
       longName: 'Dimension One',
       uri: 'https://host:port/namespace/dimensions/dimensionOne',
       cardinality: '10',
-      partial: true,
+      partialData: true,
       source: 'dummy'
     },
     {
@@ -134,7 +134,7 @@ const Payload = {
       longName: 'Dimension Two',
       uri: 'https://host:port/namespace/dimensions/dimensionTwo',
       cardinality: '5',
-      partial: true,
+      partialData: true,
       source: 'dummy'
     },
     {
@@ -143,7 +143,7 @@ const Payload = {
       longName: 'Dimension One',
       uri: 'https://host:port/namespace/dimensions/dimensionOne',
       cardinality: '10',
-      partial: true,
+      partialData: true,
       source: 'dummy'
     },
     {
@@ -152,7 +152,7 @@ const Payload = {
       longName: 'Dimension Two',
       uri: 'https://host:port/namespace/dimensions/dimensionTwo',
       cardinality: '5',
-      partial: true,
+      partialData: true,
       source: 'dummy'
     }
   ],
@@ -164,7 +164,7 @@ const Payload = {
       type: 'metric',
       uri: 'https://metric-one-url',
       valueType: 'number',
-      partial: true,
+      partialData: true,
       source: 'dummy'
     },
     {
@@ -174,7 +174,7 @@ const Payload = {
       type: 'metric',
       uri: 'https://metric-two-url',
       valueType: 'money',
-      partial: true,
+      partialData: true,
       source: 'dummy'
     },
     {
@@ -184,7 +184,7 @@ const Payload = {
       type: 'metric',
       uri: 'https://metric-one-url',
       valueType: 'number',
-      partial: true,
+      partialData: true,
       source: 'dummy'
     },
     {
@@ -194,7 +194,7 @@ const Payload = {
       type: 'metric',
       uri: 'https://metric-two-url',
       valueType: 'money',
-      partial: true,
+      partialData: true,
       source: 'dummy'
     }
   ];

--- a/packages/data/tests/unit/services/bard-metadata-test.js
+++ b/packages/data/tests/unit/services/bard-metadata-test.js
@@ -342,10 +342,10 @@ module('Unit - Service - Bard Metadata', function(hooks) {
     );
     assert.equal(Server.handledRequests.length, 2, 'Meta data endpoint called once for each metric');
 
-    keg.push('metadata/metric', Object.assign({}, MetricTwo, { partial: true }), { namespace: 'dummy' });
+    keg.push('metadata/metric', Object.assign({}, MetricTwo, { partialData: true }), { namespace: 'dummy' });
 
     const kegRecord = keg.getById('metadata/metric', 'metricTwo', 'dummy');
-    assert.ok(kegRecord?.partial, 'Partial metric exists in keg with partial flag');
+    assert.ok(kegRecord.partialData, 'Partial metric exists in keg with partial data flag');
 
     const findOnPartiallyLoadedMetric = await Service.findById('metric', 'metricTwo', 'dummy');
     assert.ok(
@@ -353,8 +353,8 @@ module('Unit - Service - Bard Metadata', function(hooks) {
       'Correct metric is returned'
     );
     assert.notOk(
-      findOnPartiallyLoadedMetric.partial,
-      'Partial flag is no longer present after direct access of metric'
+      findOnPartiallyLoadedMetric.partialData,
+      'Partial data flag is no longer present after direct access of metric'
     );
     assert.equal(Server.handledRequests.length, 3, 'Another request is sent for a partially loaded model');
 

--- a/packages/data/tests/unit/services/bard-metadata-test.js
+++ b/packages/data/tests/unit/services/bard-metadata-test.js
@@ -1,5 +1,5 @@
 import EmberObject from '@ember/object';
-import { getOwner, setOwner } from '@ember/application';
+import { getOwner } from '@ember/application';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import Pretender from 'pretender';
@@ -14,22 +14,29 @@ import metadataRoutes, {
   Host
 } from '../../helpers/metadata-routes';
 
-let Service, Server;
+let Service, Server, originalService;
 
 module('Unit - Service - Bard Metadata', function(hooks) {
   setupTest(hooks);
 
   hooks.beforeEach(function() {
-    Service = this.owner.factoryFor('service:bard-metadata').create({
+    originalService = this.owner.factoryFor('service:bard-metadata');
+    const newService = this.owner.factoryFor('service:bard-metadata').class.extend({
       host: Host
     });
-    setOwner(Service, this.owner);
+    this.owner.unregister('service:bard-metadata');
+    this.owner.register('service:bard-metadata', newService);
+
+    Service = this.owner.lookup('service:bard-metadata');
 
     //setup Pretender
     Server = new Pretender(metadataRoutes);
   });
 
   hooks.afterEach(function() {
+    this.owner.unregister('service:bard-metadata');
+    this.owner.register('service:bard-metadata', originalService);
+
     //shutdown pretender
     Server.shutdown();
   });
@@ -245,10 +252,14 @@ module('Unit - Service - Bard Metadata', function(hooks) {
 
   test('fetchById', async function(assert) {
     assert.expect(5);
+    Service.set('loadedDataSources', ['dummy']);
     metadataRoutes.bind(Server)(1);
 
     const data = await Service.fetchById('metric', 'metricOne');
-    assert.deepEqual(data, MetricOne, 'Service fetchById should load correct data');
+    assert.ok(
+      Object.keys(MetricOne).every(key => MetricOne[key] === data[key]),
+      'Service fetchById should load correct data'
+    );
 
     let keg = Service._keg;
 
@@ -269,6 +280,8 @@ module('Unit - Service - Bard Metadata', function(hooks) {
 
     await Service.fetchById('metric', 'metricThree', 'blockhead');
     assert.deepEqual(keg.all('metadata/metric').mapBy('name'), ['metricOne', 'metricThree']);
+
+    Service.set('loadedDataSources', []);
   });
 
   test('multi-source all', async function(assert) {
@@ -296,11 +309,14 @@ module('Unit - Service - Bard Metadata', function(hooks) {
   });
 
   test('findById', async function(assert) {
-    assert.expect(9);
+    assert.expect(12);
     metadataRoutes.bind(Server)(1);
     Service.set('loadedDataSources', ['dummy']);
-    const metricOne = await Service.findById('metric', 'metricOne');
-    assert.deepEqual(metricOne, MetricOne, 'Service findById should load correct data');
+    const metricOne = await Service.findById('metric', 'metricOne', 'dummy');
+    assert.ok(
+      Object.keys(MetricOne).every(key => MetricOne[key] === metricOne[key]),
+      'Service findById should load correct data'
+    );
 
     let keg = Service._keg;
 
@@ -311,12 +327,15 @@ module('Unit - Service - Bard Metadata', function(hooks) {
     );
 
     const data = await Service.findById('metric', 'metricOne');
-    assert.deepEqual(data.name, MetricOne.name, 'Service findById should return correct data');
+    assert.ok(
+      Object.keys(MetricOne).every(key => MetricOne[key] === data[key]),
+      'Service findById should return correct data'
+    );
     assert.equal(Server.handledRequests.length, 1, 'Meta data endpoint only called once');
 
     let blockheadData = await Service.findById('metric', 'metricThree', 'blockhead');
 
-    assert.deepEqual(
+    assert.equal(
       blockheadData.name,
       'metricThree',
       'Service findById should return correct data when requesting other datasource'
@@ -329,8 +348,21 @@ module('Unit - Service - Bard Metadata', function(hooks) {
     assert.ok(kegRecord?.partial, 'Partial metric exists in keg with partial flag');
 
     const findOnPartiallyLoadedMetric = await Service.findById('metric', 'metricTwo', 'dummy');
-    assert.deepEqual(findOnPartiallyLoadedMetric, MetricTwo, 'Partial flag is removed on findById');
+    assert.ok(
+      Object.keys(MetricTwo).every(key => MetricTwo[key] === findOnPartiallyLoadedMetric[key]),
+      'Correct metric is returned'
+    );
+    assert.notOk(
+      findOnPartiallyLoadedMetric.partial,
+      'Partial flag is no longer present after direct access of metric'
+    );
     assert.equal(Server.handledRequests.length, 3, 'Another request is sent for a partially loaded model');
+
+    const findAgain = await Service.findById('metric', 'metricTwo', 'dummy');
+    assert.equal(findAgain, findOnPartiallyLoadedMetric, 'Same record is returned on a second call');
+    assert.equal(Server.handledRequests.length, 3, 'No more requests are sent for subsequent findById calls');
+
+    Service.set('loadedDataSources', []);
   });
 
   test('getMetaField', async function(assert) {

--- a/packages/data/tests/unit/services/bard-metadata-test.js
+++ b/packages/data/tests/unit/services/bard-metadata-test.js
@@ -296,7 +296,7 @@ module('Unit - Service - Bard Metadata', function(hooks) {
   });
 
   test('findById', async function(assert) {
-    assert.expect(6);
+    assert.expect(9);
     metadataRoutes.bind(Server)(1);
     Service.set('loadedDataSources', ['dummy']);
     const metricOne = await Service.findById('metric', 'metricOne');
@@ -322,6 +322,15 @@ module('Unit - Service - Bard Metadata', function(hooks) {
       'Service findById should return correct data when requesting other datasource'
     );
     assert.equal(Server.handledRequests.length, 2, 'Meta data endpoint called once for each metric');
+
+    keg.push('metadata/metric', Object.assign({}, MetricTwo, { partial: true }), { namespace: 'dummy' });
+
+    const kegRecord = keg.getById('metadata/metric', 'metricTwo', 'dummy');
+    assert.ok(kegRecord?.partial, 'Partial metric exists in keg with partial flag');
+
+    const findOnPartiallyLoadedMetric = await Service.findById('metric', 'metricTwo', 'dummy');
+    assert.deepEqual(findOnPartiallyLoadedMetric, MetricTwo, 'Partial flag is removed on findById');
+    assert.equal(Server.handledRequests.length, 3, 'Another request is sent for a partially loaded model');
   });
 
   test('getMetaField', async function(assert) {

--- a/packages/data/tests/unit/services/keg-test.js
+++ b/packages/data/tests/unit/services/keg-test.js
@@ -223,13 +223,13 @@ module('Unit | Service | keg', function(hooks) {
     let secondPush = Keg.pushMany('record', [
       { id: 1, description: 'updated' },
       Record3,
-      { id: 4, description: 'partially loaded record', partial: true }
+      { id: 4, description: 'partially loaded record', partialData: true }
     ]);
 
     assert.deepEqual(
       Keg.all('record'),
       [...firstPush, secondPush[1], secondPush[2]],
-      'Pushing a records into the keg with an existing id does not add a new record'
+      'Pushing records into the keg with an existing id does not add a new record'
     );
 
     assert.equal(
@@ -261,11 +261,11 @@ module('Unit | Service | keg', function(hooks) {
     assert.deepEqual(
       Keg.all('record'),
       [...firstPush, secondPush[1], ...thirdPush],
-      'Pushing a records into the keg with an existing id does not add a new record'
+      'Pushing a record into the keg with an existing id containing partial data does not add a new record'
     );
 
     assert.notOk(
-      Keg.getById('record', 4).partial,
+      Keg.getById('record', 4).partialData,
       'Partial flag is removed when partial record is updated without flag in update set'
     );
 


### PR DESCRIPTION
## Description
Dimension Extended property started using `findById` instead of `fetchById` so that we wouldn't need to send a request if the dimension was already in the Keg. Because of the data from the `table?format=fullView` request on report builder load, there were records already in the Keg for each dimension and metric. Since `table?format=fullView` doesn't include all fields (such as `description`), this resulted in those extra fields never being fetched.

## Proposed Changes

- Set a `partialData` property to true in all metrics and dimensions in `_normalizeTable` in `serializers/bard-metadata`
- `services/bard-metadata` `findById` will now only return an existing record in the keg if it does not contain that partialData flag
- Utilize `findById` in metric too so we aren't sending so many requests
- Return model instance from `fetchById` rather than raw metadata. This is consistent with what we do with `getById`
- Keg will remove partialData flag from record if an update is pushed without the partial flag

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
