### PR TITLE
Update: Add multi-datasource report builder support

### DIFF
--- a/packages/core/addon/mirage/fixtures/reports.js
+++ b/packages/core/addon/mirage/fixtures/reports.js
@@ -531,5 +531,77 @@ export default [
       bardVersion: 'v1',
       requestVersion: 'v1'
     }
+  },
+  {
+    id: 12,
+    title: 'Report for different datasource',
+    createdOn: '2020-01-01 00:00:00',
+    updatedOn: '2020-01-01 00:00:00',
+    authorId: 'navi_user',
+    deliveryRuleIds: [],
+    visualization: {
+      type: 'table',
+      version: 1,
+      metadata: {
+        columns: [
+          {
+            field: 'dateTime',
+            type: 'dateTime',
+            displayName: 'Date'
+          },
+          {
+            field: 'container',
+            type: 'dimension',
+            displayName: 'Container'
+          },
+          {
+            field: { metric: 'usedAmount', parameters: {} },
+            type: 'metric',
+            displayName: 'Used Amount'
+          }
+        ]
+      }
+    },
+    request: {
+      logicalTable: {
+        table: 'inventory',
+        timeGrain: 'day'
+      },
+      metrics: [
+        {
+          metric: 'usedAmount',
+          parameters: {}
+        }
+      ],
+      dimensions: [
+        {
+          dimension: 'container'
+        }
+      ],
+      filters: [
+        {
+          dimension: 'container',
+          field: 'id',
+          operator: 'in',
+          values: ['2']
+        }
+      ],
+      having: [
+        {
+          metric: 'usedAmount',
+          operator: 'gt',
+          values: [50]
+        }
+      ],
+      intervals: [
+        {
+          end: 'current',
+          start: 'P3D'
+        }
+      ],
+      bardVersion: 'v1',
+      requestVersion: 'v1',
+      dataSource: 'blockhead'
+    }
   }
 ];

--- a/packages/core/addon/mirage/fixtures/reports.js
+++ b/packages/core/addon/mirage/fixtures/reports.js
@@ -571,11 +571,18 @@ export default [
         {
           metric: 'usedAmount',
           parameters: {}
+        },
+        {
+          metric: 'revenue',
+          parameters: { currency: 'GIL' }
         }
       ],
       dimensions: [
         {
           dimension: 'container'
+        },
+        {
+          dimension: 'displayCurrency'
         }
       ],
       filters: [

--- a/packages/core/addon/models/bard-request/request.js
+++ b/packages/core/addon/models/bard-request/request.js
@@ -556,26 +556,26 @@ export default Fragment.extend(Validations, {
 
     return store.createFragment('bard-request/request', {
       logicalTable: store.createFragment('bard-request/fragments/logicalTable', {
-        table: metadataService.getById('table', clonedRequest.logicalTable.table),
+        table: metadataService.getById('table', clonedRequest.logicalTable.table, clonedRequest.dataSource),
         timeGrainName: clonedRequest.logicalTable.timeGrain
       }),
 
       dimensions: clonedRequest.dimensions.map(dimension =>
         store.createFragment('bard-request/fragments/dimension', {
-          dimension: metadataService.getById('dimension', dimension.dimension)
+          dimension: metadataService.getById('dimension', dimension.dimension, clonedRequest.dataSource)
         })
       ),
 
       metrics: clonedRequest.metrics.map(metric =>
         store.createFragment('bard-request/fragments/metric', {
-          metric: metadataService.getById('metric', metric.metric),
+          metric: metadataService.getById('metric', metric.metric, clonedRequest.dataSource),
           parameters: metric.parameters
         })
       ),
 
       filters: clonedRequest.filters.map(filter =>
         store.createFragment('bard-request/fragments/filter', {
-          dimension: metadataService.getById('dimension', filter.dimension),
+          dimension: metadataService.getById('dimension', filter.dimension, clonedRequest.dataSource),
           field: filter.field,
           operator: filter.operator,
           rawValues: filter.values
@@ -586,7 +586,7 @@ export default Fragment.extend(Validations, {
       having: makeArray(clonedRequest.having).map(having =>
         store.createFragment('bard-request/fragments/having', {
           metric: store.createFragment('bard-request/fragments/metric', {
-            metric: metadataService.getById('metric', having.metric.metric),
+            metric: metadataService.getById('metric', having.metric.metric, clonedRequest.dataSource),
             parameters: having.metric.parameters || {}
           }),
           operator: having.operator,
@@ -606,7 +606,7 @@ export default Fragment.extend(Validations, {
           });
         } else {
           metric = store.createFragment('bard-request/fragments/metric', {
-            metric: metadataService.getById('metric', sort.metric.metric),
+            metric: metadataService.getById('metric', sort.metric.metric, clonedRequest.dataSource),
             parameters: sort.metric.parameters
           });
         }

--- a/packages/core/addon/transforms/base-metadata-transform.js
+++ b/packages/core/addon/transforms/base-metadata-transform.js
@@ -4,7 +4,6 @@
  */
 
 import { inject as service } from '@ember/service';
-import { get } from '@ember/object';
 import { isArray } from '@ember/array';
 import DS from 'ember-data';
 
@@ -28,28 +27,27 @@ export default DS.Transform.extend({
    * @returns {Object|Array} Ember Object | Array of Ember Objects
    */
   deserialize(serialized) {
-    let metadataService = get(this, 'metadataService');
     let namespace = null;
 
     if (isArray(serialized)) {
       return serialized.map(dimension => {
         namespace = null;
         if (dimension.includes('.')) {
-          let splitName = serialized.split('.');
+          const splitName = serialized.split('.');
           namespace = splitName[0];
           dimension = splitName[1];
         }
-        return metadataService.getById(get(this, 'type'), dimension, namespace);
+        return this.metadataService.getById(this.type, dimension, namespace);
       });
     }
 
     if (serialized.includes('.')) {
-      let splitName = serialized.split('.');
+      const splitName = serialized.split('.');
       namespace = splitName[0];
       serialized = splitName[1];
     }
 
-    return metadataService.getById(get(this, 'type'), serialized, namespace);
+    return this.metadataService.getById(this.type, serialized, namespace);
   },
 
   /**
@@ -66,9 +64,9 @@ export default DS.Transform.extend({
     }
 
     if (isArray(deserialized)) {
-      return deserialized.map(item => get(item, 'name') || null);
+      return deserialized.map(item => item.name || null);
     }
 
-    return get(deserialized, 'name') || null;
+    return deserialized.name || null;
   }
 });

--- a/packages/core/addon/transforms/base-metadata-transform.js
+++ b/packages/core/addon/transforms/base-metadata-transform.js
@@ -4,7 +4,6 @@
  */
 
 import { inject as service } from '@ember/service';
-import { isArray } from '@ember/array';
 import DS from 'ember-data';
 
 export default DS.Transform.extend({
@@ -23,23 +22,11 @@ export default DS.Transform.extend({
    *
    * Deserializes to a Ember Object or Array of Ember objects
    *
-   * @param {String|Array} serialized
-   * @returns {Object|Array} Ember Object | Array of Ember Objects
+   * @param {String} serialized
+   * @returns {Object} Ember Object
    */
   deserialize(serialized) {
     let namespace = null;
-
-    if (isArray(serialized)) {
-      return serialized.map(dimension => {
-        namespace = null;
-        if (dimension.includes('.')) {
-          const splitName = serialized.split('.');
-          namespace = splitName[0];
-          dimension = splitName[1];
-        }
-        return this.metadataService.getById(this.type, dimension, namespace);
-      });
-    }
 
     if (serialized.includes('.')) {
       const splitName = serialized.split('.');
@@ -55,16 +42,12 @@ export default DS.Transform.extend({
    *
    * Serialized to a string or array of strings
    *
-   * @param {Object|Array} deserialized
-   * @returns {String|Array|Null} - name | array of names
+   * @param {Object} deserialized
+   * @returns {String|Null} - name
    */
   serialize(deserialized = {}) {
     if (typeof deserialized === 'string') {
       return deserialized;
-    }
-
-    if (isArray(deserialized)) {
-      return deserialized.map(item => item.name || null);
     }
 
     return deserialized.name || null;

--- a/packages/core/addon/transforms/base-metadata-transform.js
+++ b/packages/core/addon/transforms/base-metadata-transform.js
@@ -29,12 +29,27 @@ export default DS.Transform.extend({
    */
   deserialize(serialized) {
     let metadataService = get(this, 'metadataService');
+    let namespace = null;
 
     if (isArray(serialized)) {
-      return serialized.map(dimension => metadataService.getById(get(this, 'type'), dimension));
+      return serialized.map(dimension => {
+        namespace = null;
+        if (dimension.includes('.')) {
+          let splitName = serialized.split('.');
+          namespace = splitName[0];
+          dimension = splitName[1];
+        }
+        return metadataService.getById(get(this, 'type'), dimension, namespace);
+      });
     }
 
-    return metadataService.getById(get(this, 'type'), serialized);
+    if (serialized.includes('.')) {
+      let splitName = serialized.split('.');
+      namespace = splitName[0];
+      serialized = splitName[1];
+    }
+
+    return metadataService.getById(get(this, 'type'), serialized, namespace);
   },
 
   /**

--- a/packages/core/addon/transforms/metric.js
+++ b/packages/core/addon/transforms/metric.js
@@ -18,7 +18,7 @@ export default BaseMetadataTransform.extend({
    */
   deserialize(serialized) {
     //This is used for special case of dateTime in sorting
-    if (serialized === 'dateTime') {
+    if (serialized === 'dateTime' || serialized.endsWith('.dateTime')) {
       return { name: 'dateTime' };
     }
 

--- a/packages/core/addon/utils/chart-data.js
+++ b/packages/core/addon/utils/chart-data.js
@@ -124,7 +124,7 @@ export function buildDimensionSeriesValues(request, rows) {
       let id = get(row, getDimensionGroupingField([row], dimension)),
         desc = get(row, `${dimension}|desc`);
 
-      values[dimension] = id;
+      values[dimension] = id || desc;
       dimensionLabels.push(desc || id);
     });
 

--- a/packages/core/addon/utils/chart-data.js
+++ b/packages/core/addon/utils/chart-data.js
@@ -124,7 +124,7 @@ export function buildDimensionSeriesValues(request, rows) {
       let id = get(row, getDimensionGroupingField([row], dimension)),
         desc = get(row, `${dimension}|desc`);
 
-      values[dimension] = id || desc;
+      values[dimension] = id;
       dimensionLabels.push(desc || id);
     });
 

--- a/packages/core/tests/dummy/config/environment.js
+++ b/packages/core/tests/dummy/config/environment.js
@@ -26,7 +26,10 @@ module.exports = function(environment) {
     navi: {
       user: 'navi_user',
       dataEpoch: '2013-01-01',
-      dataSources: [{ name: 'dummy', uri: 'https://data.naviapp.io', type: 'bard-facts' }],
+      dataSources: [
+        { name: 'dummy', uri: 'https://data.naviapp.io', type: 'bard-facts' },
+        { name: 'blockhead', uri: 'https://data2.naviapp.io', type: 'bard-facts' }
+      ],
       appPersistence: {
         type: 'webservice',
         uri: 'https://persistence.naviapp.io',

--- a/packages/core/tests/dummy/mirage/config.js
+++ b/packages/core/tests/dummy/mirage/config.js
@@ -18,6 +18,10 @@ export default function() {
   BardMeta.call(this);
   BardLite.call(this);
 
+  this.urlPrefix = `${config.navi.dataSources[1].uri}/v1`;
+  BardMeta.call(this);
+  BardLite.call(this);
+
   /* == Mock Persistence == */
   this.urlPrefix = config.navi.appPersistence.uri;
   dashboard.call(this);

--- a/packages/core/tests/integration/components/navi-visualizations/goal-gauge-test.js
+++ b/packages/core/tests/integration/components/navi-visualizations/goal-gauge-test.js
@@ -51,8 +51,8 @@ module('Integration | Component | goal gauge ', function(hooks) {
     metaData._keg.reset();
     await metaData.loadMetadata({ dataSourceName: 'blockhead' });
 
-    _setModel(this, 'pageViews', 3030000000, 'blockhead');
-    set(this, 'metric', { metric: 'pageViews', paramters: {} });
+    _setModel(this, 'available', 3030000000, 'blockhead');
+    set(this, 'metric', { metric: 'available', parameters: {} });
     await render(hbs`
     <NaviVisualizations::GoalGauge
         @model={{this.model}}
@@ -64,7 +64,7 @@ module('Integration | Component | goal gauge ', function(hooks) {
       />
     `);
 
-    assert.dom('.metric-title').hasText('Page Views', 'the default metric title is correctly displayed');
+    assert.dom('.metric-title').hasText('How many are available', 'the default metric title is correctly displayed');
     metaData._keg.reset();
   });
 

--- a/packages/core/tests/integration/components/navi-visualizations/line-chart-test.js
+++ b/packages/core/tests/integration/components/navi-visualizations/line-chart-test.js
@@ -646,25 +646,15 @@ module('Integration | Component | line chart', function(hooks) {
             config: {
               metrics: [
                 {
-                  metric: 'uniqueIdentifier',
-                  canonicalName: 'uniqueIdentifier',
+                  metric: 'ownedQuantity',
+                  canonicalName: 'ownedQuantity',
                   toJSON() {
                     return this;
                   }
                 },
                 {
-                  metric: 'totalPageViews',
-                  canonicalName: 'totalPageViews',
-                  toJSON() {
-                    return this;
-                  }
-                },
-                {
-                  metric: 'revenue',
-                  parameters: {
-                    currency: 'USD'
-                  },
-                  canonicalName: 'revenue(currency=USD)',
+                  metric: 'usedAmount',
+                  canonicalName: 'usedAmount',
                   toJSON() {
                     return this;
                   }
@@ -681,7 +671,7 @@ module('Integration | Component | line chart', function(hooks) {
       A([
         {
           request: {
-            metrics: ['uniqueIdentifier', 'totalPageViews', 'revenue(currency=USD)'],
+            metrics: ['ownedQuantity', 'usedAmount'],
             intervals: [
               {
                 start: '2016-05-30 00:00:00.000',
@@ -697,33 +687,28 @@ module('Integration | Component | line chart', function(hooks) {
             rows: [
               {
                 dateTime: '2016-05-30 00:00:00.000',
-                uniqueIdentifier: 172933788,
-                totalPageViews: 3669828357,
-                'revenue(currency=USD)': 2000323439.23
+                ownedQuantity: 172933788,
+                usedAmount: 3669828357
               },
               {
                 dateTime: '2016-05-31 00:00:00.000',
-                uniqueIdentifier: 183206656,
-                totalPageViews: 4088487125,
-                'revenue(currency=USD)': 1999243823.74
+                ownedQuantity: 183206656,
+                usedAmount: 4088487125
               },
               {
                 dateTime: '2016-06-01 00:00:00.000',
-                uniqueIdentifier: 183380921,
-                totalPageViews: 4024700302,
-                'revenue(currency=USD)': 1400324934.92
+                ownedQuantity: 183380921,
+                usedAmount: 4024700302
               },
               {
                 dateTime: '2016-06-02 00:00:00.000',
-                uniqueIdentifier: 180559793,
-                totalPageViews: 3950276031,
-                'revenue(currency=USD)': 923843934.11
+                ownedQuantity: 180559793,
+                usedAmount: 3950276031
               },
               {
                 dateTime: '2016-06-03 00:00:00.000',
-                uniqueIdentifier: 172724594,
-                totalPageViews: 3697156058,
-                'revenue(currency=USD)': 1623430236.42
+                ownedQuantity: 172724594,
+                usedAmount: 3697156058
               }
             ]
           }
@@ -734,7 +719,7 @@ module('Integration | Component | line chart', function(hooks) {
 
     assert.deepEqual(
       findAll('.c3-legend-item').map(el => el.textContent),
-      ['Unique Identifiers', 'Total Page Views', 'Revenue (USD)'],
+      ['Quantity of thing', 'Used Amount'],
       'Metric display names are used properly for parameterized and non-parameterized metrics in the legend'
     );
   });

--- a/packages/core/tests/integration/components/navi-visualizations/pie-chart-test.js
+++ b/packages/core/tests/integration/components/navi-visualizations/pie-chart-test.js
@@ -412,8 +412,6 @@ module('Integration | Component | pie chart', function(hooks) {
     assert
       .dom('.c3-title')
       .hasText('How many have sold worldwide', 'The metric name is displayed in the metric label correctly');
-
-    this.set('model', Model);
   });
 
   test('parameterized metric renders correctly for metric series', async function(assert) {

--- a/packages/core/tests/integration/components/navi-visualizations/pie-chart-test.js
+++ b/packages/core/tests/integration/components/navi-visualizations/pie-chart-test.js
@@ -388,19 +388,19 @@ module('Integration | Component | pie chart', function(hooks) {
         type: 'dimension',
         config: {
           metric: {
-            metric: 'totalPageViews',
+            metric: 'globalySold',
             parameters: {},
-            canonicalName: 'totalPageViews'
+            canonicalName: 'globalySold'
           },
-          dimensionOrder: ['age'],
+          dimensionOrder: ['container'],
           dimensions: [
             {
-              name: 'All Other',
-              values: { age: '-3' }
+              name: 'Bag',
+              values: { container: '1' }
             },
             {
-              name: 'Under 13',
-              values: { age: '1' }
+              name: 'Bank',
+              values: { container: '2' }
             }
           ]
         }
@@ -409,7 +409,11 @@ module('Integration | Component | pie chart', function(hooks) {
 
     await render(TEMPLATE);
 
-    assert.dom('.c3-title').hasText('Total Page Views', 'The metric name is displayed in the metric label correctly');
+    assert
+      .dom('.c3-title')
+      .hasText('How many have sold worldwide', 'The metric name is displayed in the metric label correctly');
+
+    this.set('model', Model);
   });
 
   test('parameterized metric renders correctly for metric series', async function(assert) {

--- a/packages/core/tests/unit/models/bard-request/request-test.js
+++ b/packages/core/tests/unit/models/bard-request/request-test.js
@@ -23,7 +23,10 @@ module('Unit | Model Fragment | BardRequest - Request', function(hooks) {
 
     MetadataService = this.owner.lookup('service:bard-metadata');
 
-    await MetadataService.loadMetadata().then(() => {
+    await Promise.all([
+      MetadataService.loadMetadata(),
+      MetadataService.loadMetadata({ dataSourceName: 'blockhead' })
+    ]).then(() => {
       run(() => {
         Store.pushPayload({
           data: [
@@ -90,7 +93,7 @@ module('Unit | Model Fragment | BardRequest - Request', function(hooks) {
                     table: 'network',
                     timeGrain: 'day'
                   },
-                  dataSource: 'blockhead',
+                  dataSource: 'dummy',
                   metrics: [
                     {
                       metric: 'uniqueIdentifier',
@@ -341,7 +344,7 @@ module('Unit | Model Fragment | BardRequest - Request', function(hooks) {
       'The property having is set with correct parameters'
     );
 
-    assert.equal(request.dataSource, 'blockhead', 'datasource was cloned correctly');
+    assert.equal(request.dataSource, 'dummy', 'datasource was cloned correctly');
   });
 
   // Test that navi supports legacy saved reports without a sort field

--- a/packages/core/tests/unit/transforms/dimension-test.js
+++ b/packages/core/tests/unit/transforms/dimension-test.js
@@ -15,7 +15,7 @@ module('Unit | Transform | Dimension', function(hooks) {
   });
 
   test('serialize and deserialize', async function(assert) {
-    assert.expect(2);
+    assert.expect(3);
 
     await settled();
     let transform = this.owner.lookup('transform:dimension'),
@@ -24,6 +24,8 @@ module('Unit | Transform | Dimension', function(hooks) {
     assert.equal(transform.serialize(dim), 'os', 'Dimension is serialized to the name');
 
     assert.equal(transform.deserialize('os'), dim, 'Dimension is deserialized to the right object');
+
+    assert.equal(transform.deserialize('dummy.os'), dim, 'Dimension with namespace is deserialized to right object');
   });
 
   test('Do not cause crash when metadata is not available', function(assert) {

--- a/packages/core/tests/unit/transforms/metric-test.js
+++ b/packages/core/tests/unit/transforms/metric-test.js
@@ -15,7 +15,7 @@ module('Unit | Transform | Metric', function(hooks) {
   });
 
   test('serialize and deserialize', async function(assert) {
-    assert.expect(2);
+    assert.expect(3);
 
     await settled();
     let transform = this.owner.lookup('transform:metric'),
@@ -24,6 +24,11 @@ module('Unit | Transform | Metric', function(hooks) {
     assert.equal(transform.serialize(metric), 'pageViews', 'Metric is serialized to the name');
 
     assert.equal(transform.deserialize('pageViews'), metric, 'Metric is deserialized to the right object');
+    assert.equal(
+      transform.deserialize('dummy.pageViews'),
+      metric,
+      'namespaced metric is deserialized to the right object'
+    );
   });
 
   test('datetime test', async function(assert) {

--- a/packages/core/tests/unit/transforms/table-test.js
+++ b/packages/core/tests/unit/transforms/table-test.js
@@ -15,7 +15,7 @@ module('Unit | Transform | Table', function(hooks) {
   });
 
   test('serialize and deserialize', async function(assert) {
-    assert.expect(2);
+    assert.expect(3);
 
     await settled();
     let transform = this.owner.lookup('transform:table'),
@@ -24,5 +24,6 @@ module('Unit | Transform | Table', function(hooks) {
     assert.equal(transform.serialize(table), 'network', 'Table is serialized to the name');
 
     assert.equal(transform.deserialize('network'), table, 'Table is deserialized to the right object');
+    assert.equal(transform.deserialize('dummy.network'), table, 'namespaced table is deserialized to the right object');
   });
 });

--- a/packages/data/addon/mirage/bard-lite/dimensions/container.js
+++ b/packages/data/addon/mirage/bard-lite/dimensions/container.js
@@ -1,0 +1,6 @@
+export default [
+  { id: '1', description: 'Bag' },
+  { id: '2', description: 'Bank' },
+  { id: '3', description: 'Saddle Bag' },
+  { id: '4', description: 'Retainer' }
+];

--- a/packages/data/addon/mirage/fixtures/bard-meta-blockhead-tables.js
+++ b/packages/data/addon/mirage/fixtures/bard-meta-blockhead-tables.js
@@ -1,0 +1,7 @@
+export default [
+  {
+    name: 'inventory',
+    longName: 'Inventory',
+    description: "What's in the box?"
+  }
+];

--- a/packages/data/addon/mirage/fixtures/bard-meta-dimensions.js
+++ b/packages/data/addon/mirage/fixtures/bard-meta-dimensions.js
@@ -290,6 +290,14 @@ export default {
       category: 'Personal',
       datatype: 'text',
       storageStrategy: 'loaded'
+    },
+    {
+      name: 'displayCurrency',
+      longName: 'Display Currency',
+      cardinality: 34,
+      category: 'Personal',
+      datatype: 'text',
+      storageStrategy: 'loaded'
     }
   ]
 };

--- a/packages/data/addon/mirage/fixtures/bard-meta-dimensions.js
+++ b/packages/data/addon/mirage/fixtures/bard-meta-dimensions.js
@@ -248,5 +248,48 @@ export default {
       datatype: 'text',
       storageStrategy: 'loaded'
     }
+  ],
+
+  blockheadDims: [
+    {
+      name: 'item',
+      longName: 'Item',
+      cardinality: 100,
+      category: 'Personal',
+      datatype: 'text',
+      storageStrategy: 'loaded'
+    },
+    {
+      name: 'container',
+      longName: 'Container',
+      cardinality: 100,
+      category: 'Personal',
+      datatype: 'text',
+      storageStrategy: 'loaded'
+    },
+    {
+      name: 'location',
+      longName: 'Location',
+      cardinality: 100,
+      category: 'World',
+      datatype: 'text',
+      storageStrategy: 'loaded'
+    },
+    {
+      name: 'requirement',
+      longName: 'Requirement',
+      cardinality: 100,
+      category: 'World',
+      datatype: 'text',
+      storageStrategy: 'loaded'
+    },
+    {
+      name: 'recipe',
+      longName: 'Recipe',
+      cardinality: 100,
+      category: 'Personal',
+      datatype: 'text',
+      storageStrategy: 'loaded'
+    }
   ]
 };

--- a/packages/data/addon/mirage/fixtures/bard-meta-metrics.js
+++ b/packages/data/addon/mirage/fixtures/bard-meta-metrics.js
@@ -305,6 +305,19 @@ export default {
       name: 'globalySold',
       longName: 'How many have sold worldwide',
       type: 'number'
+    },
+    {
+      category: 'World',
+      name: 'revenue',
+      longName: 'Revenue',
+      type: 'money',
+      parameters: {
+        currency: {
+          type: 'dimension',
+          dimensionName: 'displayCurrency',
+          defaultValue: 'GIL'
+        }
+      }
     }
   ]
 };

--- a/packages/data/addon/mirage/fixtures/bard-meta-metrics.js
+++ b/packages/data/addon/mirage/fixtures/bard-meta-metrics.js
@@ -273,5 +273,38 @@ export default {
       longName: 'Unique Identifiers (Daily Avg) per Total Unique Identifiers (Percentage)',
       type: 'number'
     }
+  ],
+
+  blockheadMetrics: [
+    {
+      category: 'Personal',
+      name: 'ownedQuantity',
+      longName: 'Quantity of thing',
+      type: 'number'
+    },
+    {
+      category: 'Personal',
+      name: 'usedAmount',
+      longName: 'Used Amount',
+      type: 'number'
+    },
+    {
+      category: 'Personal',
+      name: 'personalSold',
+      longName: 'Personally sold amount',
+      type: 'number'
+    },
+    {
+      category: 'World',
+      name: 'available',
+      longName: 'How many are available',
+      type: 'number'
+    },
+    {
+      category: 'World',
+      name: 'globalySold',
+      longName: 'How many have sold worldwide',
+      type: 'number'
+    }
   ]
 };

--- a/packages/data/addon/services/bard-metadata.js
+++ b/packages/data/addon/services/bard-metadata.js
@@ -226,7 +226,7 @@ export default Service.extend({
    * @returns {string} - namespace
    */
   getTableNamespace(table) {
-    const items = this._keg.getBy('metadata/table', recordTable => (recordTable.name = table));
+    const items = this._keg.getBy('metadata/table', recordTable => recordTable.name === table);
 
     return items.length ? items[0].source : getDefaultDataSourceName();
   }

--- a/packages/data/tests/integration/helpers/metric-format-test.js
+++ b/packages/data/tests/integration/helpers/metric-format-test.js
@@ -55,7 +55,7 @@ module('helper:metric-format', function(hooks) {
       parameters: {}
     });
 
-    await render(hbs`{{metric-format metric 'blockhead'}}`);
+    await render(hbs`{{metric-format metric "blockhead"}}`);
     assert.dom().hasText('Used Amount');
 
     this.set('metric', {

--- a/packages/data/tests/integration/helpers/metric-format-test.js
+++ b/packages/data/tests/integration/helpers/metric-format-test.js
@@ -51,20 +51,18 @@ module('helper:metric-format', function(hooks) {
     await metaData.loadMetadata({ dataSourceName: 'blockhead' });
 
     this.set('metric', {
-      metric: 'revenue',
-      parameters: { currency: 'USD', as: 'revenueUSD' }
+      metric: 'usedAmount',
+      parameters: {}
     });
 
-    this.set('namespace', 'blockhead');
-
-    await render(hbs`{{metric-format metric namespace}}`);
-    assert.dom().hasText('Revenue (USD)');
+    await render(hbs`{{metric-format metric 'blockhead'}}`);
+    assert.dom().hasText('Used Amount');
 
     this.set('metric', {
       metric: 'navClicks',
       parameters: {}
     });
-    assert.dom().hasText('Nav Link Clicks', 'Fall back works');
+    assert.dom().hasText('navClicks', 'Fall back works');
 
     this.set('namespace', undefined);
     assert.dom().hasText('navClicks', 'default works if datasource is not loaded');

--- a/packages/data/tests/unit/services/metric-name-test.js
+++ b/packages/data/tests/unit/services/metric-name-test.js
@@ -52,14 +52,14 @@ module('Unit | Service | metric long name', function(hooks) {
     let service = this.owner.lookup('service:metric-name');
 
     assert.equal(
-      service.getDisplayName({ metric: 'adClicks', parameters: {} }, 'blockhead'),
-      'Ad Clicks',
+      service.getDisplayName({ metric: 'usedAmount', parameters: {} }, 'blockhead'),
+      'Used Amount',
       'Service returns the long name for a non parameterized metric'
     );
 
     assert.equal(
-      service.getLongName('revenue', 'blockhead'),
-      'Revenue',
+      service.getLongName('available', 'blockhead'),
+      'How many are available',
       'Service can succesfully retrieve the long name for a valid metric'
     );
 

--- a/packages/reports/addon/components/common-actions/get-api.js
+++ b/packages/reports/addon/components/common-actions/get-api.js
@@ -32,7 +32,7 @@ export default Component.extend({
   requestUrl: computed('request', 'showModal', function() {
     // Observe 'showModal' to recompute each time the modal opens
     let request = get(this, 'request').serialize();
-    return get(this, 'facts').getURL(request);
+    return get(this, 'facts').getURL(request, { dataSourceName: request.dataSource });
   }),
 
   actions: {

--- a/packages/reports/addon/components/common-actions/get-api.js
+++ b/packages/reports/addon/components/common-actions/get-api.js
@@ -32,7 +32,7 @@ export default Component.extend({
   requestUrl: computed('request', 'showModal', function() {
     // Observe 'showModal' to recompute each time the modal opens
     let request = get(this, 'request').serialize();
-    return get(this, 'facts').getURL(request, { dataSourceName: request.dataSource });
+    return this.facts.getURL(request, { dataSourceName: request.dataSource });
   }),
 
   actions: {

--- a/packages/reports/addon/components/dimension-bulk-import.js
+++ b/packages/reports/addon/components/dimension-bulk-import.js
@@ -114,24 +114,32 @@ class DimensionBulkImportComponent extends Component {
     }
 
     const splitValuesPromise = get(this, '_dimensionService')
-      .find(get(this, 'dimension.name'), [
-        {
-          values: get(this, '_trimmedQueryIds'),
-          field: get(this, 'searchableIdField')
-        }
-      ])
+      .find(
+        this.dimension?.name,
+        [
+          {
+            values: get(this, '_trimmedQueryIds'),
+            field: get(this, 'searchableIdField')
+          }
+        ],
+        { dataSourceName: this.dimension?.source }
+      )
       .then(dimValues => {
         set(this, '_validDimValues', dimValues.toArray());
       });
 
     set(this, '_validRawInputDimValue', undefined);
     const rawInputPromise = get(this, '_dimensionService')
-      .find(get(this, 'dimension.name'), [
-        {
-          field: get(this, 'searchableIdField'),
-          values: [this.rawQuery]
-        }
-      ])
+      .find(
+        this.dimension?.name,
+        [
+          {
+            field: get(this, 'searchableIdField'),
+            values: [this.rawQuery]
+          }
+        ],
+        { dataSourceName: this.dimension?.source }
+      )
       .then(dimValue => set(this, '_validRawInputDimValue', dimValue.toArray()));
 
     //set loading promise
@@ -149,7 +157,7 @@ class DimensionBulkImportComponent extends Component {
    */
   @computed('dimension.name')
   get searchableIdField() {
-    const meta = this._bardMetadata.getById('dimension', get(this, 'dimension.name'));
+    const meta = this._bardMetadata.getById('dimension', this.dimension?.name, this.dimension?.source);
     return get(meta, 'idFieldName');
   }
 

--- a/packages/reports/addon/components/report-actions/export.js
+++ b/packages/reports/addon/components/report-actions/export.js
@@ -80,6 +80,6 @@ export default Component.extend({
     }
 
     let request = get(this, 'report.request').serialize();
-    return get(this, 'facts').getURL(request, { format: 'csv', dataSourceName: request.dataSource });
+    return this.facts.getURL(request, { format: 'csv', dataSourceName: request.dataSource });
   })
 });

--- a/packages/reports/addon/components/report-actions/export.js
+++ b/packages/reports/addon/components/report-actions/export.js
@@ -80,6 +80,6 @@ export default Component.extend({
     }
 
     let request = get(this, 'report.request').serialize();
-    return get(this, 'facts').getURL(request, { format: 'csv' });
+    return get(this, 'facts').getURL(request, { format: 'csv', dataSourceName: request.dataSource });
   })
 });

--- a/packages/reports/addon/components/report-actions/multiple-format-export.js
+++ b/packages/reports/addon/components/report-actions/multiple-format-export.js
@@ -48,7 +48,7 @@ export default Component.extend({
    */
   csvHref: computed('report.{request,validations.isTruelyValid}', function() {
     let request = get(this, 'report.request').serialize();
-    return get(this, 'facts').getURL(request, { format: 'csv', dataSourceName: request.dataSource });
+    return this.facts.getURL(request, { format: 'csv', dataSourceName: request.dataSource });
   }),
 
   /**

--- a/packages/reports/addon/components/report-actions/multiple-format-export.js
+++ b/packages/reports/addon/components/report-actions/multiple-format-export.js
@@ -48,7 +48,7 @@ export default Component.extend({
    */
   csvHref: computed('report.{request,validations.isTruelyValid}', function() {
     let request = get(this, 'report.request').serialize();
-    return get(this, 'facts').getURL(request, { format: 'csv' });
+    return get(this, 'facts').getURL(request, { format: 'csv', dataSourceName: request.dataSource });
   }),
 
   /**

--- a/packages/reports/addon/routes/reports/report/view.js
+++ b/packages/reports/addon/routes/reports/report/view.js
@@ -47,7 +47,8 @@ export default Route.extend({
       requestOptions = merge({}, get(this, 'requestOptions'), {
         customHeaders: {
           uiView: `report.spv.${get(report, 'id')}`
-        }
+        },
+        dataSourceName: request.dataSource
       });
 
     // Wrap the response in a promise object so we can manually handle loading spinners

--- a/packages/reports/tests/acceptance/multi-datasource-test.js
+++ b/packages/reports/tests/acceptance/multi-datasource-test.js
@@ -1,0 +1,138 @@
+import { visit, findAll, click, fillIn } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { clickItem, clickItemFilter } from 'navi-reports/test-support/report-builder';
+import { selectChoose } from 'ember-power-select/test-support';
+import { clickTrigger } from 'ember-basic-dropdown/test-support/helpers';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import config from 'ember-get-config';
+
+module('Acceptance | multi-datasource report builder', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  hooks.beforeEach(function() {
+    config.navi.FEATURES.enableVerticalCollectionTableIterator = true;
+  });
+
+  hooks.afterEach(function() {
+    config.navi.FEATURES.enableVerticalCollectionTableIterator = false;
+  });
+
+  test('multi datasource report', async function(assert) {
+    assert.expect(13);
+
+    await visit('/reports/new');
+
+    await selectChoose('.navi-table-select__dropdown', 'Inventory');
+
+    assert.deepEqual(
+      findAll('.grouped-list__group-header-content').map(el => el.textContent.trim()),
+      ['Time Grain (6)', 'Personal (3)', 'World (2)', 'Asset (2)', 'Personal (3)', 'World (2)'],
+      'Metric and dimension categories switched to metrics/dimensions of new datasource'
+    );
+
+    await clickItem('dimension', 'Container');
+    await clickItem('metric', 'Used Amount');
+
+    await clickItemFilter('dimension', 'Container');
+    await selectChoose('.filter-values--dimension-select__trigger', 'Bag');
+
+    await clickItemFilter('metric', 'Used Amount');
+    await fillIn('input.filter-values--value-input', '30');
+    await click('.navi-report__run-btn');
+
+    //Check if filters meta data is displaying properly
+    assert.deepEqual(
+      findAll('.filter-builder__subject, .filter-builder-dimension__subject').map(el => el.textContent.trim()),
+      ['Date Time (Day)', 'Container', 'Used Amount'],
+      'Filter titles rendered correctly'
+    );
+
+    assert.dom('.filter-builder-dimension__values').containsText('Bag');
+    assert.dom('.filter-values--value-input').hasValue('30');
+
+    await click('.report-builder__container-header__filters-toggle');
+    assert
+      .dom('.report-builder__container--filters--collapsed')
+      .containsText('Container equals Bag (1) Used Amount greater than (>) 30');
+
+    //check visualizations are showing up correctly
+    assert.deepEqual(
+      findAll('.table-widget__table-headers .table-header-cell__title ').map(el => el.textContent.trim()),
+      ['Date', 'Container', 'Used Amount'],
+      'Table displays correct header titles'
+    );
+    assert.dom('.table-widget__table .table-row-vc').exists({ count: 1 });
+
+    await click('.visualization-toggle__option[title="Bar Chart"]');
+    assert.dom('.c3-axis-y-label').hasText('Used Amount');
+    assert.dom('.c3-legend-item').containsText('Bag');
+
+    await click('.visualization-toggle__option[title="Pie Chart"]');
+    assert.dom('.pie-metric-label').hasText('Used Amount');
+    assert.dom('.c3-legend-item').containsText('Bag');
+
+    //check api url
+    await click('.get-api button');
+    assert
+      .dom('.get-api-modal-container input')
+      .hasValue(/^https:\/\/data2.naviapp.io\/\S+$/, 'shows api url from blockhead datasource');
+
+    //check CSV export url
+    await clickTrigger('.multiple-format-export');
+    assert
+      .dom(findAll('.multiple-format-export__dropdown a').filter(el => el.textContent.trim() === 'CSV')[0])
+      .hasAttribute('href', /^https:\/\/data2.naviapp.io\/\S+$/, 'uses csv export from right datasource');
+  });
+
+  test('multi datasource saved report', async function(assert) {
+    assert.expect(13);
+
+    await visit('/reports/12/view');
+
+    assert.dom('.navi-table-select-item').hasText('Inventory');
+
+    //Check if filters meta data is displaying properly
+    assert.deepEqual(
+      findAll('.filter-builder__subject, .filter-builder-dimension__subject').map(el => el.textContent.trim()),
+      ['Date Time (Day)', 'Container', 'Used Amount'],
+      'Filter titles rendered correctly'
+    );
+
+    assert.dom('.filter-builder-dimension__values').containsText('Bank');
+    assert.dom('.filter-values--value-input').hasValue('50');
+
+    await click('.report-builder__container-header__filters-toggle');
+    assert
+      .dom('.report-builder__container--filters--collapsed')
+      .containsText('Container equals Bank (2) Used Amount greater than (>) 50');
+
+    //check visualizations are showing up correctly
+    assert.deepEqual(
+      findAll('.table-widget__table-headers .table-header-cell__title ').map(el => el.textContent.trim()),
+      ['Date', 'Container', 'Used Amount'],
+      'Table displays correct header titles'
+    );
+    assert.dom('.table-widget__table .table-row-vc').exists({ count: 3 });
+
+    await click('.visualization-toggle__option[title="Bar Chart"]');
+    assert.dom('.c3-axis-y-label').hasText('Used Amount');
+    assert.dom('.c3-legend-item').containsText('Bank');
+
+    await click('.visualization-toggle__option[title="Line Chart"]');
+    assert.dom('.c3-axis-y-label').hasText('Used Amount');
+    assert.dom('.c3-legend-item').containsText('Bank');
+
+    //check api url
+    await click('.get-api button');
+    assert
+      .dom('.get-api-modal-container input')
+      .hasValue(/^https:\/\/data2.naviapp.io\/\S+$/, 'shows api url from blockhead datasource');
+
+    //check CSV export url
+    await clickTrigger('.multiple-format-export');
+    assert
+      .dom(findAll('.multiple-format-export__dropdown a').filter(el => el.textContent.trim() === 'CSV')[0])
+      .hasAttribute('href', /^https:\/\/data2.naviapp.io\/\S+$/, 'uses csv export from right datasource');
+  });
+});

--- a/packages/reports/tests/acceptance/multi-datasource-test.js
+++ b/packages/reports/tests/acceptance/multi-datasource-test.js
@@ -58,7 +58,7 @@ module('Acceptance | multi-datasource report builder', function(hooks) {
 
     //check visualizations are showing up correctly
     assert.deepEqual(
-      findAll('.table-widget__table-headers .table-header-cell__title ').map(el => el.textContent.trim()),
+      findAll('.table-widget__table-headers .table-header-cell__title').map(el => el.textContent.trim()),
       ['Date', 'Container', 'Used Amount'],
       'Table displays correct header titles'
     );
@@ -109,7 +109,7 @@ module('Acceptance | multi-datasource report builder', function(hooks) {
 
     //check visualizations are showing up correctly
     assert.deepEqual(
-      findAll('.table-widget__table-headers .table-header-cell__title ').map(el => el.textContent.trim()),
+      findAll('.table-widget__table-headers .table-header-cell__title').map(el => el.textContent.trim()),
       ['Date', 'Container', 'Used Amount'],
       'Table displays correct header titles'
     );

--- a/packages/reports/tests/acceptance/multi-datasource-test.js
+++ b/packages/reports/tests/acceptance/multi-datasource-test.js
@@ -1,7 +1,7 @@
 import { visit, findAll, click, fillIn } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import { clickItem, clickItemFilter } from 'navi-reports/test-support/report-builder';
+import { clickItem, clickItemFilter, getAllSelected } from 'navi-reports/test-support/report-builder';
 import { selectChoose } from 'ember-power-select/test-support';
 import { clickTrigger } from 'ember-basic-dropdown/test-support/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -27,7 +27,7 @@ module('Acceptance | multi-datasource report builder', function(hooks) {
 
     assert.deepEqual(
       findAll('.grouped-list__group-header-content').map(el => el.textContent.trim()),
-      ['Time Grain (6)', 'Personal (3)', 'World (2)', 'Asset (2)', 'Personal (3)', 'World (2)'],
+      ['Time Grain (6)', 'Personal (4)', 'World (2)', 'Asset (2)', 'Personal (3)', 'World (3)'],
       'Metric and dimension categories switched to metrics/dimensions of new datasource'
     );
 
@@ -48,13 +48,15 @@ module('Acceptance | multi-datasource report builder', function(hooks) {
       'Filter titles rendered correctly'
     );
 
-    assert.dom('.filter-builder-dimension__values').containsText('Bag');
-    assert.dom('.filter-values--value-input').hasValue('30');
+    assert
+      .dom('.filter-builder-dimension__values')
+      .containsText('Bag', 'Dimension filter input contains the right value');
+    assert.dom('.filter-values--value-input').hasValue('30', 'Having input has the right value');
 
     await click('.report-builder__container-header__filters-toggle');
     assert
       .dom('.report-builder__container--filters--collapsed')
-      .containsText('Container equals Bag (1) Used Amount greater than (>) 30');
+      .containsText('Container equals Bag (1) Used Amount greater than (>) 30', 'Collapsed filter contains right text');
 
     //check visualizations are showing up correctly
     assert.deepEqual(
@@ -62,15 +64,15 @@ module('Acceptance | multi-datasource report builder', function(hooks) {
       ['Date', 'Container', 'Used Amount'],
       'Table displays correct header titles'
     );
-    assert.dom('.table-widget__table .table-row-vc').exists({ count: 1 });
+    assert.dom('.table-widget__table .table-row-vc').exists({ count: 1 }, 'Table has rows');
 
     await click('.visualization-toggle__option[title="Bar Chart"]');
-    assert.dom('.c3-axis-y-label').hasText('Used Amount');
-    assert.dom('.c3-legend-item').containsText('Bag');
+    assert.dom('.c3-axis-y-label').hasText('Used Amount', 'Bar Chart y axis label is correct');
+    assert.dom('.c3-legend-item').containsText('Bag', 'Bar chart legend has the right value');
 
     await click('.visualization-toggle__option[title="Pie Chart"]');
-    assert.dom('.pie-metric-label').hasText('Used Amount');
-    assert.dom('.c3-legend-item').containsText('Bag');
+    assert.dom('.pie-metric-label').hasText('Used Amount', 'Pie chart has the right label');
+    assert.dom('.c3-legend-item').containsText('Bag', 'Pie chart legend has the right value');
 
     //check api url
     await click('.get-api button');
@@ -86,11 +88,11 @@ module('Acceptance | multi-datasource report builder', function(hooks) {
   });
 
   test('multi datasource saved report', async function(assert) {
-    assert.expect(13);
+    assert.expect(18);
 
     await visit('/reports/12/view');
 
-    assert.dom('.navi-table-select-item').hasText('Inventory');
+    assert.dom('.navi-table-select-item').hasText('Inventory', 'Table selector shows correct table');
 
     //Check if filters meta data is displaying properly
     assert.deepEqual(
@@ -99,29 +101,32 @@ module('Acceptance | multi-datasource report builder', function(hooks) {
       'Filter titles rendered correctly'
     );
 
-    assert.dom('.filter-builder-dimension__values').containsText('Bank');
-    assert.dom('.filter-values--value-input').hasValue('50');
+    assert.dom('.filter-builder-dimension__values').containsText('Bank', 'Dimension filter input has the right value');
+    assert.dom('.filter-values--value-input').hasValue('50', 'Having input has the right value');
 
     await click('.report-builder__container-header__filters-toggle');
     assert
       .dom('.report-builder__container--filters--collapsed')
-      .containsText('Container equals Bank (2) Used Amount greater than (>) 50');
+      .containsText(
+        'Container equals Bank (2) Used Amount greater than (>) 50',
+        'Collapsed filter has the right values'
+      );
 
     //check visualizations are showing up correctly
     assert.deepEqual(
       findAll('.table-widget__table-headers .table-header-cell__title').map(el => el.textContent.trim()),
-      ['Date', 'Container', 'Used Amount'],
+      ['Date', 'Container', 'Display Currency', 'Used Amount', 'Revenue (GIL)'],
       'Table displays correct header titles'
     );
-    assert.dom('.table-widget__table .table-row-vc').exists({ count: 3 });
+    assert.dom('.table-widget__table .table-row-vc').exists('Table rows exist');
 
     await click('.visualization-toggle__option[title="Bar Chart"]');
-    assert.dom('.c3-axis-y-label').hasText('Used Amount');
-    assert.dom('.c3-legend-item').containsText('Bank');
+    assert.dom('.c3-axis-y-label').hasText('Used Amount', 'Bar chart has right Y axis label');
+    assert.dom('.c3-legend-item').containsText('Bank', 'Bar chart legend has right value');
 
     await click('.visualization-toggle__option[title="Line Chart"]');
-    assert.dom('.c3-axis-y-label').hasText('Used Amount');
-    assert.dom('.c3-legend-item').containsText('Bank');
+    assert.dom('.c3-axis-y-label').hasText('Used Amount', 'Line chart has right Y Axis label');
+    assert.dom('.c3-legend-item').containsText('Bank', 'Line chart has right legend value');
 
     //check api url
     await click('.get-api button');
@@ -134,5 +139,24 @@ module('Acceptance | multi-datasource report builder', function(hooks) {
     assert
       .dom(findAll('.multiple-format-export__dropdown a').filter(el => el.textContent.trim() === 'CSV')[0])
       .hasAttribute('href', /^https:\/\/data2.naviapp.io\/\S+$/, 'uses csv export from right datasource');
+
+    await click('.navi-modal__close');
+
+    //switch tables from a different datasource
+    await selectChoose('.navi-table-select__dropdown', 'Network');
+
+    //assert filters, metrics and dimensions are reset
+    assert
+      .dom('.report-builder__container--filters--collapsed')
+      .hasText(/[A-Za-z]{3} \d{1,2}, \d{4} - [A-Za-z]{3} \d{1,2}, \d{4}/m, 'Collapsed filter has the right values');
+    assert
+      .dom('.report-builder__container--filters--collapsed')
+      .doesNotIncludeText('Container', 'Filters do not include dimension filters from external table');
+    assert
+      .dom('.report-builder__container--filters--collapsed')
+      .doesNotIncludeText('Used Amount', 'Havings do not include metric havings from external table');
+
+    assert.deepEqual(await getAllSelected('dimension'), ['Day'], 'Only timegrain is selected once table is changed');
+    assert.deepEqual(await getAllSelected('metric'), [], 'No metrics are selected once table is changed');
   });
 });

--- a/packages/reports/tests/acceptance/report-test.js
+++ b/packages/reports/tests/acceptance/report-test.js
@@ -122,7 +122,7 @@ module('Acceptance | Navi Report', function(hooks) {
   });
 
   test('New report - copy api', async function(assert) {
-    assert.expect(2);
+    assert.expect(3);
 
     await visit('/reports/new');
     await clickItem('metric', 'Ad Clicks');
@@ -139,6 +139,10 @@ module('Acceptance | Navi Report', function(hooks) {
       find('.navi-modal__input').value.includes('metrics=adClicks%2CaddPageViews'),
       'API query updates with request'
     );
+
+    assert
+      .dom('.get-api-modal-container input')
+      .hasValue(/^https:\/\/data.naviapp.io\/\S+$/, 'shows api url from right datasource');
   });
 
   test('Revert changes when exiting report - existing report', async function(assert) {
@@ -534,7 +538,7 @@ module('Acceptance | Navi Report', function(hooks) {
   });
 
   test('Multi export action - csv href', async function(assert) {
-    assert.expect(4);
+    assert.expect(5);
 
     await visit('/reports/1/view');
     await clickTrigger('.multiple-format-export');
@@ -578,6 +582,10 @@ module('Acceptance | Navi Report', function(hooks) {
       ),
       'Filter updates are automatically included in export url'
     );
+
+    assert
+      .dom(findAll('.multiple-format-export__dropdown a').filter(el => el.textContent.trim() === 'CSV')[0])
+      .hasAttribute('href', /^https:\/\/data.naviapp.io\/\S+$/, 'uses csv export from right datasource');
   });
 
   test('Multi export action - pdf href', async function(assert) {

--- a/packages/reports/tests/dummy/app/routes/application.js
+++ b/packages/reports/tests/dummy/app/routes/application.js
@@ -1,7 +1,5 @@
 import Route from '@ember/routing/route';
 import { inject } from '@ember/service';
-import { get } from '@ember/object';
-import { hash } from 'rsvp';
 
 export default Route.extend({
   user: inject(),
@@ -16,13 +14,11 @@ export default Route.extend({
    * @override
    * @returns {Ember.RSVP.Promise}
    */
-  model() {
-    return hash({
-      user: get(this, 'user').findOrRegister(),
-      metadata: Promise.all([
-        get(this, 'bardMetadata').loadMetadata(),
-        get(this, 'bardMetadata').loadMetadata({ dataSourceName: 'blockhead' })
-      ])
-    }).then(() => undefined);
+  async model() {
+    await this.user.findOrRegister();
+    await Promise.all([
+      this.bardMetadata.loadMetadata(),
+      this.bardMetadata.loadMetadata({ dataSourceName: 'blockhead' })
+    ]);
   }
 });

--- a/packages/reports/tests/dummy/app/routes/application.js
+++ b/packages/reports/tests/dummy/app/routes/application.js
@@ -19,7 +19,10 @@ export default Route.extend({
   model() {
     return hash({
       user: get(this, 'user').findOrRegister(),
-      metadata: get(this, 'bardMetadata').loadMetadata()
+      metadata: Promise.all([
+        get(this, 'bardMetadata').loadMetadata(),
+        get(this, 'bardMetadata').loadMetadata({ dataSourceName: 'blockhead' })
+      ])
     }).then(() => undefined);
   }
 });

--- a/packages/reports/tests/dummy/config/environment.js
+++ b/packages/reports/tests/dummy/config/environment.js
@@ -33,7 +33,11 @@ module.exports = function(environment) {
     navi: {
       user: 'navi_user',
       defaultTimeGrain: 'day',
-      dataSources: [{ name: 'dummy', uri: 'https://data.naviapp.io', type: 'bard-facts' }],
+      defaultDataTable: 'network',
+      dataSources: [
+        { name: 'dummy', uri: 'https://data.naviapp.io', type: 'bard-facts' },
+        { name: 'blockhead', uri: 'https://data2.naviapp.io', type: 'bard-facts' }
+      ],
       appPersistence: {
         type: 'webservice',
         uri: 'https://persistence.naviapp.io',

--- a/packages/reports/tests/dummy/mirage/config.js
+++ b/packages/reports/tests/dummy/mirage/config.js
@@ -15,6 +15,10 @@ export default function() {
   BardLite.call(this);
   BardMeta.call(this);
 
+  this.urlPrefix = `${config.navi.dataSources[1].uri}/v1`;
+  BardLite.call(this);
+  BardMeta.call(this);
+
   // Mock persistence
   this.urlPrefix = config.navi.appPersistence.uri;
   UserWS.call(this);

--- a/packages/reports/tests/integration/components/filter-values/dimension-select-test.js
+++ b/packages/reports/tests/integration/components/filter-values/dimension-select-test.js
@@ -5,6 +5,7 @@ import hbs from 'htmlbars-inline-precompile';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { clickTrigger, nativeMouseUp } from 'ember-power-select/test-support/helpers';
 import AgeValues from 'navi-data/mirage/bard-lite/dimensions/age';
+import ContainerValues from 'navi-data/mirage/bard-lite/dimensions/container';
 import config from 'ember-get-config';
 import $ from 'jquery';
 import { set } from '@ember/object';
@@ -76,7 +77,7 @@ module('Integration | Component | filter values/dimension select', function(hook
 
     const datasourceFilter = {
       subject: {
-        name: 'age',
+        name: 'container',
         storageStrategy: 'loaded',
         primaryKeyFieldName: 'id',
         source: 'blockhead'
@@ -95,16 +96,16 @@ module('Integration | Component | filter values/dimension select', function(hook
     let selectedValueText = findAll('.ember-power-select-multiple-option span:nth-of-type(2)').map(el =>
         el.textContent.trim()
       ),
-      expectedValueDimensions = AgeValues.filter(age => MockFilter.values.includes(age.id));
+      expectedValueDimensions = ContainerValues.filter(container => MockFilter.values.includes(container.id));
 
     assert.deepEqual(
       selectedValueText,
-      expectedValueDimensions.map(age => `${age.description} (${age.id})`),
+      expectedValueDimensions.map(container => `${container.description} (${container.id})`),
       'Filter value ids are converted into full dimension objects and displayed as selected'
     );
 
     let optionText = findAll('.ember-power-select-option').map(el => el.textContent.trim()),
-      expectedOptionText = AgeValues.map(age => `${age.description} (${age.id})`);
+      expectedOptionText = ContainerValues.map(container => `${container.description} (${container.id})`);
 
     /*
      * Since ember-collection is used for rendering the dropdown options,
@@ -121,7 +122,7 @@ module('Integration | Component | filter values/dimension select', function(hook
 
     this.set('isCollapsed', true);
 
-    assert.dom().hasText('under 13 (1) 13-17 (2) 18-20 (3)', 'Selected values are rendered correctly when collapsed');
+    assert.dom().hasText('Bag (1) Bank (2) Saddle Bag (3)', 'Selected values are rendered correctly when collapsed');
   });
 
   test('no values', async function(assert) {

--- a/packages/reports/tests/integration/serializers/bard-request/request-test.js
+++ b/packages/reports/tests/integration/serializers/bard-request/request-test.js
@@ -70,6 +70,11 @@ module('Integration | Serializer | Request Fragment', function(hooks) {
   test('Removes aliases during normalization', function(assert) {
     assert.expect(3);
     let payload = {
+      logicalTable: {
+        table: 'foo'
+      },
+      dimensions: [],
+      filters: [],
       metrics: [
         {
           metric: 'navClicks'

--- a/packages/reports/tests/unit/routes/reports/report/view-test.js
+++ b/packages/reports/tests/unit/routes/reports/report/view-test.js
@@ -50,7 +50,8 @@ module('Unit | Route | reports/report/view', function(hooks) {
               clientId: 'customReports',
               customHeaders: {
                 uiView: 'report.spv.1'
-              }
+              },
+              dataSourceName: undefined
             },
             'Options from route are passed to fact service'
           );


### PR DESCRIPTION
Resolves #665 

<!-- The above line will close the issue upon merge -->

## Description

Updating report addon to support multi-datasource

## Proposed Changes

- Update serializer so normalizing adds namespace for the transforms.
- Update base-transform to support namespaces.
- Update report builder model fetch to pass down the datasource.
- Add datasource to csv downloads and get-api
- Support for cloning, save-as and bulk dimension value import
- Add new mirage models for testing, as well as test support to mock multiple datasources that's quite a bit different config wise than default datasource.

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
