### PR TITLE
Update: Add multi-datasource dashboard support

### DIFF
--- a/packages/core/addon/mirage/fixtures/dashboard-widget.js
+++ b/packages/core/addon/mirage/fixtures/dashboard-widget.js
@@ -273,5 +273,129 @@ export default [
     ],
     createdOn: '2016-01-01 00:00:00',
     updatedOn: '2016-01-01 00:00:00'
+  },
+  {
+    id: 7,
+    dashboardId: 6,
+    authorId: 'ciela',
+    title: 'Sale Contribution Value',
+    visualization: {
+      type: 'line-chart',
+      version: 1,
+      metadata: {
+        axis: {
+          y: {
+            series: {
+              type: 'metric',
+              config: {
+                metrics: ['personalSold', 'globalySold']
+              }
+            }
+          }
+        }
+      }
+    },
+    requests: [
+      {
+        logicalTable: {
+          table: 'inventory',
+          timeGrain: 'day'
+        },
+        metrics: [{ metric: 'personalSold' }, { metric: 'globalySold' }],
+        dimensions: [],
+        filters: [],
+        intervals: [
+          {
+            end: 'current',
+            start: 'P7D'
+          }
+        ],
+        bardVersion: 'v1',
+        requestVersion: 'v1',
+        dataSource: 'blockhead'
+      }
+    ],
+    createdOn: '2016-01-01 00:00:00',
+    updatedOn: '2016-01-01 00:00:00'
+  },
+  {
+    id: 8,
+    dashboardId: 6,
+    authorId: 'navi_user',
+    title: 'Mobile DAU Goal',
+    visualization: {
+      type: 'goal-gauge',
+      version: 1,
+      metadata: {
+        baselineValue: 200,
+        goalValue: 1000,
+        metric: { metric: 'adClicks', parameters: {} }
+      }
+    },
+    requests: [
+      {
+        logicalTable: {
+          table: 'network',
+          timeGrain: 'day'
+        },
+        metrics: [{ metric: 'adClicks' }, { metric: 'navClicks' }],
+        dimensions: [],
+        filters: [],
+        intervals: [
+          {
+            end: 'current',
+            start: 'P1D'
+          }
+        ],
+        bardVersion: 'v1',
+        requestVersion: 'v1'
+      }
+    ],
+    createdOn: '2016-01-01 00:00:00',
+    updatedOn: '2016-01-01 00:00:00'
+  },
+  {
+    id: 9,
+    dashboardId: 6,
+    authorId: 'navi_user',
+    title: 'Mobile DAU Graph',
+    visualization: {
+      type: 'line-chart',
+      version: 1,
+      metadata: {
+        axis: {
+          y: {
+            series: {
+              type: 'metric',
+              config: {
+                metrics: ['adClicks', 'navClicks']
+              }
+            }
+          }
+        }
+      }
+    },
+    requests: [
+      {
+        logicalTable: {
+          table: 'network',
+          timeGrain: 'day'
+        },
+        metrics: [{ metric: 'adClicks' }, { metric: 'navClicks' }],
+        dimensions: [],
+        filters: [],
+        intervals: [
+          {
+            end: 'current',
+            start: 'P7D'
+          }
+        ],
+        bardVersion: 'v1',
+        requestVersion: 'v1',
+        dataSource: 'dummy'
+      }
+    ],
+    createdOn: '2016-01-01 00:00:00',
+    updatedOn: '2016-01-01 00:00:00'
   }
 ];

--- a/packages/core/addon/mirage/fixtures/dashboard.js
+++ b/packages/core/addon/mirage/fixtures/dashboard.js
@@ -109,5 +109,27 @@ export default [
       layout: [],
       columns: 15
     }
+  },
+  {
+    id: 6,
+    title: 'Multi Source Dashboard',
+    authorId: 'navi_user',
+    dashboardWidgetIds: [7, 8, 9],
+    createdOn: '2016-01-01 03:00:00',
+    updatedOn: '2016-01-01 03:00:00',
+    deliveryRuleIds: [],
+    filters: [
+      { dimension: 'dummy.age', operator: 'in', field: 'id', values: [1, 2, 3] },
+      { dimension: 'blockhead.container', operator: 'notin', field: 'id', values: [1] }
+    ],
+    presentation: {
+      version: 1,
+      layout: [
+        { column: 0, row: 0, height: 4, width: 6, widgetId: 9 },
+        { column: 6, row: 0, height: 4, width: 6, widgetId: 7 },
+        { column: 0, row: 4, height: 4, width: 12, widgetId: 8 }
+      ],
+      columns: 12
+    }
   }
 ];

--- a/packages/core/addon/models/dashboard.js
+++ b/packages/core/addon/models/dashboard.js
@@ -80,10 +80,13 @@ export default DeliverableItem.extend(Validations, {
       clonedDashboard = Object.assign(this.toJSON(), {
         author: user,
         widgets: [],
-        filters: this.get('filters').map(filter =>
-          this.store.createFragment('bard-request/fragments/filter', filter.toJSON())
-        ),
-        presentation: copy(get(this, 'presentation')),
+        filters: this.filters.map(filter => {
+          const filterJson = filter.toJSON();
+          const namespace = filter.dimension.source;
+          filterJson.dimension = `${namespace}.${filterJson.dimension}`;
+          return this.store.createFragment('bard-request/fragments/filter', filterJson);
+        }),
+        presentation: copy(this.presentation),
         createdOn: null,
         updatedOn: null
       });

--- a/packages/core/addon/serializers/dashboard.js
+++ b/packages/core/addon/serializers/dashboard.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 
@@ -20,6 +20,16 @@ export default AssetSerializer.extend({
       return this._super(type, newPayload);
     }
     return this._super(...arguments);
+  },
+
+  serialize(snapshot) {
+    const filterSources = snapshot.attr('filters').map(filter => filter.attr('dimension').source);
+    const dashboard = this._super(...arguments);
+    dashboard.data.attributes.filters = dashboard.data.attributes.filters.map((filter, i) => {
+      filter.dimension = filterSources[i] ? `${filterSources[i]}.${filter.dimension}` : filter.dimension;
+      return filter;
+    });
+    return dashboard;
   },
 
   /**

--- a/packages/core/tests/unit/models/dashboard-test.js
+++ b/packages/core/tests/unit/models/dashboard-test.js
@@ -118,7 +118,7 @@ module('Unit | Model | dashboard', function(hooks) {
   });
 
   test('Cloning Dashboards', async function(assert) {
-    assert.expect(1);
+    assert.expect(2);
 
     await run(async () => {
       const model = await Store.findRecord('dashboard', 3);
@@ -132,6 +132,19 @@ module('Unit | Model | dashboard', function(hooks) {
       expectedModel.updatedOn = null;
 
       assert.deepEqual(clonedModel, expectedModel, 'The cloned dashboard model has the same attrs as original model');
+
+      await this.owner.lookup('service:bard-metadata').loadMetadata({ dataSourceName: 'blockhead' });
+
+      const filterModel = await Store.findRecord('dashboard', 6);
+      const clonedFilterModel = filterModel.clone().toJSON();
+      assert.deepEqual(
+        clonedFilterModel.filters,
+        [
+          { dimension: 'dummy.age', field: 'id', operator: 'in', values: [1, 2, 3] },
+          { dimension: 'blockhead.container', field: 'id', operator: 'notin', values: [1] }
+        ],
+        'multi datasource filters has the datasource specified'
+      );
     });
   });
 

--- a/packages/core/tests/unit/serializers/dashboard-test.js
+++ b/packages/core/tests/unit/serializers/dashboard-test.js
@@ -111,4 +111,22 @@ module('Unit | Serializer | dashboard', function(hooks) {
       'No changes are made when filters is something other than null'
     );
   });
+
+  test('serialize', async function(assert) {
+    await MetadataService.loadMetadata({ dataSourceName: 'blockhead' });
+    const dashboard = await this.owner.lookup('service:store').findRecord('dashboard', 6);
+    const serialized = dashboard.serialize();
+
+    assert.equal(serialized.data.attributes.title, 'Multi Source Dashboard', 'Title got serialized correctly');
+    assert.deepEqual(
+      serialized.data.attributes.filters[0],
+      { dimension: 'dummy.age', operator: 'in', field: 'id', values: [1, 2, 3] },
+      'Dummy filter serializes correctly with datasource'
+    );
+    assert.deepEqual(
+      serialized.data.attributes.filters[1],
+      { dimension: 'blockhead.container', operator: 'notin', field: 'id', values: [1] },
+      'Blockhead filter serializes correctly with datasource'
+    );
+  });
 });

--- a/packages/dashboards/addon/components/dashboard-dimension-selector.js
+++ b/packages/dashboards/addon/components/dashboard-dimension-selector.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Usage:
@@ -11,6 +11,8 @@
 import Component from '@ember/component';
 import { computed, get } from '@ember/object';
 import layout from '../templates/components/dashboard-dimension-selector';
+import { getDefaultDataSourceName } from 'navi-data/utils/adapter';
+import { groupBy } from 'lodash-es';
 
 export default Component.extend({
   layout,
@@ -52,9 +54,15 @@ export default Component.extend({
    */
   buildPowerSelectOptions(dimObject) {
     return Object.entries(dimObject).reduce((selectOptions, [category, dimensions]) => {
-      dimensions = Object.values(dimensions);
-      dimensions.sort((a, b) => a.longName.localeCompare(b.longName));
-      selectOptions.push({ groupName: category, options: dimensions });
+      dimensions = groupBy(Object.values(dimensions), 'dataSource');
+      const needsDatasourceSpecifier = Object.keys(dimensions).length > 1;
+      Object.entries(dimensions).forEach(([dataSource, dims]) => {
+        dims.sort((a, b) => a.longName.localeCompare(b.longName));
+        selectOptions.push({
+          groupName: needsDatasourceSpecifier ? `${category} (${dataSource})` : category,
+          options: dims
+        });
+      });
       return selectOptions;
     }, []);
   },
@@ -67,19 +75,26 @@ export default Component.extend({
    */
   buildCategoryMap(dimensionMap) {
     return Object.entries(dimensionMap).reduce((results, [table, dimensions]) => {
+      let dataSource = getDefaultDataSourceName();
+      if (table.includes('.')) {
+        [dataSource, ...table] = table.split('.');
+        table = table.join('.');
+      }
+
       dimensions.forEach(dimension => {
         if (!results[dimension.category]) {
           results[dimension.category] = {};
         }
 
-        if (!results[dimension.category][dimension.name]) {
-          results[dimension.category][dimension.name] = {
+        if (!results[dimension.category][`${dataSource}.${dimension.name}`]) {
+          results[dimension.category][`${dataSource}.${dimension.name}`] = {
             dimension: dimension.name,
             longName: dimension.longName,
-            tables: [table]
+            tables: [table],
+            dataSource
           };
         } else {
-          results[dimension.category][dimension.name].tables.push(table);
+          results[dimension.category][`${dataSource}.${dimension.name}`].tables.push(table);
         }
       });
       return results;
@@ -93,10 +108,11 @@ export default Component.extend({
    */
   mergeWidgetDimensions(widgets) {
     return widgets.reduce((dimensionMap, widget) => {
-      const tableKey = get(widget, 'requests.firstObject.logicalTable.table.name');
-      const timeGrain = get(widget, 'requests.firstObject.logicalTable.timeGrain');
+      const tableKey = widget?.requests?.firstObject?.logicalTable?.table?.name;
+      const timeGrain = widget?.requests?.firstObject?.logicalTable?.timeGrain;
+      const dataSource = widget?.requests?.firstObject?.dataSource || getDefaultDataSourceName();
       if (!dimensionMap[tableKey]) {
-        dimensionMap[tableKey] = get(timeGrain, 'dimensions');
+        dimensionMap[`${dataSource}.${tableKey}`] = timeGrain.dimensions;
       }
       return dimensionMap;
     }, {});

--- a/packages/dashboards/addon/routes/dashboards/dashboard/view.js
+++ b/packages/dashboards/addon/routes/dashboards/dashboard/view.js
@@ -156,7 +156,7 @@ export default Route.extend({
           field: fil.field,
           operator: fil.operator,
           rawValues: fil.values,
-          dimension: this.get('metadataService').getById('dimension', fil.dimension)
+          dimension: this.metadataService.getById('dimension', fil.dimension, fil.dataSource)
         };
 
         const newFragment = this.store.createFragment('bard-request/fragments/filter', newFragmentFields);

--- a/packages/dashboards/addon/services/dashboard-data.js
+++ b/packages/dashboards/addon/services/dashboard-data.js
@@ -12,6 +12,7 @@ import { computed } from '@ember/object';
 import { v1 } from 'ember-uuid';
 import config from 'ember-get-config';
 import { isForbidden } from 'navi-core/helpers/is-forbidden';
+import { getDefaultDataSourceName } from 'navi-data/utils/adapter';
 
 const FETCH_MAX_CONCURRENCY = config.navi.widgetsRequestsMaxConcurrency || Infinity;
 
@@ -108,6 +109,8 @@ export default class DashboardDataService extends Service {
       options.customHeaders = {
         uiView: `dashboard.${dashboardId}.${uuid}.${widgetId}`
       };
+
+      options.dataSourceName = request.dataSource || getDefaultDataSourceName();
 
       const requestWithFilters = this._applyFilters(dashboard, request);
       const requestDecorated = this._decorate(decorators, requestWithFilters.serialize());
@@ -238,6 +241,6 @@ export default class DashboardDataService extends Service {
   _isFilterValid(request, filter) {
     const validDimensions = get(request, 'logicalTable.timeGrain.dimensionIds');
 
-    return validDimensions.includes(get(filter, 'dimension.name'));
+    return filter.dimension.source === request.dataSource && validDimensions.includes(get(filter, 'dimension.name'));
   }
 }

--- a/packages/dashboards/addon/templates/components/dashboard-dimension-selector.hbs
+++ b/packages/dashboards/addon/templates/components/dashboard-dimension-selector.hbs
@@ -9,6 +9,6 @@
     beforeOptionsComponent="power-select-search"
     as |dimension|
   }}
-    <div title="{{dimension.dataSource}}">{{dimension.longName}}</div>
+    <div title="data source: {{dimension.dataSource}}">{{dimension.longName}}</div>
   {{/power-select}}
 {{/if}}

--- a/packages/dashboards/addon/templates/components/dashboard-dimension-selector.hbs
+++ b/packages/dashboards/addon/templates/components/dashboard-dimension-selector.hbs
@@ -9,6 +9,6 @@
     beforeOptionsComponent="power-select-search"
     as |dimension|
   }}
-    {{dimension.longName}}
+    <div title="{{dimension.dataSource}}">{{dimension.longName}}</div>
   {{/power-select}}
 {{/if}}

--- a/packages/dashboards/tests/acceptance/add-widget-test.js
+++ b/packages/dashboards/tests/acceptance/add-widget-test.js
@@ -30,7 +30,7 @@ module('Acceptance | Add New Widget', function(hooks) {
     await visit('/dashboards/1/');
     assert.dom('.navi-widget').exists({ count: 3 }, 'dashboard 1 initially has 3 widgets');
 
-    const NEW_WIDGET_ID = 7;
+    const NEW_WIDGET_ID = 10;
 
     assert.notOk(!!findAll(`[data-gs-id="${NEW_WIDGET_ID}"]`).length, '4th widget is not present');
 

--- a/packages/dashboards/tests/acceptance/dashboard-filter-test.js
+++ b/packages/dashboards/tests/acceptance/dashboard-filter-test.js
@@ -101,7 +101,7 @@ module('Acceptance | Dashboard Filters', function(hooks) {
 
     assert.deepEqual(
       dashboardBody.data.attributes.filters,
-      [{ dimension: 'platform', field: 'desc', operator: 'contains', values: ['win'] }],
+      [{ dimension: 'dummy.platform', field: 'desc', operator: 'contains', values: ['win'] }],
       'Correct filters are saved with the dashboard'
     );
   });
@@ -317,7 +317,8 @@ module('Acceptance | Dashboard Filters', function(hooks) {
             dimension: 'property',
             field: 'id',
             operator: 'in',
-            values: []
+            values: [],
+            dataSource: 'dummy'
           }
         ]
       },
@@ -352,7 +353,8 @@ module('Acceptance | Dashboard Filters', function(hooks) {
             dimension: 'property',
             field: 'id',
             operator: 'in',
-            values: ['1']
+            values: ['1'],
+            dataSource: 'dummy'
           }
         ]
       },
@@ -400,7 +402,8 @@ module('Acceptance | Dashboard Filters', function(hooks) {
             dimension: 'property',
             field: 'id',
             operator: 'in',
-            values: []
+            values: [],
+            dataSource: 'dummy'
           }
         ]
       },

--- a/packages/dashboards/tests/acceptance/dashboards-test.js
+++ b/packages/dashboards/tests/acceptance/dashboards-test.js
@@ -201,7 +201,7 @@ module('Acceptance | Dashboards', function(hooks) {
     await click($('button:contains(Cancel)')[0]);
     await click('.navi-icon__copy');
 
-    assert.equal(currentURL(), '/dashboards/6/view', 'A dashboard is cloned when the action is clicked');
+    assert.equal(currentURL(), '/dashboards/7/view', 'A dashboard is cloned when the action is clicked');
   });
 
   test('Add new dashboard in index route', async function(assert) {
@@ -373,7 +373,7 @@ module('Acceptance | Dashboards', function(hooks) {
 
     await click('.navi-icon__copy');
 
-    assert.equal(currentURL(), '/dashboards/6/view', 'Cloning a dashboard transitions to newly made dashboard');
+    assert.equal(currentURL(), '/dashboards/7/view', 'Cloning a dashboard transitions to newly made dashboard');
 
     assert
       .dom('.page-title .clickable')
@@ -704,7 +704,7 @@ module('Acceptance | Dashboards', function(hooks) {
 
     await click('.navi-icon__copy');
 
-    assert.equal(currentURL(), '/dashboards/6/view', 'Cloning a dashboard transitions to newly made dashboard');
+    assert.equal(currentURL(), '/dashboards/7/view', 'Cloning a dashboard transitions to newly made dashboard');
 
     // Create new widget
     await click('.add-widget .btn');
@@ -716,7 +716,7 @@ module('Acceptance | Dashboards', function(hooks) {
     // Save without running
     await click('.navi-report-widget__save-btn');
     assert.ok(
-      currentURL().endsWith('/dashboards/6/view'),
+      currentURL().endsWith('/dashboards/7/view'),
       'After saving without running, user is brought back to dashboard view'
     );
 

--- a/packages/dashboards/tests/acceptance/mutli-datasource-dashboards-test.js
+++ b/packages/dashboards/tests/acceptance/mutli-datasource-dashboards-test.js
@@ -51,7 +51,7 @@ module('Acceptance | Multi datasource Dashboard', function(hooks) {
     );
   });
 
-  test('Create new multisource daashboard', async function(assert) {
+  test('Create new multisource dashboard', async function(assert) {
     assert.expect(8);
 
     await visit('/dashboards/new');

--- a/packages/dashboards/tests/acceptance/mutli-datasource-dashboards-test.js
+++ b/packages/dashboards/tests/acceptance/mutli-datasource-dashboards-test.js
@@ -37,7 +37,6 @@ module('Acceptance | Multi datasource Dashboard', function(hooks) {
       ['Equals', 'Not Equals'],
       'Dimension filter operators are shown correctly'
     );
-    //ember-power-select-multiple-remove-btn
 
     assert.deepEqual(
       findAll('.filter-builder-dimension__values').map(el =>

--- a/packages/dashboards/tests/acceptance/mutli-datasource-dashboards-test.js
+++ b/packages/dashboards/tests/acceptance/mutli-datasource-dashboards-test.js
@@ -1,0 +1,110 @@
+import { module } from 'qunit';
+import { visit, click, findAll, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest, test } from 'ember-qunit';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { selectChoose } from 'ember-power-select/test-support';
+import { clickItem } from 'navi-reports/test-support/report-builder';
+
+module('Acceptance | Multi datasource Dashboard', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  test('Load multi-datasource dashboard', async function(assert) {
+    assert.expect(7);
+    await visit('/dashboards/6/view');
+
+    assert.dom('.navi-widget__header').exists({ count: 3 }, 'Three widgets loaded');
+    assert.dom('.c3-chart-component').exists({ count: 3 }, 'Three visualizations loaded');
+
+    assert.dom('.navi-widget__filter-errors-icon').exists({ count: 3 }, 'Filter warning is shown on each widget');
+
+    assert
+      .dom('.filter-collection--collapsed')
+      .hasText(
+        'Age equals under 13 (1) 13-17 (2) 18-20 (3) Container not equals Bag (1)',
+        'Collapsed filter has the right text'
+      );
+
+    await click('.dashboard-filters__toggle');
+
+    assert.deepEqual(
+      findAll('.filter-builder-dimension__subject').map(el => el.textContent.trim()),
+      ['Age', 'Container'],
+      'Dimensions are properly labeled in filters'
+    );
+
+    assert.deepEqual(
+      findAll('.filter-builder-dimension__operator').map(el => el.textContent.trim()),
+      ['Equals', 'Not Equals'],
+      'Dimension filter operators are shown correctly'
+    );
+    //ember-power-select-multiple-remove-btn
+
+    assert.deepEqual(
+      findAll('.filter-builder-dimension__values').map(el =>
+        [
+          ...el.querySelectorAll(
+            '.ember-power-select-multiple-option span:not(.ember-power-select-multiple-remove-btn)'
+          )
+        ].map(el => el.textContent.trim())
+      ),
+      [['under 13 (1)', '13-17 (2)', '18-20 (3)'], ['Bag (1)']],
+      'Dimension value selector showing the right values'
+    );
+  });
+
+  test('Create new multisource daashboard', async function(assert) {
+    assert.expect(8);
+
+    await visit('/dashboards/new');
+    await click('.add-widget button');
+    await selectChoose('.report-select', 'Report 12');
+    await click('.add-to-dashboard');
+
+    assert.dom('.navi-widget__header').exists({ count: 1 }, 'One widget loaded');
+    assert.dom('.c3-chart-component').exists({ count: 1 }, 'One visualization loaded');
+
+    await click('.add-widget button');
+    await selectChoose('.report-select', 'Create new...');
+    await click('.add-to-dashboard');
+
+    await selectChoose('.navi-table-select__dropdown', 'Inventory');
+    await clickItem('dimension', 'Container');
+    await clickItem('metric', 'Used Amount');
+
+    await click('.navi-report-widget__run-btn');
+    await click('.navi-report-widget__save-btn');
+
+    assert.dom('.navi-widget__header').exists({ count: 2 }, 'Two widgets loaded');
+    assert.dom('.c3-chart-component').exists({ count: 1 }, 'One visualization loaded');
+    assert.dom('.table-widget').exists({ count: 1 }, 'Table widget is loaded');
+
+    //add filters
+    await click('.dashboard-filters__toggle');
+    await click('.dashboard-filters--expanded__add-filter-button');
+    await selectChoose('.dashboard-dimension-selector', 'Container');
+    await selectChoose('.filter-builder-dimension__values', 'Bag');
+
+    const widgetsWithFilterWarning = () =>
+      [...findAll('.navi-widget__filter-errors-icon')].map(el => el.closest('.navi-widget__title').textContent.trim());
+
+    assert.deepEqual(
+      widgetsWithFilterWarning(),
+      ['Report 12'],
+      'Widget with dummy datasource has a warning that filter does not apply'
+    );
+
+    //add another filter for other datasource
+    await click('.dashboard-filters--expanded__add-filter-button');
+    await selectChoose('.dashboard-dimension-selector', 'Age');
+    await selectChoose(findAll('.filter-builder-dimension__values')[1], 'under 13 (1)');
+
+    assert.deepEqual(
+      widgetsWithFilterWarning(),
+      ['Report 12', 'Untitled Widget'],
+      'Both widgets have a warning that filter does not apply'
+    );
+
+    await click('.navi-dashboard__save-button');
+    assert.equal(currentURL(), '/dashboards/7/view', 'Dashboard saves without issue');
+  });
+});

--- a/packages/dashboards/tests/dummy/app/routes/application.js
+++ b/packages/dashboards/tests/dummy/app/routes/application.js
@@ -1,7 +1,5 @@
-import { hash } from 'rsvp';
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
-import { get } from '@ember/object';
 
 export default Route.extend({
   user: service(),
@@ -12,9 +10,10 @@ export default Route.extend({
   bardMetadata: service(),
 
   model() {
-    return hash({
-      user: get(this, 'user').findOrRegister(),
-      metadata: get(this, 'bardMetadata').loadMetadata()
-    }).then(() => undefined);
+    return Promise.all([
+      this.user.findOrRegister(),
+      this.bardMetadata.loadMetadata(),
+      this.bardMetadata.loadMetadata({ dataSourceName: 'blockhead' })
+    ]);
   }
 });

--- a/packages/dashboards/tests/dummy/config/environment.js
+++ b/packages/dashboards/tests/dummy/config/environment.js
@@ -24,6 +24,11 @@ module.exports = function(environment) {
 
     navi: {
       widgetsRequestsMaxConcurrency: 2,
+      defaultDataTable: 'network',
+      dataSources: [
+        { name: 'dummy', uri: 'https://data.naviapp.io', type: 'bard-facts' },
+        { name: 'blockhead', uri: 'https://data2.naviapp.io', type: 'bard-facts' }
+      ],
       FEATURES: {
         enableDashboardExport: true,
         enableMultipleExport: true,

--- a/packages/dashboards/tests/dummy/mirage/config.js
+++ b/packages/dashboards/tests/dummy/mirage/config.js
@@ -17,6 +17,10 @@ export default function() {
   metaService.call(this);
   factService.call(this);
 
+  this.urlPrefix = `${config.navi.dataSources[1].uri}/v1`;
+  metaService.call(this);
+  factService.call(this);
+
   /* == Mock Persistence == */
   this.urlPrefix = config.navi.appPersistence.uri;
   dashboard.call(this);

--- a/packages/dashboards/tests/integration/components/dashboard-dimension-selector-test.js
+++ b/packages/dashboards/tests/integration/components/dashboard-dimension-selector-test.js
@@ -57,7 +57,7 @@ module('Integration | Component | dashboard dimension selector', function(hooks)
 
     this.set('changeme', function(selection) {
       assert.deepEqual(
-        { dimension: 'dim1', longName: 'dim1', tables: ['a', 'b'] },
+        { dimension: 'dim1', longName: 'dim1', tables: ['a', 'b'], dataSource: 'dummy' },
         selection,
         'Selection sends correct dimension object'
       );
@@ -71,16 +71,87 @@ module('Integration | Component | dashboard dimension selector', function(hooks)
 
     const dropdown = document.querySelector('.ember-basic-dropdown-content');
 
-    const structure = [...dropdown.querySelectorAll('.ember-power-select-group')].reduce((obj, el) => {
-      const key = el.querySelector('.ember-power-select-group-name').textContent.trim();
-      const value = [...el.querySelectorAll('.ember-power-select-option')].map(el => el.textContent.trim());
-      return Object.assign({}, obj, { [key]: value });
-    }, {});
-
-    assert.deepEqual(structure, { cat1: ['dim1'], cat2: ['dim2', 'dim3'] }, 'Correct select structure is shown');
+    assert.deepEqual(
+      structure(dropdown),
+      { cat1: ['dim1'], cat2: ['dim2', 'dim3'] },
+      'Correct select structure is shown'
+    );
 
     assert.dom('.ember-power-select-placeholder').hasText('Select a Dimension');
 
     await selectChoose('.ember-power-select-trigger', 'dim1');
   });
+
+  test('it renders multi-datasource widgets with right options', async function(assert) {
+    assert.expect(1);
+    const dashboard = {
+      widgets: Promise.resolve([
+        {
+          requests: arr([
+            {
+              dataSource: 'dummy',
+              logicalTable: {
+                table: {
+                  name: 'a',
+                  timeGrain: 'day'
+                },
+                timeGrain: {
+                  dimensions: [
+                    { name: 'dim1', longName: 'dim1', category: 'cat1' },
+                    { name: 'dim2', longName: 'dim2', category: 'cat2' }
+                  ]
+                }
+              }
+            }
+          ])
+        },
+
+        {
+          requests: arr([
+            {
+              dataSource: 'blockhead',
+              logicalTable: {
+                table: {
+                  name: 'b',
+                  timeGrain: 'day'
+                },
+                timeGrain: {
+                  dimensions: [
+                    { name: 'dim3', longName: 'dim3', category: 'cat3' },
+                    { name: 'dim4', longName: 'dim4', category: 'cat1' },
+                    { name: 'dim2', longName: 'dim2', category: 'cat4' }
+                  ]
+                }
+              }
+            }
+          ])
+        }
+      ])
+    };
+
+    this.set('dashboard', dashboard);
+
+    this.set('changeme', () => {});
+
+    await this.render(hbs`{{dashboard-dimension-selector dashboard=dashboard onChange=changeme}}`);
+
+    await settled();
+
+    await clickTrigger();
+
+    const dropdown = document.querySelector('.ember-basic-dropdown-content');
+
+    assert.deepEqual(
+      structure(dropdown),
+      { 'cat1 (blockhead)': ['dim4'], 'cat1 (dummy)': ['dim1'], cat2: ['dim2'], cat3: ['dim3'], cat4: ['dim2'] },
+      'Correct select structure is shown'
+    );
+  });
 });
+
+const structure = dropdown =>
+  [...dropdown.querySelectorAll('.ember-power-select-group')].reduce((obj, el) => {
+    const key = el.querySelector('.ember-power-select-group-name').textContent.trim();
+    const value = [...el.querySelectorAll('.ember-power-select-option')].map(el => el.textContent.trim());
+    return Object.assign({}, obj, { [key]: value });
+  }, {});

--- a/packages/dashboards/tests/unit/routes/dashboards/dashboard/clone-test.js
+++ b/packages/dashboards/tests/unit/routes/dashboards/dashboard/clone-test.js
@@ -16,21 +16,21 @@ const CLONED_MODEL = {
         column: 0,
         height: 4,
         row: 0,
-        widgetId: 7,
+        widgetId: 10,
         width: 6
       },
       {
         column: 6,
         height: 4,
         row: 0,
-        widgetId: 8,
+        widgetId: 11,
         width: 6
       },
       {
         column: 0,
         height: 4,
         row: 4,
-        widgetId: 9,
+        widgetId: 12,
         width: 12
       }
     ],

--- a/packages/dashboards/tests/unit/services/dashboard-data-test.js
+++ b/packages/dashboards/tests/unit/services/dashboard-data-test.js
@@ -275,7 +275,8 @@ module('Unit | Service | dashboard data', function(hooks) {
         timeGrain: { dimensionIds: VALID_FILTERS }
       },
       data,
-      filters: filters || [makeFilter({ dimension: `${DIMENSIONS[data + 4]}` })]
+      filters: filters || [makeFilter({ dimension: `${DIMENSIONS[data + 4]}` })],
+      dataSource: 'dummy'
     });
 
     const widgets = [
@@ -354,6 +355,37 @@ module('Unit | Service | dashboard data', function(hooks) {
         ]
       ],
       'Errors are injected into the response.'
+    );
+  });
+
+  test('multi-datasource validFilters', function(assert) {
+    assert.expect(4);
+    const request = {
+      logicalTable: {
+        table: { name: 'foo' },
+        timeGrain: { dimensionIds: ['ham', 'spam'] }
+      },
+      dimensions: [],
+      metrics: [],
+      dataSource: 'one'
+    };
+
+    const service = this.owner.lookup('service:dashboard-data');
+    assert.notOk(
+      service._isFilterValid(request, { dimension: { name: 'ham', source: 'two' } }),
+      'even though dimension name is valid datasource does not match'
+    );
+    assert.ok(
+      service._isFilterValid(request, { dimension: { name: 'ham', source: 'one' } }),
+      'dimension name is valid and datasource matches'
+    );
+    assert.notOk(
+      service._isFilterValid(request, { dimension: { name: 'scam', source: 'one' } }),
+      'dimension name is invalid and datasource matches'
+    );
+    assert.notOk(
+      service._isFilterValid(request, { dimension: { name: 'scam', source: 'two' } }),
+      'neither dimension name is valid nor datasource matches'
     );
   });
 });


### PR DESCRIPTION
Resolves #666 also known as the issue of the beast

<!-- The above line will close the issue upon merge -->

## Description

Adds Multi datasource support to dashboards

## Proposed Changes

- Update fetch to pass dataSource of widget to adapter
- Update global filters to specify the dataSource and carry it around
- Make sure dashboard serializer and cloning includes dataSource in dimension name
- Global dashboard dashboard dimension selector specifies dataSource in tooltip and resolves conflicting categories.

## Screenshots
![Screen Shot 2020-03-27 at 4 39 20 PM](https://user-images.githubusercontent.com/99422/77802759-900e4800-7049-11ea-98c9-670907ada30b.png)

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
