### PR TITLE
Update: Add missing step to README

### DIFF
--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -22,6 +22,21 @@
 - Update `package.json`
   - Update `description` field
   - Update `version` field
+  - Update versions of every navi package
+    ```diff
+    - "navi-core": "0.2.0",
+    + "navi-core": "canary",
+    - "navi-dashboards": "0.2.0",
+    + "navi-dashboards": "canary",
+    - "navi-data": "0.2.0",
+    + "navi-data": "canary",
+    - "navi-directory": "0.2.0",
+    + "navi-directory": "canary",
+    - "navi-notifications": "0.2.0",
+    + "navi-notifications": "canary",
+    - "navi-reports": "0.2.0",
+    + "navi-reports": "canary",
+    ```
 
 ## FAQ
 


### PR DESCRIPTION
## Description

Noticed a missing step when someone was trying to setup navi.
Navi package versions were set to 0.2.0 when no such version exists in npm since we are still releasing alpha versions of 0.2.0.

## Proposed Changes

- Update README

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
