### PR TITLE
Request v2: Navi-WS Support

### DIFF
--- a/packages/webservice/app/src/test/kotlin/com/yahoo/navi/ws/test/integration/ReportTest.kt
+++ b/packages/webservice/app/src/test/kotlin/com/yahoo/navi/ws/test/integration/ReportTest.kt
@@ -39,7 +39,7 @@ class ReportTest : IntegrationTest() {
             |},
             |"dataSource": "",
             |"bardVersion":"1.0",
-            |"requestVersion":"2.0",
+            |"requestVersion":"v1",
             |"intervals":[{
             |    "start":"2015-08-20 00:00:00.000",
             |    "end":"2015-08-21 00:00:00.000"
@@ -69,7 +69,7 @@ class ReportTest : IntegrationTest() {
             |"sort": [],
             |"dataSource":"",
             |"bardVersion":"1.0",
-            |"requestVersion":"2.0",
+            |"requestVersion":"v1",
             |"intervals":[{
             |    "start":"2015-08-20 00:00:00.000",
             |    "end":"2015-08-21 00:00:00.000"
@@ -97,7 +97,7 @@ class ReportTest : IntegrationTest() {
             |   "table":"base"
             |},
             |"bardVersion":"1.0",
-            |"requestVersion":"2.0",
+            |"requestVersion":"v1",
             |"intervals":[{
             |   "start":"2015-08-20 00:00:00.000",
             |   "end":"2015-08-21 00:00:00.000"
@@ -225,7 +225,7 @@ class ReportTest : IntegrationTest() {
             |   "table":"base"
             |},
             |"bardVersion":"1.0",
-            |"requestVersion":"2.0",
+            |"requestVersion":"v1",
             |"intervals":[{
             |    "start":"2015-08-20 00:00:00.000",
             |    "end":"2015-08-21 00:00:00.000"
@@ -296,7 +296,7 @@ class ReportTest : IntegrationTest() {
             |   "table":"base"
             |},
             |"bardVersion":"1.0",
-            |"requestVersion":"2.0",
+            |"requestVersion":"v1",
             |"intervals":[{
             |    "start":"2015-08-20 00:00:00.000",
             |    "end":"2015-08-21 00:00:00.000"

--- a/packages/webservice/app/src/test/kotlin/com/yahoo/navi/ws/test/integration/RequestV2Test.kt
+++ b/packages/webservice/app/src/test/kotlin/com/yahoo/navi/ws/test/integration/RequestV2Test.kt
@@ -1,0 +1,339 @@
+package com.yahoo.navi.ws.test.integration
+
+import com.jayway.restassured.RestAssured.given
+import com.yahoo.navi.ws.test.framework.IntegrationTest
+import org.apache.http.HttpStatus
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.CoreMatchers.not
+import org.hamcrest.CoreMatchers.`is` as Is
+import com.yahoo.navi.ws.test.framework.matchers.JsonMatcher.Companion.matchesJsonMap
+import org.hamcrest.Matchers.hasKey
+import org.hamcrest.Matchers.hasItems
+import org.junit.Before
+import org.junit.Test
+
+class RequestV2Test : IntegrationTest() {
+    private val USER = "user"
+    private var reqStr = String()
+    private var visualStr = String()
+    private var author = { user: String -> """
+        |"author": {
+        |   "data": {
+        |        "type": "users",
+        |        "id": "$user"
+        |    }
+        |}
+        """.trimMargin() }
+
+    @Before
+    fun setup() {
+        reqStr = ("""{
+        |"filters": [
+        |   {
+        |      "field": "product.id",
+        |      "parameters": {},
+        |      "operator": "in",
+        |      "values": [
+        |        "access_manager"
+        |      ]
+        |    },
+        |    {
+        |      "field": "timeSpent",
+        |      "parameters": {},
+        |      "operator": "gt",
+        |      "values": [
+        |        3
+        |      ]
+        |    },
+        |    { 
+        |      "field": "dateTime",
+        |      "parameters": {},
+        |      "operator": "bet",
+        |      "values": [ "P1D", "current" ]
+        |    }
+        |  ],
+        |  "columns": [
+        |    {
+        |      "field": "dateTime", 
+        |      "parameters": {
+        |        "grain": "day"
+        |      },
+        |      "type": "dimension",
+        |      "alias": "time"
+        |    },
+        |    {
+        |      "field": "product",
+        |      "parameters": {},
+        |
+        |      "type": "dimension"
+        |    },
+        |    {
+        |      "field": "spaceId.id",
+        |      "parameters": {}
+        |    },
+        |    {
+        |      "field": "timeSpent",
+        |      "parameters": {},
+        |      "type": "metric"
+        |    }
+        |  ],
+        |  "table": "certifiedAudience",
+        |  "sort": [
+        |    {
+        |      "field": "dateTime",
+        |      "parameters": {},
+        |      "direction": "desc"
+        |    }
+        |  ],
+        |  "dataSource": "audience",
+        |  "limit": null, 
+        |  "requestVersion": "2.0"
+        |}""".trimMargin())
+
+        visualStr = ("""{
+            |"metadata":{
+            |    "foo":"bar",
+            |    "nestedFoo":{"innerFoo":"innerBar"}
+            |},
+            |"type":"chart",
+            |"version":1
+            |}""".trimMargin())
+
+        registerUser(USER)
+    }
+
+    @Test
+    fun reportWithRequestV2() {
+        given()
+            .header("User", USER)
+            .contentType("application/vnd.api+json")
+            .body("""
+                {
+                    "data": {
+                        "type": "reports",
+                        "attributes": {
+                            "title": "A Report",
+                            "request": $reqStr,
+                            "visualization": $visualStr
+                        },
+                        "relationships": {
+                            ${author(USER)}
+                        }
+                    }
+                }
+            """.trimIndent())
+        .When()
+            .post("/reports")
+        .then()
+            .assertThat()
+            .statusCode(HttpStatus.SC_CREATED)
+
+        given()
+            .header("User", USER)
+            .contentType("application/vnd.api+json")
+            .When()
+                .get("/reports/1")
+            .then()
+                .assertThat()
+
+                .body("data.attributes.request.requestVersion", equalTo("2.0"))
+                .body("data.attributes.request.table", equalTo("certifiedAudience"))
+                .body("data.attributes.request.dataSource", equalTo("audience"))
+
+                .body("data.attributes.request.filters.size()", Is(3))
+                .body("data.attributes.request.filters[0].field", equalTo("product.id"))
+                .body("data.attributes.request.filters[0].operator", equalTo("in"))
+                .body("data.attributes.request.filters[0].parameters", matchesJsonMap("{}"))
+                .body("data.attributes.request.filters[0].values", hasItems("access_manager"))
+
+                .body("data.attributes.request.filters[1].field", equalTo("timeSpent"))
+                .body("data.attributes.request.filters[1].operator", equalTo("gt"))
+                .body("data.attributes.request.filters[1].parameters", matchesJsonMap("{}"))
+                .body("data.attributes.request.filters[1].values", hasItems(3))
+
+                .body("data.attributes.request.filters[2].field", equalTo("dateTime"))
+                .body("data.attributes.request.filters[2].operator", equalTo("bet"))
+                .body("data.attributes.request.filters[2].parameters", matchesJsonMap("{}"))
+                .body("data.attributes.request.filters[2].values", hasItems("P1D", "current"))
+
+                .body("data.attributes.request.columns[0].field", equalTo("dateTime"))
+                .body("data.attributes.request.columns[0].parameters", matchesJsonMap("{\"grain\":\"day\"}"))
+                .body("data.attributes.request.columns[0].type", equalTo("dimension"))
+                .body("data.attributes.request.columns[0].alias", equalTo("time"))
+
+                .body("data.attributes.request.columns.size()", Is(4))
+                .body("data.attributes.request.columns[1].field", equalTo("product"))
+                .body("data.attributes.request.columns[1].parameters", matchesJsonMap("{}"))
+                .body("data.attributes.request.columns[1].type", equalTo("dimension"))
+                .body("data.attributes.request.columns[1]", not(hasKey("alias")))
+
+                .body("data.attributes.request.columns[2].field", equalTo("spaceId.id"))
+                .body("data.attributes.request.columns[2].parameters", matchesJsonMap("{}"))
+                .body("data.attributes.request.columns[2]", not(hasKey("type")))
+                .body("data.attributes.request.columns[2]", not(hasKey("alias")))
+
+                .body("data.attributes.request.columns[3].field", equalTo("timeSpent"))
+                .body("data.attributes.request.columns[3].parameters", matchesJsonMap("{}"))
+                .body("data.attributes.request.columns[3].type", equalTo("metric"))
+                .body("data.attributes.request.columns[3]", not(hasKey("alias")))
+
+                .body("data.attributes.request.sort.size()", Is(1))
+                .body("data.attributes.request.sort[0].field", equalTo("dateTime"))
+                .body("data.attributes.request.sort[0].parameters", matchesJsonMap("{}"))
+                .body("data.attributes.request.sort[0].direction", equalTo("desc"))
+    }
+
+    @Test
+    fun testHaving() {
+        given()
+            .header("User", USER)
+            .contentType("application/vnd.api+json")
+            .body("""
+                {
+                    "data": {
+                        "type": "reports",
+                        "attributes": {
+                            "title": "A Report",
+                            "request": {
+                                "filters": [{
+                                    "field": "foo",
+                                    "operator": "gt",
+                                    "values": [3, 3.156, -1]
+                                }],
+                                "requestVersion": "2.0"
+                            },
+                            "visualization": $visualStr
+                        },
+                        "relationships": {
+                            ${author(USER)}
+                        }
+                    }
+                }
+                """.trimIndent())
+            .When()
+                .post("/reports")
+            .then()
+                .assertThat()
+                .statusCode(HttpStatus.SC_CREATED)
+
+        given()
+            .header("User", USER)
+            .contentType("application/vnd.api+json")
+            .When()
+                .get("/reports/1")
+            .then()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("data.attributes.request.filters[0].values", hasItems(3, 3.156f, -1))
+    }
+
+    @Test
+    fun dashboardsWithRequestV2() {
+        given()
+            .header("User", USER)
+            .contentType("application/vnd.api+json")
+            .body("""
+                {
+                    "data": {
+                        "type": "dashboards",
+                        "attributes": {
+                            "title": "A dashboard",
+                            "presentation": {}
+                        },
+                        "relationships": {
+                            ${author(USER)}
+                        }
+                    }
+                }
+            """.trimIndent())
+        .When()
+            .post("/dashboards")
+        .then()
+            .assertThat()
+            .statusCode(HttpStatus.SC_CREATED)
+
+        given()
+            .header("User", USER)
+            .contentType("application/vnd.api+json")
+            .body("""
+                {
+                    "data": {
+                        "type": "dashboardWidgets",
+                        "attributes": {
+                            "title": "A widget 1",
+                            "requests": [$reqStr],
+                            "visualization": $visualStr
+                        },
+                        "relationships": {
+                            "dashboard": {
+                                "data": {
+                                    "type": "dashboards",
+                                    "id":"1"
+                                }
+                            }
+                        }
+                    }
+                }
+            """.trimIndent())
+        .When()
+            .post("/dashboards/1/widgets")
+        .then()
+            .assertThat()
+            .statusCode(HttpStatus.SC_CREATED)
+
+        given()
+            .header("User", USER)
+            .contentType("application/vnd.api+json")
+            .When()
+                .get("/dashboards/1/widgets/1")
+            .then()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+
+                .body("data.attributes.requests[0].requestVersion", equalTo("2.0"))
+                .body("data.attributes.requests[0].table", equalTo("certifiedAudience"))
+                .body("data.attributes.requests[0].dataSource", equalTo("audience"))
+
+                .body("data.attributes.requests[0].filters.size()", Is(3))
+                .body("data.attributes.requests[0].filters[0].field", equalTo("product.id"))
+                .body("data.attributes.requests[0].filters[0].operator", equalTo("in"))
+                .body("data.attributes.requests[0].filters[0].parameters", matchesJsonMap("{}"))
+                .body("data.attributes.requests[0].filters[0].values", hasItems("access_manager"))
+
+                .body("data.attributes.requests[0].filters[1].field", equalTo("timeSpent"))
+                .body("data.attributes.requests[0].filters[1].operator", equalTo("gt"))
+                .body("data.attributes.requests[0].filters[1].parameters", matchesJsonMap("{}"))
+                .body("data.attributes.requests[0].filters[1].values", hasItems(3))
+
+                .body("data.attributes.requests[0].filters[2].field", equalTo("dateTime"))
+                .body("data.attributes.requests[0].filters[2].operator", equalTo("bet"))
+                .body("data.attributes.requests[0].filters[2].parameters", matchesJsonMap("{}"))
+                .body("data.attributes.requests[0].filters[2].values", hasItems("P1D", "current"))
+
+                .body("data.attributes.requests[0].columns[0].field", equalTo("dateTime"))
+                .body("data.attributes.requests[0].columns[0].parameters", matchesJsonMap("{\"grain\":\"day\"}"))
+                .body("data.attributes.requests[0].columns[0].type", equalTo("dimension"))
+                .body("data.attributes.requests[0].columns[0].alias", equalTo("time"))
+
+                .body("data.attributes.requests[0].columns.size()", Is(4))
+                .body("data.attributes.requests[0].columns[1].field", equalTo("product"))
+                .body("data.attributes.requests[0].columns[1].parameters", matchesJsonMap("{}"))
+                .body("data.attributes.requests[0].columns[1].type", equalTo("dimension"))
+                .body("data.attributes.requests[0].columns[1]", not(hasKey("alias")))
+
+                .body("data.attributes.requests[0].columns[2].field", equalTo("spaceId.id"))
+                .body("data.attributes.requests[0].columns[2].parameters", matchesJsonMap("{}"))
+                .body("data.attributes.requests[0].columns[2]", not(hasKey("type")))
+                .body("data.attributes.requests[0].columns[2]", not(hasKey("alias")))
+
+                .body("data.attributes.requests[0].columns[3].field", equalTo("timeSpent"))
+                .body("data.attributes.requests[0].columns[3].parameters", matchesJsonMap("{}"))
+                .body("data.attributes.requests[0].columns[3].type", equalTo("metric"))
+                .body("data.attributes.requests[0].columns[3]", not(hasKey("alias")))
+
+                .body("data.attributes.requests[0].sort.size()", Is(1))
+                .body("data.attributes.requests[0].sort[0].field", equalTo("dateTime"))
+                .body("data.attributes.requests[0].sort[0].parameters", matchesJsonMap("{}"))
+                .body("data.attributes.requests[0].sort[0].direction", equalTo("desc"))
+    }
+}

--- a/packages/webservice/app/src/test/kotlin/com/yahoo/navi/ws/test/integration/UserTest.kt
+++ b/packages/webservice/app/src/test/kotlin/com/yahoo/navi/ws/test/integration/UserTest.kt
@@ -145,7 +145,7 @@ class UserTest : IntegrationTest() {
                                    "table":"base"
                                 },
                                 "bardVersion":"1.0",
-                                "requestVersion":"2.0",
+                                "requestVersion":"v1",
                                 "intervals":[{
                                     "start":"2015-08-20 00:00:00.000",
                                     "end":"2015-08-21 00:00:00.000"

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/enums/ColumnType.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/enums/ColumnType.kt
@@ -1,0 +1,9 @@
+/**
+ * Copyright 2020, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+package com.yahoo.navi.ws.models.beans.enums
+
+enum class ColumnType {
+    dimension, metric, computed
+}

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/Request.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/Request.kt
@@ -1,43 +1,14 @@
 /**
- * Copyright 2019, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 package com.yahoo.navi.ws.models.beans.fragments
 
-import com.fasterxml.jackson.annotation.JsonInclude
-import com.yahoo.navi.ws.models.beans.fragments.request.Dimension
-import com.yahoo.navi.ws.models.types.JsonType
-import org.hibernate.annotations.TypeDef
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
 
-import com.yahoo.navi.ws.models.beans.fragments.request.Interval
-import com.yahoo.navi.ws.models.beans.fragments.request.Filter
-import com.yahoo.navi.ws.models.beans.fragments.request.Having
-import com.yahoo.navi.ws.models.beans.fragments.request.LogicalTable
-import com.yahoo.navi.ws.models.beans.fragments.request.Metric
-import com.yahoo.navi.ws.models.beans.fragments.request.Sort
-
-@JsonInclude(JsonInclude.Include.NON_NULL)
-@TypeDef(typeClass = JsonType::class, name = "json")
-data class Request(
-    var intervals: Array<Interval> = arrayOf(),
-    var filters: Array<Filter> = arrayOf(),
-    var dimensions: Array<Dimension> = arrayOf(),
-    var metrics: Array<Metric> = arrayOf(),
-    var logicalTable: LogicalTable,
-    var sort: Array<Sort> = arrayOf(),
-    var having: Array<Having> = arrayOf(),
-
-    var dataSource: String? = null,
-    var bardVersion: String,
-    var requestVersion: String
-) {
-    constructor() : this(
-        arrayOf<Interval>(),
-        arrayOf<Filter>(),
-        arrayOf<Dimension>(),
-        arrayOf<Metric>(),
-        LogicalTable("", ""),
-        arrayOf<Sort>(),
-        arrayOf<Having>(), null, "v1", "v1"
-    )
-}
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "requestVersion")
+@JsonSubTypes(
+    JsonSubTypes.Type(value = RequestV1::class, name = "v1"),
+    JsonSubTypes.Type(value = RequestV2::class, name = "2.0"))
+interface Request

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/RequestV1.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/RequestV1.kt
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2020, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+package com.yahoo.navi.ws.models.beans.fragments
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.yahoo.navi.ws.models.beans.fragments.request.Dimension
+import com.yahoo.navi.ws.models.types.JsonType
+import org.hibernate.annotations.TypeDef
+
+import com.yahoo.navi.ws.models.beans.fragments.request.Interval
+import com.yahoo.navi.ws.models.beans.fragments.request.Filter
+import com.yahoo.navi.ws.models.beans.fragments.request.Having
+import com.yahoo.navi.ws.models.beans.fragments.request.LogicalTable
+import com.yahoo.navi.ws.models.beans.fragments.request.Metric
+import com.yahoo.navi.ws.models.beans.fragments.request.Sort
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@TypeDef(typeClass = JsonType::class, name = "json")
+data class RequestV1(
+    var intervals: Array<Interval> = arrayOf(),
+    var filters: Array<Filter> = arrayOf(),
+    var dimensions: Array<Dimension> = arrayOf(),
+    var metrics: Array<Metric> = arrayOf(),
+    var logicalTable: LogicalTable,
+    var sort: Array<Sort> = arrayOf(),
+    var having: Array<Having> = arrayOf(),
+    var dataSource: String? = null,
+    var bardVersion: String,
+    val requestVersion: String
+) : Request {
+    constructor() : this(
+        arrayOf<Interval>(),
+        arrayOf<Filter>(),
+        arrayOf<Dimension>(),
+        arrayOf<Metric>(),
+        LogicalTable("", ""),
+        arrayOf<Sort>(),
+        arrayOf<Having>(),
+        null,
+        "v1",
+        "v1"
+    )
+}

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/RequestV2.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/RequestV2.kt
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2020, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+package com.yahoo.navi.ws.models.beans.fragments
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.yahoo.navi.ws.models.beans.fragments.request.v2.Column
+import com.yahoo.navi.ws.models.beans.fragments.request.v2.Filter
+import com.yahoo.navi.ws.models.beans.fragments.request.v2.Sort
+import com.yahoo.navi.ws.models.types.JsonType
+import org.hibernate.annotations.TypeDef
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@TypeDef(typeClass = JsonType::class, name = "json")
+data class RequestV2(
+    var filters: Array<Filter>,
+    var columns: Array<Column>,
+    var table: String,
+    var sort: Array<Sort>,
+    var limit: Int?,
+    var dataSource: String?,
+    val requestVersion: String
+) : Request {
+    constructor() : this(
+            emptyArray(),
+            emptyArray(),
+            "",
+            emptyArray(),
+            null,
+            null,
+            "2.0"
+    )
+}

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/request/v2/Column.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/request/v2/Column.kt
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2020, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+package com.yahoo.navi.ws.models.beans.fragments.request.v2
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.yahoo.navi.ws.models.beans.enums.ColumnType
+import org.hibernate.annotations.Parameter
+import org.hibernate.annotations.Type
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class Column(
+    var field: String,
+    @get: Type(type = "com.yahoo.navi.ws.models.types.JsonType", parameters = [
+        Parameter(name = "class", value = "kotlin.collections.HashMap")
+    ]) var parameters: Map<String, String>,
+    var type: ColumnType?,
+    var alias: String?
+) {
+    constructor() : this(
+            "",
+            emptyMap(),
+            null,
+            null
+    )
+}

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/request/v2/Filter.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/request/v2/Filter.kt
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2020, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+package com.yahoo.navi.ws.models.beans.fragments.request.v2
+
+import org.hibernate.annotations.Parameter
+import org.hibernate.annotations.Type
+
+data class Filter(
+    var field: String,
+    @get: Type(type = "com.yahoo.navi.ws.models.types.JsonType", parameters = [
+      Parameter(name = "class", value = "kotlin.collections.HashMap")
+      ]) var parameters: Map<String, String>,
+    var operator: String,
+    var values: Array<Any>
+) {
+    constructor() : this(
+            "",
+            emptyMap(),
+            "",
+            emptyArray()
+    )
+}

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/request/v2/Sort.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/request/v2/Sort.kt
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2020, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+package com.yahoo.navi.ws.models.beans.fragments.request.v2
+
+import org.hibernate.annotations.Parameter
+import org.hibernate.annotations.Type
+
+data class Sort(
+    var field: String,
+    @get: Type(type = "com.yahoo.navi.ws.models.types.JsonType", parameters = [
+        Parameter(name = "class", value = "kotlin.collections.HashMap")
+    ]) var parameters: Map<String, String>,
+    var direction: String
+) {
+    constructor() : this(
+            "",
+            emptyMap(),
+            ""
+    )
+}


### PR DESCRIPTION
Resolves #746 

<!-- The above line will close the issue upon merge -->

## Description

Webservice change to support storing Request V2 while still supporting v1

## Proposed Changes

- Add jackson magic to serialize/deserialize request objects in either v1 or 2.0 
- Note that there are some minor differences than Java implementations based on Kotlin data class limitations.

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
