### PR TITLE
New: Use number directly as timeout for notifications

### DIFF
--- a/packages/notifications/addon/services/navi-notifications.js
+++ b/packages/notifications/addon/services/navi-notifications.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Notification service
@@ -24,7 +24,7 @@ export default class NaviNotifications extends NaviNotificationInterface {
    * @param {Object} options
    * @param {String} options.message - Required. The message that the flash message displays.
    * @param {String} [options.type] - The flash message's type is set as a class name on the rendered component.
-   * @param {String} [options.timeout] - Key into navi.notifications config
+   * @param {String|Number} [options.timeout] - Key into navi.notifications config
    * @param {Boolean} [options.sticky] - By default, flash messages disappear after a certain amount of time.
    *                                   To disable this and make flash messages permanent (they can still
    *                                   be dismissed by click), set sticky to true.
@@ -34,10 +34,10 @@ export default class NaviNotifications extends NaviNotificationInterface {
     const { notificationService } = this;
     if (notificationService.queue.find(q => q.message === options.message)) {
       return notificationService;
-    } else {
-      options.timeout = TIMEOUTS[options.timeout];
-      return notificationService.add(options);
     }
+
+    options.timeout = Number(TIMEOUTS[options.timeout]) || Number(options.timeout);
+    return notificationService.add(options);
   }
 
   /**

--- a/packages/notifications/addon/services/navi-notifications.js
+++ b/packages/notifications/addon/services/navi-notifications.js
@@ -36,7 +36,7 @@ export default class NaviNotifications extends NaviNotificationInterface {
       return notificationService;
     }
 
-    options.timeout = Number(TIMEOUTS[options.timeout]) || Number(options.timeout);
+    options.timeout = Number(TIMEOUTS[options.timeout] || options.timeout);
     return notificationService.add(options);
   }
 

--- a/packages/notifications/tests/unit/navi-notifications-test.js
+++ b/packages/notifications/tests/unit/navi-notifications-test.js
@@ -1,14 +1,12 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-let Container, ServiceFactory;
-
 module('Unit | Service | navi-notifications', function(hooks) {
   setupTest(hooks);
+  let ServiceFactory;
 
   hooks.beforeEach(function() {
-    Container = this.owner;
-    ServiceFactory = Container.factoryFor('service:navi-notifications');
+    ServiceFactory = this.owner.factoryFor('service:navi-notifications');
   });
 
   test('add notification options', function(assert) {

--- a/packages/notifications/tests/unit/navi-notifications-test.js
+++ b/packages/notifications/tests/unit/navi-notifications-test.js
@@ -1,0 +1,35 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+let Container, ServiceFactory;
+
+module('Unit | Service | navi-notifications', function(hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function() {
+    Container = this.owner;
+    ServiceFactory = Container.factoryFor('service:navi-notifications');
+  });
+
+  test('add notification options', function(assert) {
+    assert.expect(2);
+    const service = ServiceFactory.create();
+
+    service.notificationService = {
+      queue: [],
+      add() {}
+    };
+
+    const assertThat = (input, output, message) => {
+      service.notificationService.add = options => assert.deepEqual(options, output, message);
+      service.add(input);
+    };
+
+    assertThat(
+      { message: 'e', timeout: 'short' },
+      { message: 'e', timeout: 3000 },
+      'The timeout alias is mapped to the duration'
+    );
+    assertThat({ message: 'e', timeout: 23 }, { message: 'e', timeout: 23 }, 'A number as a timeout is not modified');
+  });
+});


### PR DESCRIPTION
## Description
Notifications can't show a custom timeout duration

## Proposed Changes
- allow passing in number to timeout

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
