### PR TITLE
Fix: VIsuailzation config firefox overflow bug

### DIFF
--- a/packages/core/app/styles/navi-core/components/navi-visualization-config/wrapper.less
+++ b/packages/core/app/styles/navi-core/components/navi-visualization-config/wrapper.less
@@ -9,6 +9,7 @@
   flex-flow: column;
   flex: 1;
   flex-basis: 0;
+  max-width: 300px;
   padding: 10px 5px;
   overflow-y: auto;
 


### PR DESCRIPTION
## Description

Firefox visualization config has a tendency to overflow (stack config for long metric names)

## Proposed Changes

- add max width to config wrapper

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
