### PR TITLE
Update: Add column config to invalid route

### DIFF
--- a/packages/reports/addon/templates/reports/report/invalid.hbs
+++ b/packages/reports/addon/templates/reports/report/invalid.hbs
@@ -1,27 +1,46 @@
-{{!-- Copyright 2019, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
-{{#navi-info-message classNames="navi-report-invalid__info-message"}}
-  {{#with (get (model-for (parent-route)) "request.validations") as |validations|}}
-    {{#if validations.isTruelyValid}}
-      <span>
-        {{navi-icon "check-square-o"}}
-      </span>
-      <p>
-        Lookin' good. We're ready to
-        {{#link-to (sibling-route "view") class="navi-link info-message__run-link"}}run{{/link-to}}.
-      </p>
-    {{else}}
-      <span>
-        {{navi-icon "ambulance"}}
-      </span>
-      <p>Whoa! We can't run this query. Let's figure out what went wrong.</p>
-      <ul class="navi-info-message__error-list">
-        {{#each validations.messages as |message|}}
-          <li class="navi-info-message__error-list-item">
-            {{navi-icon "times" class="navi-info-message__error-list-icon"}}
-            {{message}}
-          </li>
-        {{/each}}
-      </ul>
-    {{/if}}
-  {{/with}}
-{{/navi-info-message}}
+{{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{#let (model-for (parent-route)) as | report |}}
+  {{#if (feature-flag "enableRequestPreview")}}
+    <NaviColumnConfig
+      @isOpen={{true}}
+      @report={{report}}
+      @openFilters={{route-action "openFilters"}}
+      @onRemoveDateTime={{update-report-action "REMOVE_TIME_GRAIN"}}
+      @onRemoveDimension={{update-report-action "REMOVE_DIMENSION_FRAGMENT"}}
+      @onRemoveMetric={{update-report-action "REMOVE_METRIC_FRAGMENT"}}
+      @onAddDimension={{update-report-action "ADD_DIMENSION"}}
+      @onAddMetric={{update-report-action "ADD_METRIC"}}
+      @onAddMetricWithParameter={{update-report-action "ADD_METRIC_WITH_PARAM"}}
+      @onToggleDimFilter={{update-report-action "TOGGLE_DIM_FILTER"}}
+      @onToggleMetricFilter={{update-report-action "TOGGLE_METRIC_FILTER"}}
+      @onToggleParameterizedMetricFilter={{update-report-action "TOGGLE_PARAMETERIZED_METRIC_FILTER"}}
+    />
+  {{/if}}
+  <NaviInfoMessage class="navi-report-invalid__info-message">
+    {{#let (get report "request.validations") as |validations|}}
+      {{#if validations.isTruelyValid}}
+        <span>
+          <NaviIcon @icon="check-square-o" />
+        </span>
+        <p>
+          Lookin' good. We're ready to
+          <LinkTo @route={{sibling-route "view"}} class="navi-link info-message__run-link">run</LinkTo>.
+        </p>
+      {{else}}
+        <span>
+          <NaviIcon @icon="ambulance" />
+        </span>
+        <p>Whoa! We can't run this query. Let's figure out what went wrong.</p>
+        <ul class="navi-info-message__error-list">
+          {{#each validations.messages as |message|}}
+            <li class="navi-info-message__error-list-item">
+              <NaviIcon @icon="times" class="navi-info-message__error-list-icon" />
+              {{message}}
+            </li>
+          {{/each}}
+        </ul>
+      {{/if}}
+    {{/let}}
+  </NaviInfoMessage>
+{{/let}}
+

--- a/packages/reports/tests/acceptance/invalid-route-test.js
+++ b/packages/reports/tests/acceptance/invalid-route-test.js
@@ -1,0 +1,32 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { visit, findAll, currentURL, click } from '@ember/test-helpers';
+import config from 'ember-get-config';
+import { clickItemFilter } from 'navi-reports/test-support/report-builder';
+
+module('Acceptance | Navi Report | Invalid Route', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  test('Error data request', async function(assert) {
+    assert.expect(2);
+    const originalFeatureFlag = config.navi.FEATURES.enableRequestPreview;
+    config.navi.FEATURES.enableRequestPreview = true;
+
+    await visit('/reports/5/view');
+
+    await clickItemFilter('metric', 'Ad Clicks');
+    await click('.navi-report__run-btn');
+
+    assert.ok(currentURL().endsWith('/invalid'), 'We are on the edit report route');
+
+    assert.deepEqual(
+      findAll('.navi-column-config-item__name').map(e => e.textContent),
+      ['Date Time (Day)', 'Ad Clicks', 'Nav Link Clicks'],
+      'The column config is displayed in the error route'
+    );
+
+    config.navi.FEATURES.enableRequestPreview = originalFeatureFlag;
+  });
+});


### PR DESCRIPTION
## Description
If you end up with an invalid report, you aren't able to see the column config

## Proposed Changes
- Add it to the invalid route

## Screenshots
![column config invalid route](https://user-images.githubusercontent.com/12093492/77457903-56c8a480-6dcb-11ea-9d22-83c03ff4c637.png)

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
