### PR TITLE
Fragment meta

### DIFF
--- a/packages/core/addon/models/bard-request-v2/fragments/base.js
+++ b/packages/core/addon/models/bard-request-v2/fragments/base.js
@@ -3,10 +3,12 @@
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import attr from 'ember-data/attr';
-import Fragment, { internalModelFor } from 'ember-data-model-fragments/fragment';
+import Fragment from 'ember-data-model-fragments/fragment';
 import { validator, buildValidations } from 'ember-cp-validations';
 import { inject as service } from '@ember/service';
-import { getDefaultDataSourceName } from 'navi-data/utils/adapter';
+import { computed } from '@ember/object';
+import { assert } from '@ember/debug';
+import { isPresent } from '@ember/utils';
 
 const Validations = buildValidations({
   field: validator('presence', {
@@ -27,68 +29,50 @@ export default class Base extends Fragment.extend(Validations) {
   @service('bard-metadata')
   metadataService;
 
-  _meta;
+  /**
+   * Datasource or namespace
+   * @property {string}
+   */
+  source;
+
+  /**
+   * 'metric', 'dimension', 'timeDimension' used to look up metadata;
+   * @property {string}
+   */
+  columnMetaType;
 
   /**
    * @type {Meta}
    */
-  get meta() {
-    if (!this._meta) {
-      if (this.lookupField === 'dateTime') {
-        this._meta = { id: 'dateTime', name: 'Date Time' };
-        return this._meta;
-      }
-      const request = internalModelFor(this)._recordData.getOwner();
-      const dataSource = request?.dataSource || getDefaultDataSourceName();
-      const type = this.getFieldType(request);
-      if (type) {
-        this._meta = this.metadataService.getById(type, this.lookupField, dataSource);
-      }
-      //can't figure out type? then let's guess.
-      ['time-dimension', 'metric', 'dimension'].some(guessType => {
-        this._meta = this.metadataService.getById(guessType, this.lookupField, dataSource);
-        return !!this._meta;
-      });
+  @computed('field', 'columnMetaType')
+  get columnMeta() {
+    assert('Source must be set in order to access columnMeta', isPresent(this.source));
+    assert('columnMetaType must be set in order to access columnMeta', isPresent(this.columnMetaType));
+    if (this.lookupField === 'dateTime') {
+      return {
+        id: 'dateTime',
+        name: 'Date Time'
+      };
     }
-
-    return this._meta;
+    return this.metadataService.getById(this.columnMetaType, this.lookupField, this.source);
   }
 
   /**
-   * @type {Meta}
+   * Field without dimension subfield
+   * @type {string}
    */
-  set meta(meta) {
-    this._meta = meta;
-  }
-
   get lookupField() {
-    return this.field.includes('.') ? this.field.split('.')[0] : this.field;
+    return this.field.split('.')[0];
   }
 
   /**
    * Adds meta data to the fragment given column type and namespace
-   * @param {string} type - 'dimension or metric'
-   * @param {string} namespace
+   * @param {string} columnMetaType - 'dimension or metric'
+   * @param {string} source
    * @return {void}
    */
-  applyMeta(type, namespace) {
-    this._meta = this.metadataService.getById(type, this.lookupField, namespace);
-  }
-
-  /**
-   * Given a request, gives the predicted field type of this fragment by looking through columns
-   * @param {bard-request-v2/Request} request - request with columns to look through
-   * @returns {string}
-   */
-  getFieldType(request) {
-    if (this.type) {
-      return this.type;
-    }
-
-    //get type from request columns
-    const matchingCol = request.columns.filter(col => col.field === this.field || col.field === this.lookupField)[0];
-    if (matchingCol) {
-      return matchingCol.type;
-    }
+  applyMeta(columnMetaType, source) {
+    this.columnMetaType = columnMetaType;
+    this.source = source;
   }
 }

--- a/packages/core/addon/models/bard-request-v2/fragments/base.js
+++ b/packages/core/addon/models/bard-request-v2/fragments/base.js
@@ -20,7 +20,7 @@ const Validations = buildValidations({
     allowBlank: true,
     message() {
       const { field } = this.model;
-      return 'The `type` field of `' + field + '` column must equal to `dimension` or `metric`';
+      return 'The `type` field of `' + field + '` column must equal to `dimension`, `metric`, or `time-dimension`';
     }
   })
 });
@@ -51,20 +51,12 @@ export default class Base extends Fragment.extend(Validations) {
   get columnMeta() {
     assert('Source must be set in order to access columnMeta', isPresent(this.source));
     assert('column type must be set in order to access columnMeta', isPresent(this.type));
-    if (this.lookupField === 'dateTime') {
+    if (this.field === 'dateTime') {
       return {
         id: 'dateTime',
         name: 'Date Time'
       };
     }
-    return this.metadataService.getById(this.type, this.lookupField, this.source);
-  }
-
-  /**
-   * Field without dimension subfield
-   * @type {string}
-   */
-  get lookupField() {
-    return this.field.split('.')[0];
+    return this.metadataService.getById(this.type, this.field, this.source);
   }
 }

--- a/packages/core/addon/models/bard-request-v2/fragments/base.js
+++ b/packages/core/addon/models/bard-request-v2/fragments/base.js
@@ -3,8 +3,10 @@
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import attr from 'ember-data/attr';
-import Fragment from 'ember-data-model-fragments/fragment';
+import Fragment, { internalModelFor } from 'ember-data-model-fragments/fragment';
 import { validator, buildValidations } from 'ember-cp-validations';
+import { inject as service } from '@ember/service';
+import { getDefaultDataSourceName } from 'navi-data/utils/adapter';
 
 const Validations = buildValidations({
   field: validator('presence', {
@@ -21,4 +23,72 @@ export default class Base extends Fragment.extend(Validations) {
     }
   })
   parameters;
+
+  @service('bard-metadata')
+  metadataService;
+
+  _meta;
+
+  /**
+   * @type {Meta}
+   */
+  get meta() {
+    if (!this._meta) {
+      if (this.lookupField === 'dateTime') {
+        this._meta = { id: 'dateTime', name: 'Date Time' };
+        return this._meta;
+      }
+      const request = internalModelFor(this)._recordData.getOwner();
+      const dataSource = request?.dataSource || getDefaultDataSourceName();
+      const type = this.getFieldType(request);
+      if (type) {
+        this._meta = this.metadataService.getById(type, this.lookupField, dataSource);
+      }
+      //can't figure out type? then let's guess.
+      ['time-dimension', 'metric', 'dimension'].some(guessType => {
+        this._meta = this.metadataService.getById(guessType, this.lookupField, dataSource);
+        return !!this._meta;
+      });
+    }
+
+    return this._meta;
+  }
+
+  /**
+   * @type {Meta}
+   */
+  set meta(meta) {
+    this._meta = meta;
+  }
+
+  get lookupField() {
+    return this.field.includes('.') ? this.field.split('.')[0] : this.field;
+  }
+
+  /**
+   * Adds meta data to the fragment given column type and namespace
+   * @param {string} type - 'dimension or metric'
+   * @param {string} namespace
+   * @return {void}
+   */
+  applyMeta(type, namespace) {
+    this._meta = this.metadataService.getById(type, this.lookupField, namespace);
+  }
+
+  /**
+   * Given a request, gives the predicted field type of this fragment by looking through columns
+   * @param {bard-request-v2/Request} request - request with columns to look through
+   * @returns {string}
+   */
+  getFieldType(request) {
+    if (this.type) {
+      return this.type;
+    }
+
+    //get type from request columns
+    const matchingCol = request.columns.filter(col => col.field === this.field || col.field === this.lookupField)[0];
+    if (matchingCol) {
+      return matchingCol.type;
+    }
+  }
 }

--- a/packages/core/addon/models/bard-request-v2/fragments/column.js
+++ b/packages/core/addon/models/bard-request-v2/fragments/column.js
@@ -17,6 +17,9 @@ const Validations = buildValidations({
   })
 });
 
+/**
+ * @augments {BaseFragment}
+ */
 export default class Column extends BaseFragment.extend(Validations) {
   @attr('string') type;
   @attr('string') alias;

--- a/packages/core/addon/models/bard-request-v2/fragments/column.js
+++ b/packages/core/addon/models/bard-request-v2/fragments/column.js
@@ -3,24 +3,11 @@
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import attr from 'ember-data/attr';
-import { validator, buildValidations } from 'ember-cp-validations';
 import BaseFragment from './base';
-
-const Validations = buildValidations({
-  type: validator('inclusion', {
-    in: ['dimension', 'metric'],
-    allowBlank: true,
-    message() {
-      const { field } = this.model;
-      return 'The `type` field of `' + field + '` column must equal to `dimension` or `metric`';
-    }
-  })
-});
 
 /**
  * @augments {BaseFragment}
  */
-export default class Column extends BaseFragment.extend(Validations) {
-  @attr('string') type;
+export default class Column extends BaseFragment {
   @attr('string') alias;
 }

--- a/packages/core/addon/models/bard-request-v2/fragments/filter.js
+++ b/packages/core/addon/models/bard-request-v2/fragments/filter.js
@@ -20,6 +20,9 @@ const Validations = buildValidations({
   })
 });
 
+/**
+ * @augments {BaseFragment}
+ */
 export default class Filter extends BaseFragment.extend(Validations) {
   @attr('string', { defaultValue: 'in' }) operator;
   @attr({

--- a/packages/core/addon/models/bard-request-v2/fragments/sort.js
+++ b/packages/core/addon/models/bard-request-v2/fragments/sort.js
@@ -13,6 +13,9 @@ const Validations = buildValidations({
   })
 });
 
+/**
+ * @augments {BaseFragment}
+ */
 export default class Sort extends BaseFragment.extend(Validations) {
   @attr('string', {
     defaultValue: 'desc'

--- a/packages/core/addon/services/fragment-factory.ts
+++ b/packages/core/addon/services/fragment-factory.ts
@@ -1,0 +1,167 @@
+/**
+ * Copyright 2020, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+import Service, { inject as service } from '@ember/service';
+import Store from 'ember-data/store';
+import Column from 'navi-data/models/metadata/column';
+import Metric from 'navi-data/models/metadata/metric';
+import ColumnFragment from '../models/bard-request-v2/fragments/column';
+import FilterFragment from '../models/bard-request-v2/fragments/filter';
+import SortFragment from '../models/bard-request-v2/fragments/sort';
+
+interface StoreWithFragment extends Store {
+  createFragment(fragmentName: string, attributes: object): ColumnFragment | FilterFragment | SortFragment;
+}
+export default class FragmentFactory extends Service {
+  @service store!: StoreWithFragment;
+
+  /**
+   * Builds a request v2 column fragment given meta data object.
+   * @param meta - The metadata object to use as field to build this fragment from
+   * @param parameters - parameters to attach to column, if none pass empty object `{}`
+   * @param alias - optional alias for this column
+   * @param dimensionField - dimension field if passing in a dimension `id` or `description` for example
+   */
+  createColumnFromMeta(meta: Column, parameters: object = {}, alias?: string, dimensionField?: string): ColumnFragment {
+    const type = meta instanceof Metric ? 'metric' : 'dimension';
+    const column = this.store.createFragment('bard-request-v2/fragments/column', {
+      field: dimensionField ? `${meta.id}.${dimensionField}` : meta.id,
+      type,
+      parameters,
+      alias
+    }) as ColumnFragment;
+    column.meta = meta;
+    return column;
+  }
+
+  /**
+   * Builds a request v2 column fragment and applies the appropriate meta data
+   * @param type - metric or dimension
+   * @param dataSource - datasource or namespace for metadata lookups
+   * @param field - field name, if dimension includes field `dimension.id`
+   * @param parameters - parameters to attach to column, if noen pass empty object `{}`
+   * @param alias - optional alias for this column
+   */
+  createColumn(
+    type: 'metric' | 'dimension',
+    dataSource: string,
+    field: string,
+    parameters: object = {},
+    alias?: string
+  ): ColumnFragment {
+    const column = this.store.createFragment('bard-request-v2/fragments/column', {
+      field,
+      type,
+      parameters,
+      alias
+    }) as ColumnFragment;
+    column.applyMeta(type, dataSource);
+    return column;
+  }
+
+  /**
+   * Builds a request v2 filter fragment given meta data object.
+   * @param meta - meta data object to build this filter from
+   * @param parameters - parameters to attach to column, if noen pass empty object `{}`
+   * @param operator - operator to pass in: 'contains, in, notnull etc'
+   * @param values - array of values to filter by
+   * @param dimensionField - dimension field if passing in a dimension `id` or `description` for example
+   */
+  createFilterFromMeta(
+    meta: Column,
+    parameters: object = {},
+    operator: string,
+    values: Array<string | number>,
+    dimensionField?: string
+  ): FilterFragment {
+    const filter = this.store.createFragment('bard-request-v2/fragments/filter', {
+      field: dimensionField ? `${meta.id}.${dimensionField}` : meta.id,
+      parameters,
+      operator,
+      values
+    }) as FilterFragment;
+    filter.meta = meta;
+    return filter;
+  }
+
+  /**
+   * Builds a request v2 filter fragment and applies the appropriate meta data
+   * @param type - metric or dimension
+   * @param dataSource - datasource or namespace for metadata lookups
+   * @param field - field name, if dimension includes field `dimension.id`
+   * @param parameters - parameters to attach to column, if noen pass empty object `{}`
+   * @param operator - operator to pass in: 'contains, in, notnull etc'
+   * @param values - array of values to filter by
+   */
+  createFilter(
+    type: 'metric' | 'dimension',
+    dataSource: string,
+    field: string,
+    parameters: object = {},
+    operator: string,
+    values: Array<string | number>
+  ): FilterFragment {
+    const filter = this.store.createFragment('bard-request-v2/fragments/filter', {
+      field,
+      parameters,
+      operator,
+      values
+    }) as FilterFragment;
+
+    filter.applyMeta(type, dataSource);
+    return filter;
+  }
+
+  /**
+   * Builds a request v2 sort fragment given meta data object.
+   * @param meta - meta data object to build this filter from
+   * @param parameters - parameters to attach to column, if noen pass empty object `{}`
+   * @param direction  - `desc` or `asc`
+   * @param dimensionField - dimension field if passing in a dimension `id` or `description` for example
+   */
+  createSortFromMeta(
+    meta: Column,
+    parameters: object = {},
+    direction: 'asc' | 'desc',
+    dimensionField?: string
+  ): SortFragment {
+    const sort = this.store.createFragment('bard-request-v2/fragments/sort', {
+      field: dimensionField ? `${meta.id}.${dimensionField}` : meta.id,
+      parameters,
+      direction
+    }) as SortFragment;
+    sort.meta = meta;
+    return sort;
+  }
+
+  /**
+   * Builds a request v2 sort fragment and applies the appropriate meta data
+   * @param type - metric or dimension
+   * @param dataSource - datasource or namespace for metadata lookups
+   * @param field - field name, if dimension includes field `dimension.id`
+   * @param parameters - parameters to attach to column, if noen pass empty object `{}`
+   * @param direction - `desc` or `asc`
+   */
+  createSort(
+    type: 'metric' | 'dimension',
+    dataSource: string,
+    field: string,
+    parameters: object = {},
+    direction: 'asc' | 'desc'
+  ): SortFragment {
+    const sort = this.store.createFragment('bard-request-v2/fragments/sort', {
+      field,
+      parameters,
+      direction
+    }) as SortFragment;
+    sort.applyMeta(type, dataSource);
+    return sort;
+  }
+}
+
+declare module '@ember/service' {
+  interface Registry {
+    'fragment-factory': FragmentFactory;
+  }
+}

--- a/packages/core/addon/services/fragment-factory.ts
+++ b/packages/core/addon/services/fragment-factory.ts
@@ -23,22 +23,16 @@ export default class FragmentFactory extends Service {
    * @param meta - The metadata object to use as field to build this fragment from
    * @param parameters - parameters to attach to column, if none pass empty object `{}`
    * @param alias - optional alias for this column
-   * @param dimensionField - dimension field if passing in a dimension `id` or `description` for example
    */
-  createColumnFromMeta(
-    columnMetadata: Column,
-    parameters: Dict<string> = {},
-    alias?: string,
-    dimensionField?: string
-  ): ColumnFragment {
+  createColumnFromMeta(columnMetadata: Column, parameters: Dict<string> = {}, alias?: string): ColumnFragment {
     const type = this._getMetaColumnType(columnMetadata);
-    const field = dimensionField ? `${columnMetadata.id}.${dimensionField}` : columnMetadata.id;
+    const field = columnMetadata.id;
     return this.createColumn(type, columnMetadata.source, field, parameters, alias);
   }
 
   /**
    * Builds a request v2 column fragment and applies the appropriate meta data
-   * @param type - metric or dimension
+   * @param type - metric, dimension or time-dimension
    * @param dataSource - datasource or namespace for metadata lookups
    * @param field - field name, if dimension includes field `dimension.id`
    * @param parameters - parameters to attach to column, if none pass empty object `{}`
@@ -67,23 +61,21 @@ export default class FragmentFactory extends Service {
    * @param parameters - parameters to attach to column, if none pass empty object `{}`
    * @param operator - operator to pass in: 'contains, in, notnull etc'
    * @param values - array of values to filter by
-   * @param dimensionField - dimension field if passing in a dimension `id` or `description` for example
    */
   createFilterFromMeta(
     columnMetadata: Column,
     parameters: Dict<string> = {},
     operator: string,
-    values: Array<string | number>,
-    dimensionField?: string
+    values: Array<string | number>
   ): FilterFragment {
     const type = this._getMetaColumnType(columnMetadata);
-    const field = dimensionField ? `${columnMetadata.id}.${dimensionField}` : columnMetadata.id;
+    const field = columnMetadata.id;
     return this.createFilter(type, columnMetadata.source, field, parameters, operator, values);
   }
 
   /**
    * Builds a request v2 filter fragment and applies the appropriate meta data
-   * @param type - metric or dimension
+   * @param type - metric, dimension or time-dimension
    * @param dataSource - datasource or namespace for metadata lookups
    * @param field - field name, if dimension includes field `dimension.id`
    * @param parameters - parameters to attach to column, if none pass empty object `{}`
@@ -114,22 +106,16 @@ export default class FragmentFactory extends Service {
    * @param meta - meta data object to build this filter from
    * @param parameters - parameters to attach to column, if none pass empty object `{}`
    * @param direction  - `desc` or `asc`
-   * @param dimensionField - dimension field if passing in a dimension `id` or `description` for example
    */
-  createSortFromMeta(
-    columnMetadata: Column,
-    parameters: Dict<string> = {},
-    direction: 'asc' | 'desc',
-    dimensionField?: string
-  ): SortFragment {
+  createSortFromMeta(columnMetadata: Column, parameters: Dict<string> = {}, direction: 'asc' | 'desc'): SortFragment {
     const type = this._getMetaColumnType(columnMetadata);
-    const field = dimensionField ? `${columnMetadata.id}.${dimensionField}` : columnMetadata.id;
+    const field = columnMetadata.id;
     return this.createSort(type, columnMetadata.source, field, parameters, direction);
   }
 
   /**
    * Builds a request v2 sort fragment and applies the appropriate meta data
-   * @param type - metric or dimension
+   * @param type - metric, dimension or time-dimension
    * @param dataSource - datasource or namespace for metadata lookups
    * @param field - field name, if dimension includes field `dimension.id`
    * @param parameters - parameters to attach to column, if none pass empty object `{}`

--- a/packages/core/addon/services/fragment-factory.ts
+++ b/packages/core/addon/services/fragment-factory.ts
@@ -13,7 +13,7 @@ import { dasherize } from '@ember/string';
 interface StoreWithFragment extends Store {
   createFragment(fragmentName: string, attributes: object): ColumnFragment | FilterFragment | SortFragment;
 }
-type fieldType = 'metric' | 'dimension' | 'time-dimension';
+type FieldType = 'metric' | 'dimension' | 'time-dimension';
 
 export default class FragmentFactory extends Service {
   @service store!: StoreWithFragment;
@@ -39,7 +39,7 @@ export default class FragmentFactory extends Service {
    * @param alias - optional alias for this column
    */
   createColumn(
-    type: fieldType,
+    type: FieldType,
     dataSource: string,
     field: string,
     parameters: Dict<string> = {},
@@ -83,7 +83,7 @@ export default class FragmentFactory extends Service {
    * @param values - array of values to filter by
    */
   createFilter(
-    type: fieldType,
+    type: FieldType,
     dataSource: string,
     field: string,
     parameters: Dict<string> = {},
@@ -122,7 +122,7 @@ export default class FragmentFactory extends Service {
    * @param direction - `desc` or `asc`
    */
   createSort(
-    type: fieldType,
+    type: FieldType,
     dataSource: string,
     field: string,
     parameters: Dict<string> = {},
@@ -142,8 +142,8 @@ export default class FragmentFactory extends Service {
    * Deducts meta column type from class type
    * @param columnMetadata - meta data to get type from
    */
-  private _getMetaColumnType(columnMetadata: Column): fieldType {
-    return dasherize(columnMetadata.constructor.name) as fieldType;
+  private _getMetaColumnType(columnMetadata: Column): FieldType {
+    return dasherize(columnMetadata.constructor.name) as FieldType;
   }
 }
 

--- a/packages/core/addon/services/fragment-factory.ts
+++ b/packages/core/addon/services/fragment-factory.ts
@@ -13,6 +13,8 @@ import { dasherize } from '@ember/string';
 interface StoreWithFragment extends Store {
   createFragment(fragmentName: string, attributes: object): ColumnFragment | FilterFragment | SortFragment;
 }
+type fieldType = 'metric' | 'dimension' | 'time-dimension';
+
 export default class FragmentFactory extends Service {
   @service store!: StoreWithFragment;
 
@@ -30,14 +32,8 @@ export default class FragmentFactory extends Service {
     dimensionField?: string
   ): ColumnFragment {
     const type = this._getMetaColumnType(columnMetadata);
-    const column = this.store.createFragment('bard-request-v2/fragments/column', {
-      field: dimensionField ? `${columnMetadata.id}.${dimensionField}` : columnMetadata.id,
-      type,
-      parameters,
-      alias
-    }) as ColumnFragment;
-    column.source = columnMetadata.source;
-    return column;
+    const field = dimensionField ? `${columnMetadata.id}.${dimensionField}` : columnMetadata.id;
+    return this.createColumn(type, columnMetadata.source, field, parameters, alias);
   }
 
   /**
@@ -49,7 +45,7 @@ export default class FragmentFactory extends Service {
    * @param alias - optional alias for this column
    */
   createColumn(
-    type: 'metric' | 'dimension' | 'time-dimension',
+    type: fieldType,
     dataSource: string,
     field: string,
     parameters: Dict<string> = {},
@@ -81,15 +77,8 @@ export default class FragmentFactory extends Service {
     dimensionField?: string
   ): FilterFragment {
     const type = this._getMetaColumnType(columnMetadata);
-    const filter = this.store.createFragment('bard-request-v2/fragments/filter', {
-      field: dimensionField ? `${columnMetadata.id}.${dimensionField}` : columnMetadata.id,
-      parameters,
-      type,
-      operator,
-      values
-    }) as FilterFragment;
-    filter.source = columnMetadata.source;
-    return filter;
+    const field = dimensionField ? `${columnMetadata.id}.${dimensionField}` : columnMetadata.id;
+    return this.createFilter(type, columnMetadata.source, field, parameters, operator, values);
   }
 
   /**
@@ -102,7 +91,7 @@ export default class FragmentFactory extends Service {
    * @param values - array of values to filter by
    */
   createFilter(
-    type: 'metric' | 'dimension' | 'time-dimension',
+    type: fieldType,
     dataSource: string,
     field: string,
     parameters: Dict<string> = {},
@@ -134,14 +123,8 @@ export default class FragmentFactory extends Service {
     dimensionField?: string
   ): SortFragment {
     const type = this._getMetaColumnType(columnMetadata);
-    const sort = this.store.createFragment('bard-request-v2/fragments/sort', {
-      field: dimensionField ? `${columnMetadata.id}.${dimensionField}` : columnMetadata.id,
-      parameters,
-      type,
-      direction
-    }) as SortFragment;
-    sort.source = columnMetadata.source;
-    return sort;
+    const field = dimensionField ? `${columnMetadata.id}.${dimensionField}` : columnMetadata.id;
+    return this.createSort(type, columnMetadata.source, field, parameters, direction);
   }
 
   /**
@@ -153,7 +136,7 @@ export default class FragmentFactory extends Service {
    * @param direction - `desc` or `asc`
    */
   createSort(
-    type: 'metric' | 'dimension' | 'time-dimension',
+    type: fieldType,
     dataSource: string,
     field: string,
     parameters: Dict<string> = {},
@@ -173,8 +156,8 @@ export default class FragmentFactory extends Service {
    * Deducts meta column type from class type
    * @param columnMetadata - meta data to get type from
    */
-  private _getMetaColumnType(columnMetadata: Column): string {
-    return dasherize(columnMetadata.constructor.name);
+  private _getMetaColumnType(columnMetadata: Column): fieldType {
+    return dasherize(columnMetadata.constructor.name) as fieldType;
   }
 }
 

--- a/packages/core/addon/services/fragment-factory.ts
+++ b/packages/core/addon/services/fragment-factory.ts
@@ -4,7 +4,7 @@
  */
 import Service, { inject as service } from '@ember/service';
 import Store from 'ember-data/store';
-import Column from 'navi-data/models/metadata/column';
+import ColumnMetadata from 'navi-data/models/metadata/column';
 import ColumnFragment from '../models/bard-request-v2/fragments/column';
 import FilterFragment from '../models/bard-request-v2/fragments/filter';
 import SortFragment from '../models/bard-request-v2/fragments/sort';
@@ -24,7 +24,7 @@ export default class FragmentFactory extends Service {
    * @param parameters - parameters to attach to column, if none pass empty object `{}`
    * @param alias - optional alias for this column
    */
-  createColumnFromMeta(columnMetadata: Column, parameters: Dict<string> = {}, alias?: string): ColumnFragment {
+  createColumnFromMeta(columnMetadata: ColumnMetadata, parameters: Dict<string> = {}, alias?: string): ColumnFragment {
     const type = this._getMetaColumnType(columnMetadata);
     const field = columnMetadata.id;
     return this.createColumn(type, columnMetadata.source, field, parameters, alias);
@@ -63,7 +63,7 @@ export default class FragmentFactory extends Service {
    * @param values - array of values to filter by
    */
   createFilterFromMeta(
-    columnMetadata: Column,
+    columnMetadata: ColumnMetadata,
     parameters: Dict<string> = {},
     operator: string,
     values: Array<string | number>
@@ -107,7 +107,11 @@ export default class FragmentFactory extends Service {
    * @param parameters - parameters to attach to column, if none pass empty object `{}`
    * @param direction  - `desc` or `asc`
    */
-  createSortFromMeta(columnMetadata: Column, parameters: Dict<string> = {}, direction: 'asc' | 'desc'): SortFragment {
+  createSortFromMeta(
+    columnMetadata: ColumnMetadata,
+    parameters: Dict<string> = {},
+    direction: 'asc' | 'desc'
+  ): SortFragment {
     const type = this._getMetaColumnType(columnMetadata);
     const field = columnMetadata.id;
     return this.createSort(type, columnMetadata.source, field, parameters, direction);
@@ -142,7 +146,7 @@ export default class FragmentFactory extends Service {
    * Deducts meta column type from class type
    * @param columnMetadata - meta data to get type from
    */
-  private _getMetaColumnType(columnMetadata: Column): FieldType {
+  private _getMetaColumnType(columnMetadata: ColumnMetadata): FieldType {
     return dasherize(columnMetadata.constructor.name) as FieldType;
   }
 }

--- a/packages/core/app/services/fragment-factory.js
+++ b/packages/core/app/services/fragment-factory.js
@@ -1,0 +1,1 @@
+export { default } from 'navi-core/services/fragment-factory';

--- a/packages/core/tests/dummy/app/models/fragments-v2-mock.js
+++ b/packages/core/tests/dummy/app/models/fragments-v2-mock.js
@@ -1,9 +1,11 @@
 import Model from '@ember-data/model';
 import { fragment, fragmentArray } from 'ember-data-model-fragments/attributes';
+import attr from 'ember-data/attr';
 
 export default class FragmentsV2MockModel extends Model {
   @fragmentArray('bard-request-v2/fragments/filter') filters;
   @fragmentArray('bard-request-v2/fragments/column') columns;
   @fragmentArray('bard-request-v2/fragments/sort') sort;
   @fragment('bard-request-v2/request') request;
+  @attr('string', { defaultValue: 'dummy' }) dataSource;
 }

--- a/packages/core/tests/unit/models/bard-request-v2/fragments/column-test.js
+++ b/packages/core/tests/unit/models/bard-request-v2/fragments/column-test.js
@@ -1,13 +1,16 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 let mockModel;
 
 module('Unit | Model | Fragment | BardRequest V2 - Column', function(hooks) {
   setupTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(async function() {
+    await this.owner.lookup('service:bard-metadata').loadMetadata();
     mockModel = run(() =>
       this.owner.lookup('service:store').createRecord('fragments-v2-mock', {
         columns: [
@@ -23,7 +26,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Column', function(hooks) {
   });
 
   test('Model using the Column Fragment', async function(assert) {
-    assert.expect(9);
+    assert.expect(10);
 
     assert.ok(mockModel, 'mockModel is fetched from the store');
 
@@ -49,6 +52,8 @@ module('Unit | Model | Fragment | BardRequest V2 - Column', function(hooks) {
     assert.equal(column.type, 'metric', 'the `type` property is set correctly');
 
     assert.equal(column.alias, 'revenueUSD', 'the `alias` property is set correctly');
+
+    assert.equal(column.meta.id, 'revenue', 'metadata is populated with the right field');
   });
 
   test('Validation', async function(assert) {

--- a/packages/core/tests/unit/models/bard-request-v2/fragments/column-test.js
+++ b/packages/core/tests/unit/models/bard-request-v2/fragments/column-test.js
@@ -53,7 +53,8 @@ module('Unit | Model | Fragment | BardRequest V2 - Column', function(hooks) {
 
     assert.equal(column.alias, 'revenueUSD', 'the `alias` property is set correctly');
 
-    assert.equal(column.meta.id, 'revenue', 'metadata is populated with the right field');
+    column.applyMeta('metric', 'dummy');
+    assert.equal(column.columnMeta.id, 'revenue', 'metadata is populated with the right field');
   });
 
   test('Validation', async function(assert) {

--- a/packages/core/tests/unit/models/bard-request-v2/fragments/column-test.js
+++ b/packages/core/tests/unit/models/bard-request-v2/fragments/column-test.js
@@ -31,6 +31,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Column', function(hooks) {
     assert.ok(mockModel, 'mockModel is fetched from the store');
 
     const column = mockModel.columns.objectAt(0);
+    column.source = 'dummy';
 
     assert.equal(column.field, 'dateTime', 'the `field` property has the correct value');
 
@@ -53,7 +54,6 @@ module('Unit | Model | Fragment | BardRequest V2 - Column', function(hooks) {
 
     assert.equal(column.alias, 'revenueUSD', 'the `alias` property is set correctly');
 
-    column.applyMeta('metric', 'dummy');
     assert.equal(column.columnMeta.id, 'revenue', 'metadata is populated with the right field');
   });
 

--- a/packages/core/tests/unit/models/bard-request-v2/fragments/filter-test.js
+++ b/packages/core/tests/unit/models/bard-request-v2/fragments/filter-test.js
@@ -17,6 +17,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Filter', function(hooks) {
           {
             field: 'revenue',
             parameters: { currency: 'USD' },
+            type: 'metric',
             operator: 'gt',
             values: [3]
           }
@@ -31,6 +32,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Filter', function(hooks) {
     assert.ok(mockModel, 'mockModel is fetched from the store');
 
     const filter = mockModel.filters.objectAt(0);
+    filter.source = 'dummy';
 
     assert.equal(filter.field, 'revenue', 'the `field` property has the correct value');
 
@@ -53,7 +55,6 @@ module('Unit | Model | Fragment | BardRequest V2 - Filter', function(hooks) {
 
     assert.deepEqual(filter.values, ['P1D', 'current'], 'the `values` property is set correctly');
 
-    filter.applyMeta('dimension', 'dummy');
     assert.equal(filter.columnMeta.id, 'dateTime', 'metadata is loaded correctly');
   });
 
@@ -103,6 +104,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Filter', function(hooks) {
           parameters: {
             currency: 'USD'
           },
+          type: 'metric',
           operator: 'gt',
           values: [3]
         }
@@ -118,6 +120,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Filter', function(hooks) {
         {
           field: 'revenue',
           operator: 'gt',
+          type: 'metric',
           values: [3]
         }
       ],
@@ -132,6 +135,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Filter', function(hooks) {
         {
           field: 'revenue',
           operator: 'gt',
+          type: 'metric',
           values: [3]
         }
       ],

--- a/packages/core/tests/unit/models/bard-request-v2/fragments/filter-test.js
+++ b/packages/core/tests/unit/models/bard-request-v2/fragments/filter-test.js
@@ -1,13 +1,16 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 let mockModel;
 
 module('Unit | Model | Fragment | BardRequest V2 - Filter', function(hooks) {
   setupTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(async function() {
+    await this.owner.lookup('service:bard-metadata').loadMetadata();
     mockModel = run(() =>
       this.owner.lookup('service:store').createRecord('fragments-v2-mock', {
         filters: [
@@ -23,7 +26,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Filter', function(hooks) {
   });
 
   test('Model using the Filter Fragment', async function(assert) {
-    assert.expect(9);
+    assert.expect(10);
 
     assert.ok(mockModel, 'mockModel is fetched from the store');
 
@@ -49,6 +52,8 @@ module('Unit | Model | Fragment | BardRequest V2 - Filter', function(hooks) {
     assert.equal(filter.operator, 'bet', 'the `operator` property is set correctly');
 
     assert.deepEqual(filter.values, ['P1D', 'current'], 'the `values` property is set correctly');
+
+    assert.equal(filter.meta.id, 'dateTime', 'metadata is loaded correctly');
   });
 
   test('Validation', async function(assert) {

--- a/packages/core/tests/unit/models/bard-request-v2/fragments/filter-test.js
+++ b/packages/core/tests/unit/models/bard-request-v2/fragments/filter-test.js
@@ -53,7 +53,8 @@ module('Unit | Model | Fragment | BardRequest V2 - Filter', function(hooks) {
 
     assert.deepEqual(filter.values, ['P1D', 'current'], 'the `values` property is set correctly');
 
-    assert.equal(filter.meta.id, 'dateTime', 'metadata is loaded correctly');
+    filter.applyMeta('dimension', 'dummy');
+    assert.equal(filter.columnMeta.id, 'dateTime', 'metadata is loaded correctly');
   });
 
   test('Validation', async function(assert) {

--- a/packages/core/tests/unit/models/bard-request-v2/fragments/sort-test.js
+++ b/packages/core/tests/unit/models/bard-request-v2/fragments/sort-test.js
@@ -45,7 +45,8 @@ module('Unit | Model | Fragment | BardRequest V2 - Sort', function(hooks) {
     assert.deepEqual(sort.parameters, { grain: 'day' }, 'the `parameters` property is set correctly');
 
     assert.equal(sort.direction, 'asc', 'the `direction` property is set correctly');
-    assert.equal(sort.meta.id, 'dateTime', 'correct meta data is populated');
+    sort.applyMeta('dimension', 'dummy');
+    assert.equal(sort.columnMeta.id, 'dateTime', 'correct meta data is populated');
   });
 
   test('Validation', async function(assert) {

--- a/packages/core/tests/unit/models/bard-request-v2/fragments/sort-test.js
+++ b/packages/core/tests/unit/models/bard-request-v2/fragments/sort-test.js
@@ -16,6 +16,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Sort', function(hooks) {
         sort: [
           {
             field: 'revenue',
+            type: 'metric',
             parameters: { currency: 'USD' }
           }
         ]
@@ -29,6 +30,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Sort', function(hooks) {
     assert.ok(mockModel, 'mockModel is fetched from the store');
 
     const sort = mockModel.sort.objectAt(0);
+    sort.source = 'dummy';
 
     assert.equal(sort.field, 'revenue', 'the `field` property has the correct value');
 
@@ -45,7 +47,6 @@ module('Unit | Model | Fragment | BardRequest V2 - Sort', function(hooks) {
     assert.deepEqual(sort.parameters, { grain: 'day' }, 'the `parameters` property is set correctly');
 
     assert.equal(sort.direction, 'asc', 'the `direction` property is set correctly');
-    sort.applyMeta('dimension', 'dummy');
     assert.equal(sort.columnMeta.id, 'dateTime', 'correct meta data is populated');
   });
 
@@ -94,6 +95,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Sort', function(hooks) {
           parameters: {
             currency: 'USD'
           },
+          type: 'metric',
           direction: 'desc'
         }
       ],
@@ -107,6 +109,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Sort', function(hooks) {
       [
         {
           field: 'revenue',
+          type: 'metric',
           direction: 'desc'
         }
       ],
@@ -120,6 +123,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Sort', function(hooks) {
       [
         {
           field: 'revenue',
+          type: 'metric',
           direction: 'desc'
         }
       ],

--- a/packages/core/tests/unit/models/bard-request-v2/fragments/sort-test.js
+++ b/packages/core/tests/unit/models/bard-request-v2/fragments/sort-test.js
@@ -1,13 +1,16 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 let mockModel;
 
 module('Unit | Model | Fragment | BardRequest V2 - Sort', function(hooks) {
   setupTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(async function() {
+    await this.owner.lookup('service:bard-metadata').loadMetadata();
     mockModel = run(() =>
       this.owner.lookup('service:store').createRecord('fragments-v2-mock', {
         sort: [
@@ -21,7 +24,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Sort', function(hooks) {
   });
 
   test('Model using the Sort Fragment', async function(assert) {
-    assert.expect(7);
+    assert.expect(8);
 
     assert.ok(mockModel, 'mockModel is fetched from the store');
 
@@ -42,6 +45,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Sort', function(hooks) {
     assert.deepEqual(sort.parameters, { grain: 'day' }, 'the `parameters` property is set correctly');
 
     assert.equal(sort.direction, 'asc', 'the `direction` property is set correctly');
+    assert.equal(sort.meta.id, 'dateTime', 'correct meta data is populated');
   });
 
   test('Validation', async function(assert) {

--- a/packages/core/tests/unit/models/bard-request-v2/request-test.js
+++ b/packages/core/tests/unit/models/bard-request-v2/request-test.js
@@ -36,7 +36,8 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
               alias: 'time'
             },
             {
-              field: 'property.id',
+              field: 'property',
+              parameters: { projection: 'id' },
               type: 'dimension'
             },
             {
@@ -348,7 +349,8 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
             alias: 'time'
           },
           {
-            field: 'property.id',
+            field: 'property',
+            parameters: { projection: 'id' },
             type: 'dimension',
             alias: null
           },

--- a/packages/core/tests/unit/models/bard-request-v2/request-test.js
+++ b/packages/core/tests/unit/models/bard-request-v2/request-test.js
@@ -63,6 +63,14 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
         }
       })
     );
+    /**
+     * TODO: remove these applyMeta when serializer is in place that will do this automatically
+     */
+    mockModel.request.columns.objectAt(1).applyMeta('dimension', 'dummy');
+    mockModel.request.columns.objectAt(2).applyMeta('metric', 'dummy');
+    mockModel.request.columns.objectAt(3).applyMeta('metric', 'dummy');
+    mockModel.request.filters.objectAt(1).applyMeta('metric', 'dummy');
+    mockModel.request.sort.objectAt(1).applyMeta('metric', 'dummy');
   });
 
   test('Model using the Request Fragment', async function(assert) {
@@ -80,10 +88,15 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
 
     assert.equal(request.dataSource, 'dummy', 'the `dataSource` property has the correct value');
 
-    assert.equal(request.columns.objectAt(1).meta.category, 'Asset', 'meta data is populated on sub fragments');
-    assert.equal(request.columns.objectAt(2).meta.category, 'Revenue', 'meta data is populated on sub fragments');
-    assert.equal(request.filters.objectAt(1).meta.category, 'Identifiers', 'Filters also have meta data populated');
-    assert.equal(request.sort.objectAt(1).meta.category, 'Clicks', 'Sorts have meta data populated');
+    assert.equal(request.columns.objectAt(1).columnMeta.category, 'Asset', 'meta data is populated on sub fragments');
+    assert.equal(request.columns.objectAt(2).columnMeta.category, 'Revenue', 'meta data is populated on sub fragments');
+    assert.equal(
+      request.filters.objectAt(1).columnMeta.category,
+      'Identifiers',
+      'Filters also have meta data populated'
+    );
+
+    assert.equal(request.sort.objectAt(1).columnMeta.category, 'Clicks', 'Sorts have meta data populated');
   });
 
   test('Clone Request', async function(assert) {
@@ -123,7 +136,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
       'the `values` property of the second filter has the correct value'
     );
 
-    assert.equal(request.filters.objectAt(1).meta.category, 'Identifiers', 'the meta data attached is correct');
+    assert.equal(request.filters.objectAt(1).columnMeta.category, 'Identifiers', 'the meta data attached is correct');
 
     // columns
 
@@ -151,7 +164,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
       'the `type` property of the second column has the correct value'
     );
 
-    assert.equal(request.columns.objectAt(1).meta.category, 'Asset', 'the meta data attached is correct');
+    assert.equal(request.columns.objectAt(1).columnMeta.category, 'Asset', 'the meta data attached is correct');
 
     // sort
 
@@ -167,7 +180,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
       'the `direction` property of the second sort has the correct value'
     );
 
-    assert.equal(request.sort.objectAt(1).meta.category, 'Clicks', 'the meta data attached is correct');
+    assert.equal(request.sort.objectAt(1).columnMeta.category, 'Clicks', 'the meta data attached is correct');
   });
 
   test('Validation', async function(assert) {

--- a/packages/core/tests/unit/models/bard-request-v2/request-test.js
+++ b/packages/core/tests/unit/models/bard-request-v2/request-test.js
@@ -68,7 +68,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
       })
     );
     /**
-     * TODO: remove these applyMeta when serializer is in place that will do this automatically
+     * TODO: remove when serializer is in place that will do this automatically
      */
     mockModel.request.columns.forEach(column => {
       column.source = 'dummy';

--- a/packages/core/tests/unit/models/bard-request-v2/request-test.js
+++ b/packages/core/tests/unit/models/bard-request-v2/request-test.js
@@ -1,13 +1,16 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 let mockModel;
 
 module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
   setupTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(async function() {
+    await this.owner.lookup('service:bard-metadata').loadMetadata();
     mockModel = run(() =>
       this.owner.lookup('service:store').createRecord('fragments-v2-mock', {
         request: {
@@ -31,7 +34,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
               alias: 'time'
             },
             {
-              field: 'property',
+              field: 'property.id',
               type: 'dimension'
             },
             {
@@ -63,7 +66,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
   });
 
   test('Model using the Request Fragment', async function(assert) {
-    assert.expect(5);
+    assert.expect(9);
 
     assert.ok(mockModel, 'mockModel is fetched from the store');
 
@@ -76,10 +79,15 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
     assert.equal(request.requestVersion, '2.0', 'the `requestVersion` property has the correct default value');
 
     assert.equal(request.dataSource, 'dummy', 'the `dataSource` property has the correct value');
+
+    assert.equal(request.columns.objectAt(1).meta.category, 'Asset', 'meta data is populated on sub fragments');
+    assert.equal(request.columns.objectAt(2).meta.category, 'Revenue', 'meta data is populated on sub fragments');
+    assert.equal(request.filters.objectAt(1).meta.category, 'Identifiers', 'Filters also have meta data populated');
+    assert.equal(request.sort.objectAt(1).meta.category, 'Clicks', 'Sorts have meta data populated');
   });
 
   test('Clone Request', async function(assert) {
-    assert.expect(13);
+    assert.expect(16);
 
     const request = mockModel.request.clone();
 
@@ -115,6 +123,8 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
       'the `values` property of the second filter has the correct value'
     );
 
+    assert.equal(request.filters.objectAt(1).meta.category, 'Identifiers', 'the meta data attached is correct');
+
     // columns
 
     assert.equal(
@@ -141,6 +151,8 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
       'the `type` property of the second column has the correct value'
     );
 
+    assert.equal(request.columns.objectAt(1).meta.category, 'Asset', 'the meta data attached is correct');
+
     // sort
 
     assert.equal(
@@ -154,6 +166,8 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
       'desc',
       'the `direction` property of the second sort has the correct value'
     );
+
+    assert.equal(request.sort.objectAt(1).meta.category, 'Clicks', 'the meta data attached is correct');
   });
 
   test('Validation', async function(assert) {
@@ -308,7 +322,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
             alias: 'time'
           },
           {
-            field: 'property',
+            field: 'property.id',
             type: 'dimension',
             alias: null
           },

--- a/packages/core/tests/unit/models/bard-request-v2/request-test.js
+++ b/packages/core/tests/unit/models/bard-request-v2/request-test.js
@@ -18,10 +18,12 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
             {
               field: 'dateTime',
               operator: 'bet',
+              type: 'time-dimension',
               values: ['P1D', 'current']
             },
             {
               field: 'uniqueIdentifier',
+              type: 'metric',
               operator: 'gt',
               values: [3]
             }
@@ -47,13 +49,15 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
               type: 'metric'
             }
           ],
-          sort: [
+          sorts: [
             {
               field: 'dateTime',
+              type: 'time-dimension',
               direction: 'asc'
             },
             {
               field: 'navClicks',
+              type: 'metric',
               direction: 'desc'
             }
           ],
@@ -66,11 +70,15 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
     /**
      * TODO: remove these applyMeta when serializer is in place that will do this automatically
      */
-    mockModel.request.columns.objectAt(1).applyMeta('dimension', 'dummy');
-    mockModel.request.columns.objectAt(2).applyMeta('metric', 'dummy');
-    mockModel.request.columns.objectAt(3).applyMeta('metric', 'dummy');
-    mockModel.request.filters.objectAt(1).applyMeta('metric', 'dummy');
-    mockModel.request.sort.objectAt(1).applyMeta('metric', 'dummy');
+    mockModel.request.columns.forEach(column => {
+      column.source = 'dummy';
+    });
+    mockModel.request.filters.forEach(filter => {
+      filter.source = 'dummy';
+    });
+    mockModel.request.sorts.forEach(sort => {
+      sort.source = 'dummy';
+    });
   });
 
   test('Model using the Request Fragment', async function(assert) {
@@ -96,7 +104,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
       'Filters also have meta data populated'
     );
 
-    assert.equal(request.sort.objectAt(1).columnMeta.category, 'Clicks', 'Sorts have meta data populated');
+    assert.equal(request.sorts.objectAt(1).columnMeta.category, 'Clicks', 'Sorts have meta data populated');
   });
 
   test('Clone Request', async function(assert) {
@@ -169,18 +177,18 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
     // sort
 
     assert.equal(
-      request.sort.objectAt(0).field,
+      request.sorts.objectAt(0).field,
       'dateTime',
       'the `field` property of the first sort has the correct value'
     );
 
     assert.equal(
-      request.sort.objectAt(1).direction,
+      request.sorts.objectAt(1).direction,
       'desc',
       'the `direction` property of the second sort has the correct value'
     );
 
-    assert.equal(request.sort.objectAt(1).columnMeta.category, 'Clicks', 'the meta data attached is correct');
+    assert.equal(request.sorts.objectAt(1).columnMeta.category, 'Clicks', 'the meta data attached is correct');
   });
 
   test('Validation', async function(assert) {
@@ -225,12 +233,12 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
       'error messages collection is correct for a request with an empty `columns` collection'
     );
 
-    request.set('sort', null);
-    assert.notOk(request.validations.isValid, 'a request without a `sort` collection is invalid');
+    request.set('sorts', null);
+    assert.notOk(request.validations.isValid, 'a request without a `sorts` collection is invalid');
     assert.equal(
       request.validations.messages.objectAt(1),
-      'Sort must be a collection',
-      'error messages collection is correct for a request without a `sort` collection'
+      'Sorts must be a collection',
+      'error messages collection is correct for a request without a `sorts` collection'
     );
   });
 
@@ -244,11 +252,13 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
       {
         field: 'dateTime',
         operator: 'bet',
+        type: 'time-dimension',
         values: ['P1D', 'current']
       },
       {
         field: null,
         operator: null,
+        type: null,
         values: null
       }
     ]);
@@ -285,15 +295,16 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
     );
   });
 
-  test('Validation - sort has-many', async function(assert) {
+  test('Validation - sorts has-many', async function(assert) {
     assert.expect(3);
 
     const { request } = mockModel;
 
     //TODO: use addSort()
-    request.set('sort', [
+    request.set('sorts', [
       {
         field: 'dateTime',
+        type: 'time-dimension',
         direction: 'asc'
       },
       {
@@ -318,11 +329,13 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
         filters: [
           {
             field: 'dateTime',
+            type: 'time-dimension',
             operator: 'bet',
             values: ['P1D', 'current']
           },
           {
             field: 'uniqueIdentifier',
+            type: 'metric',
             operator: 'gt',
             values: [3]
           }
@@ -351,13 +364,15 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
             alias: null
           }
         ],
-        sort: [
+        sorts: [
           {
             field: 'dateTime',
+            type: 'time-dimension',
             direction: 'asc'
           },
           {
             field: 'navClicks',
+            type: 'metric',
             direction: 'desc'
           }
         ],

--- a/packages/core/tests/unit/services/fragment-factory-test.js
+++ b/packages/core/tests/unit/services/fragment-factory-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-let metadataService;
+let metadataService, service;
 
 module('Unit | Service | fragmentFactory', function(hooks) {
   setupTest(hooks);
@@ -10,11 +10,11 @@ module('Unit | Service | fragmentFactory', function(hooks) {
 
   hooks.beforeEach(function() {
     metadataService = this.owner.lookup('service:bard-metadata');
+    service = this.owner.lookup('service:fragment-factory');
     return metadataService.loadMetadata();
   });
 
   test('Build Column Fragments From Meta', function(assert) {
-    let service = this.owner.lookup('service:fragment-factory');
     const metricMeta = metadataService.getById('metric', 'navClicks');
     const dimMeta = metadataService.getById('dimension', 'browser');
 
@@ -27,21 +27,19 @@ module('Unit | Service | fragmentFactory', function(hooks) {
     assert.equal(metricMetaFragment.parameters.avg, 'trailing31day', 'Metric fragment has right parameters');
     assert.equal(metricMetaFragment.alias, 'clicksTrailingMonthAvg', 'Metric Fragment has passed alias');
     assert.equal(metricMetaFragment.type, 'metric', 'Metric Fragment has metric type');
-    assert.equal(metricMetaFragment.meta.category, 'Clicks', 'Metric fragment meta is populated correctly');
-    assert.equal(metricMetaFragment.meta.source, 'dummy', 'Metric fragment meta data has right datasource');
+    assert.equal(metricMetaFragment.columnMeta.category, 'Clicks', 'Metric fragment meta is populated correctly');
+    assert.equal(metricMetaFragment.columnMeta.source, 'dummy', 'Metric fragment meta data has right datasource');
 
     const dimensionMetaFragment = service.createColumnFromMeta(dimMeta, {}, 'agent', 'description');
     assert.equal(dimensionMetaFragment.field, 'browser.description', 'Dimension has right field');
     assert.deepEqual(dimensionMetaFragment.parameters, {}, 'Dimension fragment has right parameters');
     assert.equal(dimensionMetaFragment.alias, 'agent', 'Dimension Fragment has passed alias');
     assert.equal(dimensionMetaFragment.type, 'dimension', 'Dimension Fragment has metric type');
-    assert.equal(dimensionMetaFragment.meta.category, 'test', 'Dimension fragment meta is populated correctly');
-    assert.equal(dimensionMetaFragment.meta.source, 'dummy', 'Dimension fragment meta data has right datasource');
+    assert.equal(dimensionMetaFragment.columnMeta.category, 'test', 'Dimension fragment meta is populated correctly');
+    assert.equal(dimensionMetaFragment.columnMeta.source, 'dummy', 'Dimension fragment meta data has right datasource');
   });
 
   test('Build Column Fragments Without Meta', function(assert) {
-    let service = this.owner.lookup('service:fragment-factory');
-
     const metricMetaFragment = service.createColumn(
       'metric',
       'dummy',
@@ -53,20 +51,19 @@ module('Unit | Service | fragmentFactory', function(hooks) {
     assert.equal(metricMetaFragment.parameters.currency, 'USD', 'Metric fragment has right parameters');
     assert.equal(metricMetaFragment.alias, 'revenueTrailingMonthAvg', 'Metric Fragment has passed alias');
     assert.equal(metricMetaFragment.type, 'metric', 'Metric Fragment has metric type');
-    assert.equal(metricMetaFragment.meta.category, 'Revenue', 'Metric fragment meta is populated correctly');
-    assert.equal(metricMetaFragment.meta.source, 'dummy', 'Metric fragment meta data has right datasource');
+    assert.equal(metricMetaFragment.columnMeta.category, 'Revenue', 'Metric fragment meta is populated correctly');
+    assert.equal(metricMetaFragment.columnMeta.source, 'dummy', 'Metric fragment meta data has right datasource');
 
     const dimensionMetaFragment = service.createColumn('dimension', 'dummy', 'browser.description', {}, 'agent');
     assert.equal(dimensionMetaFragment.field, 'browser.description', 'Dimension has right field');
     assert.deepEqual(dimensionMetaFragment.parameters, {}, 'Dimension fragment has right parameters');
     assert.equal(dimensionMetaFragment.alias, 'agent', 'Dimension Fragment has passed alias');
     assert.equal(dimensionMetaFragment.type, 'dimension', 'Dimension Fragment has metric type');
-    assert.equal(dimensionMetaFragment.meta.category, 'test', 'Dimension fragment meta is populated correctly');
-    assert.equal(dimensionMetaFragment.meta.source, 'dummy', 'Dimension fragment meta data has right datasource');
+    assert.equal(dimensionMetaFragment.columnMeta.category, 'test', 'Dimension fragment meta is populated correctly');
+    assert.equal(dimensionMetaFragment.columnMeta.source, 'dummy', 'Dimension fragment meta data has right datasource');
   });
 
   test('Build Filter Fragments From Meta', function(assert) {
-    let service = this.owner.lookup('service:fragment-factory');
     const metricMeta = metadataService.getById('metric', 'navClicks');
     const dimMeta = metadataService.getById('dimension', 'browser');
 
@@ -75,8 +72,8 @@ module('Unit | Service | fragmentFactory', function(hooks) {
     assert.equal(metricMetaFragment.parameters.avg, 'trailing31day', 'Metric fragment has right parameters');
     assert.equal(metricMetaFragment.operator, 'in', 'Metric Fragment has passed operator');
     assert.deepEqual(metricMetaFragment.values, [1, 2, 3], 'Metric Fragment has right values');
-    assert.equal(metricMetaFragment.meta.category, 'Clicks', 'Metric fragment meta is populated correctly');
-    assert.equal(metricMetaFragment.meta.source, 'dummy', 'Metric fragment meta data has right datasource');
+    assert.equal(metricMetaFragment.columnMeta.category, 'Clicks', 'Metric fragment meta is populated correctly');
+    assert.equal(metricMetaFragment.columnMeta.source, 'dummy', 'Metric fragment meta data has right datasource');
 
     const dimensionMetaFragment = service.createFilterFromMeta(
       dimMeta,
@@ -89,13 +86,11 @@ module('Unit | Service | fragmentFactory', function(hooks) {
     assert.deepEqual(dimensionMetaFragment.parameters, {}, 'Dimension fragment has right parameters');
     assert.equal(dimensionMetaFragment.operator, 'contains', 'Dimension Fragment has passed opeator');
     assert.deepEqual(dimensionMetaFragment.values, ['chrome', 'firefox'], 'Dimension Fragment has metric values');
-    assert.equal(dimensionMetaFragment.meta.category, 'test', 'Dimension fragment meta is populated correctly');
-    assert.equal(dimensionMetaFragment.meta.source, 'dummy', 'Dimension fragment meta data has right datasource');
+    assert.equal(dimensionMetaFragment.columnMeta.category, 'test', 'Dimension fragment meta is populated correctly');
+    assert.equal(dimensionMetaFragment.columnMeta.source, 'dummy', 'Dimension fragment meta data has right datasource');
   });
 
   test('Build Filter Fragments Without Meta', function(assert) {
-    let service = this.owner.lookup('service:fragment-factory');
-
     const metricMetaFragment = service.createFilter('metric', 'dummy', 'navClicks', { avg: 'trailing31day' }, 'in', [
       1,
       2,
@@ -105,8 +100,8 @@ module('Unit | Service | fragmentFactory', function(hooks) {
     assert.equal(metricMetaFragment.parameters.avg, 'trailing31day', 'Metric fragment has right parameters');
     assert.equal(metricMetaFragment.operator, 'in', 'Metric Fragment has passed operator');
     assert.deepEqual(metricMetaFragment.values, [1, 2, 3], 'Metric Fragment has right values');
-    assert.equal(metricMetaFragment.meta.category, 'Clicks', 'Metric fragment meta is populated correctly');
-    assert.equal(metricMetaFragment.meta.source, 'dummy', 'Metric fragment meta data has right datasource');
+    assert.equal(metricMetaFragment.columnMeta.category, 'Clicks', 'Metric fragment meta is populated correctly');
+    assert.equal(metricMetaFragment.columnMeta.source, 'dummy', 'Metric fragment meta data has right datasource');
 
     const dimensionMetaFragment = service.createFilter(
       'dimension',
@@ -121,30 +116,27 @@ module('Unit | Service | fragmentFactory', function(hooks) {
     assert.deepEqual(dimensionMetaFragment.parameters, {}, 'Dimension fragment has right parameters');
     assert.equal(dimensionMetaFragment.operator, 'contains', 'Dimension Fragment has passed opeator');
     assert.deepEqual(dimensionMetaFragment.values, ['chrome', 'firefox'], 'Dimension Fragment has metric values');
-    assert.equal(dimensionMetaFragment.meta.category, 'test', 'Dimension fragment meta is populated correctly');
-    assert.equal(dimensionMetaFragment.meta.source, 'dummy', 'Dimension fragment meta data has right datasource');
+    assert.equal(dimensionMetaFragment.columnMeta.category, 'test', 'Dimension fragment meta is populated correctly');
+    assert.equal(dimensionMetaFragment.columnMeta.source, 'dummy', 'Dimension fragment meta data has right datasource');
   });
 
   test('Build Sort Fragments From Meta', function(assert) {
-    let service = this.owner.lookup('service:fragment-factory');
     const metricMeta = metadataService.getById('metric', 'navClicks');
 
     const metricMetaFragment = service.createSortFromMeta(metricMeta, { avg: 'trailing31day' }, 'asc');
     assert.equal(metricMetaFragment.field, 'navClicks', 'Sort Fragment has right field');
     assert.equal(metricMetaFragment.parameters.avg, 'trailing31day', 'Sort fragment has right parameters');
     assert.equal(metricMetaFragment.direction, 'asc', 'Sort Fragment has passed operator');
-    assert.equal(metricMetaFragment.meta.category, 'Clicks', 'Sort fragment meta is populated correctly');
-    assert.equal(metricMetaFragment.meta.source, 'dummy', 'Sort fragment meta data has right datasource');
+    assert.equal(metricMetaFragment.columnMeta.category, 'Clicks', 'Sort fragment meta is populated correctly');
+    assert.equal(metricMetaFragment.columnMeta.source, 'dummy', 'Sort fragment meta data has right datasource');
   });
 
   test('Build Sort Fragments Without Meta', function(assert) {
-    let service = this.owner.lookup('service:fragment-factory');
-
     const metricMetaFragment = service.createSort('metric', 'dummy', 'revenue', { currency: 'USD' }, 'desc');
     assert.equal(metricMetaFragment.field, 'revenue', 'Sort Fragment has right field');
     assert.equal(metricMetaFragment.parameters.currency, 'USD', 'Sort fragment has right parameters');
     assert.equal(metricMetaFragment.direction, 'desc', 'Sort Fragment has passed operator');
-    assert.equal(metricMetaFragment.meta.category, 'Revenue', 'Sort fragment meta is populated correctly');
-    assert.equal(metricMetaFragment.meta.source, 'dummy', 'Sort fragment meta data has right datasource');
+    assert.equal(metricMetaFragment.columnMeta.category, 'Revenue', 'Sort fragment meta is populated correctly');
+    assert.equal(metricMetaFragment.columnMeta.source, 'dummy', 'Sort fragment meta data has right datasource');
   });
 });

--- a/packages/core/tests/unit/services/fragment-factory-test.js
+++ b/packages/core/tests/unit/services/fragment-factory-test.js
@@ -1,0 +1,150 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+let metadataService;
+
+module('Unit | Service | fragmentFactory', function(hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function() {
+    metadataService = this.owner.lookup('service:bard-metadata');
+    return metadataService.loadMetadata();
+  });
+
+  test('Build Column Fragments From Meta', function(assert) {
+    let service = this.owner.lookup('service:fragment-factory');
+    const metricMeta = metadataService.getById('metric', 'navClicks');
+    const dimMeta = metadataService.getById('dimension', 'browser');
+
+    const metricMetaFragment = service.createColumnFromMeta(
+      metricMeta,
+      { avg: 'trailing31day' },
+      'clicksTrailingMonthAvg'
+    );
+    assert.equal(metricMetaFragment.field, 'navClicks', 'Metric has right field');
+    assert.equal(metricMetaFragment.parameters.avg, 'trailing31day', 'Metric fragment has right parameters');
+    assert.equal(metricMetaFragment.alias, 'clicksTrailingMonthAvg', 'Metric Fragment has passed alias');
+    assert.equal(metricMetaFragment.type, 'metric', 'Metric Fragment has metric type');
+    assert.equal(metricMetaFragment.meta.category, 'Clicks', 'Metric fragment meta is populated correctly');
+    assert.equal(metricMetaFragment.meta.source, 'dummy', 'Metric fragment meta data has right datasource');
+
+    const dimensionMetaFragment = service.createColumnFromMeta(dimMeta, {}, 'agent', 'description');
+    assert.equal(dimensionMetaFragment.field, 'browser.description', 'Dimension has right field');
+    assert.deepEqual(dimensionMetaFragment.parameters, {}, 'Dimension fragment has right parameters');
+    assert.equal(dimensionMetaFragment.alias, 'agent', 'Dimension Fragment has passed alias');
+    assert.equal(dimensionMetaFragment.type, 'dimension', 'Dimension Fragment has metric type');
+    assert.equal(dimensionMetaFragment.meta.category, 'test', 'Dimension fragment meta is populated correctly');
+    assert.equal(dimensionMetaFragment.meta.source, 'dummy', 'Dimension fragment meta data has right datasource');
+  });
+
+  test('Build Column Fragments Without Meta', function(assert) {
+    let service = this.owner.lookup('service:fragment-factory');
+
+    const metricMetaFragment = service.createColumn(
+      'metric',
+      'dummy',
+      'revenue',
+      { currency: 'USD' },
+      'revenueTrailingMonthAvg'
+    );
+    assert.equal(metricMetaFragment.field, 'revenue', 'Metric has right field');
+    assert.equal(metricMetaFragment.parameters.currency, 'USD', 'Metric fragment has right parameters');
+    assert.equal(metricMetaFragment.alias, 'revenueTrailingMonthAvg', 'Metric Fragment has passed alias');
+    assert.equal(metricMetaFragment.type, 'metric', 'Metric Fragment has metric type');
+    assert.equal(metricMetaFragment.meta.category, 'Revenue', 'Metric fragment meta is populated correctly');
+    assert.equal(metricMetaFragment.meta.source, 'dummy', 'Metric fragment meta data has right datasource');
+
+    const dimensionMetaFragment = service.createColumn('dimension', 'dummy', 'browser.description', {}, 'agent');
+    assert.equal(dimensionMetaFragment.field, 'browser.description', 'Dimension has right field');
+    assert.deepEqual(dimensionMetaFragment.parameters, {}, 'Dimension fragment has right parameters');
+    assert.equal(dimensionMetaFragment.alias, 'agent', 'Dimension Fragment has passed alias');
+    assert.equal(dimensionMetaFragment.type, 'dimension', 'Dimension Fragment has metric type');
+    assert.equal(dimensionMetaFragment.meta.category, 'test', 'Dimension fragment meta is populated correctly');
+    assert.equal(dimensionMetaFragment.meta.source, 'dummy', 'Dimension fragment meta data has right datasource');
+  });
+
+  test('Build Filter Fragments From Meta', function(assert) {
+    let service = this.owner.lookup('service:fragment-factory');
+    const metricMeta = metadataService.getById('metric', 'navClicks');
+    const dimMeta = metadataService.getById('dimension', 'browser');
+
+    const metricMetaFragment = service.createFilterFromMeta(metricMeta, { avg: 'trailing31day' }, 'in', [1, 2, 3]);
+    assert.equal(metricMetaFragment.field, 'navClicks', 'Metric has right field');
+    assert.equal(metricMetaFragment.parameters.avg, 'trailing31day', 'Metric fragment has right parameters');
+    assert.equal(metricMetaFragment.operator, 'in', 'Metric Fragment has passed operator');
+    assert.deepEqual(metricMetaFragment.values, [1, 2, 3], 'Metric Fragment has right values');
+    assert.equal(metricMetaFragment.meta.category, 'Clicks', 'Metric fragment meta is populated correctly');
+    assert.equal(metricMetaFragment.meta.source, 'dummy', 'Metric fragment meta data has right datasource');
+
+    const dimensionMetaFragment = service.createFilterFromMeta(
+      dimMeta,
+      {},
+      'contains',
+      ['chrome', 'firefox'],
+      'description'
+    );
+    assert.equal(dimensionMetaFragment.field, 'browser.description', 'Dimension has right field');
+    assert.deepEqual(dimensionMetaFragment.parameters, {}, 'Dimension fragment has right parameters');
+    assert.equal(dimensionMetaFragment.operator, 'contains', 'Dimension Fragment has passed opeator');
+    assert.deepEqual(dimensionMetaFragment.values, ['chrome', 'firefox'], 'Dimension Fragment has metric values');
+    assert.equal(dimensionMetaFragment.meta.category, 'test', 'Dimension fragment meta is populated correctly');
+    assert.equal(dimensionMetaFragment.meta.source, 'dummy', 'Dimension fragment meta data has right datasource');
+  });
+
+  test('Build Filter Fragments Without Meta', function(assert) {
+    let service = this.owner.lookup('service:fragment-factory');
+
+    const metricMetaFragment = service.createFilter('metric', 'dummy', 'navClicks', { avg: 'trailing31day' }, 'in', [
+      1,
+      2,
+      3
+    ]);
+    assert.equal(metricMetaFragment.field, 'navClicks', 'Metric has right field');
+    assert.equal(metricMetaFragment.parameters.avg, 'trailing31day', 'Metric fragment has right parameters');
+    assert.equal(metricMetaFragment.operator, 'in', 'Metric Fragment has passed operator');
+    assert.deepEqual(metricMetaFragment.values, [1, 2, 3], 'Metric Fragment has right values');
+    assert.equal(metricMetaFragment.meta.category, 'Clicks', 'Metric fragment meta is populated correctly');
+    assert.equal(metricMetaFragment.meta.source, 'dummy', 'Metric fragment meta data has right datasource');
+
+    const dimensionMetaFragment = service.createFilter(
+      'dimension',
+      'dummy',
+      'browser.description',
+      {},
+      'contains',
+      ['chrome', 'firefox'],
+      'description'
+    );
+    assert.equal(dimensionMetaFragment.field, 'browser.description', 'Dimension has right field');
+    assert.deepEqual(dimensionMetaFragment.parameters, {}, 'Dimension fragment has right parameters');
+    assert.equal(dimensionMetaFragment.operator, 'contains', 'Dimension Fragment has passed opeator');
+    assert.deepEqual(dimensionMetaFragment.values, ['chrome', 'firefox'], 'Dimension Fragment has metric values');
+    assert.equal(dimensionMetaFragment.meta.category, 'test', 'Dimension fragment meta is populated correctly');
+    assert.equal(dimensionMetaFragment.meta.source, 'dummy', 'Dimension fragment meta data has right datasource');
+  });
+
+  test('Build Sort Fragments From Meta', function(assert) {
+    let service = this.owner.lookup('service:fragment-factory');
+    const metricMeta = metadataService.getById('metric', 'navClicks');
+
+    const metricMetaFragment = service.createSortFromMeta(metricMeta, { avg: 'trailing31day' }, 'asc');
+    assert.equal(metricMetaFragment.field, 'navClicks', 'Sort Fragment has right field');
+    assert.equal(metricMetaFragment.parameters.avg, 'trailing31day', 'Sort fragment has right parameters');
+    assert.equal(metricMetaFragment.direction, 'asc', 'Sort Fragment has passed operator');
+    assert.equal(metricMetaFragment.meta.category, 'Clicks', 'Sort fragment meta is populated correctly');
+    assert.equal(metricMetaFragment.meta.source, 'dummy', 'Sort fragment meta data has right datasource');
+  });
+
+  test('Build Sort Fragments Without Meta', function(assert) {
+    let service = this.owner.lookup('service:fragment-factory');
+
+    const metricMetaFragment = service.createSort('metric', 'dummy', 'revenue', { currency: 'USD' }, 'desc');
+    assert.equal(metricMetaFragment.field, 'revenue', 'Sort Fragment has right field');
+    assert.equal(metricMetaFragment.parameters.currency, 'USD', 'Sort fragment has right parameters');
+    assert.equal(metricMetaFragment.direction, 'desc', 'Sort Fragment has passed operator');
+    assert.equal(metricMetaFragment.meta.category, 'Revenue', 'Sort fragment meta is populated correctly');
+    assert.equal(metricMetaFragment.meta.source, 'dummy', 'Sort fragment meta data has right datasource');
+  });
+});

--- a/packages/core/tests/unit/services/fragment-factory-test.js
+++ b/packages/core/tests/unit/services/fragment-factory-test.js
@@ -30,8 +30,8 @@ module('Unit | Service | fragmentFactory', function(hooks) {
     assert.equal(metricMetaFragment.columnMeta.category, 'Clicks', 'Metric fragment meta is populated correctly');
     assert.equal(metricMetaFragment.columnMeta.source, 'dummy', 'Metric fragment meta data has right datasource');
 
-    const dimensionMetaFragment = service.createColumnFromMeta(dimMeta, {}, 'agent', 'description');
-    assert.equal(dimensionMetaFragment.field, 'browser.description', 'Dimension has right field');
+    const dimensionMetaFragment = service.createColumnFromMeta(dimMeta, {}, 'agent');
+    assert.equal(dimensionMetaFragment.field, 'browser', 'Dimension has right field');
     assert.deepEqual(dimensionMetaFragment.parameters, {}, 'Dimension fragment has right parameters');
     assert.equal(dimensionMetaFragment.alias, 'agent', 'Dimension Fragment has passed alias');
     assert.equal(dimensionMetaFragment.type, 'dimension', 'Dimension Fragment has metric type');
@@ -54,8 +54,8 @@ module('Unit | Service | fragmentFactory', function(hooks) {
     assert.equal(metricMetaFragment.columnMeta.category, 'Revenue', 'Metric fragment meta is populated correctly');
     assert.equal(metricMetaFragment.columnMeta.source, 'dummy', 'Metric fragment meta data has right datasource');
 
-    const dimensionMetaFragment = service.createColumn('dimension', 'dummy', 'browser.description', {}, 'agent');
-    assert.equal(dimensionMetaFragment.field, 'browser.description', 'Dimension has right field');
+    const dimensionMetaFragment = service.createColumn('dimension', 'dummy', 'browser', {}, 'agent');
+    assert.equal(dimensionMetaFragment.field, 'browser', 'Dimension has right field');
     assert.deepEqual(dimensionMetaFragment.parameters, {}, 'Dimension fragment has right parameters');
     assert.equal(dimensionMetaFragment.alias, 'agent', 'Dimension Fragment has passed alias');
     assert.equal(dimensionMetaFragment.type, 'dimension', 'Dimension Fragment has metric type');
@@ -75,14 +75,8 @@ module('Unit | Service | fragmentFactory', function(hooks) {
     assert.equal(metricMetaFragment.columnMeta.category, 'Clicks', 'Metric fragment meta is populated correctly');
     assert.equal(metricMetaFragment.columnMeta.source, 'dummy', 'Metric fragment meta data has right datasource');
 
-    const dimensionMetaFragment = service.createFilterFromMeta(
-      dimMeta,
-      {},
-      'contains',
-      ['chrome', 'firefox'],
-      'description'
-    );
-    assert.equal(dimensionMetaFragment.field, 'browser.description', 'Dimension has right field');
+    const dimensionMetaFragment = service.createFilterFromMeta(dimMeta, {}, 'contains', ['chrome', 'firefox']);
+    assert.equal(dimensionMetaFragment.field, 'browser', 'Dimension has right field');
     assert.deepEqual(dimensionMetaFragment.parameters, {}, 'Dimension fragment has right parameters');
     assert.equal(dimensionMetaFragment.operator, 'contains', 'Dimension Fragment has passed opeator');
     assert.deepEqual(dimensionMetaFragment.values, ['chrome', 'firefox'], 'Dimension Fragment has metric values');
@@ -103,16 +97,11 @@ module('Unit | Service | fragmentFactory', function(hooks) {
     assert.equal(metricMetaFragment.columnMeta.category, 'Clicks', 'Metric fragment meta is populated correctly');
     assert.equal(metricMetaFragment.columnMeta.source, 'dummy', 'Metric fragment meta data has right datasource');
 
-    const dimensionMetaFragment = service.createFilter(
-      'dimension',
-      'dummy',
-      'browser.description',
-      {},
-      'contains',
-      ['chrome', 'firefox'],
-      'description'
-    );
-    assert.equal(dimensionMetaFragment.field, 'browser.description', 'Dimension has right field');
+    const dimensionMetaFragment = service.createFilter('dimension', 'dummy', 'browser', {}, 'contains', [
+      'chrome',
+      'firefox'
+    ]);
+    assert.equal(dimensionMetaFragment.field, 'browser', 'Dimension has right field');
     assert.deepEqual(dimensionMetaFragment.parameters, {}, 'Dimension fragment has right parameters');
     assert.equal(dimensionMetaFragment.operator, 'contains', 'Dimension Fragment has passed opeator');
     assert.deepEqual(dimensionMetaFragment.values, ['chrome', 'firefox'], 'Dimension Fragment has metric values');

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -28,6 +28,8 @@
       "navi-core/*": ["addon/*"],
       "navi-core/test-support": ["addon-test-support"],
       "navi-core/test-support/*": ["addon-test-support/*"],
+      "navi-data": ["node_modules/navi-data/addon"],
+      "navi-data/*": ["node_modules/navi-data/addon/*"],
       "*": ["types/*"]
     }
   },

--- a/packages/core/types/@ember/service/index.d.ts
+++ b/packages/core/types/@ember/service/index.d.ts
@@ -1,0 +1,5 @@
+declare module '@ember/service';
+
+interface Registry {
+  [key: string]: any;
+}


### PR DESCRIPTION
Resolves #751 

<!-- The above line will close the issue upon merge -->

## Description

Current approach to metadata is to replace the field component of a fragment with the metadata at transform time, this has been a headache.
 - Field has different shape depending on serialized or unserialized which is confusing
 - transforms don't give access to all information needed to get ahold of the metadata so work arounds are needed. 

## Proposed Changes

Request V2 will have the following approach to metadata
- Metadata moved onto a lazy fetched property on the base fragment.
- lazy based fetch will fetch from metadata service looking up info from the parent request v2 model if available.
- Factories are provided to attach meta to newly created fragments that are not part of a request yet. 

Note: this PR contains typescript rebase from master.

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
