### PR TITLE
Fix: Dont serialize metric params with null values

### DIFF
--- a/packages/data/addon/utils/metric.js
+++ b/packages/data/addon/utils/metric.js
@@ -52,7 +52,10 @@ export function serializeParameters(obj = {}) {
   // TODO remove this line when aliases are natively supported in the fact web service
   paramArray = paramArray.filter(([key]) => key.toLowerCase() !== 'as');
   paramArray.sort(([keyA], [keyB]) => keyA.localeCompare(keyB));
-  return paramArray.map(([key, value]) => `${key}=${value}`).join(',');
+  return paramArray
+    .filter(([, value]) => value !== null && value !== undefined)
+    .map(([key, value]) => `${key}=${value}`)
+    .join(',');
 }
 
 /**

--- a/packages/data/tests/unit/adapters/bard-facts-test.js
+++ b/packages/data/tests/unit/adapters/bard-facts-test.js
@@ -143,7 +143,7 @@ module('Unit | Bard facts Adapter', function(hooks) {
   });
 
   test('_buildMetricsParam', function(assert) {
-    assert.expect(4);
+    assert.expect(5);
 
     let singleMetric = {
       metrics: [{ metric: 'm1' }]
@@ -190,6 +190,21 @@ module('Unit | Bard facts Adapter', function(hooks) {
       Adapter._buildMetricsParam(duplicateMetrics),
       'm1,m2,r(p=123)',
       '_buildMetricsParam built the correct string for duplicate metrics'
+    );
+
+    let nullParams = {
+      metrics: [
+        { metric: 'm1' },
+        { metric: 'm2' },
+        { metric: 'r', parameters: { p: '123', q: 'bar' } },
+        { metric: 'r', parameters: { p: 'xyz', q: null } },
+        { metric: 'r', parameters: { p: 'tuv', q: undefined } }
+      ]
+    };
+    assert.equal(
+      Adapter._buildMetricsParam(nullParams),
+      'm1,m2,r(p=123,q=bar),r(p=xyz),r(p=tuv)',
+      '_buildMetricsParam built correctly with null parameter values'
     );
   });
 

--- a/packages/data/tests/unit/utils/metric-test.js
+++ b/packages/data/tests/unit/utils/metric-test.js
@@ -12,7 +12,7 @@ import { module, test } from 'qunit';
 
 module('Unit - Utils - Metrics Utils', function() {
   test('canonicalize metric', function(assert) {
-    assert.expect(5);
+    assert.expect(6);
     assert.equal(canonicalizeMetric({ metric: 'foo' }), 'foo', 'correctly serializes metric with no params');
 
     assert.equal(
@@ -37,6 +37,12 @@ module('Unit - Utils - Metrics Utils', function() {
       canonicalizeMetric({ metric: 'foo', parameters: { p1: '100', a: '12' } }),
       'foo(a=12,p1=100)',
       'correctly serializes metric with multiple params'
+    );
+
+    assert.equal(
+      canonicalizeMetric({ metric: 'ham', parameters: { p1: 'value', p2: null } }),
+      'ham(p1=value)',
+      'Do not send parameters with null or undefined values'
     );
   });
 


### PR DESCRIPTION
## Description

We are serializing parameter null values which breaks the fili contract

## Proposed Changes

- filter out null valued parameters.

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
