### PR TITLE
New: Bard Facts Adapter for Request V2

### DIFF
--- a/packages/data/addon/adapters/bard-facts-v2.ts
+++ b/packages/data/addon/adapters/bard-facts-v2.ts
@@ -60,10 +60,10 @@ type AliasFn = (column: string) => string;
 
 /**
  * @function formatDimensionFieldName
- * @param {string} field - dimension id
- * @param {Parameters} parameters - parameters object
+ * @param field - dimension id
+ * @param parameters - parameters object
  * @param {boolean} includeFieldProj - whether to include the projected field in the formatted name e.g. age|id  OR  age
- * @returns {string} formatted dimension name
+ * @returns formatted dimension name
  */
 function formatDimensionFieldName(field: string, parameters: Parameters, includeFieldProj = true): string {
   const [fieldName, displayField = 'id'] = field.split('.'); // default dimension field projection to "id"
@@ -77,8 +77,8 @@ function formatDimensionFieldName(field: string, parameters: Parameters, include
 
 /**
  * Serializes a list of filters to a fili filter string
- * @param {Array<Filter>} filters - list of filters to be ANDed together for fili
- * @returns {string} serialized filter string
+ * @param filters - list of filters to be ANDed together for fili
+ * @returns serialized filter string
  */
 export function serializeFilters(filters: Filter[]): string {
   return filters
@@ -111,8 +111,8 @@ export default class BardFactsAdapter extends EmberObject {
    *
    * @method _buildDimensionsPath
    * @private
-   * @param {Object} request
-   * @return {String} dimensions path
+   * @param request
+   * @return dimensions path
    */
   _buildDimensionsPath(request: RequestV2 /*options*/): string {
     const dimensions = array(request.columns)
@@ -131,8 +131,8 @@ export default class BardFactsAdapter extends EmberObject {
    *
    * @method _buildDateTimeParam
    * @private
-   * @param {Object} request
-   * @return {String} dateTime param value
+   * @param request
+   * @return dateTime param value
    */
   _buildDateTimeParam(request: RequestV2): string {
     const dateTimeFilters = request.filters.filter(fil => fil.field === 'dateTime');
@@ -145,8 +145,8 @@ export default class BardFactsAdapter extends EmberObject {
    *
    * @method _buildMetricsParam
    * @private
-   * @param {Object} request
-   * @return {String} metrics param value
+   * @param request
+   * @return metrics param value
    */
   _buildMetricsParam(request: RequestV2): string {
     const metrics = request.columns.filter(col => col.type === 'metric');
@@ -164,10 +164,10 @@ export default class BardFactsAdapter extends EmberObject {
    *
    * @method _buildFiltersParam
    * @private
-   * @param {Object} request
-   * @return {String} filters param value
+   * @param request
+   * @return filters param value
    */
-  _buildFiltersParam(request: RequestV2) {
+  _buildFiltersParam(request: RequestV2): string | undefined {
     const filters = request.filters.filter((fil: Filter) => fil.type === 'dimension');
 
     if (filters?.length) {
@@ -181,11 +181,11 @@ export default class BardFactsAdapter extends EmberObject {
    *
    * @method _buildSortParam
    * @private
-   * @param {Object} request
-   * @param {function} aliasFunction function that returns metrics from aliases
-   * @return {String} sort param value
+   * @param request
+   * @param aliasFunction function that returns metrics from aliases
+   * @return sort param value
    */
-  _buildSortParam(request: RequestV2, aliasFunction: AliasFn = a => a) {
+  _buildSortParam(request: RequestV2, aliasFunction: AliasFn = a => a): string | undefined {
     const { sort } = request;
 
     if (sort.length) {
@@ -211,11 +211,11 @@ export default class BardFactsAdapter extends EmberObject {
    *
    * @method _buildHavingParam
    * @private
-   * @param {Object} request
-   * @param {function} aliasFunction function that returns metrics from aliases
-   * @return {String} having param value
+   * @param request
+   * @param aliasFunction function that returns metrics from aliases
+   * @return having param value
    */
-  _buildHavingParam(request: RequestV2, aliasFunction: AliasFn = a => a) {
+  _buildHavingParam(request: RequestV2, aliasFunction: AliasFn = a => a): string | undefined {
     const having = request.filters.filter(fil => fil.type === 'metric');
 
     if (having?.length) {
@@ -235,11 +235,11 @@ export default class BardFactsAdapter extends EmberObject {
    *
    * @method _buildURLPath
    * @private
-   * @param {Object} request
-   * @param {Object} options - optional host options
-   * @return {String} URL Path
+   * @param request
+   * @param options - optional host options
+   * @return URL Path
    */
-  _buildURLPath(request: RequestV2, options: RequestOptions = {}) {
+  _buildURLPath(request: RequestV2, options: RequestOptions = {}): string {
     const host = configHost(options);
     const { namespace } = this;
     const table = request.table;
@@ -254,17 +254,11 @@ export default class BardFactsAdapter extends EmberObject {
    *
    * @method _buildQuery
    * @private
-   *
-   * @param {Object} request
-   * @param {Number} options.page - page number
-   * @param {Number} options.perPage - number of results per page
-   * @param {String} options.format - result format type
-   * @param {Boolean} options.cache - with/without cache
-   * @param {Object} options.queryParams - other params
-   *
-   * @return {Object} query object
+   * @param request
+   * @param options
+   * @returns query object
    */
-  _buildQuery(request: RequestV2, options: RequestOptions) {
+  _buildQuery(request: RequestV2, options: RequestOptions): Query {
     const { columns } = request;
     const metrics = columns
       .filter(col => col.type === 'metric')
@@ -321,11 +315,11 @@ export default class BardFactsAdapter extends EmberObject {
    * Returns URL String for a request
    *
    * @method urlForFindQuery
-   * @param {Request} request
-   * @param {RequestOptions} [options] - options object
-   * @return {String} url
+   * @param request
+   * @param options
+   * @return url
    */
-  urlForFindQuery(request: RequestV2, options: RequestOptions) {
+  urlForFindQuery(request: RequestV2, options: RequestOptions): string {
     assert('Request for bard-facts-v2 adapter must be version 2', request.requestVersion.startsWith('2.'));
 
     // Decorate and translate the request
@@ -347,8 +341,8 @@ export default class BardFactsAdapter extends EmberObject {
   /**
    * @method _decorate
    * @private
-   * @param {Request} request - request to decorate
-   * @returns {Object} decorated request
+   * @param request - request to decorate
+   * @returns decorated request
    */
   _decorate(request: RequestV2): RequestV2 {
     return this.requestDecorator.applyGlobalDecorators(request);
@@ -356,14 +350,8 @@ export default class BardFactsAdapter extends EmberObject {
 
   /**
    * @method fetchDataForRequest - Uses the url generated using the adapter to make an ajax request
-   * @param {Request} request - request (v2) object
-   * @param {RequestOptions} [options] - options object
-   *      Ex: {
-   *        page: 1,
-   *        perPage: 200,
-   *        clientId: 'custom id',
-   *        ...
-   *      }
+   * @param request - request (v2) object
+   * @param options - options object
    * @returns {Promise} - Promise with the response
    */
   fetchDataForRequest(request: RequestV2, options: RequestOptions) {

--- a/packages/data/addon/adapters/bard-facts-v2.ts
+++ b/packages/data/addon/adapters/bard-facts-v2.ts
@@ -1,0 +1,406 @@
+/**
+ * Copyright 2020, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ *
+ * Description: The adapter for the bard-facts request v2 model.
+ */
+
+import { assert } from '@ember/debug';
+import { inject as service } from '@ember/service';
+import { A as array } from '@ember/array';
+import { assign } from '@ember/polyfills';
+import EmberObject from '@ember/object';
+import { canonicalizeMetric, serializeParameters, getAliasedMetrics, canonicalizeAlias } from '../utils/metric';
+import { configHost } from '../utils/adapter';
+
+const SORT_DIRECTIONS = ['desc', 'asc'];
+
+type RequestOptions = {
+  clientId?: string;
+  customHeaders?: Dict<string>;
+  timeout?: number;
+  page?: number;
+  perPage?: number;
+  format?: string;
+  cache?: boolean;
+  queryParams?: Dict<string>;
+};
+type Query = RequestOptions & Dict<string | number | boolean>;
+type SortDirection = typeof SORT_DIRECTIONS[number];
+type ColumnType = 'metric' | 'dimension' | 'timeDimension';
+type Parameters = Dict<string>;
+type Column = {
+  field: string;
+  parameters: Parameters;
+  type: ColumnType;
+  alias: string;
+};
+type Filter = {
+  field: string;
+  parameters: Parameters;
+  type: ColumnType;
+  operator: string;
+  values: string[];
+};
+type Sort = {
+  field: string;
+  parameters: Parameters;
+  direction: SortDirection;
+};
+type Request = {
+  filters: Filter[];
+  columns: Column[];
+  table: string;
+  sort: Sort[];
+  limit: TODO<string>;
+  requestVersion: string;
+};
+
+/**
+ * @function formatDimensionFieldName
+ * @param {string} field - dimension id
+ * @param {Parameters} parameters - parameters object
+ * @param {boolean} includeFieldProj - whether to include the projected field in the formatted name e.g. age|id  OR  age
+ * @returns {string} formatted dimension name
+ */
+function formatDimensionFieldName(field: string, parameters: Parameters, includeFieldProj = true): string {
+  const [fieldName, displayField = 'id'] = field.split('.'); // default dimension field projection to "id"
+  let parameterString = serializeParameters(parameters);
+
+  if (parameterString.length > 0) {
+    parameterString = `(${parameterString})`;
+  }
+  return `${fieldName}${parameterString}${includeFieldProj ? '|' + displayField : ''}`;
+}
+
+/**
+ * Serializes a list of filters to a fili filter string
+ * @param {Array<Filter>} filters - list of filters to be ANDed together for fili
+ * @param {Filter} filter - filters object
+ */
+export function serializeFilters(filters: Filter[]) {
+  return filters
+    .map(filter => {
+      const { field, operator, values, parameters } = filter;
+      const serializedValues = values
+        .map(v => String(v).replace(/"/g, '""')) // csv serialize " -> ""
+        .map(v => `"${v}"`) // wrap each "value"
+        .join(','); // comma to separate
+      const formattedFieldName = formatDimensionFieldName(field, parameters, true);
+
+      return `${formattedFieldName}-${operator}[${serializedValues}]`;
+    })
+    .join(',');
+}
+
+export default class BardFactsAdapter extends EmberObject {
+  /**
+   * @property namespace
+   */
+  namespace = 'v1/data';
+
+  /**
+   * @property {Service} ajax
+   */
+  @service ajax: TODO;
+
+  /**
+   * Builds the dimensions path for a request
+   *
+   * @method _buildDimensionsPath
+   * @private
+   * @param {Object} request
+   * @return {String} dimensions path
+   */
+  _buildDimensionsPath(request: Request /*options*/): string {
+    const dimensions = array(request.columns)
+      .filterBy('type', 'dimension')
+      .map(dim => formatDimensionFieldName(dim.field, dim.parameters, false));
+
+    return dimensions.length
+      ? `/${array(dimensions)
+          .uniq()
+          .join('/')}`
+      : '';
+  }
+
+  /**
+   * Builds a dateTime param string for a request
+   *
+   * @method _buildDateTimeParam
+   * @private
+   * @param {Object} request
+   * @return {String} dateTime param value
+   */
+  _buildDateTimeParam(request: Request): string {
+    const dateTimeFilters = request.filters.filter(fil => fil.field === 'dateTime');
+
+    return dateTimeFilters.map(filter => `${filter.values[0]}/${filter.values[1]}`).join(',');
+  }
+
+  /**
+   * Builds a metrics param string for a request
+   *
+   * @method _buildMetricsParam
+   * @private
+   * @param {Object} request
+   * @return {String} metrics param value
+   */
+  _buildMetricsParam(request: Request): string {
+    const metrics = request.columns.filter(col => col.type === 'metric');
+    const metricIds = (metrics || []).map(metric =>
+      canonicalizeMetric({ metric: metric.field, parameters: metric.parameters })
+    );
+
+    return array(metricIds)
+      .uniq()
+      .join(',');
+  }
+
+  /**
+   * Builds a filters param string for a request
+   *
+   * @method _buildFiltersParam
+   * @private
+   * @param {Object} request
+   * @return {String} filters param value
+   */
+  _buildFiltersParam(request: Request) {
+    const filters = request.filters?.filter((fil: Filter) => fil.type === 'dimension');
+
+    if (filters?.length) {
+      return serializeFilters(filters);
+    }
+    return undefined;
+  }
+
+  /**
+   * Builds a sort param string for a request
+   *
+   * @method _buildSortParam
+   * @private
+   * @param {Object} request
+   * @param {function} aliasFunction function that returns metrics from aliases
+   * @return {String} sort param value
+   */
+  _buildSortParam(request: Request, aliasFunction = (a: string) => a) {
+    const { sort } = request;
+
+    if (sort?.length) {
+      return sort
+        .map(sortField => {
+          const field = aliasFunction(sortField.field);
+          const direction = sortField.direction || 'desc';
+
+          assert(
+            `'${direction}' must be a valid sort direction (${SORT_DIRECTIONS.join()})`,
+            SORT_DIRECTIONS.includes(direction)
+          );
+
+          return `${field}|${direction}`;
+        })
+        .join(',');
+    }
+    return undefined;
+  }
+
+  /**
+   * Builds a having param string for a request
+   *
+   * @method _buildHavingParam
+   * @private
+   * @param {Object} request
+   * @param {function} aliasFunction function that returns metrics from aliases
+   * @return {String} having param value
+   */
+  _buildHavingParam(request: Request, aliasFunction = (a: string) => a) {
+    const having = request.filters?.filter(fil => fil.type === 'metric');
+
+    if (having?.length) {
+      return having
+        .map(having => {
+          const { field, operator, values = [] } = having;
+
+          return `${aliasFunction(field)}-${operator}[${values.join(',')}]`;
+        })
+        .join(',');
+    }
+    return undefined;
+  }
+
+  /**
+   * Builds a URL path for a request
+   *
+   * @method _buildURLPath
+   * @private
+   * @param {Object} request
+   * @param {Object} options - optional host options
+   * @return {String} URL Path
+   */
+  _buildURLPath(request: Request, options: RequestOptions = {}) {
+    const host = configHost(options);
+    const { namespace } = this;
+    const table = request.table;
+    const timeGrain = request.columns.find(col => col.field === 'dateTime')?.parameters.grain || 'all';
+    const dimensions = this._buildDimensionsPath(request);
+
+    return `${host}/${namespace}/${table}/${timeGrain}${dimensions}/`;
+  }
+
+  /**
+   * Builds a query object for a request
+   *
+   * @method _buildQuery
+   * @private
+   *
+   * @param {Object} request
+   * @param {Number} options.page - page number
+   * @param {Number} options.perPage - number of results per page
+   * @param {String} options.format - result format type
+   * @param {Boolean} options.cache - with/without cache
+   * @param {Object} options.queryParams - other params
+   *
+   * @return {Object} query object
+   */
+  _buildQuery(request: Request, options: RequestOptions) {
+    const { columns } = request;
+    const metrics = columns
+      .filter(col => col.type === 'metric')
+      .map(col => ({ metric: col.field, parameters: col.parameters }));
+    const aliasMap = getAliasedMetrics(metrics);
+    const aliasFunction = (alias: string) => canonicalizeAlias(alias, aliasMap);
+    const filters = this._buildFiltersParam(request);
+    const having = this._buildHavingParam(request, aliasFunction);
+    const sort = this._buildSortParam(request, aliasFunction);
+    const query: Query = {
+      dateTime: this._buildDateTimeParam(request),
+      metrics: this._buildMetricsParam(request)
+    };
+
+    if (filters) {
+      query.filters = filters;
+    }
+
+    if (having) {
+      query.having = having;
+    }
+
+    if (sort) {
+      query.sort = sort;
+    }
+
+    //default format
+    query.format = 'json';
+
+    if (options) {
+      if (options.page && options.perPage) {
+        query.page = options.page;
+        query.perPage = options.perPage;
+      }
+
+      if (options.format) {
+        query.format = options.format;
+      }
+
+      if (options.cache === false) {
+        query._cache = false;
+      }
+
+      //catch all query param and add to the query
+      if (options.queryParams) {
+        assign(query, options.queryParams);
+      }
+    }
+
+    return query;
+  }
+
+  /**
+   * Returns URL String for a request
+   *
+   * @method urlForFindQuery
+   * @param {Request} request
+   * @param {RequestOptions} [options] - options object
+   * @return {String} url
+   */
+  urlForFindQuery(request: Request, options: RequestOptions) {
+    assert('Request for bard-facts-v2 adapter must be version 2', request.requestVersion.startsWith('2.'));
+
+    // Decorate and translate the request
+    let decoratedRequest = this._decorate(request),
+      path = this._buildURLPath(decoratedRequest, options),
+      query = this._buildQuery(decoratedRequest, options),
+      queryStr = Object.entries(query)
+        .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+        .join('&');
+
+    return `${path}?${queryStr}`;
+  }
+
+  /**
+   * @property {Ember.Service} requestDecorator
+   */
+  @service requestDecorator: TODO;
+
+  /**
+   * @method _decorate
+   * @private
+   * @param {Request} request - request to decorate
+   * @returns {Object} decorated request
+   */
+  _decorate(request: Request): Request {
+    return this.requestDecorator.applyGlobalDecorators(request);
+  }
+
+  /**
+   * @method fetchDataForRequest - Uses the url generated using the adapter to make an ajax request
+   * @param {Request} request - request (v2) object
+   * @param {RequestOptions} [options] - options object
+   *      Ex: {
+   *        page: 1,
+   *        perPage: 200,
+   *        clientId: 'custom id',
+   *        ...
+   *      }
+   * @returns {Promise} - Promise with the response
+   */
+  fetchDataForRequest(request: Request, options: RequestOptions) {
+    assert('Request for bard-facts-v2 adapter must be version 2', request.requestVersion.startsWith('2.'));
+
+    // Decorate and translate the request
+    const decoratedRequest = this._decorate(request);
+    const url = this._buildURLPath(decoratedRequest, options);
+    const query = this._buildQuery(decoratedRequest, options);
+    let clientId = 'UI';
+    let customHeaders: Dict<string> = {};
+    let timeout = 600000;
+
+    // Support custom clientid header
+    if (options?.clientId) {
+      clientId = options.clientId;
+    }
+
+    // Support custom timeout
+    if (options?.timeout) {
+      timeout = options.timeout;
+    }
+
+    // Support custom headers
+    if (options?.customHeaders) {
+      customHeaders = options.customHeaders;
+    }
+
+    return this.ajax.request(url, {
+      xhrFields: {
+        withCredentials: true
+      },
+      beforeSend(xhr: TODO) {
+        xhr.setRequestHeader('clientid', clientId);
+        Object.keys(customHeaders).forEach(name => xhr.setRequestHeader(name, customHeaders[name]));
+      },
+      crossDomain: true,
+      data: query,
+      timeout: timeout
+    });
+  }
+}

--- a/packages/data/addon/request-decorators/replace-null.ts
+++ b/packages/data/addon/request-decorators/replace-null.ts
@@ -16,7 +16,7 @@ const NULL_STRING_VALUE = '';
  */
 export function replaceNullFilter(request: TODO) {
   // only decorate if the request and the filters array are defined
-  if (request && request.filters) {
+  if (request?.filters) {
     const updatedFilters = request.filters.map((filter: TODO) => {
       // Update any filter that matches the given dimension
       if (filter.operator === 'null' || filter.operator === 'notnull') {

--- a/packages/data/app/adapters/bard-facts-v2.js
+++ b/packages/data/app/adapters/bard-facts-v2.js
@@ -1,0 +1,1 @@
+export { default } from 'navi-data/adapters/bard-facts-v2';

--- a/packages/data/tests/unit/adapters/bard-facts-v2-test.js
+++ b/packages/data/tests/unit/adapters/bard-facts-v2-test.js
@@ -1,0 +1,965 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import Pretender from 'pretender';
+import config from 'ember-get-config';
+import { assign } from '@ember/polyfills';
+
+const HOST = config.navi.dataSources[0].uri;
+const HOST2 = config.navi.dataSources[1].uri;
+
+const TestRequest = {
+    table: 'table1',
+    limit: null,
+    requestVersion: '2.0',
+    filters: [
+      {
+        field: 'dateTime',
+        parameters: {},
+        type: 'timeDimension',
+        operator: 'bet',
+        values: ['2015-01-03', '2015-01-04']
+      },
+      {
+        field: 'd3',
+        parameters: {},
+        type: 'dimension',
+        operator: 'in',
+        values: ['v1', 'v2']
+      },
+      {
+        field: 'd4',
+        parameters: {},
+        type: 'dimension',
+        operator: 'in',
+        values: ['v3', 'v4']
+      },
+      {
+        field: 'd5',
+        parameters: {},
+        type: 'dimension',
+        operator: 'notnull',
+        values: ['']
+      },
+      {
+        field: 'm1',
+        parameters: {},
+        type: 'metric',
+        operator: 'gt',
+        values: [0]
+      }
+    ],
+    columns: [
+      {
+        field: 'dateTime',
+        parameters: {
+          grain: 'grain1'
+        },
+        type: 'timeDimension'
+      },
+      {
+        field: 'm1',
+        parameters: {},
+        type: 'metric'
+      },
+      {
+        field: 'm2',
+        parameters: {},
+        type: 'metric'
+      },
+      {
+        field: 'r',
+        parameters: { p: '123', as: 'a' },
+        type: 'metric'
+      },
+      {
+        field: 'd1',
+        parameters: {},
+        type: 'dimension'
+      },
+      {
+        field: 'd2',
+        parameters: {},
+        type: 'dimension'
+      }
+    ]
+  },
+  Response = {
+    rows: [
+      {
+        table: 'table1',
+        grain: 'grain1'
+      }
+    ],
+    meta: {
+      test: true
+    }
+  },
+  MockBardResponse = [200, { 'Content-Type': 'application/json' }, JSON.stringify(Response)];
+
+let Adapter,
+  Server,
+  aliasFunction = alias => (alias === 'a' ? 'r(p=123)' : alias);
+
+module('Unit | Bard Facts V2 Adapter', function(hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function() {
+    Adapter = this.owner.lookup('adapter:bard-facts-v2');
+
+    //setup Pretender
+    Server = new Pretender(function() {
+      this.get(`${HOST}/v1/data/table1/grain1/d1/d2/`, function(request) {
+        if (request.queryParams.page && request.queryParams.perPage) {
+          let paginatedResponse = assign({}, Response);
+          paginatedResponse.meta.pagination = {
+            page: request.queryParams.page,
+            perPage: request.queryParams.perPage
+          };
+          return [200, { 'Content-Type': 'application/json' }, JSON.stringify(paginatedResponse)];
+        }
+
+        return MockBardResponse;
+      });
+    });
+  });
+
+  hooks.afterEach(function() {
+    //shutdown pretender
+    Server.shutdown();
+  });
+
+  test('_buildDimensionsPath', function(assert) {
+    assert.expect(4);
+
+    let singleDim = {
+      columns: [{ field: 'd1', type: 'dimension', parameters: {} }]
+    };
+    assert.equal(
+      Adapter._buildDimensionsPath(singleDim),
+      '/d1',
+      '_buildDimensionsPath built the correct string for a single dimension'
+    );
+
+    let manyDims = {
+      columns: [
+        { field: 'd1', type: 'dimension', parameters: {} },
+        { field: 'd2', type: 'dimension', parameters: {} }
+      ]
+    };
+    assert.equal(
+      Adapter._buildDimensionsPath(manyDims),
+      '/d1/d2',
+      '_buildDimensionsPath built the correct string for many dimensions'
+    );
+
+    let duplicateDims = {
+      columns: [
+        { field: 'd1', type: 'dimension', parameters: {} },
+        { field: 'd2', type: 'dimension', parameters: {} },
+        { field: 'd1', type: 'dimension', parameters: {} }
+      ]
+    };
+    assert.equal(
+      Adapter._buildDimensionsPath(duplicateDims),
+      '/d1/d2',
+      '_buildDimensionsPath built the correct string for duplicate dimensions'
+    );
+
+    let noDims = {};
+    assert.equal(
+      Adapter._buildDimensionsPath(noDims),
+      '',
+      '_buildDimensionsPath built the correct string for no dimensions'
+    );
+  });
+
+  test('_buildDateTimeParam', function(assert) {
+    assert.expect(2);
+
+    let singleInterval = {
+      filters: [
+        {
+          field: 'dateTime',
+          parameters: {},
+          operator: 'bet',
+          values: ['start', 'end']
+        }
+      ]
+    };
+    assert.equal(
+      Adapter._buildDateTimeParam(singleInterval),
+      'start/end',
+      '_buildDateTimeParam built the correct string for a single interval'
+    );
+
+    let manyIntervals = {
+      filters: [
+        {
+          field: 'dateTime',
+          parameters: {},
+          operator: 'bet',
+          values: ['start1', 'end1']
+        },
+        {
+          field: 'dateTime',
+          parameters: {},
+          operator: 'bet',
+          values: ['start2', 'end2']
+        }
+      ]
+    };
+    assert.equal(
+      Adapter._buildDateTimeParam(manyIntervals),
+      'start1/end1,start2/end2',
+      '_buildDateTimeParam built the correct string for many intervals'
+    );
+  });
+
+  test('_buildMetricsParam', function(assert) {
+    assert.expect(5);
+
+    let singleMetric = {
+      columns: [
+        {
+          field: 'm1',
+          parameters: {},
+          type: 'metric'
+        }
+      ]
+    };
+    assert.equal(
+      Adapter._buildMetricsParam(singleMetric),
+      'm1',
+      '_buildMetricsParam built the correct string for a single metric'
+    );
+
+    let manyMetrics = {
+      columns: [
+        {
+          field: 'm1',
+          parameters: {},
+          type: 'metric'
+        },
+        {
+          field: 'm2',
+          parameters: {},
+          type: 'metric'
+        }
+      ]
+    };
+    assert.equal(
+      Adapter._buildMetricsParam(manyMetrics),
+      'm1,m2',
+      '_buildMetricsParam built the correct string for many metrics'
+    );
+
+    let differentParams = {
+      columns: [
+        { field: 'm1', parameters: {}, type: 'metric' },
+        { field: 'm2', parameters: {}, type: 'metric' },
+        { field: 'r', parameters: { p: '123', as: 'm1' }, type: 'metric' },
+        { field: 'r', parameters: { p: 'xyz', as: 'm2' }, type: 'metric' }
+      ]
+    };
+    assert.equal(
+      Adapter._buildMetricsParam(differentParams),
+      'm1,m2,r(p=123),r(p=xyz)',
+      '_buildMetricsParam built the correct string for different parameters'
+    );
+
+    let duplicateMetrics = {
+      columns: [
+        { field: 'm1', parameters: {}, type: 'metric' },
+        { field: 'm2', parameters: {}, type: 'metric' },
+        { field: 'm1', parameters: {}, type: 'metric' },
+        { field: 'r', parameters: { p: '123', as: 'm1' }, type: 'metric' },
+        { field: 'r', parameters: { p: '123', as: 'm2' }, type: 'metric' }
+      ]
+    };
+    assert.equal(
+      Adapter._buildMetricsParam(duplicateMetrics),
+      'm1,m2,r(p=123)',
+      '_buildMetricsParam built the correct string for duplicate metrics'
+    );
+
+    let nullParams = {
+      columns: [
+        { field: 'm1', parameters: {}, type: 'metric' },
+        { field: 'm2', parameters: {}, type: 'metric' },
+        { field: 'r', parameters: { p: '123', q: 'bar' }, type: 'metric' },
+        { field: 'r', parameters: { p: 'xyz', q: null }, type: 'metric' },
+        { field: 'r', parameters: { p: 'tuv', q: undefined }, type: 'metric' }
+      ]
+    };
+    assert.equal(
+      Adapter._buildMetricsParam(nullParams),
+      'm1,m2,r(p=123,q=bar),r(p=xyz),r(p=tuv)',
+      '_buildMetricsParam built correctly with null parameter values'
+    );
+  });
+
+  test('_buildFiltersParam', function(assert) {
+    assert.expect(8);
+
+    let singleFilter = {
+      filters: [{ field: 'd1.desc', parameters: {}, type: 'dimension', operator: 'in', values: ['v1', 'v2'] }]
+    };
+    assert.equal(
+      Adapter._buildFiltersParam(singleFilter),
+      'd1|desc-in["v1","v2"]',
+      '_buildFiltersParam built the correct string for a single filter'
+    );
+
+    let manyFilters = {
+      filters: [
+        { field: 'd1.desc', parameters: {}, type: 'dimension', operator: 'in', values: ['v1', 'v2'] },
+        { field: 'd2.id', parameters: {}, type: 'dimension', operator: 'notin', values: ['v3', 'v4'] }
+      ]
+    };
+    assert.equal(
+      Adapter._buildFiltersParam(manyFilters),
+      'd1|desc-in["v1","v2"],d2|id-notin["v3","v4"]',
+      '_buildFiltersParam built the correct string for many filters'
+    );
+
+    let noFilters = {};
+    assert.equal(
+      Adapter._buildFiltersParam(noFilters),
+      undefined,
+      '_buildFiltersParam returns undefined with no filters'
+    );
+
+    let emptyFilters = { filters: [] };
+    assert.equal(
+      Adapter._buildFiltersParam(emptyFilters),
+      undefined,
+      '_buildFiltersParam returns undefined with empty filters'
+    );
+
+    let noDimensionFilters = { filters: [{ type: 'metric' }] };
+    assert.equal(
+      Adapter._buildFiltersParam(noDimensionFilters),
+      undefined,
+      '_buildFiltersParam returns undefined with only filters of non-dimension types'
+    );
+
+    let commaFilters = {
+      filters: [
+        { field: 'd3.id', parameters: {}, type: 'dimension', operator: 'in', values: ['with, comma', 'no comma'] }
+      ]
+    };
+    assert.equal(
+      Adapter._buildFiltersParam(commaFilters),
+      'd3|id-in["with, comma","no comma"]',
+      '_buildFiltersParam quotes values correctly with commas'
+    );
+
+    let noIdFilters = {
+      filters: [{ field: 'd3', parameters: {}, type: 'dimension', operator: 'in', values: ['with, comma', 'no comma'] }]
+    };
+    assert.equal(
+      Adapter._buildFiltersParam(noIdFilters),
+      'd3|id-in["with, comma","no comma"]',
+      '_buildFiltersParam defaults to "id" field'
+    );
+
+    let quoteFilters = {
+      filters: [
+        { field: 'd3.id', parameters: {}, type: 'dimension', operator: 'in', values: ['with "quote"', 'but why'] }
+      ]
+    };
+    assert.equal(
+      Adapter._buildFiltersParam(quoteFilters),
+      'd3|id-in["with ""quote""","but why"]',
+      '_buildFiltersParam correctly escapes " in filters'
+    );
+  });
+
+  test('_buildSortParam', function(assert) {
+    assert.expect(8);
+
+    let singleSort = {
+      sort: [
+        {
+          field: 'm1',
+          parameters: {},
+          direction: 'asc'
+        }
+      ]
+    };
+    assert.equal(
+      Adapter._buildSortParam(singleSort),
+      'm1|asc',
+      '_buildSortParam built the correct string for a single sort'
+    );
+
+    let sortNoDirection = {
+      sort: [
+        {
+          field: 'm1'
+        }
+      ]
+    };
+    assert.equal(
+      Adapter._buildSortParam(sortNoDirection),
+      'm1|desc',
+      '_buildSortParam uses desc as default sort direction'
+    );
+
+    let manySorts = {
+      sort: [
+        {
+          field: 'm1',
+          direction: 'asc'
+        },
+        {
+          field: 'm2',
+          direction: 'asc'
+        }
+      ]
+    };
+    assert.equal(
+      Adapter._buildSortParam(manySorts),
+      'm1|asc,m2|asc',
+      '_buildSortParam built the correct string for multiple sorts'
+    );
+
+    assert.equal(
+      Adapter._buildSortParam(
+        {
+          sort: [
+            {
+              field: 'a',
+              direction: 'asc'
+            }
+          ]
+        },
+        aliasFunction
+      ),
+      'r(p=123)|asc',
+      'sort param with aliases work'
+    );
+
+    assert.equal(
+      Adapter._buildSortParam(
+        {
+          sort: [
+            {
+              field: 'a',
+              direction: 'asc'
+            },
+            {
+              field: 'm1',
+              direction: 'desc'
+            }
+          ]
+        },
+        aliasFunction
+      ),
+      'r(p=123)|asc,m1|desc',
+      'sort param with aliases mixed with non aliases work'
+    );
+
+    let noSorts = {};
+    assert.equal(Adapter._buildSortParam(noSorts), undefined, '_buildSortParam returns undefined with no sort');
+
+    let emptySorts = { sort: [] };
+    assert.equal(Adapter._buildSortParam(emptySorts), undefined, '_buildSortParam returns undefined with empty sort');
+
+    let invalidSort = {
+      sort: [
+        { field: 'valid1' },
+        { field: 'valid2', direction: 'asc' },
+        { field: 'valid3', direction: 'desc' },
+        { field: 'invalid', direction: 'foo' }
+      ]
+    };
+    assert.throws(
+      () => {
+        Adapter._buildSortParam(invalidSort);
+      },
+      /'foo' must be a valid sort direction \(desc,asc\)/,
+      '_buildSortParam throws error when invalid sort is given'
+    );
+  });
+
+  test('_buildHavingParam', function(assert) {
+    assert.expect(7);
+
+    let singleHaving = {
+      filters: [
+        {
+          field: 'm1',
+          type: 'metric',
+          operator: 'gt',
+          values: [0]
+        }
+      ]
+    };
+    assert.equal(
+      Adapter._buildHavingParam(singleHaving),
+      'm1-gt[0]',
+      '_buildHavingParam built the correct string for a single having'
+    );
+
+    let manyHavings = {
+      filters: [
+        {
+          field: 'm1',
+          type: 'metric',
+          operator: 'gt',
+          values: [0]
+        },
+        {
+          field: 'm2',
+          type: 'metric',
+          operator: 'lte',
+          values: [10]
+        }
+      ]
+    };
+    assert.equal(
+      Adapter._buildHavingParam(manyHavings),
+      'm1-gt[0],m2-lte[10]',
+      '_buildHavingParam built the correct string for multiple having'
+    );
+
+    let noHavings = {};
+    assert.equal(Adapter._buildHavingParam(noHavings), undefined, '_buildHavingParam returns undefined with no having');
+
+    let emptyHavings = { filters: [] };
+    assert.equal(
+      Adapter._buildHavingParam(emptyHavings),
+      undefined,
+      '_buildHavingParam returns undefined with empty having'
+    );
+
+    let onlyDimFilters = { filters: [{ field: 'foo', type: 'dimension', operator: 'gt', values: [0] }] };
+    assert.equal(
+      Adapter._buildHavingParam(onlyDimFilters),
+      undefined,
+      '_buildHavingParam returns undefined with only dimension filters in request'
+    );
+
+    let havingValueArray = {
+      filters: [
+        {
+          field: 'm1',
+          type: 'metric',
+          operator: 'gt',
+          values: [1, 2, 3]
+        }
+      ]
+    };
+    assert.equal(
+      Adapter._buildHavingParam(havingValueArray),
+      'm1-gt[1,2,3]',
+      '_buildHavingParam built the correct string when having a `values` array'
+    );
+
+    let aliasedHaving = {
+      filters: [
+        {
+          field: 'm1',
+          type: 'metric',
+          operator: 'gt',
+          values: [1, 2, 3]
+        },
+        {
+          field: 'a',
+          type: 'metric',
+          operator: 'lt',
+          values: [50]
+        }
+      ]
+    };
+
+    assert.equal(
+      Adapter._buildHavingParam(aliasedHaving, aliasFunction),
+      'm1-gt[1,2,3],r(p=123)-lt[50]',
+      '_buildHavingParam built the correct string when having a `values` array'
+    );
+  });
+
+  test('_buildURLPath', function(assert) {
+    assert.expect(2);
+
+    assert.equal(
+      Adapter._buildURLPath(TestRequest),
+      `${HOST}/v1/data/table1/grain1/d1/d2/`,
+      '_buildURLPath correctly built the URL path for the provided request when a host is not configured'
+    );
+
+    assert.equal(
+      Adapter._buildURLPath(TestRequest, { dataSourceName: 'blockhead' }),
+      `${HOST2}/v1/data/table1/grain1/d1/d2/`,
+      '_buildURLPath correctly built the URL path for the provided request when a host is configured'
+    );
+  });
+
+  test('_buildQuery', function(assert) {
+    assert.expect(7);
+
+    assert.deepEqual(
+      Adapter._buildQuery(TestRequest),
+      {
+        dateTime: '2015-01-03/2015-01-04',
+        filters: 'd3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notnull[""]',
+        metrics: 'm1,m2,r(p=123)',
+        having: 'm1-gt[0]',
+        format: 'json'
+      },
+      '_buildQuery correctly built the query object for the provided request'
+    );
+
+    let noFiltersAndNoHavings = assign({}, TestRequest, {
+      filters: [
+        {
+          field: 'dateTime',
+          parameters: {},
+          type: 'timeDimension',
+          operator: 'bet',
+          values: ['2015-01-03', '2015-01-04']
+        }
+      ]
+    });
+    assert.deepEqual(
+      Adapter._buildQuery(noFiltersAndNoHavings),
+      {
+        dateTime: '2015-01-03/2015-01-04',
+        metrics: 'm1,m2,r(p=123)',
+        format: 'json'
+      },
+      '_buildQuery correctly built the query object for a request with no filters and no having'
+    );
+
+    assert.deepEqual(
+      Adapter._buildQuery(TestRequest, { format: 'jsonApi' }),
+      {
+        dateTime: '2015-01-03/2015-01-04',
+        filters: 'd3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notnull[""]',
+        metrics: 'm1,m2,r(p=123)',
+        having: 'm1-gt[0]',
+        format: 'jsonApi'
+      },
+      '_buildQuery sets non default format if format is set in the options object'
+    );
+
+    let sortRequest = assign({}, TestRequest, { sort: [{ field: 'm1' }] });
+    assert.deepEqual(
+      Adapter._buildQuery(sortRequest),
+      {
+        dateTime: '2015-01-03/2015-01-04',
+        filters: 'd3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notnull[""]',
+        format: 'json',
+        metrics: 'm1,m2,r(p=123)',
+        having: 'm1-gt[0]',
+        sort: 'm1|desc'
+      },
+      '_buildQuery correctly built the query object for a request with sort'
+    );
+
+    sortRequest = assign({}, TestRequest, { sort: [{ field: 'a' }] });
+    assert.deepEqual(
+      Adapter._buildQuery(sortRequest),
+      {
+        dateTime: '2015-01-03/2015-01-04',
+        filters: 'd3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notnull[""]',
+        format: 'json',
+        metrics: 'm1,m2,r(p=123)',
+        having: 'm1-gt[0]',
+        sort: 'r(p=123)|desc'
+      },
+      '_buildQuery correctly built the query object for an aliased with sort'
+    );
+
+    const aliasedHaving = {
+      field: 'a',
+      type: 'metric',
+      operator: 'lt',
+      values: [50]
+    };
+    const havingRequest = assign({}, TestRequest, {
+      filters: assign([], TestRequest.filters).concat(aliasedHaving)
+    });
+
+    assert.deepEqual(
+      Adapter._buildQuery(havingRequest),
+      {
+        dateTime: '2015-01-03/2015-01-04',
+        filters: 'd3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notnull[""]',
+        format: 'json',
+        metrics: 'm1,m2,r(p=123)',
+        having: 'm1-gt[0],r(p=123)-lt[50]'
+      },
+      '_buildQuery correctly built the query object for an aliased having'
+    );
+
+    assert.deepEqual(
+      Adapter._buildQuery(TestRequest, { cache: false }),
+      {
+        dateTime: '2015-01-03/2015-01-04',
+        filters: 'd3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notnull[""]',
+        metrics: 'm1,m2,r(p=123)',
+        having: 'm1-gt[0]',
+        format: 'json',
+        _cache: false
+      },
+      '_buildQuery correctly built the query object for a request without caching'
+    );
+  });
+
+  test('_buildQuery with catchAll Query Params', function(assert) {
+    assert.expect(1);
+
+    let options = {
+      page: 1,
+      perPage: 100,
+      queryParams: {
+        perPage: 150,
+        topN: 150
+      }
+    };
+
+    assert.deepEqual(
+      Adapter._buildQuery(TestRequest, options),
+      {
+        dateTime: '2015-01-03/2015-01-04',
+        filters: 'd3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notnull[""]',
+        metrics: 'm1,m2,r(p=123)',
+        having: 'm1-gt[0]',
+        format: 'json',
+        page: 1,
+        perPage: 150,
+        topN: 150
+      },
+      '_buildQuery correctly built the query object for a request catching all unsupported query params'
+    );
+  });
+
+  test('_buildQuery with pagination', function(assert) {
+    assert.expect(4);
+
+    assert.deepEqual(
+      Adapter._buildQuery(TestRequest),
+      {
+        dateTime: '2015-01-03/2015-01-04',
+        filters: 'd3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notnull[""]',
+        metrics: 'm1,m2,r(p=123)',
+        having: 'm1-gt[0]',
+        format: 'json'
+      },
+      '_buildQuery correctly builds the query object for the provided request ' +
+        'without any pagination options when options passed in are undefined'
+    );
+
+    assert.deepEqual(
+      Adapter._buildQuery(TestRequest, {}),
+      {
+        dateTime: '2015-01-03/2015-01-04',
+        filters: 'd3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notnull[""]',
+        metrics: 'm1,m2,r(p=123)',
+        having: 'm1-gt[0]',
+        format: 'json'
+      },
+      '_buildQuery correctly builds the query object for the provided request ' +
+        'without any pagination options when options passed in are empty'
+    );
+
+    assert.deepEqual(
+      Adapter._buildQuery(TestRequest, { page: 1, perPage: 100 }),
+      {
+        dateTime: '2015-01-03/2015-01-04',
+        filters: 'd3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notnull[""]',
+        metrics: 'm1,m2,r(p=123)',
+        having: 'm1-gt[0]',
+        format: 'json',
+        page: 1,
+        perPage: 100
+      },
+      '_buildQuery correctly builds query with pagination options when options are defined'
+    );
+
+    assert.deepEqual(
+      Adapter._buildQuery(TestRequest, { format: 'csv' }),
+      {
+        dateTime: '2015-01-03/2015-01-04',
+        filters: 'd3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notnull[""]',
+        metrics: 'm1,m2,r(p=123)',
+        having: 'm1-gt[0]',
+        format: 'csv'
+      },
+      '_buildQuery correctly builds query with provided format setting'
+    );
+  });
+
+  test('urlForFindQuery', function(assert) {
+    assert.expect(7);
+
+    assert.throws(
+      () => {
+        Adapter.urlForFindQuery({ requestVersion: 'v1' });
+      },
+      /Request for bard-facts-v2 adapter must be version 2/,
+      'urlForFindQuery fails assertion if v1 request is passed in'
+    );
+
+    assert.equal(
+      decodeURIComponent(Adapter.urlForFindQuery(TestRequest)),
+      HOST +
+        '/v1/data/table1/grain1/d1/d2/?dateTime=2015-01-03/2015-01-04&' +
+        'metrics=m1,m2,r(p=123)&filters=d3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notin[""]&having=m1-gt[0]&' +
+        'format=json',
+      'urlForFindQuery correctly built the URL for the provided request'
+    );
+
+    assert.equal(
+      decodeURIComponent(Adapter.urlForFindQuery(TestRequest, { format: 'csv' })),
+      HOST +
+        '/v1/data/table1/grain1/d1/d2/?dateTime=2015-01-03/2015-01-04&' +
+        'metrics=m1,m2,r(p=123)&filters=d3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notin[""]&having=m1-gt[0]&' +
+        'format=csv',
+      'urlForFindQuery correctly built the URL for the provided request with the format option'
+    );
+
+    let onlyDateFilter = assign({}, TestRequest, {
+      filters: [{ field: 'dateTime', type: 'timeDimension', operator: 'bet', values: ['2015-01-03', '2015-01-04'] }]
+    });
+    assert.equal(
+      decodeURIComponent(Adapter.urlForFindQuery(onlyDateFilter)),
+      HOST + '/v1/data/table1/grain1/d1/d2/?dateTime=2015-01-03/2015-01-04&' + 'metrics=m1,m2,r(p=123)&format=json',
+      'urlForFindQuery correctly built the URL for a request with no filters'
+    );
+
+    let requestWithSort = assign({}, TestRequest, {
+      filters: [{ field: 'dateTime', type: 'timeDimension', operator: 'bet', values: ['2015-01-03', '2015-01-04'] }],
+      sort: [{ field: 'm1' }, { field: 'm2' }]
+    });
+    assert.equal(
+      decodeURIComponent(Adapter.urlForFindQuery(requestWithSort)),
+      HOST +
+        '/v1/data/table1/grain1/d1/d2/?dateTime=2015-01-03/2015-01-04&' +
+        'metrics=m1,m2,r(p=123)&sort=m1|desc,m2|desc&format=json',
+      'urlForFindQuery correctly built the URL for a request with sort'
+    );
+
+    assert.equal(
+      decodeURIComponent(Adapter.urlForFindQuery(TestRequest, { cache: false })),
+      HOST +
+        '/v1/data/table1/grain1/d1/d2/?dateTime=2015-01-03/2015-01-04&' +
+        'metrics=m1,m2,r(p=123)&filters=d3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notin[""]&having=m1-gt[0]&' +
+        'format=json&_cache=false',
+      'urlForFindQuery correctly built the URL for the provided request with the cache option'
+    );
+
+    assert.equal(
+      decodeURIComponent(Adapter.urlForFindQuery(TestRequest, { dataSourceName: 'blockhead' })),
+      HOST2 +
+        '/v1/data/table1/grain1/d1/d2/?dateTime=2015-01-03/2015-01-04&' +
+        'metrics=m1,m2,r(p=123)&filters=d3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notin[""]&having=m1-gt[0]&' +
+        'format=json',
+      'uriForFindQuery renders alternative host name if option is given'
+    );
+  });
+
+  test('fetchDataForRequest', function(assert) {
+    assert.expect(2);
+
+    assert.throws(
+      () => {
+        Adapter.fetchDataForRequest({ requestVersion: 'v1' });
+      },
+      /Request for bard-facts-v2 adapter must be version 2/,
+      'fetchDataForRequest fails assertion if v1 request is passed in'
+    );
+
+    return Adapter.fetchDataForRequest(TestRequest).then(function(result) {
+      return assert.deepEqual(result, Response, 'Ajax GET returns the response object for TEST Request');
+    });
+  });
+
+  test('fetchDataForRequest with pagination options', function(assert) {
+    assert.expect(1);
+    return Adapter.fetchDataForRequest(TestRequest, {
+      page: 1,
+      perPage: 100
+    }).then(function(result) {
+      return assert.deepEqual(
+        result,
+        {
+          rows: [
+            {
+              table: 'table1',
+              grain: 'grain1'
+            }
+          ],
+          meta: {
+            pagination: {
+              page: '1',
+              perPage: '100'
+            },
+            test: true
+          }
+        },
+        'Ajax GET returns the response object for TEST Request'
+      );
+    });
+  });
+
+  test('fetchDataForRequest with client id options', function(assert) {
+    assert.expect(2);
+
+    // Setting up assert for default clientId
+    Server.get(`${HOST}/v1/data/table1/grain1/d1/d2/`, request => {
+      assert.equal(request.requestHeaders.clientid, 'UI', 'Client id defaults to "UI"');
+
+      return MockBardResponse;
+    });
+
+    // Sending request for default clientId
+    return Adapter.fetchDataForRequest(TestRequest).then(() => {
+      // Setting up assert for provided clientId
+      Server.get(`${HOST}/v1/data/table1/grain1/d1/d2/`, request => {
+        assert.equal(request.requestHeaders.clientid, 'test id', 'Client id is set to value given in options');
+
+        return MockBardResponse;
+      });
+
+      // Sending request for provided clientId
+      return Adapter.fetchDataForRequest(TestRequest, {
+        clientId: 'test id'
+      });
+    });
+  });
+
+  test('fetchDataForRequest with custom headers', function(assert) {
+    assert.expect(2);
+
+    Server.get(`${HOST}/v1/data/table1/grain1/d1/d2/`, request => {
+      assert.equal(request.requestHeaders.foo, 'bar', 'custom header `foo` was sent with the request');
+
+      assert.equal(request.requestHeaders.baz, 'qux', 'custom header `baz` was sent with the request');
+
+      return MockBardResponse;
+    });
+
+    return Adapter.fetchDataForRequest(TestRequest, {
+      customHeaders: {
+        foo: 'bar',
+        baz: 'qux'
+      }
+    });
+  });
+
+  test('fetchDataForRequest with alternative datasource', function(assert) {
+    assert.expect(1);
+
+    Server.get(`${HOST2}/v1/data/table1/grain1/d1/d2/`, request => {
+      assert.ok(request.url.startsWith(HOST2), 'Alternative host was accessed');
+
+      return MockBardResponse;
+    });
+
+    return Adapter.fetchDataForRequest(TestRequest, { dataSourceName: 'blockhead' });
+  });
+});

--- a/packages/data/tests/unit/adapters/bard-facts-v2-test.js
+++ b/packages/data/tests/unit/adapters/bard-facts-v2-test.js
@@ -81,7 +81,8 @@ const TestRequest = {
         parameters: {},
         type: 'dimension'
       }
-    ]
+    ],
+    sort: []
   },
   Response = {
     rows: [
@@ -299,7 +300,7 @@ module('Unit | Bard Facts V2 Adapter', function(hooks) {
   });
 
   test('_buildFiltersParam', function(assert) {
-    assert.expect(8);
+    assert.expect(7);
 
     let singleFilter = {
       filters: [{ field: 'd1.desc', parameters: {}, type: 'dimension', operator: 'in', values: ['v1', 'v2'] }]
@@ -320,13 +321,6 @@ module('Unit | Bard Facts V2 Adapter', function(hooks) {
       Adapter._buildFiltersParam(manyFilters),
       'd1|desc-in["v1","v2"],d2|id-notin["v3","v4"]',
       '_buildFiltersParam built the correct string for many filters'
-    );
-
-    let noFilters = {};
-    assert.equal(
-      Adapter._buildFiltersParam(noFilters),
-      undefined,
-      '_buildFiltersParam returns undefined with no filters'
     );
 
     let emptyFilters = { filters: [] };
@@ -376,7 +370,7 @@ module('Unit | Bard Facts V2 Adapter', function(hooks) {
   });
 
   test('_buildSortParam', function(assert) {
-    assert.expect(8);
+    assert.expect(7);
 
     let singleSort = {
       sort: [
@@ -460,9 +454,6 @@ module('Unit | Bard Facts V2 Adapter', function(hooks) {
       'sort param with aliases mixed with non aliases work'
     );
 
-    let noSorts = {};
-    assert.equal(Adapter._buildSortParam(noSorts), undefined, '_buildSortParam returns undefined with no sort');
-
     let emptySorts = { sort: [] };
     assert.equal(Adapter._buildSortParam(emptySorts), undefined, '_buildSortParam returns undefined with empty sort');
 
@@ -484,7 +475,7 @@ module('Unit | Bard Facts V2 Adapter', function(hooks) {
   });
 
   test('_buildHavingParam', function(assert) {
-    assert.expect(7);
+    assert.expect(6);
 
     let singleHaving = {
       filters: [
@@ -523,9 +514,6 @@ module('Unit | Bard Facts V2 Adapter', function(hooks) {
       'm1-gt[0],m2-lte[10]',
       '_buildHavingParam built the correct string for multiple having'
     );
-
-    let noHavings = {};
-    assert.equal(Adapter._buildHavingParam(noHavings), undefined, '_buildHavingParam returns undefined with no having');
 
     let emptyHavings = { filters: [] };
     assert.equal(


### PR DESCRIPTION
## Description
The request V2 shape will not work with the existing bard-facts adapter.

## Proposed Changes

- Create bard-facts-v2 adapter to send requests to fili with the new v2 request

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
