### PR TITLE
Update: Specify search field for table selector

### DIFF
--- a/packages/reports/addon/components/navi-table-select.js
+++ b/packages/reports/addon/components/navi-table-select.js
@@ -18,7 +18,7 @@ import layout from '../templates/components/navi-table-select';
 
 @templateLayout(layout)
 @tagName('')
-export default class NaviTableSelectComponent extends Component {
+class NaviTableSelectComponent extends Component {
   /**
    * @property {Boolean} searchEnabled
    */
@@ -29,3 +29,5 @@ export default class NaviTableSelectComponent extends Component {
    */
   searchField = 'longName';
 }
+
+export default NaviTableSelectComponent;

--- a/packages/reports/addon/components/navi-table-select.js
+++ b/packages/reports/addon/components/navi-table-select.js
@@ -7,6 +7,7 @@
  *          selected=selected
  *          onChange=onChange
  *          searchEnabled=searchEnabled
+ *          searchField=searchField
  *          tagName=tagName
  *        }}
  */
@@ -22,5 +23,10 @@ export default Component.extend({
   /**
    * @property {Boolean} searchEnabled
    */
-  searchEnabled: false
+  searchEnabled: false,
+
+  /**
+   * @property {String} searchField
+   */
+  searchField: 'longName'
 });

--- a/packages/reports/addon/components/navi-table-select.js
+++ b/packages/reports/addon/components/navi-table-select.js
@@ -1,15 +1,15 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
- * Usage: {{navi-table-select
- *          options=options
- *          selected=selected
- *          onChange=onChange
- *          searchEnabled=searchEnabled
- *          searchField=searchField
- *          tagName=tagName
- *        }}
+ * Usage: <NaviTableSelect
+ *          @options={{options}}
+ *          @selected={{selected}}
+ *          @onChange={{onChange}}
+ *          @searchEnabled={{searchEnabled}}
+ *          @searchField={{searchField}}
+ *          @tagName={{tagName}}
+ *        />
  */
 
 import Component from '@ember/component';

--- a/packages/reports/addon/components/navi-table-select.js
+++ b/packages/reports/addon/components/navi-table-select.js
@@ -15,18 +15,21 @@
 import Component from '@ember/component';
 import layout from '../templates/components/navi-table-select';
 
-export default Component.extend({
-  layout,
+export default class NaviTableSelect extends Component {
+  layout = layout;
 
-  classNames: ['navi-table-select'],
+  /**
+   * @property {Array} classNames
+   */
+  classNames = ['navi-table-select'];
 
   /**
    * @property {Boolean} searchEnabled
    */
-  searchEnabled: false,
+  searchEnabled = false;
 
   /**
    * @property {String} searchField
    */
-  searchField: 'longName'
-});
+  searchField = 'longName';
+}

--- a/packages/reports/addon/components/navi-table-select.js
+++ b/packages/reports/addon/components/navi-table-select.js
@@ -12,12 +12,11 @@
  */
 
 import Component from '@ember/component';
-import { layout as templateLayout, tagName } from '@ember-decorators/component';
 import layout from '../templates/components/navi-table-select';
 
-@templateLayout(layout)
-@tagName('')
 class NaviTableSelectComponent extends Component {
+  layout = layout;
+
   /**
    * @property {Boolean} searchEnabled
    */

--- a/packages/reports/addon/components/navi-table-select.js
+++ b/packages/reports/addon/components/navi-table-select.js
@@ -8,7 +8,6 @@
  *          @onChange={{onChange}}
  *          @searchEnabled={{searchEnabled}}
  *          @searchField={{searchField}}
- *          @tagName={{tagName}}
  *        />
  */
 

--- a/packages/reports/addon/components/navi-table-select.js
+++ b/packages/reports/addon/components/navi-table-select.js
@@ -13,16 +13,12 @@
  */
 
 import Component from '@ember/component';
+import { layout as templateLayout, tagName } from '@ember-decorators/component';
 import layout from '../templates/components/navi-table-select';
 
-export default class NaviTableSelect extends Component {
-  layout = layout;
-
-  /**
-   * @property {Array} classNames
-   */
-  classNames = ['navi-table-select'];
-
+@templateLayout(layout)
+@tagName('')
+export default class NaviTableSelectComponent extends Component {
   /**
    * @property {Boolean} searchEnabled
    */

--- a/packages/reports/addon/templates/components/navi-table-select.hbs
+++ b/packages/reports/addon/templates/components/navi-table-select.hbs
@@ -1,15 +1,17 @@
 {{!-- Copyright 2019, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
-<PowerSelect
-  @classNames="navi-table-select__dropdown"
-  @dropdownClass="navi-table-select__dropdown-list"
-  @options={{@options}}
-  @selected={{@selected}}
-  @searchEnabled={{this.searchEnabled}}
-  @searchField={{this.searchField}}
-  @tagName={{@tagName}}
-  @onchange={{@onChange}}
-  @selectedItemComponent="navi-table-select-trigger"
-  as | item |
->
-  <NaviTableSelectItem @option={{item}} />
-</PowerSelect>
+<div class="navi-table-select" ...attributes>
+  <PowerSelect
+    @classNames="navi-table-select__dropdown"
+    @dropdownClass="navi-table-select__dropdown-list"
+    @options={{@options}}
+    @selected={{@selected}}
+    @searchEnabled={{this.searchEnabled}}
+    @searchField={{this.searchField}}
+    @tagName={{@tagName}}
+    @onchange={{@onChange}}
+    @selectedItemComponent="navi-table-select-trigger"
+    as | item |
+  >
+    <NaviTableSelectItem @option={{item}} />
+  </PowerSelect>
+</div>

--- a/packages/reports/addon/templates/components/navi-table-select.hbs
+++ b/packages/reports/addon/templates/components/navi-table-select.hbs
@@ -4,8 +4,8 @@
   @dropdownClass="navi-table-select__dropdown-list"
   @options={{@options}}
   @selected={{@selected}}
-  @searchEnabled={{searchEnabled}}
-  @searchField={{searchField}}
+  @searchEnabled={{this.searchEnabled}}
+  @searchField={{this.searchField}}
   @tagName={{@tagName}}
   @onchange={{@onChange}}
   @selectedItemComponent="navi-table-select-trigger"

--- a/packages/reports/addon/templates/components/navi-table-select.hbs
+++ b/packages/reports/addon/templates/components/navi-table-select.hbs
@@ -5,6 +5,7 @@
   @options={{@options}}
   @selected={{@selected}}
   @searchEnabled={{searchEnabled}}
+  @searchField={{searchField}}
   @tagName={{@tagName}}
   @onchange={{@onChange}}
   @selectedItemComponent="navi-table-select-trigger"

--- a/packages/reports/tests/integration/components/navi-table-select-test.js
+++ b/packages/reports/tests/integration/components/navi-table-select-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, findAll } from '@ember/test-helpers';
+import { render, findAll, fillIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import $ from 'jquery';
 import { clickTrigger, nativeMouseUp } from '../../helpers/ember-power-select';
@@ -58,15 +58,45 @@ module('Integration | Component | navi table select', function(hooks) {
     assert.expect(2);
 
     this.set('searchEnabled', true);
-    await render(hbs`{{navi-table-select
-          selected=selected
-          options=options
-          onChange=onChange
-          searchEnabled=searchEnabled
-      }}`);
+    this.set('searchField', 'longName');
+    await render(hbs`<NaviTableSelect
+          @selected={{selected}}
+          @options={{options}}
+          @onChange={{onChange}}
+          @searchEnabled={{searchEnabled}}
+          @searchField={{searchField}}
+      />`);
 
     assert.dom('.ember-power-select-search').isNotVisible('search input should not be visible');
     await clickTrigger();
     assert.dom('.ember-power-select-search').isVisible('search input should be visible');
+  });
+
+  test('search longName', async function(assert) {
+    assert.expect(2);
+
+    this.set('searchEnabled', true);
+    this.set('searchField', 'longName');
+    await render(hbs`<NaviTableSelect
+          @selected={{selected}}
+          @options={{options}}
+          @onChange={{onChange}}
+          @searchEnabled={{searchEnabled}}
+          @searchField={{searchField}}
+      />`);
+
+    await clickTrigger();
+    assert.deepEqual(
+      findAll('.ember-power-select-option').map(el => el.textContent.trim()),
+      ['network', 'network2'],
+      'All options are shown'
+    );
+
+    await fillIn('.ember-power-select-search-input', '2');
+    assert.deepEqual(
+      findAll('.ember-power-select-option').map(el => el.textContent.trim()),
+      ['network2'],
+      'Filtered options are shown'
+    );
   });
 });

--- a/packages/reports/tests/integration/components/navi-table-select-test.js
+++ b/packages/reports/tests/integration/components/navi-table-select-test.js
@@ -99,4 +99,60 @@ module('Integration | Component | navi table select', function(hooks) {
       'Filtered options are shown'
     );
   });
+
+  test('search empty longName', async function(assert) {
+    assert.expect(2);
+
+    this.set('searchEnabled', true);
+    this.set('searchField', 'longName');
+    await render(hbs`<NaviTableSelect
+          @selected={{selected}}
+          @options={{options}}
+          @onChange={{onChange}}
+          @searchEnabled={{searchEnabled}}
+          @searchField={{searchField}}
+      />`);
+
+    await clickTrigger();
+    assert.deepEqual(
+      findAll('.ember-power-select-option').map(el => el.textContent.trim()),
+      ['network', 'network2'],
+      'All options are shown'
+    );
+
+    await fillIn('.ember-power-select-search-input', '');
+    assert.deepEqual(
+      findAll('.ember-power-select-option').map(el => el.textContent.trim()),
+      ['network', 'network2'],
+      'All options are shown again'
+    );
+  });
+
+  test('search longName no match', async function(assert) {
+    assert.expect(2);
+
+    this.set('searchEnabled', true);
+    this.set('searchField', 'longName');
+    await render(hbs`<NaviTableSelect
+          @selected={{selected}}
+          @options={{options}}
+          @onChange={{onChange}}
+          @searchEnabled={{searchEnabled}}
+          @searchField={{searchField}}
+      />`);
+
+    await clickTrigger();
+    assert.deepEqual(
+      findAll('.ember-power-select-option').map(el => el.textContent.trim()),
+      ['network', 'network2'],
+      'All options are shown'
+    );
+
+    await fillIn('.ember-power-select-search-input', 'hello');
+    assert.deepEqual(
+      findAll('.ember-power-select-option').map(el => el.textContent.trim()),
+      ['No results found'],
+      'No options are shown'
+    );
+  });
 });


### PR DESCRIPTION
Resolves #

<!-- The above line will close the issue upon merge -->

## Description
Add the searchField property to the navi-table-select so that you can specify which field you want to use for search when search is enabled.

## Proposed Changes

- Add searchField property.

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
