### PR TITLE
Update: Lift column config to report route

### DIFF
--- a/packages/reports/addon/components/report-view.js
+++ b/packages/reports/addon/components/report-view.js
@@ -21,7 +21,6 @@ import { observes } from '@ember-decorators/object';
 import move from 'ember-animated/motions/move';
 import { easeOut, easeIn } from 'ember-animated/easings/cosine';
 import { fadeOut, fadeIn } from 'ember-animated/motions/opacity';
-import fade from 'ember-animated/transitions/fade';
 import config from 'ember-get-config';
 
 const VISUALIZATION_RESIZE_EVENT = 'resizestop';
@@ -70,11 +69,6 @@ class ReportView extends Component {
       .map(capitalize)
       .join(' ');
   }
-
-  /**
-   * @property {Boolean} isColumnDrawerOpen - Display column config or not
-   */
-  isColumnDrawerOpen = config.navi.FEATURES.enableRequestPreview;
 
   /**
    * @property {Boolean} isEditingVisualization - Display visualization config or not
@@ -167,11 +161,6 @@ class ReportView extends Component {
     newVisualization.rebuildConfig(request, response);
     set(report, 'visualization', newVisualization);
   }
-
-  /**
-   * @property fadeTransition - fade transition
-   */
-  fadeTransition = fade;
 
   /**
    * Custom fade transition when editing a visualization

--- a/packages/reports/addon/controllers/reports/report.js
+++ b/packages/reports/addon/controllers/reports/report.js
@@ -1,10 +1,12 @@
 /**
- * Copyright 2019, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import Controller from '@ember/controller';
-import { get, set, computed } from '@ember/object';
+import { action, set, computed } from '@ember/object';
 import { assert } from '@ember/debug';
+import config from 'ember-get-config';
+import fade from 'ember-animated/transitions/fade';
 
 const REPORT_STATE = {
   RUNNING: 'running',
@@ -13,71 +15,104 @@ const REPORT_STATE = {
   FAILED: 'failed'
 };
 
-export default Controller.extend({
+export default class ReportsReportController extends Controller {
   /**
    * @property {Boolean} showSaveAs - whether the save as dialog is showing
    */
-  showSaveAs: false,
+  showSaveAs = false;
 
   /**
    * @property {Boolean} isFiltersCollapsed
    */
-  isFiltersCollapsed: false,
+  isFiltersCollapsed = false;
+
+  /**
+   * @property {Boolean} isColumnDrawerOpen - Display column config or not
+   */
+  isColumnDrawerOpen = config.navi.FEATURES.enableRequestPreview;
 
   /**
    * @property {Object} modifiedRequest - the serialized request after calling `onUpdateReport`
    */
-  modifiedRequest: null,
+  modifiedRequest = null;
 
   /**
    * @property {String} reportState - state of the the report
    */
-  reportState: computed({
-    get() {
-      return get(this, '_reportState');
-    },
-    set(key, value) {
-      const states = Object.values(REPORT_STATE);
-      assert(`Invalid reportState: \`${value}\`. Must be one of the following: ${states}`, states.includes(value));
-      set(this, '_reportState', value);
-      return value;
-    }
-  }),
+  get reportState() {
+    return this._reportState;
+  }
+
+  set reportState(value) {
+    const states = Object.values(REPORT_STATE);
+    assert(`Invalid reportState: \`${value}\`. Must be one of the following: ${states}`, states.includes(value));
+    return (this._reportState = value);
+  }
 
   /**
    * @property {Boolean} isEditingReport - is the report being edited
    */
-  isEditingReport: computed('reportState', function() {
-    return get(this, 'reportState') === REPORT_STATE.EDITING;
-  }),
+  @computed('reportState')
+  get isEditingReport() {
+    return this.reportState === REPORT_STATE.EDITING;
+  }
 
   /**
    * @property {Boolean} isRunningReport - is the report running
    */
-  isRunningReport: computed('reportState', function() {
-    return get(this, 'reportState') === REPORT_STATE.RUNNING;
-  }),
+  @computed('reportState')
+  get isRunningReport() {
+    return this.reportState === REPORT_STATE.RUNNING;
+  }
 
   /**
    * @property {Boolean} didReportComplete - did the report complete successfully
    */
-  didReportComplete: computed('reportState', function() {
-    return get(this, 'reportState') === REPORT_STATE.COMPLETED;
-  }),
+  @computed('reportState')
+  get didReportComplete() {
+    return this.reportState === REPORT_STATE.COMPLETED;
+  }
 
   /**
    * @property {Boolean} didReportFail - did the report fail when running
    */
-  didReportFail: computed('reportState', function() {
-    return get(this, 'reportState') === REPORT_STATE.FAILED;
-  }),
+  @computed('reportState')
+  get didReportFail() {
+    return this.reportState === REPORT_STATE.FAILED;
+  }
 
-  actions: {
-    /**
-     * Closes save as modal
-     */
-    closeSaveAs() {
-      this.set('showSaveAs', false);
+  /**
+   * Closes save as modal
+   */
+  @action
+  closeSaveAs() {
+    set(this, 'showSaveAs', false);
+  }
+
+  /**
+   * Toggles the column config open and close as well as configuring a listener to resize the visualization
+   * @param {ReportBuilderComponent} reportBuilder - The report builder component containing the visualization
+   */
+  @action
+  toggleColumnConfig(reportBuilder) {
+    const { isColumnDrawerOpen } = this;
+    set(this, 'isColumnDrawerOpen', !isColumnDrawerOpen);
+
+    const visualizationElement = reportBuilder.element.querySelector('.report-view');
+    if (visualizationElement) {
+      const visualizationResizeEvent = new Event('resizestop');
+      this.onFadeEnd = () => visualizationElement.dispatchEvent(visualizationResizeEvent);
+    } else {
+      this.onFadeEnd = null;
     }
   }
-});
+
+  /**
+   * A fade transition that will resize the visualization
+   */
+  @action
+  *fadeTransition() {
+    yield* fade(...arguments);
+    this.onFadeEnd?.();
+  }
+}

--- a/packages/reports/addon/templates/components/report-builder.hbs
+++ b/packages/reports/addon/templates/components/report-builder.hbs
@@ -67,6 +67,6 @@
     </div>
   {{/if}}
   <div class="report-builder__container report-builder__container--result">
-    {{yield}}
+    {{yield this}}
   </div>
 </div>

--- a/packages/reports/addon/templates/components/report-view.hbs
+++ b/packages/reports/addon/templates/components/report-view.hbs
@@ -1,21 +1,4 @@
 {{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
-{{#if (feature-flag "enableRequestPreview")}}
-  <NaviColumnConfig
-    @isOpen={{this.isColumnDrawerOpen}}
-    @drawerDidChange={{this.resizeVisualization}}
-    @report={{@report}}
-    @openFilters={{route-action "openFilters"}}
-    @onRemoveDateTime={{update-report-action "REMOVE_TIME_GRAIN"}}
-    @onRemoveDimension={{update-report-action "REMOVE_DIMENSION_FRAGMENT"}}
-    @onRemoveMetric={{update-report-action "REMOVE_METRIC_FRAGMENT"}}
-    @onAddDimension={{update-report-action "ADD_DIMENSION"}}
-    @onAddMetric={{update-report-action "ADD_METRIC"}}
-    @onAddMetricWithParameter={{update-report-action "ADD_METRIC_WITH_PARAM"}}
-    @onToggleDimFilter={{update-report-action "TOGGLE_DIM_FILTER"}}
-    @onToggleMetricFilter={{update-report-action "TOGGLE_METRIC_FILTER"}}
-    @onToggleParameterizedMetricFilter={{update-report-action "TOGGLE_PARAMETERIZED_METRIC_FILTER"}}
-  />
-{{/if}}
 <div class="report-view__visualization-main">
   <div class="report-view__visualization-header">
     <div class="report-view__visualization-header-left">
@@ -39,17 +22,6 @@
       {{/animated-if}}
   </div>
   <div class= "report-view__visualization-body">
-    {{#if (feature-flag "enableRequestPreview")}}
-      <div class="report-view__columns-toggle">
-        <button class="report-view__columns-button" type="button" aria-label="Toggle column drawer" {{on "click" (toggle "isColumnDrawerOpen" this)}}>
-          {{#animated-if this.isColumnDrawerOpen use=this.fadeTransition}}
-            <NaviIcon @icon="chevron-left" class="report-view__columns-icon" />
-          {{else}}
-            <NaviIcon @icon="columns" class="report-view__columns-icon" />
-          {{/animated-if}}
-        </button>
-      </div>
-    {{/if}}
     <div class="report-view__visualization-container">
       {{#if hasNoData}}
         <div class="report-view__visualization-no-results">

--- a/packages/reports/addon/templates/reports/report.hbs
+++ b/packages/reports/addon/templates/reports/report.hbs
@@ -42,7 +42,35 @@
       @disabled={{this.isRunningReport}}
       @isFiltersCollapsed={{this.isFiltersCollapsed}}
       @onUpdateFiltersCollapsed={{set this.isFiltersCollapsed _}}
+      as |builder|
     >
+      {{#if (feature-flag "enableRequestPreview")}}
+        <NaviColumnConfig
+          class="{{if this.isRunningReport "navi-column-config--disabled"}}"
+          @isOpen={{this.isColumnDrawerOpen}}
+          @report={{this.model}}
+          @openFilters={{route-action "openFilters"}}
+          @onRemoveDateTime={{update-report-action "REMOVE_TIME_GRAIN"}}
+          @onRemoveDimension={{update-report-action "REMOVE_DIMENSION_FRAGMENT"}}
+          @onRemoveMetric={{update-report-action "REMOVE_METRIC_FRAGMENT"}}
+          @onAddDimension={{update-report-action "ADD_DIMENSION"}}
+          @onAddMetric={{update-report-action "ADD_METRIC"}}
+          @onAddMetricWithParameter={{update-report-action "ADD_METRIC_WITH_PARAM"}}
+          @onToggleDimFilter={{update-report-action "TOGGLE_DIM_FILTER"}}
+          @onToggleMetricFilter={{update-report-action "TOGGLE_METRIC_FILTER"}}
+          @onToggleParameterizedMetricFilter={{update-report-action "TOGGLE_PARAMETERIZED_METRIC_FILTER"}}
+        />
+
+        <div class="report-view__columns-toggle">
+          <button class="report-view__columns-button" type="button" aria-label="Toggle column drawer" {{on "click" (fn this.toggleColumnConfig builder)}}>
+            {{#animated-if this.isColumnDrawerOpen use=this.fadeTransition}}
+              <NaviIcon @icon="chevron-left" class="report-view__columns-icon" />
+            {{else}}
+              <NaviIcon @icon="columns" class="report-view__columns-icon" />
+            {{/animated-if}}
+          </button>
+        </div>
+      {{/if}}
       {{outlet}}
     </ReportBuilder>
   </div>

--- a/packages/reports/addon/templates/reports/report/edit.hbs
+++ b/packages/reports/addon/templates/reports/report/edit.hbs
@@ -1,21 +1,5 @@
 {{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 {{#let (model-for (parent-route)) as | report |}}
-  {{#if (feature-flag "enableRequestPreview")}}
-    <NaviColumnConfig
-      @isOpen={{true}}
-      @report={{report}}
-      @openFilters={{route-action "openFilters"}}
-      @onRemoveDateTime={{update-report-action "REMOVE_TIME_GRAIN"}}
-      @onRemoveDimension={{update-report-action "REMOVE_DIMENSION_FRAGMENT"}}
-      @onRemoveMetric={{update-report-action "REMOVE_METRIC_FRAGMENT"}}
-      @onAddDimension={{update-report-action "ADD_DIMENSION"}}
-      @onAddMetric={{update-report-action "ADD_METRIC"}}
-      @onAddMetricWithParameter={{update-report-action "ADD_METRIC_WITH_PARAM"}}
-      @onToggleDimFilter={{update-report-action "TOGGLE_DIM_FILTER"}}
-      @onToggleMetricFilter={{update-report-action "TOGGLE_METRIC_FILTER"}}
-      @onToggleParameterizedMetricFilter={{update-report-action "TOGGLE_PARAMETERIZED_METRIC_FILTER"}}
-    />
-  {{/if}}
   <NaviInfoMessage class="navi-report-new__info-message">
     <span class="navi-report-new__report-icons">
       <NaviIcon @icon="line-chart" />

--- a/packages/reports/addon/templates/reports/report/error.hbs
+++ b/packages/reports/addon/templates/reports/report/error.hbs
@@ -1,35 +1,17 @@
-{{!-- Copyright 2018, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
-{{#let (model-for (parent-route)) as | report |}}
-  {{#if (feature-flag "enableRequestPreview")}}
-    <NaviColumnConfig
-      @isOpen={{true}}
-      @report={{report}}
-      @openFilters={{route-action "openFilters"}}
-      @onRemoveDateTime={{update-report-action "REMOVE_TIME_GRAIN"}}
-      @onRemoveDimension={{update-report-action "REMOVE_DIMENSION_FRAGMENT"}}
-      @onRemoveMetric={{update-report-action "REMOVE_METRIC_FRAGMENT"}}
-      @onAddDimension={{update-report-action "ADD_DIMENSION"}}
-      @onAddMetric={{update-report-action "ADD_METRIC"}}
-      @onAddMetricWithParameter={{update-report-action "ADD_METRIC_WITH_PARAM"}}
-      @onToggleDimFilter={{update-report-action "TOGGLE_DIM_FILTER"}}
-      @onToggleMetricFilter={{update-report-action "TOGGLE_METRIC_FILTER"}}
-      @onToggleParameterizedMetricFilter={{update-report-action "TOGGLE_PARAMETERIZED_METRIC_FILTER"}}
-    />
-  {{/if}}
-  <NaviInfoMessage class="navi-report-error__info-message">
-    <span>
-      <NaviIcon @icon="ambulance" />
-    </span>
-    <p>Oops! There was an error with your request.</p>
-    <ul class="navi-info-message__error-list">
-      {{#let model.payload.description as | error | }}
-        <li class="navi-info-message__error-list-item">
-          <NaviIcon @icon="times" class="navi-info-message__error-list-icon" />
-          {{error-message (hash detail=error)}}
-        </li>
-      {{/let}}
-    </ul>
-    {{!-- The App will handle the look and feel of this component --}}
-    <SubmitDefect />
-  </NaviInfoMessage>
-{{/let}}
+{{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+<NaviInfoMessage class="navi-report-error__info-message">
+  <span>
+    <NaviIcon @icon="ambulance" />
+  </span>
+  <p>Oops! There was an error with your request.</p>
+  <ul class="navi-info-message__error-list">
+    {{#let model.payload.description as | error | }}
+      <li class="navi-info-message__error-list-item">
+        <NaviIcon @icon="times" class="navi-info-message__error-list-icon" />
+        {{error-message (hash detail=error)}}
+      </li>
+    {{/let}}
+  </ul>
+  {{!-- The App will handle the look and feel of this component --}}
+  <SubmitDefect />
+</NaviInfoMessage>

--- a/packages/reports/addon/templates/reports/report/invalid.hbs
+++ b/packages/reports/addon/templates/reports/report/invalid.hbs
@@ -1,21 +1,5 @@
 {{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 {{#let (model-for (parent-route)) as | report |}}
-  {{#if (feature-flag "enableRequestPreview")}}
-    <NaviColumnConfig
-      @isOpen={{true}}
-      @report={{report}}
-      @openFilters={{route-action "openFilters"}}
-      @onRemoveDateTime={{update-report-action "REMOVE_TIME_GRAIN"}}
-      @onRemoveDimension={{update-report-action "REMOVE_DIMENSION_FRAGMENT"}}
-      @onRemoveMetric={{update-report-action "REMOVE_METRIC_FRAGMENT"}}
-      @onAddDimension={{update-report-action "ADD_DIMENSION"}}
-      @onAddMetric={{update-report-action "ADD_METRIC"}}
-      @onAddMetricWithParameter={{update-report-action "ADD_METRIC_WITH_PARAM"}}
-      @onToggleDimFilter={{update-report-action "TOGGLE_DIM_FILTER"}}
-      @onToggleMetricFilter={{update-report-action "TOGGLE_METRIC_FILTER"}}
-      @onToggleParameterizedMetricFilter={{update-report-action "TOGGLE_PARAMETERIZED_METRIC_FILTER"}}
-    />
-  {{/if}}
   <NaviInfoMessage class="navi-report-invalid__info-message">
     {{#let (get report "request.validations") as |validations|}}
       {{#if validations.isTruelyValid}}

--- a/packages/reports/app/styles/navi-reports/components/navi-column-config.less
+++ b/packages/reports/app/styles/navi-reports/components/navi-column-config.less
@@ -38,4 +38,9 @@
     flex: 1;
     overflow-y: auto;
   }
+
+  &--disabled {
+    background: @denali-gray-300;
+    cursor: not-allowed;
+  }
 }

--- a/packages/reports/tests/acceptance/column-config-test.js
+++ b/packages/reports/tests/acceptance/column-config-test.js
@@ -63,6 +63,33 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
     assert.dom('.navi-column-config').doesNotExist('The column config is not present after running the report either');
   });
 
+  test('toggle columns drawer', async function(assert) {
+    assert.expect(6);
+
+    await visit('reports/1/view');
+
+    assert.dom('.navi-column-config__panel').exists('Column config drawer is open by default');
+    assert
+      .dom('.report-view__columns-icon.fa-chevron-left')
+      .exists('Column config drawer displays "back" icon when open');
+
+    await click('.report-view__columns-button');
+    await animationsSettled();
+    assert
+      .dom('.navi-column-config__panel')
+      .doesNotExist('Column config drawer is closed after toggling the columns button');
+    assert
+      .dom('.report-view__columns-icon.fa-columns')
+      .exists('Column config drawer displays "column" icon when closed');
+
+    await click('.report-view__columns-button');
+    await animationsSettled();
+    assert.dom('.navi-column-config__panel').exists('Column config drawer is open after toggling the columns button');
+    assert
+      .dom('.report-view__columns-icon.fa-chevron-left')
+      .exists('Column config drawer displays "back" icon when open');
+  });
+
   test('adding and removing - date time', async function(assert) {
     assert.expect(5);
     await visit('reports/1/view');

--- a/packages/reports/tests/integration/components/report-view-test.js
+++ b/packages/reports/tests/integration/components/report-view-test.js
@@ -2,13 +2,11 @@ import { A } from '@ember/array';
 import { helper as buildHelper } from '@ember/component/helper';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, render } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import $ from 'jquery';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import hbs from 'htmlbars-inline-precompile';
 import Interval from 'navi-core/utils/classes/interval';
-import config from 'ember-get-config';
-import { animationsSettled } from 'ember-animated/test-support';
 
 const RESPONSE = {
   rows: [
@@ -210,50 +208,5 @@ module('Integration | Component | report view', function(hooks) {
     assert
       .dom('.report-view__visualization-no-results')
       .hasText('No results available.', 'A message is displayed when the response has no data');
-  });
-
-  test('toggle columns drawer', async function(assert) {
-    const originalFeatureFlag = config.navi.FEATURES.enableRequestPreview;
-    config.navi.FEATURES.enableRequestPreview = true;
-
-    this.set('response', {
-      rows: [],
-      meta: {
-        pagination: {
-          currentPage: 1,
-          rowsPerPage: 10000,
-          numberOfResults: 0
-        }
-      }
-    });
-
-    await render(hbs`
-      <ReportView
-        @report={{this.report}}
-        @response={{this.response}}
-      />
-    `);
-
-    assert.dom('.navi-column-config__panel').exists('Column config drawer is open by default');
-    assert
-      .dom('.report-view__columns-icon.fa-chevron-left')
-      .exists('Column config drawer displays "back" icon when open');
-
-    await click('.report-view__columns-button');
-    await animationsSettled();
-    assert
-      .dom('.navi-column-config__panel')
-      .doesNotExist('Column config drawer is closed after toggling the columns button');
-    assert
-      .dom('.report-view__columns-icon.fa-columns')
-      .exists('Column config drawer displays "column" icon when closed');
-
-    await click('.report-view__columns-button');
-    await animationsSettled();
-    assert.dom('.navi-column-config__panel').exists('Column config drawer is open after toggling the columns button');
-    assert
-      .dom('.report-view__columns-icon.fa-chevron-left')
-      .exists('Column config drawer displays "back" icon when open');
-    config.navi.FEATURES.enableRequestPreview = originalFeatureFlag;
   });
 });


### PR DESCRIPTION
## Description
While playing around with the column config, if you move things around/open/close/etc those changes are destroyed every time you transition to a new report route such as when running a report/etc

## Proposed Changes
Lift up the column config to the report route level so that it persists between transitions

## Screenshots
![persisted column config](https://user-images.githubusercontent.com/12093492/78169004-64f37200-7416-11ea-820b-3fe4c45c1a63.gif)

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
