### PR TITLE
Fix: Advanced date picker

### DIFF
--- a/packages/reports/addon/components/filter-builders/date-time.js
+++ b/packages/reports/addon/components/filter-builders/date-time.js
@@ -29,7 +29,7 @@ export default class DateTimeFilterBuilder extends Base {
   /**
    * @property {String} dateTimePeriodName - the date time period
    */
-  @computed('request.logicalTable.timeGrain')
+  @computed('request.logicalTable.{timeGrain,table.timeGrains.[]}')
   get dateTimePeriodName() {
     const {
       logicalTable: {

--- a/packages/reports/addon/components/filter-values/advanced-interval-input.js
+++ b/packages/reports/addon/components/filter-values/advanced-interval-input.js
@@ -10,7 +10,7 @@
  *   />
  */
 import BaseIntervalComponent from './base-interval-component';
-import { computed } from '@ember/object';
+import { computed, action } from '@ember/object';
 import layout from '../../templates/components/filter-values/advanced-interval-input';
 import { layout as templateLayout, tagName } from '@ember-decorators/component';
 import DateUtils from 'navi-core/utils/date';
@@ -23,17 +23,10 @@ class AdvancedIntervalInputComponent extends BaseIntervalComponent {
   /**
    * @property {Object} dateStrings - the formatted {start, end} dates
    */
-  @computed('interval')
+  @computed('interval', 'calendarDateTimePeriod')
   get dateStrings() {
-    const { dateTimePeriod, interval } = this;
-    let end;
-    if (moment.isMoment(interval._end)) {
-      const endMoment = interval.asMomentsForTimePeriod(dateTimePeriod).end;
-      end = endMoment.clone().subtract(1, dateTimePeriod);
-    } else {
-      end = interval._end;
-    }
-    return new Interval(interval._start, end).asStrings(DateUtils.PARAM_DATE_FORMAT_STRING);
+    const { calendarDateTimePeriod, interval } = this;
+    return new Interval(interval._start, interval._end).asStrings(DateUtils.PARAM_DATE_FORMAT_STRING);
   }
 
   /**
@@ -48,6 +41,15 @@ class AdvancedIntervalInputComponent extends BaseIntervalComponent {
       return Interval.fromString(value);
     }
     return value;
+  }
+
+  /**
+   * @action setIntervalEndExact
+   * @param {Moment} value - end date for interval
+   */
+  @action
+  setIntervalEndExact(value) {
+    return this.setInterval(this.interval._start, value, false);
   }
 }
 

--- a/packages/reports/addon/components/filter-values/base-interval-component.js
+++ b/packages/reports/addon/components/filter-values/base-interval-component.js
@@ -10,6 +10,19 @@ import { formatDateRange } from 'navi-reports/helpers/format-interval-inclusive-
 import { getIsoDateTimePeriod } from 'navi-core/utils/date';
 import moment from 'moment';
 
+const timeGrainSorting = {
+  millisecond: 1,
+  second: 2,
+  minute: 3,
+  hour: 4,
+  day: 5,
+  week: 6,
+  month: 7,
+  quarter: 8,
+  year: 9,
+  all: 10
+};
+
 export default class BaseIntervalComponent extends Component {
   /**
    * @property {String} startPlaceholder - The text displayed when there is no startDate
@@ -29,7 +42,17 @@ export default class BaseIntervalComponent extends Component {
   /**
    * @property {String} lowestDateTimePeriod - the lowest supported time grain of the table
    */
-  @readOnly('request.logicalTable.table.timeGrains.0.id') lowestDateTimePeriod;
+  @computed('request.logicalTable.table.timeGrainIds.[]')
+  get lowestDateTimePeriod() {
+    const { timeGrainIds } = this.request.logicalTable.table;
+    const sorted = [...timeGrainIds].sort((lId, rId) => {
+      const leftValue = timeGrainSorting[lId] || Infinity;
+      const rightValue = timeGrainSorting[rId] || Infinity;
+      return leftValue >= rightValue;
+    });
+
+    return sorted[0];
+  }
 
   /**
    * @property {String} calendarDateTimePeriod - the active dateTimePeriod which does not include 'all'

--- a/packages/reports/addon/templates/components/filter-values/advanced-interval-input.hbs
+++ b/packages/reports/addon/templates/components/filter-values/advanced-interval-input.hbs
@@ -16,7 +16,7 @@
     <input
       class="filter-values--advanced-interval-input__value"
       value={{this.dateStrings.end}}
-      {{on "focusout" (pipe this.parseDate this.setIntervalEnd)}}
+      {{on "focusout" (pipe this.parseDate this.setIntervalEndExact)}}
     >
 
     <div class="filter-values--advanced-interval-input__label">

--- a/packages/reports/tests/acceptance/report-test.js
+++ b/packages/reports/tests/acceptance/report-test.js
@@ -1985,6 +1985,38 @@ module('Acceptance | Navi Report', function(hooks) {
       .hasText('May 30, 2015', 'Calendar defaults "all" grain  to show the lowest grain which is day');
   });
 
+  test('Date picker advanced doesnt modify interval', async function(assert) {
+    assert.expect(6);
+    await visit('/reports/1/view');
+
+    await selectChoose('.filter-builder__select-trigger', 'Advanced');
+    const startInput = findAll('.filter-values--advanced-interval-input__value')[0];
+    const endInput = findAll('.filter-values--advanced-interval-input__value')[1];
+    assert.dom(startInput).hasValue('P7D', 'The start input is not modified');
+    assert.dom(endInput).hasValue('2015-11-16', 'The end input is not modified');
+
+    await click('.get-api__btn');
+    assert.ok(
+      find('.navi-modal__input').value.includes('dateTime=P7D%2F2015-11-16'),
+      'The while in advanced mode shows exactly what is in the start/end inputs'
+    );
+    await click('.navi-modal__close');
+
+    await fillIn(startInput, 'P1M');
+    await blur(startInput);
+    await fillIn(endInput, '2020-04-01');
+    await blur(endInput);
+    assert.dom(startInput).hasValue('P1M', 'The start input was updated exactly');
+    assert.dom(endInput).hasValue('2020-04-01', 'The end input was updated exactly');
+
+    await click('.get-api__btn');
+    assert.ok(
+      find('.navi-modal__input').value.includes('dateTime=P1M%2F2020-04-01'),
+      'The query is updated to show the new start/end inputs exactly'
+    );
+    await click('.navi-modal__close');
+  });
+
   test("Report with an unknown table doesn't crash", async function(assert) {
     assert.expect(1);
     await visit('/reports/9');

--- a/packages/reports/tests/acceptance/report-test.js
+++ b/packages/reports/tests/acceptance/report-test.js
@@ -1809,7 +1809,7 @@ module('Acceptance | Navi Report', function(hooks) {
     assert.dom(findAll('.filter-values--advanced-interval-input__value')[0]).hasValue('P7D', 'The start date is P7D');
     assert
       .dom(findAll('.filter-values--advanced-interval-input__value')[1])
-      .hasValue('2015-11-15', 'The end date is 2015-11-15');
+      .hasValue('2015-11-16', 'The end date is 2015-11-16');
 
     await selectChoose('.filter-builder__select-trigger', 'Between');
     assert

--- a/packages/reports/tests/acceptance/report-test.js
+++ b/packages/reports/tests/acceptance/report-test.js
@@ -1985,7 +1985,7 @@ module('Acceptance | Navi Report', function(hooks) {
       .hasText('May 30, 2015', 'Calendar defaults "all" grain  to show the lowest grain which is day');
   });
 
-  test('Date picker advanced doesnt modify interval', async function(assert) {
+  test("Date picker advanced doesn't modify interval", async function(assert) {
     assert.expect(6);
     await visit('/reports/1/view');
 

--- a/packages/reports/tests/integration/components/filter-collection-test.js
+++ b/packages/reports/tests/integration/components/filter-collection-test.js
@@ -34,7 +34,7 @@ const MockFilterFragment1 = {
     filters: [MockFilterFragment1, MockFilterFragment2],
     intervals: [MockIntervalFragment],
     having: [MockMetricFragment1, MockMetricFragment2],
-    logicalTable: { timeGrain: 'day', table: { timeGrains: [{ id: 'day', name: 'Day' }] } }
+    logicalTable: { timeGrain: 'day', table: { timeGrainIds: ['day'], timeGrains: [{ id: 'day', name: 'Day' }] } }
   };
 
 module('Integration | Component | filter collection', function(hooks) {

--- a/packages/reports/tests/integration/components/filter-values/advanced-interval-input-test.js
+++ b/packages/reports/tests/integration/components/filter-values/advanced-interval-input-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, findAll, fillIn, focus, blur } from '@ember/test-helpers';
+import { render, findAll, fillIn, blur } from '@ember/test-helpers';
 import { A as arr } from '@ember/array';
 import hbs from 'htmlbars-inline-precompile';
 import Interval from 'navi-core/utils/classes/interval';

--- a/packages/reports/tests/integration/components/filter-values/advanced-interval-input-test.js
+++ b/packages/reports/tests/integration/components/filter-values/advanced-interval-input-test.js
@@ -1,29 +1,30 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, findAll, fillIn, blur } from '@ember/test-helpers';
+import { render, findAll, fillIn, focus, blur } from '@ember/test-helpers';
 import { A as arr } from '@ember/array';
 import hbs from 'htmlbars-inline-precompile';
 import Interval from 'navi-core/utils/classes/interval';
 import { getDateRangeFormat } from './date-range-test';
 
+const TEMPLATE = hbs`
+<FilterValues::AdvancedIntervalInput
+  @filter={{this.filter}}
+  @request={{this.request}}
+  @onUpdateFilter={{this.onUpdateFilter}}
+  @isCollapsed={{this.isCollapsed}}
+/>`;
 module('Integration | Component | filter values/advanced interval input', function(hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(async function() {
-    this.filter = { values: arr([Interval.parseFromStrings('P4D', '2020-01-10')]) };
-    this.request = { logicalTable: { timeGrain: 'day', table: { timeGrains: [{ id: 'day', name: 'Day' }] } } };
+    this.filter = { values: arr([Interval.parseFromStrings('P4D', '2020-01-09')]) };
+    this.request = { logicalTable: { timeGrain: 'day', table: { timeGrainIds: ['all', 'day', 'week', 'month'] } } };
     this.onUpdateFilter = () => null;
-
-    await render(hbs`<FilterValues::AdvancedIntervalInput
-            @filter={{this.filter}}
-            @request={{this.request}}
-            @onUpdateFilter={{this.onUpdateFilter}}
-            @isCollapsed={{this.isCollapsed}}
-        />`);
   });
 
-  test('it renders', function(assert) {
+  test('it renders', async function(assert) {
     assert.expect(3);
+    await render(TEMPLATE);
 
     assert.dom(findAll('.filter-values--advanced-interval-input__value')[0]).hasValue('P4D', 'Has lookback string');
     assert
@@ -32,13 +33,14 @@ module('Integration | Component | filter values/advanced interval input', functi
     assert.dom('.filter-values--advanced-interval-input__label').hasText('Interval Help', 'Has interval help link');
   });
 
-  test('changing values', async function(assert) {
+  test('changing start value', async function(assert) {
     assert.expect(5);
+    await render(TEMPLATE);
 
     const originalRange = getDateRangeFormat(this);
     this.set('onUpdateFilter', ({ interval }) => {
       assert.equal(interval._start, 'P6D', 'The lookback is correct');
-      assert.equal(interval._end.format('YYYY-MM-DD'), '2020-01-10', 'The end date is set inclusive');
+      assert.equal(interval._end.format('YYYY-MM-DD'), '2020-01-09', 'The end date is not modified');
       this.set('filter', { values: arr([interval]) });
     });
 
@@ -52,8 +54,30 @@ module('Integration | Component | filter values/advanced interval input', functi
     assert.dom(endElement).hasValue('2020-01-09', 'The end input value shows the inclusive end date');
   });
 
+  test('changing end value all grain', async function(assert) {
+    assert.expect(6);
+    this.set('request.logicalTable.timeGrain', 'all');
+    await render(TEMPLATE);
+
+    this.set('onUpdateFilter', ({ interval }) => {
+      assert.equal(interval._start, 'P4D', 'The lookback is correct');
+      assert.equal(interval._end.format('YYYY-MM-DD'), '2020-01-09', 'The end date is set exactly as typed in');
+      this.set('filter', { values: arr([interval]) });
+    });
+
+    const startElement = findAll('.filter-values--advanced-interval-input__value')[0];
+    const endElement = findAll('.filter-values--advanced-interval-input__value')[1];
+    assert.dom(startElement).hasValue('P4D', 'The start input value shows the correct lookback');
+    assert.dom(endElement).hasValue('2020-01-09', 'The end input value shows the inclusive end date');
+    await fillIn(endElement, '2020-01-09');
+    await blur(endElement);
+    assert.dom(startElement).hasValue('P4D', 'The start input value shows the correct lookback');
+    assert.dom(endElement).hasValue('2020-01-09', 'The end input value shows the inclusive end date');
+  });
+
   test('collapsed', async function(assert) {
     assert.expect(2);
+    await render(TEMPLATE);
 
     this.set('isCollapsed', true);
 

--- a/packages/reports/tests/integration/components/filter-values/current-period-test.js
+++ b/packages/reports/tests/integration/components/filter-values/current-period-test.js
@@ -11,7 +11,7 @@ module('Integration | Component | filter values/current period', function(hooks)
 
   hooks.beforeEach(async function() {
     this.filter = { values: arr([Interval.parseFromStrings('current', 'next')]) };
-    this.request = { logicalTable: { timeGrain: 'day' } };
+    this.request = { logicalTable: { timeGrain: 'day', table: { timeGrainIds: ['day', 'week'] } } };
 
     await render(hbs`<FilterValues::CurrentPeriod
             @filter={{this.filter}}
@@ -27,7 +27,7 @@ module('Integration | Component | filter values/current period', function(hooks)
       .dom('.filter-values--current-period')
       .hasText(`The current day. (${getDateRangeFormat(this)})`, 'The current period is day');
 
-    this.set('request', { logicalTable: { timeGrain: 'week' } });
+    this.set('request.logicalTable.timeGrain', 'week');
     assert
       .dom('.filter-values--current-period')
       .hasText(`The current week. (${getDateRangeFormat(this)})`, 'The current period changes to week');

--- a/packages/reports/tests/integration/components/filter-values/date-range-test.js
+++ b/packages/reports/tests/integration/components/filter-values/date-range-test.js
@@ -20,7 +20,7 @@ module('Integration | Component | filter values/date range', function(hooks) {
 
   hooks.beforeEach(async function() {
     this.filter = { values: [] };
-    this.request = { logicalTable: { timeGrain: 'day' } };
+    this.request = { logicalTable: { timeGrain: 'day', table: { timeGrainIds: ['day'] } } };
     this.onUpdateFilter = () => null;
 
     await render(hbs`<FilterValues::DateRange

--- a/packages/reports/tests/integration/components/filter-values/lookback-input-test.js
+++ b/packages/reports/tests/integration/components/filter-values/lookback-input-test.js
@@ -13,7 +13,7 @@ module('Integration | Component | filter values/lookback input', function(hooks)
 
   hooks.beforeEach(async function() {
     this.filter = { values: arr([Interval.parseFromStrings('P4D', 'current')]) };
-    this.request = { logicalTable: { timeGrain: 'day' } };
+    this.request = { logicalTable: { timeGrain: 'day', table: { timeGrainIds: ['day'] } } };
     this.onUpdateFilter = () => null;
 
     await render(hbs`<FilterValues::LookbackInput

--- a/packages/reports/tests/integration/components/filter-values/since-input-test.js
+++ b/packages/reports/tests/integration/components/filter-values/since-input-test.js
@@ -11,7 +11,7 @@ module('Integration | Component | filter values/since input', function(hooks) {
 
   hooks.beforeEach(async function() {
     this.filter = { values: arr([Interval.parseFromStrings('2020-01-01', 'current')]) };
-    this.request = { logicalTable: { timeGrain: 'day' } };
+    this.request = { logicalTable: { timeGrain: 'day', table: { timeGrainIds: ['day'] } } };
     this.onUpdateFilter = () => null;
 
     await render(hbs`<FilterValues::SinceInput


### PR DESCRIPTION
## Description
The advanced date picker currently adds an extra period to the end of the interval, but this is confusing as it's not what the user typed in

## Proposed Changes
Update the advanced date picker so that it does not modify the date from user input

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
