### PR TITLE
Update: Use denali link and hover colors

### DIFF
--- a/packages/app/app/styles/components/nav-bar.less
+++ b/packages/app/app/styles/components/nav-bar.less
@@ -25,7 +25,7 @@
     text-align: center;
 
     &:hover {
-      background: @denali-link;
+      background: @denali-link-hover;
       color: @navi-white;
     }
   }

--- a/packages/app/app/styles/components/nav-bar.less
+++ b/packages/app/app/styles/components/nav-bar.less
@@ -17,15 +17,15 @@
 
   &__nav-item-link {
     align-items: center;
-    border: 1px solid @link-blue;
+    border: 1px solid @denali-link;
     border-radius: 5px;
-    color: @link-blue;
+    color: @denali-link;
     display: flex;
     padding: 5px 10px;
     text-align: center;
 
     &:hover {
-      background: @link-blue;
+      background: @denali-link;
       color: @navi-white;
     }
   }

--- a/packages/app/app/styles/views/landing.less
+++ b/packages/app/app/styles/views/landing.less
@@ -26,11 +26,11 @@
     border: 1px solid;
     padding: 5px 10px;
     border-radius: 4px;
-    color: @link-blue;
+    color: @denali-link;
   }
 
   &__get-started-link:hover {
     color: @navi-white;
-    background-color: @link-blue;
+    background-color: @denali-link;
   }
 }

--- a/packages/app/app/styles/views/landing.less
+++ b/packages/app/app/styles/views/landing.less
@@ -31,6 +31,6 @@
 
   &__get-started-link:hover {
     color: @navi-white;
-    background-color: @denali-link;
+    background-color: @denali-link-hover;
   }
 }

--- a/packages/core/app/styles/navi-core/utils/mixins.less
+++ b/packages/core/app/styles/navi-core/utils/mixins.less
@@ -39,7 +39,7 @@
 }
 
 .navi-link {
-  color: @link-blue;
+  color: @denali-link;
 }
 
 .navi-page-title {

--- a/packages/core/app/styles/navi-core/variables/colors.less
+++ b/packages/core/app/styles/navi-core/variables/colors.less
@@ -97,7 +97,9 @@
 @navi-disabled-element-background-color: @navi-gray-200;
 
 // TODO update names and move to theme.less
-@link-blue: @navi-blue;
+@denali-link: @denali-brand-600;
+@denali-link-hover: @denali-brand-700;
+
 @button-blue: @navi-blue;
 @body-font-gray: @gray-9;
 @favorite-gold: @navi-gold;

--- a/packages/core/app/styles/navi-core/variables/colors.less
+++ b/packages/core/app/styles/navi-core/variables/colors.less
@@ -96,7 +96,6 @@
 
 @navi-disabled-element-background-color: @navi-gray-200;
 
-// TODO update names and move to theme.less
 @denali-link: @denali-brand-600;
 @denali-link-hover: @denali-brand-700;
 

--- a/packages/dashboards/app/styles/navi-dashboards/common.less
+++ b/packages/dashboards/app/styles/navi-dashboards/common.less
@@ -18,7 +18,7 @@
 
   &__add-widget-text {
     .clickable;
-    color: @link-blue;
+    color: @denali-link;
     display: inline-block;
   }
 

--- a/packages/dashboards/app/styles/navi-dashboards/components/add-to-dashboard-modal.less
+++ b/packages/dashboards/app/styles/navi-dashboards/components/add-to-dashboard-modal.less
@@ -24,7 +24,7 @@
 
   button.dashboard-action-text {
     .clickable;
-    color: @link-blue;
+    color: @denali-link;
     display: block;
     font-size: @font-size-base;
     position: absolute;

--- a/packages/directory/app/styles/navi-directory/components/dir-empty.less
+++ b/packages/directory/app/styles/navi-directory/components/dir-empty.less
@@ -5,7 +5,7 @@
       color: @denali-link;
     }
     &:hover {
-      color: darken(@denali-link, 10%);
+      color: @denali-link-hover;
     }
   }
 }

--- a/packages/directory/app/styles/navi-directory/components/dir-empty.less
+++ b/packages/directory/app/styles/navi-directory/components/dir-empty.less
@@ -2,10 +2,10 @@
   a {
     &:visited,
     &:link {
-      color: @link-blue;
+      color: @denali-link;
     }
     &:hover {
-      color: darken(@link-blue, 10%);
+      color: darken(@denali-link, 10%);
     }
   }
 }

--- a/packages/reports/app/styles/navi-reports/common/breadcrumb.less
+++ b/packages/reports/app/styles/navi-reports/common/breadcrumb.less
@@ -6,7 +6,7 @@
 .breadcrumb-title {
   font-size: @font-size-base;
   a {
-    color: @link-blue;
+    color: @denali-link;
     text-decoration: none;
   }
   i.icon {

--- a/packages/reports/app/styles/navi-reports/common/report-not-found.less
+++ b/packages/reports/app/styles/navi-reports/common/report-not-found.less
@@ -17,7 +17,7 @@
     margin-top: 30px;
 
     a {
-      color: @link-blue;
+      color: @denali-link;
     }
   }
 }

--- a/packages/reports/app/styles/navi-reports/components/grouped-list.less
+++ b/packages/reports/app/styles/navi-reports/components/grouped-list.less
@@ -47,7 +47,7 @@
       &:hover {
         .grouped-list__add-icon {
           color: @denali-link-hover;
-          opacity: 1;
+          opacity: unset;
         }
       }
     }
@@ -150,9 +150,13 @@
     margin: 0 5px;
     opacity: 0.5;
 
-    &:hover,
+    &:hover {
+      color: @denali-link-hover;
+      opacity: unset;
+    }
+
     &--active {
-      opacity: 1;
+      opacity: unset;
     }
   }
 }

--- a/packages/reports/app/styles/navi-reports/components/grouped-list.less
+++ b/packages/reports/app/styles/navi-reports/components/grouped-list.less
@@ -43,6 +43,15 @@
       }
     }
 
+    &-label {
+      &:hover {
+        .grouped-list__add-icon {
+          color: @denali-link-hover;
+          opacity: 1;
+        }
+      }
+    }
+
     &-checkbox {
       opacity: 0; // Hide it
       position: absolute; // Take it out of the document flow
@@ -66,7 +75,7 @@
     }
 
     &-checkbox:hover + &-label:before {
-      box-shadow: 0 0 0 2px @denali-brand-600;
+      box-shadow: 0 0 0 2px @denali-link;
     }
 
     &-checkbox:focus + &-label:before {
@@ -74,8 +83,8 @@
     }
 
     &-checkbox:checked + &-label:before {
-      box-shadow: 0 0 0 2px @denali-brand-600;
-      background: @denali-brand-600;
+      box-shadow: 0 0 0 2px @denali-link;
+      background: @denali-link;
     }
 
     &-checkbox:checked + &-label:after {
@@ -111,7 +120,7 @@
   }
 
   &__add-icon {
-    color: @denali-brand-600;
+    color: @denali-link;
     cursor: pointer;
     display: inline-block;
     font-size: @font-size-base;
@@ -136,7 +145,7 @@
   }
 
   &__filter {
-    color: @denali-brand-600;
+    color: @denali-link;
     cursor: pointer;
     margin: 0 5px;
     opacity: 0.5;

--- a/packages/reports/app/styles/navi-reports/components/navi-column-config.less
+++ b/packages/reports/app/styles/navi-reports/components/navi-column-config.less
@@ -6,11 +6,10 @@
 .navi-column-config-icon {
   color: @denali-brand-600;
   cursor: pointer;
-  opacity: 0.5;
 
   &--active,
   &:hover {
-    opacity: 1;
+    color: @denali-link-hover;
   }
 }
 

--- a/packages/reports/app/styles/navi-reports/components/navi-column-config.less
+++ b/packages/reports/app/styles/navi-reports/components/navi-column-config.less
@@ -4,7 +4,7 @@
 */
 
 .navi-column-config-icon {
-  color: @denali-brand-600;
+  color: @denali-link;
   cursor: pointer;
 
   &--active,

--- a/packages/reports/app/styles/navi-reports/components/navi-column-config/item.less
+++ b/packages/reports/app/styles/navi-reports/components/navi-column-config/item.less
@@ -23,6 +23,11 @@
     text-align: left;
     text-overflow: ellipsis;
     white-space: nowrap;
+    &:hover {
+      .navi-column-config-item__dropdown-icon {
+        color: @denali-link-hover;
+      }
+    }
   }
 
   &__name {

--- a/packages/reports/app/styles/navi-reports/components/report-view.less
+++ b/packages/reports/app/styles/navi-reports/components/report-view.less
@@ -133,9 +133,12 @@
 
   &__columns-icon {
     font-size: @font-size-base;
-    color: @navi-blue-300;
+    color: @denali-link;
     left: -1px;
     position: relative;
+    &:hover {
+      color: @denali-link-hover;
+    }
   }
 
   &__columns-toggle {

--- a/packages/reports/app/styles/navi-reports/components/visualization-toggle.less
+++ b/packages/reports/app/styles/navi-reports/components/visualization-toggle.less
@@ -15,17 +15,23 @@
   &__option {
     border: 2px solid transparent;
     border-radius: 4px;
-    color: @navi-blue-300;
+    color: @denali-link;
     cursor: pointer;
     font-size: 16px;
     padding: 2px 12px;
-    transition: 0.5s ease;
+    transition: border 0.5s ease;
+    &:hover {
+      color: @denali-link-hover;
+    }
 
     &--is-active {
       background: @navi-white;
-      border-color: @navi-blue-300;
+      border-color: @denali-link;
       color: @navi-black;
       cursor: default;
+      &:hover {
+        color: unset;
+      }
     }
   }
 }


### PR DESCRIPTION
## Description

Use denali link and hover colors

## Proposed Changes

Use denali link and hover colors based the repo's current css variables:

```css
  --links-text-color: var(--color-brand-600);
  --links-hover-text-color: var(--color-brand-700);
```
https://github.com/denali-design/denali-site/blob/96fee64f00208c3993fb9a5c240b42c4ae2c86d5/assets/denali.css#L177-L178

## Screenshots

<img width="306" alt="Screen Shot 2020-03-16 at 4 04 40 PM" src="https://user-images.githubusercontent.com/2983409/76805121-0094a980-67ac-11ea-8b03-57d7e9f2d2c1.png">


## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
