### PR TITLE
Update: Install typescript for navi data

### DIFF
--- a/packages/data/.eslintrc.js
+++ b/packages/data/.eslintrc.js
@@ -1,20 +1,33 @@
 module.exports = {
   root: true,
-  parser: 'babel-eslint',
-  parserOptions: {
-    ecmaVersion: 2018,
-    sourceType: 'module',
-    ecmaFeatures: {
-      legacyDecorators: true
-    }
-  },
-  plugins: ['ember'],
-  extends: ['eslint:recommended', 'plugin:ember/recommended', 'prettier'],
+  parser: '@typescript-eslint/parser',
+  plugins: ['ember', 'prettier', 'qunit', '@typescript-eslint'],
+  extends: [
+    'eslint:recommended',
+    'plugin:ember/recommended',
+    'plugin:qunit/recommended',
+    'plugin:@typescript-eslint/recommended',
+    'prettier',
+    'prettier/@typescript-eslint'
+  ],
   env: {
     browser: true
   },
   rules: {
-    'ember/no-jquery': 'error'
+    'ember/no-jquery': 'error',
+
+    // cleanliness & consistency
+    'prefer-const': 'off', // const has misleading safety implications
+
+    // typescript
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    '@typescript-eslint/explicit-function-return-type': 'off',
+
+    // prettier
+    'prettier/prettier': 'error',
+
+    // better handled by prettier:
+    '@typescript-eslint/indent': 'off'
   },
   overrides: [
     // node files
@@ -40,6 +53,8 @@ module.exports = {
       plugins: ['node'],
       rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
         // add your custom rules and overrides for node files here
+        '@typescript-eslint/camelcase': 'off',
+        '@typescript-eslint/no-var-requires': 'off'
       })
     }
   ]

--- a/packages/data/.eslintrc.js
+++ b/packages/data/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
 
     // cleanliness & consistency
     'prefer-const': 'off', // const has misleading safety implications
+    'prefer-rest-params': 'off', // useful for super(...arguments) calls
 
     // typescript
     '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],

--- a/packages/data/addon/adapters/bard-metadata.js
+++ b/packages/data/addon/adapters/bard-metadata.js
@@ -35,9 +35,9 @@ export default class BardMetadataAdapter extends EmberObject {
     const host = configHost(options);
     const { namespace } = this;
     const urlId =
-        getOwner(this)
-          .lookup(`adapter:metadata/${dasherize(type)}`)
-          ?.buildURLId(id) || id;
+      getOwner(this)
+        .lookup(`adapter:metadata/${dasherize(type)}`)
+        ?.buildURLId(id) || id;
 
     return `${host}/${namespace}/${camelize(pluralize(type))}/${urlId}`;
   }

--- a/packages/data/addon/adapters/dimensions/bard.js
+++ b/packages/data/addon/adapters/dimensions/bard.js
@@ -73,9 +73,9 @@ export default class BardDimensionAdapter extends EmberObject {
     const host = configHost(options);
     const { namespace } = this;
     const urlId =
-        getOwner(this)
-          .lookup(`adapter:metadata/dimension`)
-          ?.buildURLId(dimension) || dimension;
+      getOwner(this)
+        .lookup(`adapter:metadata/dimension`)
+        ?.buildURLId(dimension) || dimension;
 
     return `${host}/${namespace}/dimensions/${urlId}/${path}/`;
   }

--- a/packages/data/addon/adapters/dimensions/keg.js
+++ b/packages/data/addon/adapters/dimensions/keg.js
@@ -179,7 +179,10 @@ export default class KegDimensionAdapter extends EmberObject {
       });
       stringQueries.forEach(query => (query.values = query.values.split(',')));
     }
-    assert("Only 'Array' query values are currently supported in Keg", andQueries.every(q => Array.isArray(q.values)));
+    assert(
+      "Only 'Array' query values are currently supported in Keg",
+      andQueries.every(q => Array.isArray(q.values))
+    );
 
     let defaultQueryOptions = {
       field: this._getDimensionMetadata(dimension, namespace).get('primaryKeyFieldName'),

--- a/packages/data/addon/helpers/metric-format.js
+++ b/packages/data/addon/helpers/metric-format.js
@@ -14,6 +14,25 @@ import { isPresent } from '@ember/utils';
 import Helper from '@ember/component/helper';
 import { getDefaultDataSourceName } from 'navi-data/utils/adapter';
 
+function _formatParameters(obj) {
+  return Object.entries(obj)
+    .filter(([key]) => key !== 'as')
+    .map(([, val]) => val)
+    .join(',');
+}
+
+/**
+ * Formats a metric given the longName
+ * @param {object} metric - bard-request metric fragment
+ * @param {string} longName - longname from metric meta data
+ * @returns {string} - formatted string
+ */
+export function metricFormat(metric, longName = '--') {
+  return isPresent(metric) && hasParameters(metric)
+    ? `${longName} (${_formatParameters(metric.parameters)})`
+    : longName;
+}
+
 export default class MetricFormatHelper extends Helper {
   /**
    * @property {Service} metricName
@@ -37,23 +56,4 @@ export default class MetricFormatHelper extends Helper {
     }
     return metricFormat(metric, longName);
   }
-}
-
-function _formatParameters(obj) {
-  return Object.entries(obj)
-    .filter(([key]) => key !== 'as')
-    .map(([, val]) => val)
-    .join(',');
-}
-
-/**
- * Formats a metric given the longName
- * @param {object} metric - bard-request metric fragment
- * @param {string} longName - longname from metric meta data
- * @returns {string} - formatted string
- */
-export function metricFormat(metric, longName = '--') {
-  return isPresent(metric) && hasParameters(metric)
-    ? `${longName} (${_formatParameters(metric.parameters)})`
-    : longName;
 }

--- a/packages/data/addon/mirage/fixtures/bard-meta-metrics.js
+++ b/packages/data/addon/mirage/fixtures/bard-meta-metrics.js
@@ -150,7 +150,10 @@ export default {
         },
         aggregation: {
           type: 'enum',
-          values: [{ id: 'dayAvg', description: 'Daily Average' }, { id: 'total', description: 'Total' }],
+          values: [
+            { id: 'dayAvg', description: 'Daily Average' },
+            { id: 'total', description: 'Total' }
+          ],
           defaultValue: 'total'
         },
         age: {

--- a/packages/data/addon/mirage/routes/bard-lite.js
+++ b/packages/data/addon/mirage/routes/bard-lite.js
@@ -89,19 +89,6 @@ function _filterDimensions(dimensions, filter) {
 }
 
 /**
- * @method _getDimensionValues
- * @param {String} name - dimension to get values for
- * @returns {Array} list of object with id + description
- */
-function _getDimensionValues(name, filter) {
-  // Return cached values, or fake new ones
-  let values =
-    DIMENSION_VALUE_MAP[name] ||
-    (DIMENSION_VALUE_MAP[name] = _fakeDimensionValues(name, faker.random.number({ min: 3, max: 5 })));
-  return _filterDimensions(values, filter);
-}
-
-/**
  * @method _fakeDimensionValues
  * @param {String} name - dimension to fake values for
  * @param {Number} count - number of values dimension should have
@@ -128,6 +115,19 @@ function _fakeDimensionValues(name, count) {
   }
 
   return fakeValues;
+}
+
+/**
+ * @method _getDimensionValues
+ * @param {String} name - dimension to get values for
+ * @returns {Array} list of object with id + description
+ */
+function _getDimensionValues(name, filter) {
+  // Return cached values, or fake new ones
+  let values =
+    DIMENSION_VALUE_MAP[name] ||
+    (DIMENSION_VALUE_MAP[name] = _fakeDimensionValues(name, faker.random.number({ min: 3, max: 5 })));
+  return _filterDimensions(values, filter);
 }
 
 /**

--- a/packages/data/addon/request-decorators/replace-null.ts
+++ b/packages/data/addon/request-decorators/replace-null.ts
@@ -14,10 +14,10 @@ const NULL_STRING_VALUE = '';
  * @param {Object} request - object with filters to replace
  * @returns {Object} new request object with updated filters
  */
-export function replaceNullFilter(request) {
+export function replaceNullFilter(request: TODO) {
   // only decorate if the request and the filters array are defined
   if (request && request.filters) {
-    const updatedFilters = request.filters.map(filter => {
+    const updatedFilters = request.filters.map((filter: TODO) => {
       // Update any filter that matches the given dimension
       if (filter.operator === 'null' || filter.operator === 'notnull') {
         // Build new value array and replace id with newIds

--- a/packages/data/addon/services/metric-parameter.js
+++ b/packages/data/addon/services/metric-parameter.js
@@ -7,7 +7,6 @@
 
 import Service from '@ember/service';
 import { inject as service } from '@ember/service';
-import { set } from '@ember/object';
 import { assert } from '@ember/debug';
 import { resolve, hash } from 'rsvp';
 

--- a/packages/data/addon/services/request-decorator.ts
+++ b/packages/data/addon/services/request-decorator.ts
@@ -3,7 +3,7 @@
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import Service from '@ember/service';
-import ReplaceNull from 'navi-data/request-decorators/replace-null';
+import { replaceNullFilter } from '../request-decorators/replace-null';
 
 export default class RequestDecoratorService extends Service {
   /**
@@ -11,7 +11,7 @@ export default class RequestDecoratorService extends Service {
    * @param {Object} request - object to modify
    * @returns {Object} transformed version of request
    */
-  applyGlobalDecorators(request) {
-    return ReplaceNull.replaceNullFilter(request);
+  applyGlobalDecorators(request: TODO) {
+    return replaceNullFilter(request);
   }
 }

--- a/packages/data/addon/utils/metric.js
+++ b/packages/data/addon/utils/metric.js
@@ -6,25 +6,22 @@ import { isEmpty } from '@ember/utils';
 import { get } from '@ember/object';
 
 /**
- * Returns canonicalized name of a paramterized metric
- * @function canonicalizeMetric
- * @param {Object} metric
- * @param {String} metric.metric - metric name
- * @param {Object} metric.parameters - a key: value object of parameters
- */
-export function canonicalizeMetric(metric) {
-  return hasParameters(metric) ? `${metric.metric}(${serializeParameters(metric.parameters)})` : metric.metric;
-}
-
-/**
- * Returns canonicalized name given metric column attributes
- * @function canonicalizeColumnAttributes
- * @param {Object} attributes
+ * Returns a metric object given column attributes
+ * @function mapColumnAttributes
+ * @param {Object} attributes - column attributes
  * @param {String} attributes.name - metric name
- * @param {Object} attributes.parameters - a key: value object of parameters
+ * @param {Object} attributes.parameters - metric parameters
+ * @returns {Object} - object with metric name and parameters
  */
-export function canonicalizeColumnAttributes(attributes) {
-  return canonicalizeMetric(mapColumnAttributes(attributes));
+export function mapColumnAttributes(attributes) {
+  let metric = get(attributes, 'name'),
+    parameters = get(attributes, 'parameters') || {};
+
+  if (isEmpty(metric)) {
+    throw new Error('Metric Column Attributes Mapper: Error, empty metric name');
+  }
+
+  return { metric, parameters };
 }
 
 /**
@@ -56,6 +53,28 @@ export function serializeParameters(obj = {}) {
     .filter(([, value]) => value !== null && value !== undefined)
     .map(([key, value]) => `${key}=${value}`)
     .join(',');
+}
+
+/**
+ * Returns canonicalized name of a paramterized metric
+ * @function canonicalizeMetric
+ * @param {Object} metric
+ * @param {String} metric.metric - metric name
+ * @param {Object} metric.parameters - a key: value object of parameters
+ */
+export function canonicalizeMetric(metric) {
+  return hasParameters(metric) ? `${metric.metric}(${serializeParameters(metric.parameters)})` : metric.metric;
+}
+
+/**
+ * Returns canonicalized name given metric column attributes
+ * @function canonicalizeColumnAttributes
+ * @param {Object} attributes
+ * @param {String} attributes.name - metric name
+ * @param {Object} attributes.parameters - a key: value object of parameters
+ */
+export function canonicalizeColumnAttributes(attributes) {
+  return canonicalizeMetric(mapColumnAttributes(attributes));
 }
 
 /**
@@ -135,23 +154,4 @@ export function parseMetricName(canonicalName) {
     metric,
     parameters
   };
-}
-
-/**
- * Returns a metric object given column attributes
- * @function mapColumnAttributes
- * @param {Object} attributes - column attributes
- * @param {String} attributes.name - metric name
- * @param {Object} attributes.parameters - metric parameters
- * @returns {Object} - object with metric name and parameters
- */
-export function mapColumnAttributes(attributes) {
-  let metric = get(attributes, 'name'),
-    parameters = get(attributes, 'parameters') || {};
-
-  if (isEmpty(metric)) {
-    throw new Error('Metric Column Attributes Mapper: Error, empty metric name');
-  }
-
-  return { metric, parameters };
 }

--- a/packages/data/addon/utils/search.js
+++ b/packages/data/addon/utils/search.js
@@ -22,11 +22,11 @@ export default {
    */
   getPartialMatchWeight(string, query) {
     // Split search query into individual words
-    var searchTokens = w(query.trim()),
+    let searchTokens = w(query.trim()),
       allTokensFound = true;
 
     // Check that all words in the search query can be found in the given string
-    for (var i = 0; i < searchTokens.length; i++) {
+    for (let i = 0; i < searchTokens.length; i++) {
       if (string.indexOf(searchTokens[i]) === -1) {
         allTokensFound = false;
         break;

--- a/packages/data/config/environment.d.ts
+++ b/packages/data/config/environment.d.ts
@@ -1,0 +1,17 @@
+export default config;
+
+/**
+ * Type declarations for
+ *    import config from './config/environment'
+ *
+ * For now these need to be managed by the developer
+ * since different ember addons can materialize new entries.
+ */
+declare const config: {
+  environment: any;
+  modulePrefix: string;
+  podModulePrefix: string;
+  locationType: string;
+  rootURL: string;
+  APP: any;
+};

--- a/packages/data/package-lock.json
+++ b/packages/data/package-lock.json
@@ -1523,7 +1523,6 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.8.3.tgz",
       "integrity": "sha512-GO1MQ/SGGGoiEXY0e0bSpHimJvxqB7lktLLIq2pv8xG7WZ8IMEle74jIe1FhprHBWjwjZtXHkycDLZXIWM5Wfg==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3"
       },
@@ -1531,8 +1530,7 @@
         "@babel/helper-plugin-utils": {
           "version": "7.8.3",
           "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-          "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-          "dev": true
+          "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
         }
       }
     },
@@ -2218,6 +2216,23 @@
         }
       }
     },
+    "@babel/plugin-transform-typescript": {
+      "version": "7.8.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.8.7.tgz",
+      "integrity": "sha512-7O0UsPQVNKqpHeHLpfvOG4uXmlw+MOxYvUv6Otc9uH5SYMIxvF6eBdjkWvC3f9G+VXe0RsNExyAQBeTRug/wqQ==",
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-syntax-typescript": "^7.8.3"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
+          "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
+        }
+      }
+    },
     "@babel/plugin-transform-unicode-regex": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.8.3.tgz",
@@ -2328,6 +2343,35 @@
             "esutils": "^2.0.2",
             "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/preset-typescript": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.9.0.tgz",
+      "integrity": "sha512-S4cueFnGrIbvYJgwsVFKdvOmpiL0XGw9MFW9D0vgRys5g36PBhZRL8NX8Gr2akz8XRtzq6HuDXPD/1nniagNUg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-transform-typescript": "^7.9.0"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
+          "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
+          "dev": true
+        },
+        "@babel/plugin-transform-typescript": {
+          "version": "7.9.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.9.4.tgz",
+          "integrity": "sha512-yeWeUkKx2auDbSxRe8MusAG+n4m9BFY/v+lPjmQDgOFX5qnySkUY5oXzkp6FwPdsYqnKay6lorXYdC0n3bZO7w==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-create-class-features-plugin": "^7.8.3",
+            "@babel/helper-plugin-utils": "^7.8.3",
+            "@babel/plugin-syntax-typescript": "^7.8.3"
           }
         }
       }
@@ -3046,6 +3090,219 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
+    "@types/ember": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@types/ember/-/ember-3.1.2.tgz",
+      "integrity": "sha512-Z4jxklUlnoWEkenLaMDDmzguL3UUcAIaCiu28nNYlIovWTGmvKuJgUKSqd+03j4jjzaz+yz0fepM408XULew/A==",
+      "dev": true,
+      "requires": {
+        "@types/ember__application": "*",
+        "@types/ember__array": "*",
+        "@types/ember__component": "*",
+        "@types/ember__controller": "*",
+        "@types/ember__debug": "*",
+        "@types/ember__engine": "*",
+        "@types/ember__error": "*",
+        "@types/ember__object": "*",
+        "@types/ember__polyfills": "*",
+        "@types/ember__routing": "*",
+        "@types/ember__runloop": "*",
+        "@types/ember__service": "*",
+        "@types/ember__string": "*",
+        "@types/ember__template": "*",
+        "@types/ember__test": "*",
+        "@types/ember__utils": "*",
+        "@types/htmlbars-inline-precompile": "*",
+        "@types/jquery": "*",
+        "@types/rsvp": "*"
+      }
+    },
+    "@types/ember-qunit": {
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/@types/ember-qunit/-/ember-qunit-3.4.8.tgz",
+      "integrity": "sha512-eAFYXit9vIXLiJiLzmI3Y37+AprHX0aVkgkC9cZzOLPAFeTSJ9T6Mso0o9EvrlAeFe/opg9uGp/QUgbX7X7IAw==",
+      "dev": true,
+      "requires": {
+        "@types/ember": "*",
+        "@types/ember-test-helpers": "*"
+      }
+    },
+    "@types/ember-test-helpers": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@types/ember-test-helpers/-/ember-test-helpers-1.0.7.tgz",
+      "integrity": "sha512-qxBdoXv+cW4J907s9CftS6qrgkkXWROT6I1TV2yW5eErCMu9YvPU7X8z4qFQ/ZVZOgoT5lVnsgYX1a36RJE8xw==",
+      "dev": true,
+      "requires": {
+        "@types/ember": "*",
+        "@types/htmlbars-inline-precompile": "*",
+        "@types/jquery": "*",
+        "@types/rsvp": "*"
+      }
+    },
+    "@types/ember__application": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/ember__application/-/ember__application-3.0.8.tgz",
+      "integrity": "sha512-+Swh9w3s921nrbzYWbVl9W+zGIjel8LNvczVhtUdmss7PMii/yzU52/41a+VoesfO/1zfIkG3KJpvBBob5mTvw==",
+      "dev": true,
+      "requires": {
+        "@types/ember__application": "*",
+        "@types/ember__engine": "*",
+        "@types/ember__object": "*",
+        "@types/ember__routing": "*"
+      }
+    },
+    "@types/ember__array": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/ember__array/-/ember__array-3.0.6.tgz",
+      "integrity": "sha512-cLIpWjOYCDtqKk+YlsrT5Bf4qAxThYngOk9vHzzBxPqmbTY/E5zRsyxbYIuDmeOPiyWVJ6qliBomnTVdgZK0cA==",
+      "dev": true,
+      "requires": {
+        "@types/ember__array": "*",
+        "@types/ember__object": "*"
+      }
+    },
+    "@types/ember__component": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/ember__component/-/ember__component-3.0.7.tgz",
+      "integrity": "sha512-IC919wn7OfDFAGVgwWA26QRvyPk/XTJJh/inlFwwHuOUmysQ0hB2KOGgU8nSWfL8aIoNH99HB3oyIAH2tM9gQg==",
+      "dev": true,
+      "requires": {
+        "@types/ember__component": "*",
+        "@types/ember__object": "*",
+        "@types/jquery": "*"
+      }
+    },
+    "@types/ember__controller": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/ember__controller/-/ember__controller-3.0.8.tgz",
+      "integrity": "sha512-AgBA3T3nPa14OyTLCtR2FJyoRtKvR5lbzvvYli2z1smCJEdmyvNuGk71sgJNai57SW7la93HQS+g6d18VZgEKw==",
+      "dev": true,
+      "requires": {
+        "@types/ember__object": "*"
+      }
+    },
+    "@types/ember__debug": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/ember__debug/-/ember__debug-3.0.7.tgz",
+      "integrity": "sha512-GtS8vwt0t1KwzFvOllKCJ0k8gGzhohsCjlfeksmR1rnMuzb/tiuKKXWOP5UszTRg+OK68bSzZMuw1SQKFAZE4w==",
+      "dev": true,
+      "requires": {
+        "@types/ember__debug": "*",
+        "@types/ember__engine": "*",
+        "@types/ember__object": "*"
+      }
+    },
+    "@types/ember__engine": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/ember__engine/-/ember__engine-3.0.5.tgz",
+      "integrity": "sha512-RfmgcNuwj6OJzsJejj9Zu/4td5xHHIj/Mydk0dYqBLoNFp/BKVMhYwuxOHZLkcF/Vy36R33UJ8zIklZuYli1SA==",
+      "dev": true,
+      "requires": {
+        "@types/ember__engine": "*",
+        "@types/ember__object": "*"
+      }
+    },
+    "@types/ember__error": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/ember__error/-/ember__error-3.0.4.tgz",
+      "integrity": "sha512-GBYIuZBanzMgai6sfZAzgxe5PPIABBR7IkZEzu/pzSxeZl26TkurK1IlwP+L3RKet+2Fw2r4Cfsw5O2vRUsv1Q==",
+      "dev": true
+    },
+    "@types/ember__object": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/ember__object/-/ember__object-3.1.3.tgz",
+      "integrity": "sha512-4B9XK76TIuWCgGEgwbcGbmaIH2R2C5+BXg1zgGYagxnoLl/TCCKYwtSaUm3/z/z3l5Yk+4PA2MZeXBQmPKMC6A==",
+      "dev": true,
+      "requires": {
+        "@types/ember__object": "*",
+        "@types/rsvp": "*"
+      }
+    },
+    "@types/ember__polyfills": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/ember__polyfills/-/ember__polyfills-3.0.7.tgz",
+      "integrity": "sha512-aQUI0HTIlTroMrQrfu533pBiNm39v5O6ec2bNcfDRFhKYVRVCaI88llH/QssRCUywrPdnQnLpUJFF95JNk0rUQ==",
+      "dev": true
+    },
+    "@types/ember__routing": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@types/ember__routing/-/ember__routing-3.0.12.tgz",
+      "integrity": "sha512-uguCrJdycNJtLrdgiu3bfqpcQ4dhCCrS7wB5CyTAvy0SNcqfRBxGOlPUBzgljxPYCtQ1kIqJpmoPorG56hTi0A==",
+      "dev": true,
+      "requires": {
+        "@types/ember__component": "*",
+        "@types/ember__controller": "*",
+        "@types/ember__object": "*",
+        "@types/ember__routing": "*",
+        "@types/ember__service": "*"
+      }
+    },
+    "@types/ember__runloop": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/ember__runloop/-/ember__runloop-3.0.7.tgz",
+      "integrity": "sha512-mi1GquXQDtAvc5yww8QgUgOIb+SBZnSyffx6bvv1POjpQSvb5/sYEyEGGTg2nbjArB9zhOtg9CfCj6llOchdjA==",
+      "dev": true,
+      "requires": {
+        "@types/ember__runloop": "*"
+      }
+    },
+    "@types/ember__service": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/ember__service/-/ember__service-3.0.6.tgz",
+      "integrity": "sha512-UA1QEDQylGgxdLHr03uMOeX5idW6fqsqHUvPjCjTvxmJlIHCcejJ/qwXtZRri4GsLfMlMJowJQVxRm29WwdScg==",
+      "dev": true,
+      "requires": {
+        "@types/ember__object": "*"
+      }
+    },
+    "@types/ember__string": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/ember__string/-/ember__string-3.0.8.tgz",
+      "integrity": "sha512-xOGHilXWx/talkpGhgRL+FEQJAImwe97JXcFTFD2rELbh0slL/HI7rSvBeWCPKp75cflNHUCr1N943iTGt5J0g==",
+      "dev": true,
+      "requires": {
+        "@types/ember__template": "*"
+      }
+    },
+    "@types/ember__template": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/ember__template/-/ember__template-3.0.1.tgz",
+      "integrity": "sha512-6hYGNLvYhwv+XvRFXeObMu8Fr2h3tslb+YQNE2UKU81ul8AJZ+utZuGpEVZ221sa49HWm220yNVuOFeQcC4PhA==",
+      "dev": true
+    },
+    "@types/ember__test": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/ember__test/-/ember__test-3.0.6.tgz",
+      "integrity": "sha512-q5BmDF0NZ3nXUAy8da/dXDfVZMsHxNj6vqONBoq/GLGS5kxNJNXiYsa5NG5BVXv1Gd4fIT6lySlX5x/yUqtYdA==",
+      "dev": true,
+      "requires": {
+        "@types/ember__application": "*"
+      }
+    },
+    "@types/ember__test-helpers": {
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/@types/ember__test-helpers/-/ember__test-helpers-0.7.10.tgz",
+      "integrity": "sha512-e+NVsScAO+BcWCki9CuepScJ4akiKORrFyYaEvpoRSyyM5UpvY4Ov175hXxcNFv5JSyIvPUvhZtOH2W3BlLHhA==",
+      "dev": true,
+      "requires": {
+        "@types/ember": "*",
+        "@types/ember__application": "*",
+        "@types/ember__error": "*",
+        "@types/htmlbars-inline-precompile": "*"
+      }
+    },
+    "@types/ember__utils": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/ember__utils/-/ember__utils-3.0.4.tgz",
+      "integrity": "sha512-JmX5VPRmvAKHzLGBLXPqupcGLEeqvTVjIdsg09WRn+QvEOlVUzLgl/DM9uaOXXmp+aZUhNKtz2skmsxxu/ac2w==",
+      "dev": true
+    },
+    "@types/eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
+      "dev": true
+    },
     "@types/estree": {
       "version": "0.0.44",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.44.tgz",
@@ -3075,6 +3332,27 @@
         "@types/node": "*"
       }
     },
+    "@types/htmlbars-inline-precompile": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/htmlbars-inline-precompile/-/htmlbars-inline-precompile-1.0.1.tgz",
+      "integrity": "sha512-sVD2e6QAAHW0Y6Btse+tTA9k9g0iKm87wjxRsgZRU5EwSooz80tenbV+fA+f2BI2g0G2CqxsS1rIlwQCtPRQow==",
+      "dev": true
+    },
+    "@types/jquery": {
+      "version": "3.3.34",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.34.tgz",
+      "integrity": "sha512-lW9vsVL53Xu/Nj4gi2hNmHGc4u3KKghjqTkAlO0kF5GIOPxbqqnQpgqJBzmn3yXLrPqHb6cmNJ6URnS23Vtvbg==",
+      "dev": true,
+      "requires": {
+        "@types/sizzle": "*"
+      }
+    },
+    "@types/json-schema": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
+      "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
+      "dev": true
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -3085,6 +3363,12 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.5.tgz",
       "integrity": "sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w=="
     },
+    "@types/qunit": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@types/qunit/-/qunit-2.9.1.tgz",
+      "integrity": "sha512-v51Fz/orMOkBGzrRvskky3UN0I81ka6rokAxkcuVyLHAh0qNKp+Roqympg/gTia8vGOIEbeSykevI0VKiIF13Q==",
+      "dev": true
+    },
     "@types/rimraf": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-2.0.3.tgz",
@@ -3093,6 +3377,18 @@
         "@types/glob": "*",
         "@types/node": "*"
       }
+    },
+    "@types/rsvp": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/rsvp/-/rsvp-4.0.3.tgz",
+      "integrity": "sha512-OpRwxbgx16nL/0/7ol0WoLLyLaMXBvtPOHjqLljnzAB/E7Qk1wtjytxgBhOTBMZvuLXnJUqfnjb4W/QclNFvSA==",
+      "dev": true
+    },
+    "@types/sizzle": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.2.tgz",
+      "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==",
+      "dev": true
     },
     "@types/symlink-or-copy": {
       "version": "1.2.0",
@@ -3104,6 +3400,117 @@
       "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.0.tgz",
       "integrity": "sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==",
       "dev": true
+    },
+    "@typescript-eslint/eslint-plugin": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.28.0.tgz",
+      "integrity": "sha512-w0Ugcq2iatloEabQP56BRWJowliXUP5Wv6f9fKzjJmDW81hOTBxRoJ4LoEOxRpz9gcY51Libytd2ba3yLmSOfg==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "2.28.0",
+        "functional-red-black-tree": "^1.0.1",
+        "regexpp": "^3.0.0",
+        "tsutils": "^3.17.1"
+      },
+      "dependencies": {
+        "regexpp": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+          "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+          "dev": true
+        }
+      }
+    },
+    "@typescript-eslint/experimental-utils": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.28.0.tgz",
+      "integrity": "sha512-4SL9OWjvFbHumM/Zh/ZeEjUFxrYKtdCi7At4GyKTbQlrj1HcphIDXlje4Uu4cY+qzszR5NdVin4CCm6AXCjd6w==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.3",
+        "@typescript-eslint/typescript-estree": "2.28.0",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^2.0.0"
+      },
+      "dependencies": {
+        "eslint-scope": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+          "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "eslint-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
+          "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        }
+      }
+    },
+    "@typescript-eslint/parser": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.28.0.tgz",
+      "integrity": "sha512-RqPybRDquui9d+K86lL7iPqH6Dfp9461oyqvlXMNtap+PyqYbkY5dB7LawQjDzot99fqzvS0ZLZdfe+1Bt3Jgw==",
+      "dev": true,
+      "requires": {
+        "@types/eslint-visitor-keys": "^1.0.0",
+        "@typescript-eslint/experimental-utils": "2.28.0",
+        "@typescript-eslint/typescript-estree": "2.28.0",
+        "eslint-visitor-keys": "^1.1.0"
+      }
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.28.0.tgz",
+      "integrity": "sha512-HDr8MP9wfwkiuqzRVkuM3BeDrOC4cKbO5a6BymZBHUt5y/2pL0BXD6I/C/ceq2IZoHWhcASk+5/zo+dwgu9V8Q==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "eslint-visitor-keys": "^1.1.0",
+        "glob": "^7.1.6",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.15",
+        "semver": "^6.3.0",
+        "tsutils": "^3.17.1"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "is-glob": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
     },
     "@webassemblyjs/ast": {
       "version": "1.7.11",
@@ -3430,7 +3837,6 @@
       "version": "0.6.14",
       "resolved": "https://registry.npmjs.org/ansi-to-html/-/ansi-to-html-0.6.14.tgz",
       "integrity": "sha512-7ZslfB1+EnFSDO5Ju+ue5Y6It19DRnZXWv8jrGHgIlPna5Mh4jz7BV5jCbQneXNFurQcKoolaaAjHtgSBfOIuA==",
-      "dev": true,
       "requires": {
         "entities": "^1.1.2"
       }
@@ -10923,6 +11329,15 @@
         }
       }
     },
+    "ember-cli-test-info": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-test-info/-/ember-cli-test-info-1.0.0.tgz",
+      "integrity": "sha1-7U6WDySel1I8+JHkrtIHLOhFd7Q=",
+      "dev": true,
+      "requires": {
+        "ember-cli-string-utils": "^1.0.0"
+      }
+    },
     "ember-cli-test-loader": {
       "version": "2.2.0",
       "resolved": "https://ynpm-registry.corp.yahoo.com/ember-cli-test-loader/-/ember-cli-test-loader-2.2.0.tgz",
@@ -11114,6 +11529,210 @@
         }
       }
     },
+    "ember-cli-typescript": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-3.1.3.tgz",
+      "integrity": "sha512-bFi15H60L9TLYfn9XUzi+RAP1gTWHFtVdSy9IHvxXHlCvTlFZ+2rfuugr/f8reQLz9gvJccKc5TyRD7v+uhx0Q==",
+      "requires": {
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.4.4",
+        "@babel/plugin-proposal-optional-chaining": "^7.6.0",
+        "@babel/plugin-transform-typescript": "~7.8.0",
+        "ansi-to-html": "^0.6.6",
+        "broccoli-stew": "^3.0.0",
+        "debug": "^4.0.0",
+        "ember-cli-babel-plugin-helpers": "^1.0.0",
+        "execa": "^3.0.0",
+        "fs-extra": "^8.0.0",
+        "resolve": "^1.5.0",
+        "rsvp": "^4.8.1",
+        "semver": "^6.3.0",
+        "stagehand": "^1.0.0",
+        "walk-sync": "^2.0.0"
+      },
+      "dependencies": {
+        "broccoli-funnel": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+          "requires": {
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
+          },
+          "dependencies": {
+            "broccoli-plugin": {
+              "version": "1.3.1",
+              "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
+              "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
+              "requires": {
+                "promise-map-series": "^0.2.1",
+                "quick-temp": "^0.1.3",
+                "rimraf": "^2.3.4",
+                "symlink-or-copy": "^1.1.8"
+              }
+            },
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "walk-sync": {
+              "version": "0.3.4",
+              "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.4.tgz",
+              "integrity": "sha512-ttGcuHA/OBnN2pcM6johpYlEms7XpO5/fyKIr48541xXedan4roO8cS1Q2S/zbbjGH/BarYDAMeS2Mi9HE5Tig==",
+              "requires": {
+                "ensure-posix-path": "^1.0.0",
+                "matcher-collection": "^1.0.0"
+              }
+            }
+          }
+        },
+        "broccoli-plugin": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-2.1.0.tgz",
+          "integrity": "sha512-ElE4caljW4slapyEhSD9jU9Uayc8SoSABWdmY9SqbV8DHNxU6xg1jJsPcMm+cXOvggR3+G+OXAYQeFjWVnznaw==",
+          "requires": {
+            "promise-map-series": "^0.2.1",
+            "quick-temp": "^0.1.3",
+            "rimraf": "^2.3.4",
+            "symlink-or-copy": "^1.1.8"
+          }
+        },
+        "broccoli-stew": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/broccoli-stew/-/broccoli-stew-3.0.0.tgz",
+          "integrity": "sha512-NXfi+Vas24n3Ivo21GvENTI55qxKu7OwKRnCLWXld8MiLiQKQlWIq28eoARaFj0lTUFwUa4jKZeA7fW9PiWQeg==",
+          "requires": {
+            "broccoli-debug": "^0.6.5",
+            "broccoli-funnel": "^2.0.0",
+            "broccoli-merge-trees": "^3.0.1",
+            "broccoli-persistent-filter": "^2.3.0",
+            "broccoli-plugin": "^2.1.0",
+            "chalk": "^2.4.1",
+            "debug": "^4.1.1",
+            "ensure-posix-path": "^1.0.1",
+            "fs-extra": "^8.0.1",
+            "minimatch": "^3.0.4",
+            "resolve": "^1.11.1",
+            "rsvp": "^4.8.5",
+            "symlink-or-copy": "^1.2.0",
+            "walk-sync": "^1.1.3"
+          },
+          "dependencies": {
+            "walk-sync": {
+              "version": "1.1.4",
+              "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-1.1.4.tgz",
+              "integrity": "sha512-nowc9thB/Jg0KW4TgxoRjLLYRPvl3DB/98S89r4ZcJqq2B0alNcKDh6pzLkBSkPMzRSMsJghJHQi79qw0YWEkA==",
+              "requires": {
+                "@types/minimatch": "^3.0.3",
+                "ensure-posix-path": "^1.1.0",
+                "matcher-collection": "^1.1.1"
+              }
+            }
+          }
+        },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        },
+        "walk-sync": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.1.0.tgz",
+          "integrity": "sha512-KpH9Xw64LNSx7/UI+3guRZvJWlDxVA4+KKb/4puRoVrG8GkvZRxnF3vhxdjgpoKJGL2TVg1OrtkXIE/VuGPLHQ==",
+          "requires": {
+            "@types/minimatch": "^3.0.3",
+            "ensure-posix-path": "^1.1.0",
+            "matcher-collection": "^2.0.0"
+          },
+          "dependencies": {
+            "matcher-collection": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
+              "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
+              "requires": {
+                "@types/minimatch": "^3.0.3",
+                "minimatch": "^3.0.2"
+              }
+            }
+          }
+        }
+      }
+    },
+    "ember-cli-typescript-blueprints": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-typescript-blueprints/-/ember-cli-typescript-blueprints-3.0.0.tgz",
+      "integrity": "sha512-nJScjIjwDY96q9eiIBse9npLht/1FNmDRMpoTLJUrgSTzmx7/S6JhlH4BrMELkLCvtPkWoduDNBGiGBdCqf9FA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.1",
+        "ember-cli-babel": "^7.0.0",
+        "ember-cli-get-component-path-option": "^1.0.0",
+        "ember-cli-is-package-missing": "^1.0.0",
+        "ember-cli-normalize-entity-name": "^1.0.0",
+        "ember-cli-path-utils": "^1.0.0",
+        "ember-cli-string-utils": "^1.1.0",
+        "ember-cli-test-info": "^1.0.0",
+        "ember-cli-valid-component-name": "^1.0.0",
+        "ember-cli-version-checker": "^3.0.0",
+        "ember-router-generator": "^2.0.0",
+        "exists-sync": "^0.1.0",
+        "fs-extra": "^8.0.0",
+        "inflection": "^1.12.0",
+        "silent-error": "^1.1.0"
+      },
+      "dependencies": {
+        "ember-cli-version-checker": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-3.1.3.tgz",
+          "integrity": "sha512-PZNSvpzwWgv68hcXxyjREpj3WWb81A7rtYNQq1lLEgrWIchF8ApKJjWP3NBpHjaatwILkZAV8klair5WFlXAKg==",
+          "dev": true,
+          "requires": {
+            "resolve-package-path": "^1.2.6",
+            "semver": "^5.6.0"
+          }
+        },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        }
+      }
+    },
     "ember-cli-uglify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ember-cli-uglify/-/ember-cli-uglify-3.0.0.tgz",
@@ -11122,6 +11741,15 @@
       "requires": {
         "broccoli-uglify-sourcemap": "^3.1.0",
         "lodash.defaultsdeep": "^4.6.0"
+      }
+    },
+    "ember-cli-valid-component-name": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-valid-component-name/-/ember-cli-valid-component-name-1.0.0.tgz",
+      "integrity": "sha1-cVUM44fgIzBl8wswsVEKot++h+8=",
+      "dev": true,
+      "requires": {
+        "silent-error": "^1.0.0"
       }
     },
     "ember-cli-version-checker": {
@@ -14204,8 +14832,7 @@
     "entities": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-      "dev": true
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
     },
     "errno": {
       "version": "0.1.7",
@@ -14364,9 +14991,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-3.6.0.tgz",
-      "integrity": "sha512-ixJ4U3uTLXwJts4rmSVW/lMXjlGwCijhBJHk8iVqKKSifeI0qgFEfWl8L63isfc8Od7EiBALF6BX3jKLluf/jQ==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.1.tgz",
+      "integrity": "sha512-svTy6zh1ecQojvpbJSgH3aei/Rt7C6i090l5f2WQ4aB05lYHeZIR1qL4wZyyILTbtmnbHP5Yn8MrsOJMGa8RkQ==",
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"
@@ -14454,6 +15081,21 @@
           "dev": true
         }
       }
+    },
+    "eslint-plugin-prettier": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.3.tgz",
+      "integrity": "sha512-+HG5jmu/dN3ZV3T6eCD7a4BlAySdN7mLIbJYo0z1cFQuI+r2DiTJEFeF68ots93PsnrMxbzIZ2S/ieX+mkrBeQ==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
+      }
+    },
+    "eslint-plugin-qunit": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-4.0.0.tgz",
+      "integrity": "sha512-+0i2xcYryUoLawi47Lp0iJKzkP931G5GXwIOq1KBKQc2pknV1VPjfE6b4mI2mR2RnL7WRoS30YjwC9SjQgJDXQ==",
+      "dev": true
     },
     "eslint-scope": {
       "version": "4.0.3",
@@ -14572,10 +15214,89 @@
       "integrity": "sha512-sEFIkc61v75sWeOe72qyrqg2Qg0OuLESziUDk/O/z2qgS15y2gWVFrI6f2Qn/qw/0/NCfCEsmNA4zOjkwEZT1A==",
       "dev": true
     },
+    "execa": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
+      "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
+      "requires": {
+        "cross-spawn": "^7.0.0",
+        "get-stream": "^5.0.0",
+        "human-signals": "^1.1.1",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.0",
+        "onetime": "^5.1.0",
+        "p-finally": "^2.0.0",
+        "signal-exit": "^3.0.2",
+        "strip-final-newline": "^2.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.2.tgz",
+          "integrity": "sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==",
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+        },
+        "onetime": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
+        },
+        "p-finally": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+          "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw=="
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "exists-stat": {
       "version": "1.0.0",
       "resolved": "https://ynpm-registry.corp.yahoo.com/exists-stat/-/exists-stat-1.0.0.tgz",
       "integrity": "sha1-BmDjUlouidnkRhKUQMJy7foktSk=",
+      "dev": true
+    },
+    "exists-sync": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/exists-sync/-/exists-sync-0.1.0.tgz",
+      "integrity": "sha512-qEfFekfBVid4b14FNug/RNY1nv+BADnlzKGHulc+t6ZLqGY4kdHGh1iFha8lnE3sJU/1WzMzKRNxS6EvSakJUg==",
       "dev": true
     },
     "exit": {
@@ -14831,6 +15552,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+    },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "dev": true
     },
     "fast-glob": {
       "version": "3.1.1",
@@ -16044,6 +16771,14 @@
       "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
       "dev": true
     },
+    "get-stream": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+      "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+      "requires": {
+        "pump": "^3.0.0"
+      }
+    },
     "get-value": {
       "version": "2.0.6",
       "resolved": "https://ynpm-registry.corp.yahoo.com/get-value/-/get-value-2.0.6.tgz",
@@ -16650,6 +17385,11 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
     },
+    "human-signals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -17044,6 +17784,11 @@
       "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
       "dev": true
     },
+    "is-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+    },
     "is-symbol": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
@@ -17094,8 +17839,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://ynpm-registry.corp.yahoo.com/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
       "version": "3.0.1",
@@ -18063,6 +18807,11 @@
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true
     },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+    },
     "merge-trees": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-2.0.0.tgz",
@@ -18586,6 +19335,21 @@
         "osenv": "^0.1.5",
         "semver": "^5.6.0",
         "validate-npm-package-name": "^3.0.0"
+      }
+    },
+    "npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "requires": {
+        "path-key": "^3.0.0"
+      },
+      "dependencies": {
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+        }
       }
     },
     "npmlog": {
@@ -19377,6 +20141,15 @@
         "@xg-wang/whatwg-fetch": "^3.0.0",
         "fake-xml-http-request": "^2.0.0",
         "route-recognizer": "^0.3.3"
+      }
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
       }
     },
     "pretty-ms": {
@@ -20565,8 +21338,7 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://ynpm-registry.corp.yahoo.com/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "silent-error": {
       "version": "1.1.1",
@@ -21065,7 +21837,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stagehand/-/stagehand-1.0.0.tgz",
       "integrity": "sha512-zrXl0QixAtSHFyN1iv04xOBgplbT4HgC8T7g+q8ESZbDNi5uZbMtxLukFVXPJ5Nl7zCYvYcrT3Mj24WYCH93hw==",
-      "dev": true,
       "requires": {
         "debug": "^4.1.0"
       }
@@ -21265,6 +22036,11 @@
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
+    },
+    "strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -21840,6 +22616,15 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
       "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
+    "tsutils": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
+      "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      }
+    },
     "tty-browserify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
@@ -21895,6 +22680,12 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typescript": {
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
+      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
+      "dev": true
     },
     "typescript-memoize": {
       "version": "1.0.0-alpha.3",

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "ember build --environment=production",
     "lint:hbs": "ember-template-lint .",
-    "lint:js": "eslint . && tsc --noEmit",
+    "lint:js": "eslint . && tsc --allowJs false --noEmit",
     "lint": "npm run lint:hbs && npm run lint:js",
     "start": "ember serve",
     "test": "export COVERAGE=true; ember test --test-port 0",

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -17,10 +17,12 @@
   "scripts": {
     "build": "ember build --environment=production",
     "lint:hbs": "ember-template-lint .",
-    "lint:js": "eslint .",
+    "lint:js": "eslint . && tsc --noEmit",
     "lint": "npm run lint:hbs && npm run lint:js",
     "start": "ember serve",
-    "test": "export COVERAGE=true; ember test --test-port 0"
+    "test": "export COVERAGE=true; ember test --test-port 0",
+    "prepublishOnly": "ember ts:precompile",
+    "postpublish": "ember ts:clean"
   },
   "dependencies": {
     "apollo-link-context": "^1.0.19",
@@ -33,10 +35,19 @@
     "ember-get-config": "0.2.4",
     "graphql-tag": "^2.10.1",
     "lodash-es": "^4.17.11",
-    "papaparse": "^5.1.1"
+    "papaparse": "^5.1.1",
+    "ember-cli-typescript": "^3.1.3"
   },
   "devDependencies": {
+    "@babel/preset-typescript": "^7.8.3",
     "@ember/optional-features": "^1.3.0",
+    "@types/ember": "^3.1.2",
+    "@types/ember-qunit": "^3.4.8",
+    "@types/ember__test-helpers": "^0.7.10",
+    "@types/qunit": "^2.9.1",
+    "@types/rsvp": "^4.0.3",
+    "@typescript-eslint/eslint-plugin": "^2.23.0",
+    "@typescript-eslint/parser": "^2.23.0",
     "babel-eslint": "^10.0.3",
     "broccoli-asset-rev": "^3.0.0",
     "ember-apollo-client": "^2.0.0",
@@ -50,6 +61,7 @@
     "ember-cli-qunit": "^4.3.2",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-template-lint": "^2.0.0",
+    "ember-cli-typescript-blueprints": "^3.0.0",
     "ember-cli-uglify": "^3.0.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.1",
@@ -61,12 +73,15 @@
     "ember-source": "~3.16.0",
     "ember-source-channel-url": "^2.0.1",
     "ember-try": "^1.4.0",
-    "eslint-config-prettier": "^3.0.1",
-    "eslint-plugin-ember": "^7.7.2",
+    "eslint-config-prettier": "^6.10.0",
+    "eslint-plugin-ember": "^7.8.1",
     "eslint-plugin-node": "^11.0.0",
+    "eslint-plugin-prettier": "^3.1.2",
+    "eslint-plugin-qunit": "^4.0.0",
     "graphql": "^14.6.0",
     "loader.js": "^4.7.0",
-    "qunit-dom": "^1.0.0"
+    "qunit-dom": "^1.0.0",
+    "typescript": "3.7.5"
   },
   "engines": {
     "node": "10.* || >= 12"

--- a/packages/data/test-support/helpers/metadata-routes.js
+++ b/packages/data/test-support/helpers/metadata-routes.js
@@ -340,6 +340,16 @@ export const MetricFunctionAggTrend = {
   }
 };
 
+const METRIC_MAP = {
+  metricOne: MetricOne,
+  metricTwo: MetricTwo,
+  metricThree: MetricThree,
+  metricFour: MetricFour,
+  metricFive: MetricFive,
+  metricSix: MetricSix,
+  pageViews: PageViews
+};
+
 export default function(index = 0) {
   const host = config.navi.dataSources[index].uri;
   this.get(`${host}/v1/tables`, function() {
@@ -370,13 +380,3 @@ export default function(index = 0) {
     ];
   });
 }
-
-const METRIC_MAP = {
-  metricOne: MetricOne,
-  metricTwo: MetricTwo,
-  metricThree: MetricThree,
-  metricFour: MetricFour,
-  metricFive: MetricFive,
-  metricSix: MetricSix,
-  pageViews: PageViews
-};

--- a/packages/data/tests/dummy/app/config/environment.d.ts
+++ b/packages/data/tests/dummy/app/config/environment.d.ts
@@ -1,0 +1,16 @@
+export default config;
+
+/**
+ * Type declarations for
+ *    import config from './config/environment'
+ *
+ * For now these need to be managed by the developer
+ * since different ember addons can materialize new entries.
+ */
+declare const config: {
+  environment: any;
+  modulePrefix: string;
+  podModulePrefix: string;
+  locationType: string;
+  rootURL: string;
+};

--- a/packages/data/tests/dummy/app/router.js
+++ b/packages/data/tests/dummy/app/router.js
@@ -6,4 +6,6 @@ export default class Router extends EmberRouter {
   rootURL = config.rootURL;
 }
 
-Router.map(function() {});
+Router.map(function() {
+  // no routes
+});

--- a/packages/data/tests/test-helper.ts
+++ b/packages/data/tests/test-helper.ts
@@ -1,7 +1,11 @@
+// @ts-ignore
 import Application from '../app';
 import config from '../config/environment';
 import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
+
+// Install types for qunit-dom
+import 'qunit-dom';
 
 setApplication(Application.create(config.APP));
 

--- a/packages/data/tests/unit/adapters/bard-facts-test.js
+++ b/packages/data/tests/unit/adapters/bard-facts-test.js
@@ -133,7 +133,10 @@ module('Unit | Bard facts Adapter', function(hooks) {
     );
 
     let manyIntervals = {
-      intervals: [{ start: 'start1', end: 'end1' }, { start: 'start2', end: 'end2' }]
+      intervals: [
+        { start: 'start1', end: 'end1' },
+        { start: 'start2', end: 'end2' }
+      ]
     };
     assert.equal(
       Adapter._buildDateTimeParam(manyIntervals),

--- a/packages/data/tests/unit/adapters/dimensions/bard-test.js
+++ b/packages/data/tests/unit/adapters/dimensions/bard-test.js
@@ -8,7 +8,10 @@ import { assign } from '@ember/polyfills';
 const HOST = config.navi.dataSources[0].uri;
 
 const Response = {
-  rows: [{ id: 'v1', description: 'value1' }, { id: 'v2', description: 'value2' }],
+  rows: [
+    { id: 'v1', description: 'value1' },
+    { id: 'v2', description: 'value2' }
+  ],
   meta: { test: true }
 };
 

--- a/packages/data/tests/unit/adapters/dimensions/keg-test.js
+++ b/packages/data/tests/unit/adapters/dimensions/keg-test.js
@@ -43,9 +43,16 @@ module('Unit | Adapters | Dimensions | Keg', function(hooks) {
 
     Keg = Adapter.get('keg');
     Keg.pushMany('dimension/dummy.dimensionOne', Records, { namespace: 'dummy' });
-    Keg.pushMany('dimension/blockhead.dimensionFour', [{ id: 1, description: 'one' }, { id: 2, description: 'two' }], {
-      namespace: 'blockhead'
-    });
+    Keg.pushMany(
+      'dimension/blockhead.dimensionFour',
+      [
+        { id: 1, description: 'one' },
+        { id: 2, description: 'two' }
+      ],
+      {
+        namespace: 'blockhead'
+      }
+    );
 
     //Load metadata
     Server = new Pretender(metadataRoutes);
@@ -197,10 +204,20 @@ module('Unit | Adapters | Dimensions | Keg', function(hooks) {
 
   test('pushMany', function(assert) {
     assert.expect(4);
-    Adapter.pushMany('dimensionOne', [{ id: 22, foo: 'bar' }, { id: 44, foo: 'baz' }]);
-    Adapter.pushMany('dimensionFour', [{ id: 77, foo: 'quux' }, { id: 99, foo: 'plugh' }], {
-      dataSourceName: 'blockhead'
-    });
+    Adapter.pushMany('dimensionOne', [
+      { id: 22, foo: 'bar' },
+      { id: 44, foo: 'baz' }
+    ]);
+    Adapter.pushMany(
+      'dimensionFour',
+      [
+        { id: 77, foo: 'quux' },
+        { id: 99, foo: 'plugh' }
+      ],
+      {
+        dataSourceName: 'blockhead'
+      }
+    );
 
     let { foo: bar } = Keg.getById('dimension/dummy.dimensionOne', 22, 'dummy');
     assert.deepEqual(bar, 'bar', 'pushMany stores records into the keg');

--- a/packages/data/tests/unit/models/metadata/dimension-test.js
+++ b/packages/data/tests/unit/models/metadata/dimension-test.js
@@ -130,7 +130,10 @@ module('Unit | Metadata Model | Dimension', function(hooks) {
     );
 
     let twoKeys = DimensionMetadataModel.create({
-      fields: [{ name: 'key1', tags: ['primaryKey'] }, { name: 'key2', tags: ['primaryKey'] }]
+      fields: [
+        { name: 'key1', tags: ['primaryKey'] },
+        { name: 'key2', tags: ['primaryKey'] }
+      ]
     });
     assert.deepEqual(
       twoKeys.get('primaryKeyFieldName'),
@@ -172,7 +175,10 @@ module('Unit | Metadata Model | Dimension', function(hooks) {
     );
 
     let twoKeys = DimensionMetadataModel.create({
-      fields: [{ name: 'name1', tags: ['description'] }, { name: 'name2', tags: ['description'] }]
+      fields: [
+        { name: 'name1', tags: ['description'] },
+        { name: 'name2', tags: ['description'] }
+      ]
     });
     assert.deepEqual(
       twoKeys.get('descriptionFieldName'),
@@ -256,7 +262,10 @@ module('Unit | Metadata Model | Dimension', function(hooks) {
     assert.deepEqual(noId.idFieldName, 'id', 'idFieldName returned `id` as the default id field name');
 
     let twoKeys = DimensionMetadataModel.create({
-      fields: [{ name: 'name1', tags: ['id'] }, { name: 'name2', tags: ['id'] }]
+      fields: [
+        { name: 'name1', tags: ['id'] },
+        { name: 'name2', tags: ['id'] }
+      ]
     });
     assert.deepEqual(twoKeys.idFieldName, 'name1', 'idFieldName returns the first field tagged as `id`');
 

--- a/packages/data/tests/unit/models/metadata/function-argument-test.js
+++ b/packages/data/tests/unit/models/metadata/function-argument-test.js
@@ -66,7 +66,10 @@ module('Unit | Metadata Model | Function Argument', function(hooks) {
     assert.expect(3);
 
     const valuesResponse = {
-      rows: [{ id: 'USD', description: 'US Dollars' }, { id: 'EUR', description: 'Euros' }],
+      rows: [
+        { id: 'USD', description: 'US Dollars' },
+        { id: 'EUR', description: 'Euros' }
+      ],
       meta: { test: true }
     };
 

--- a/packages/data/tests/unit/models/navi-facts-model-test.js
+++ b/packages/data/tests/unit/models/navi-facts-model-test.js
@@ -4,7 +4,7 @@ import NaviFactsModel from 'navi-data/models/navi-facts';
 
 module('Unit | Navi Facts Model', function(hooks) {
   let Response, Payload;
-  
+
   hooks.beforeEach(function() {
     Payload = {
       request: {
@@ -63,20 +63,19 @@ module('Unit | Navi Facts Model', function(hooks) {
     //Mocking facts service
     Response.set('_factService', {
       fetchNext: () => {
-        assert.ok('The service`s fetch Next method is invoked with the response and request')
+        assert.ok('The service`s fetch Next method is invoked with the response and request');
       }
     });
 
     Response.next();
 
-
     //Mocking facts service
     Response.set('_factService', {
       fetchPrevious: () => {
-        assert.ok('The service`s fetch Previous method is invoked with the response and request')
+        assert.ok('The service`s fetch Previous method is invoked with the response and request');
       }
     });
-    
+
     Response.previous();
   });
 });

--- a/packages/data/tests/unit/services/bard-dimensions-test.js
+++ b/packages/data/tests/unit/services/bard-dimensions-test.js
@@ -14,12 +14,18 @@ let Service, Server, MetadataService;
 const TestDimension = 'dimensionOne';
 
 const Response = {
-  rows: [{ id: 'v1', description: 'value1' }, { id: 'v2', description: 'value2' }],
+  rows: [
+    { id: 'v1', description: 'value1' },
+    { id: 'v2', description: 'value2' }
+  ],
   meta: { test: true }
 };
 
 const KegResponse = {
-  rows: [{ id: 'v3', description: 'value3' }, { id: 'v4', description: 'value4' }],
+  rows: [
+    { id: 'v3', description: 'value3' },
+    { id: 'v4', description: 'value4' }
+  ],
   meta: { test: true }
 };
 
@@ -171,7 +177,7 @@ module('Unit | Service | Dimensions', function(hooks) {
     });
   });
 
-  test('find from keg with pagination', function(assert) {
+  test('find from keg with pagination - dimensions are loaded', function(assert) {
     assert.expect(1);
 
     let keg = Service.get('_kegAdapter').get('keg');
@@ -248,7 +254,7 @@ module('Unit | Service | Dimensions', function(hooks) {
     });
   });
 
-  test('find from keg with pagination', function(assert) {
+  test('find from keg with pagination - dimension not loaded', function(assert) {
     assert.expect(1);
 
     //Mock service - dimensions are loaded in keg
@@ -456,7 +462,10 @@ module('Unit | Service | Dimensions', function(hooks) {
     assert.expect(2);
 
     let response3 = {
-      rows: [{ id: 'v1', desc: 'value1' }, { id: 'v2', desc: 'value2' }],
+      rows: [
+        { id: 'v1', desc: 'value1' },
+        { id: 'v2', desc: 'value2' }
+      ],
       meta: { test: true }
     };
 
@@ -492,7 +501,10 @@ module('Unit | Service | Dimensions', function(hooks) {
     const options = { dataSourceName: 'blockhead' };
 
     let response3 = {
-      rows: [{ id: 'v4', desc: 'value4' }, { id: 'v5', desc: 'value5' }],
+      rows: [
+        { id: 'v4', desc: 'value4' },
+        { id: 'v5', desc: 'value5' }
+      ],
       meta: { test: true }
     };
 
@@ -526,7 +538,10 @@ module('Unit | Service | Dimensions', function(hooks) {
     assert.expect(7);
 
     let response3 = {
-      rows: [{ id: 'v1', desc: 'value1' }, { id: 'v2', desc: 'value2' }],
+      rows: [
+        { id: 'v1', desc: 'value1' },
+        { id: 'v2', desc: 'value2' }
+      ],
       meta: { test: true }
     };
 

--- a/packages/data/tests/unit/services/metric-parameter-test.js
+++ b/packages/data/tests/unit/services/metric-parameter-test.js
@@ -118,13 +118,19 @@ module('Unit | Service | metric parameter', function(hooks) {
       parameter = {
         type: 'ref',
         expression: 'self',
-        _localValues: [{ id: 1, description: 'One' }, { id: 2, description: 'Two' }]
+        _localValues: [
+          { id: 1, description: 'One' },
+          { id: 2, description: 'Two' }
+        ]
       };
 
     const results = await service.fetchAllValues(parameter);
 
     assert.deepEqual(
-      [{ id: 1, description: 'One' }, { id: 2, description: 'Two' }],
+      [
+        { id: 1, description: 'One' },
+        { id: 2, description: 'Two' }
+      ],
       results,
       'Enum paramter type returns correct values from meta.'
     );

--- a/packages/data/tsconfig.json
+++ b/packages/data/tsconfig.json
@@ -1,0 +1,35 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "allowJs": true,
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "strictNullChecks": true,
+    "strictPropertyInitialization": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noEmitOnError": false,
+    "noEmit": true,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "baseUrl": ".",
+    "module": "es6",
+    "experimentalDecorators": true,
+    "paths": {
+      "dummy/tests/*": ["tests/*"],
+      "dummy/mirage/*": ["tests/dummy/mirage/*"],
+      "dummy/*": ["tests/dummy/app/*", "app/*"],
+      "navi-data": ["addon"],
+      "navi-data/*": ["addon/*"],
+      "navi-data/test-support": ["addon-test-support"],
+      "navi-data/test-support/*": ["addon-test-support/*"],
+      "*": ["types/*"]
+    }
+  },
+  "include": ["app/**/*", "addon/**/*", "tests/**/*", "types/**/*", "test-support/**/*", "addon-test-support/**/*"]
+}

--- a/packages/data/types/global.d.ts
+++ b/packages/data/types/global.d.ts
@@ -1,0 +1,9 @@
+// Types for compiled templates
+declare module 'navi-data/templates/*' {
+  import { TemplateFactory } from 'htmlbars-inline-precompile';
+  const tmpl: TemplateFactory;
+  export default tmpl;
+}
+
+type Dict<T = string> = { [key: string]: T };
+type TODO<T = any> = T;

--- a/packages/directory/package.json
+++ b/packages/directory/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "ember build --environment=production",
     "lint:hbs": "ember-template-lint .",
-    "lint:js": "eslint . && tsc --noEmit",
+    "lint:js": "eslint . && tsc --allowJs false --noEmit",
     "lint": "npm run lint:hbs && npm run lint:js",
     "start": "ember serve",
     "test": "export COVERAGE=true; ember test --test-port 0",


### PR DESCRIPTION
## Description
Allow for using typescript in `navi-data`

## Proposed Changes
- lots of small file changes to satisfy stricter prettier/eslint stuff
- Set allowJs to false so that it runs like ember ts:precompile (this just means you have to add `//@ts-ignore` to import js files)

The first commit should be a pretty good skeleton for converting other packages

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
