### PR TITLE
Update: Move where cardinality sizes are exported from

### DIFF
--- a/packages/data/addon/models/metadata/dimension.js
+++ b/packages/data/addon/models/metadata/dimension.js
@@ -5,8 +5,7 @@
 import { inject as service } from '@ember/service';
 import { assert } from '@ember/debug';
 import Column from './column';
-
-export const CARDINALITY_SIZES = ['SMALL', 'MEDIUM', 'LARGE'];
+import CARDINALITY_SIZES from '../../utils/enums/cardinality-sizes';
 
 export default class Dimension extends Column {
   /**

--- a/packages/data/addon/serializers/bard-metadata.js
+++ b/packages/data/addon/serializers/bard-metadata.js
@@ -8,7 +8,7 @@
 import EmberObject from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import { constructFunctionArguments } from 'navi-data/serializers/metadata/metric-function';
-import { CARDINALITY_SIZES } from '../models/metadata/dimension';
+import CARDINALITY_SIZES from '../utils/enums/cardinality-sizes';
 import config from 'ember-get-config';
 
 const LOAD_CARDINALITY = config.navi.searchThresholds.contains;

--- a/packages/data/addon/services/bard-dimensions.js
+++ b/packages/data/addon/services/bard-dimensions.js
@@ -15,7 +15,7 @@ import BardDimensionArray from 'navi-data/models/bard-dimension-array';
 import SearchUtils from 'navi-data/utils/search';
 import { intersection } from 'lodash-es';
 import { getDefaultDataSourceName } from '../utils/adapter';
-import { CARDINALITY_SIZES } from '../models/metadata/dimension';
+import CARDINALITY_SIZES from '../utils/enums/cardinality-sizes';
 
 const SEARCH_OPERATOR_PRIORITY = ['contains', 'in'];
 

--- a/packages/data/addon/utils/enums/cardinality-sizes.js
+++ b/packages/data/addon/utils/enums/cardinality-sizes.js
@@ -1,0 +1,5 @@
+/**
+ * Copyright 2020, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+export default ['SMALL', 'MEDIUM', 'LARGE'];

--- a/packages/data/app/utils/enums/cardinality-sizes.js
+++ b/packages/data/app/utils/enums/cardinality-sizes.js
@@ -1,0 +1,1 @@
+export { default } from 'navi-data/utils/enums/cardinality-sizes';

--- a/packages/reports/addon/components/filter-values/dimension-select.js
+++ b/packages/reports/addon/components/filter-values/dimension-select.js
@@ -16,7 +16,7 @@ import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { get, set, computed, action } from '@ember/object';
 import { readOnly } from '@ember/object/computed';
-import { CARDINALITY_SIZES } from 'navi-data/models/metadata/dimension';
+import CARDINALITY_SIZES from 'navi-data/utils/enums/cardinality-sizes';
 import layout from '../../templates/components/filter-values/dimension-select';
 import { layout as templateLayout, tagName } from '@ember-decorators/component';
 


### PR DESCRIPTION
## Description
Expose cardinality size export outside of navi-data addon

## Proposed Changes

- move to enums file

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
