### PR TITLE
Update: Better interface typing around metadata models

### DIFF
--- a/packages/data/addon/gql/fragments/table.js
+++ b/packages/data/addon/gql/fragments/table.js
@@ -21,6 +21,8 @@ const fragment = gql`
           valueType
           columnTags
           defaultFormat
+          columnType
+          expression
         }
       }
     }
@@ -33,6 +35,8 @@ const fragment = gql`
           category
           valueType
           columnTags
+          columnType
+          expression
         }
       }
     }

--- a/packages/data/addon/gql/schema.js
+++ b/packages/data/addon/gql/schema.js
@@ -76,6 +76,8 @@ const schema = gql`
     category: String
     valueType: com_yahoo_elide_datastores_aggregation_metadata_enums_ValueType
     columnTags: [String!]
+    columnType: ColumnType
+    expression: String
   }
 
   type Metric implements Node & ColumnInterface {
@@ -88,6 +90,8 @@ const schema = gql`
     columnTags: [String!]
     defaultFormat: String
     metricFunction: metricFunction
+    columnType: ColumnType
+    expression: String
   }
 
   type Dimension implements Node & ColumnInterface {
@@ -98,6 +102,8 @@ const schema = gql`
     category: String
     valueType: com_yahoo_elide_datastores_aggregation_metadata_enums_ValueType
     columnTags: [String!]
+    columnType: ColumnType
+    expression: String
   }
 
   type TimeDimension implements Node & ColumnInterface {
@@ -108,6 +114,8 @@ const schema = gql`
     category: String
     valueType: com_yahoo_elide_datastores_aggregation_metadata_enums_ValueType
     columnTags: [String!]
+    columnType: ColumnType
+    expression: String
     supportedGrains: [TimeGrain]
     timeZone: TimeZone
   }
@@ -123,8 +131,14 @@ const schema = gql`
     id: DeferredID!
     name: String
     description: String
-    type: com_yahoo_elide_datastores_aggregation_metadata_enums_ValueType
-    subType: String
+    valueType: com_yahoo_elide_datastores_aggregation_metadata_enums_ValueType
+    type: FunctionArgumentType
+    expression: String
+  }
+
+  enum FunctionArgumentType {
+    ref
+    primitive
   }
 
   enum com_yahoo_elide_datastores_aggregation_annotation_CardinalitySize {
@@ -147,6 +161,12 @@ const schema = gql`
     TEXT
     COORDINATE
     BOOLEAN
+  }
+
+  enum ColumnType {
+    ref
+    formula
+    field
   }
 
   type TimeZone { # modeled after java.util.TimeZone

--- a/packages/data/addon/models/metadata/column.ts
+++ b/packages/data/addon/models/metadata/column.ts
@@ -9,7 +9,9 @@ import KegService from '../../services/keg';
 import Table from './table';
 
 export type ColumnType = 'ref' | 'formula' | 'field';
-export interface ColumnMetadata {
+
+// Shape passed to model constructor
+export interface ColumnMetadataPayload {
   id: string;
   name: string;
   category?: string;
@@ -20,11 +22,23 @@ export interface ColumnMetadata {
   tags: string[];
 }
 
+// Shape of public properties on model
+export interface ColumnMetadata {
+  id: string;
+  name: string;
+  category?: string;
+  description?: string;
+  table: Table;
+  source: string;
+  valueType: TODO<string>;
+  tags: string[];
+}
+
 export type BaseExtendedAttributes = {
   description?: string;
 };
 
-export default class ColumnMetadataModel extends EmberObject implements ColumnMetadata {
+export default class ColumnMetadataModel extends EmberObject implements ColumnMetadata, ColumnMetadataPayload {
   /**
    * @property {KegService} keg
    */

--- a/packages/data/addon/models/metadata/column.ts
+++ b/packages/data/addon/models/metadata/column.ts
@@ -19,6 +19,8 @@ export interface ColumnMetadataPayload {
   tableId: string;
   source: string;
   valueType: TODO<string>;
+  type: ColumnType;
+  expression?: string;
   tags: string[];
 }
 
@@ -31,6 +33,8 @@ export interface ColumnMetadata {
   table: Table;
   source: string;
   valueType: TODO<string>;
+  type: ColumnType;
+  expression?: string;
   tags: string[];
 }
 

--- a/packages/data/addon/models/metadata/dimension.ts
+++ b/packages/data/addon/models/metadata/dimension.ts
@@ -4,16 +4,20 @@
  */
 import { inject as service } from '@ember/service';
 import { assert } from '@ember/debug';
-import ColumnMetadataModel, { BaseExtendedAttributes, ColumnMetadata } from './column';
+import ColumnMetadataModel, { BaseExtendedAttributes, ColumnMetadata, ColumnMetadataPayload } from './column';
 import CARDINALITY_SIZES from '../../utils/enums/cardinality-sizes';
 
 type Cardinality = typeof CARDINALITY_SIZES[number] | undefined;
 type Field = TODO;
 type ExtendedAttributes = BaseExtendedAttributes;
 
+// Shape of public properties on model
 export type DimensionMetadata = ColumnMetadata;
+// Shape passed to model constructor
+export type DimensionMetadataPayload = ColumnMetadataPayload;
 
-export default class DimensionMetadataModel extends ColumnMetadataModel implements DimensionMetadata {
+export default class DimensionMetadataModel extends ColumnMetadataModel
+  implements DimensionMetadata, DimensionMetadataPayload {
   /**
    * @static
    * @property {string} identifierField

--- a/packages/data/addon/models/metadata/dimension.ts
+++ b/packages/data/addon/models/metadata/dimension.ts
@@ -24,6 +24,7 @@ export interface DimensionMetadata extends ColumnMetadata {
 // Shape passed to model constructor
 export interface DimensionMetadataPayload extends ColumnMetadataPayload {
   fields?: Field[];
+  cardinality?: Cardinality;
 }
 
 export default class DimensionMetadataModel extends ColumnMetadataModel

--- a/packages/data/addon/models/metadata/dimension.ts
+++ b/packages/data/addon/models/metadata/dimension.ts
@@ -12,9 +12,19 @@ type Field = TODO;
 type ExtendedAttributes = BaseExtendedAttributes;
 
 // Shape of public properties on model
-export type DimensionMetadata = ColumnMetadata;
+export interface DimensionMetadata extends ColumnMetadata {
+  cardinality: Cardinality;
+  getTagsForField(fieldName: string): string[];
+  getFieldsForTag(tag: string): Field[];
+  primaryKeyFieldName: string;
+  descriptionFieldName: string;
+  idFieldName: string;
+  extended: Promise<DimensionMetadataModel & ExtendedAttributes>;
+}
 // Shape passed to model constructor
-export type DimensionMetadataPayload = ColumnMetadataPayload;
+export interface DimensionMetadataPayload extends ColumnMetadataPayload {
+  fields?: Field[];
+}
 
 export default class DimensionMetadataModel extends ColumnMetadataModel
   implements DimensionMetadata, DimensionMetadataPayload {

--- a/packages/data/addon/models/metadata/metric.ts
+++ b/packages/data/addon/models/metadata/metric.ts
@@ -3,15 +3,20 @@
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import { inject as service } from '@ember/service';
-import ColumnMetadataModel, { BaseExtendedAttributes, ColumnMetadata } from './column';
+import ColumnMetadataModel, { BaseExtendedAttributes, ColumnMetadata, ColumnMetadataPayload } from './column';
 import MetricFunction from './metric-function';
 
+// Shape of public properties on model
 export interface MetricMetadata extends ColumnMetadata {
+  defaultFormat: string;
+}
+// Shape passed to model constructor
+export interface MetricMetadataPayload extends ColumnMetadataPayload {
   defaultFormat: string;
 }
 
 type ExtendedAttributes = BaseExtendedAttributes;
-export default class MetricMetadataModel extends ColumnMetadataModel implements MetricMetadata {
+export default class MetricMetadataModel extends ColumnMetadataModel implements MetricMetadata, MetricMetadataPayload {
   /**
    * @static
    * @property {string} identifierField

--- a/packages/data/addon/models/metadata/metric.ts
+++ b/packages/data/addon/models/metadata/metric.ts
@@ -9,10 +9,17 @@ import MetricFunction from './metric-function';
 // Shape of public properties on model
 export interface MetricMetadata extends ColumnMetadata {
   defaultFormat: string;
+  metricFunction: MetricFunction | undefined;
+  hasParameters: boolean;
+  arguments: TODO[];
+  getParameter(id: string): TODO | undefined;
+  getDefaultParameters(): Dict<string> | undefined;
+  extended: Promise<MetricMetadataModel & ExtendedAttributes>;
 }
 // Shape passed to model constructor
 export interface MetricMetadataPayload extends ColumnMetadataPayload {
   defaultFormat: string;
+  metricFunctionId?: string;
 }
 
 type ExtendedAttributes = BaseExtendedAttributes;

--- a/packages/data/addon/models/metadata/table.ts
+++ b/packages/data/addon/models/metadata/table.ts
@@ -15,7 +15,9 @@ export type TimeGrain = {
   id: string;
   name: string;
 };
-export interface TableMetadata {
+
+// Shape passed to model constructor
+export interface TableMetadataPayload {
   id: string;
   name: string;
   category?: string;
@@ -26,8 +28,20 @@ export interface TableMetadata {
   timeDimensionIds: string[];
   source: string;
 }
+// Shape of public properties on model
+export interface TableMetadata {
+  id: string;
+  name: string;
+  category?: string;
+  description?: string;
+  cardinality: typeof CARDINALITY_SIZES[number];
+  metrics: Metric[];
+  dimensions: Dimension[];
+  timeDimensions: TimeDimension[];
+  source: string;
+}
 
-export default class TableMetadataModel extends EmberObject implements TableMetadata {
+export default class TableMetadataModel extends EmberObject implements TableMetadata, TableMetadataPayload {
   /**
    * @static
    * @property {string} identifierField

--- a/packages/data/addon/models/metadata/table.ts
+++ b/packages/data/addon/models/metadata/table.ts
@@ -27,6 +27,8 @@ export interface TableMetadataPayload {
   dimensionIds: string[];
   timeDimensionIds: string[];
   source: string;
+  timeGrainIds?: string[];
+  tags?: string[];
 }
 // Shape of public properties on model
 export interface TableMetadata {
@@ -39,6 +41,8 @@ export interface TableMetadata {
   dimensions: Dimension[];
   timeDimensions: TimeDimension[];
   source: string;
+  timeGrains: TimeGrain[];
+  tags: string[];
 }
 
 export default class TableMetadataModel extends EmberObject implements TableMetadata, TableMetadataPayload {
@@ -139,7 +143,7 @@ export default class TableMetadataModel extends EmberObject implements TableMeta
   /**
    * @property {string[]} timeGrainIds - supported timegrains for a column
    */
-  private timeGrainIds: string[] = [];
+  timeGrainIds: string[] = [];
 
   /**
    * @property {Object[]} timeGrains - timeGrain objects with id and display name

--- a/packages/data/addon/models/metadata/time-dimension.ts
+++ b/packages/data/addon/models/metadata/time-dimension.ts
@@ -2,14 +2,21 @@
  * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
-import DimensionMetadataModel, { DimensionMetadata } from './dimension';
+import DimensionMetadataModel, { DimensionMetadata, DimensionMetadataPayload } from './dimension';
 
+// Shape of public properties on model
 export interface TimeDimensionMetadata extends DimensionMetadata {
   supportedGrains: string[];
   timeZone: TODO;
 }
+// Shape passed to model constructor
+export interface TimeDimensionMetadataPayload extends DimensionMetadataPayload {
+  supportedGrains: string[];
+  timeZone: TODO;
+}
 
-export default class TimeDimensionMetadataModel extends DimensionMetadataModel implements TimeDimensionMetadata {
+export default class TimeDimensionMetadataModel extends DimensionMetadataModel
+  implements TimeDimensionMetadata, TimeDimensionMetadataPayload {
   /**
    * @property {string[]} supportedGrains
    */

--- a/packages/data/addon/serializers/elide-metadata.ts
+++ b/packages/data/addon/serializers/elide-metadata.ts
@@ -4,6 +4,7 @@
  */
 import EmberObject from '@ember/object';
 import CARDINALITY_SIZES from '../utils/enums/cardinality-sizes';
+import { ColumnType } from '../models/metadata/column';
 import { TableMetadataPayload } from '../models/metadata/table';
 import { MetricMetadataPayload } from '../models/metadata/metric';
 import { DimensionMetadataPayload } from '../models/metadata/dimension';
@@ -27,7 +28,6 @@ type ColumnNode = {
   columnType: ColumnType;
   expression: string;
 };
-type ColumnType = 'ref' | 'formula' | 'field';
 type MetricNode = ColumnNode & { defaultFormat: string };
 type DimensionNode = ColumnNode;
 type TimeDimensionNode = DimensionNode & {
@@ -82,9 +82,9 @@ export default class ElideMetadataSerializer extends EmberObject {
       const newTableDimensions = this._normalizeTableDimensions(table.dimensions, table.id, source);
       const newTableTimeDimensions = this._normalizeTableTimeDimensions(table.timeDimensions, table.id, source);
 
-      newTable.metricIds = newTableMetrics.map((m: MetricMetadataPayload) => m.id);
-      newTable.dimensionIds = newTableDimensions.map((d: DimensionMetadataPayload) => d.id);
-      newTable.timeDimensionIds = newTableTimeDimensions.map((d: TimeDimensionMetadataPayload) => d.id);
+      newTable.metricIds = newTableMetrics.map(m => m.id);
+      newTable.dimensionIds = newTableDimensions.map(d => d.id);
+      newTable.timeDimensionIds = newTableTimeDimensions.map(d => d.id);
 
       metrics = metrics.concat(newTableMetrics);
       dimensions = dimensions.concat(newTableDimensions);
@@ -109,7 +109,11 @@ export default class ElideMetadataSerializer extends EmberObject {
    * @param {string} source - datasource name
    * @returns {Object[]} - normalized metric objects
    */
-  _normalizeTableMetrics(metricConnection: Connection<MetricNode>, tableId: string, source: string) {
+  _normalizeTableMetrics(
+    metricConnection: Connection<MetricNode>,
+    tableId: string,
+    source: string
+  ): MetricMetadataPayload[] {
     return metricConnection.edges.map((edge: Edge<MetricNode>) => {
       const { node } = edge;
       return {
@@ -135,7 +139,11 @@ export default class ElideMetadataSerializer extends EmberObject {
    * @param {string} source - datasource name
    * @returns {Object[]} - normalized dimension objects
    */
-  _normalizeTableDimensions(dimensionConnection: Connection<DimensionNode>, tableId: string, source: string) {
+  _normalizeTableDimensions(
+    dimensionConnection: Connection<DimensionNode>,
+    tableId: string,
+    source: string
+  ): DimensionMetadataPayload[] {
     return dimensionConnection.edges.map((edge: Edge<DimensionNode>) => {
       const { node } = edge;
       return {
@@ -164,7 +172,7 @@ export default class ElideMetadataSerializer extends EmberObject {
     timeDimensionConnection: Connection<TimeDimensionNode>,
     tableId: string,
     source: string
-  ) {
+  ): TimeDimensionMetadataPayload[] {
     return timeDimensionConnection.edges.map((edge: Edge<TimeDimensionNode>) => {
       const { node } = edge;
       return {

--- a/packages/data/addon/serializers/elide-metadata.ts
+++ b/packages/data/addon/serializers/elide-metadata.ts
@@ -4,10 +4,10 @@
  */
 import EmberObject from '@ember/object';
 import CARDINALITY_SIZES from '../utils/enums/cardinality-sizes';
-import { TableMetadata } from '../models/metadata/table';
-import { MetricMetadata } from '../models/metadata/metric';
-import { DimensionMetadata } from '../models/metadata/dimension';
-import { TimeDimensionMetadata } from '../models/metadata/time-dimension';
+import { TableMetadataPayload } from '../models/metadata/table';
+import { MetricMetadataPayload } from '../models/metadata/metric';
+import { DimensionMetadataPayload } from '../models/metadata/dimension';
+import { TimeDimensionMetadataPayload } from '../models/metadata/time-dimension';
 
 type Edge<T> = {
   node: T;
@@ -58,12 +58,12 @@ export default class ElideMetadataSerializer extends EmberObject {
    */
   _normalizeTableConnection(tableConnection: Connection<TableNode>, source: string) {
     const edges = tableConnection.edges || [];
-    let metrics: MetricMetadata[] = [];
-    let dimensions: DimensionMetadata[] = [];
-    let timeDimensions: TimeDimensionMetadata[] = [];
+    let metrics: MetricMetadataPayload[] = [];
+    let dimensions: DimensionMetadataPayload[] = [];
+    let timeDimensions: TimeDimensionMetadataPayload[] = [];
 
     const tables = edges.map(({ node: table }) => {
-      const newTable: TableMetadata = {
+      const newTable: TableMetadataPayload = {
         id: table.id,
         name: table.name,
         category: table.category,
@@ -79,9 +79,9 @@ export default class ElideMetadataSerializer extends EmberObject {
       const newTableDimensions = this._normalizeTableDimensions(table.dimensions, table.id, source);
       const newTableTimeDimensions = this._normalizeTableTimeDimensions(table.timeDimensions, table.id, source);
 
-      newTable.metricIds = newTableMetrics.map((m: MetricMetadata) => m.id);
-      newTable.dimensionIds = newTableDimensions.map((d: DimensionMetadata) => d.id);
-      newTable.timeDimensionIds = newTableTimeDimensions.map((d: TimeDimensionMetadata) => d.id);
+      newTable.metricIds = newTableMetrics.map((m: MetricMetadataPayload) => m.id);
+      newTable.dimensionIds = newTableDimensions.map((d: DimensionMetadataPayload) => d.id);
+      newTable.timeDimensionIds = newTableTimeDimensions.map((d: TimeDimensionMetadataPayload) => d.id);
 
       metrics = metrics.concat(newTableMetrics);
       dimensions = dimensions.concat(newTableDimensions);

--- a/packages/data/addon/serializers/elide-metadata.ts
+++ b/packages/data/addon/serializers/elide-metadata.ts
@@ -24,7 +24,10 @@ type ColumnNode = {
   category: string;
   valueType: TODO<string>;
   columnTags: string[];
+  columnType: ColumnType;
+  expression: string;
 };
+type ColumnType = 'ref' | 'formula' | 'field';
 type MetricNode = ColumnNode & { defaultFormat: string };
 type DimensionNode = ColumnNode;
 type TimeDimensionNode = DimensionNode & {
@@ -118,7 +121,9 @@ export default class ElideMetadataSerializer extends EmberObject {
         tableId,
         source,
         tags: node.columnTags,
-        defaultFormat: node.defaultFormat
+        defaultFormat: node.defaultFormat,
+        type: node.columnType,
+        expression: node.expression
       };
     });
   }
@@ -141,7 +146,9 @@ export default class ElideMetadataSerializer extends EmberObject {
         valueType: node.valueType,
         tableId,
         source,
-        tags: node.columnTags
+        tags: node.columnTags,
+        type: node.columnType,
+        expression: node.expression
       };
     });
   }
@@ -170,7 +177,9 @@ export default class ElideMetadataSerializer extends EmberObject {
         source,
         tags: node.columnTags,
         supportedGrains: node.supportedGrains,
-        timeZone: node.timeZone
+        timeZone: node.timeZone,
+        type: node.columnType,
+        expression: node.expression
       };
     });
   }

--- a/packages/data/tests/dummy/mirage/factories/dimension.js
+++ b/packages/data/tests/dummy/mirage/factories/dimension.js
@@ -15,5 +15,7 @@ export default Factory.extend({
   },
   category: 'categoryOne',
   valueType: 'TEXT',
-  columnTags: () => ['DISPLAY']
+  columnTags: () => ['DISPLAY'],
+  columnType: 'field',
+  expression: null
 });

--- a/packages/data/tests/dummy/mirage/factories/metric.js
+++ b/packages/data/tests/dummy/mirage/factories/metric.js
@@ -18,5 +18,7 @@ export default Factory.extend({
   columnTags() {
     return ['DISPLAY'];
   },
-  defaultFormat: 'number'
+  defaultFormat: 'number',
+  columnType: 'field',
+  expression: null
 });

--- a/packages/data/tests/unit/adapters/elide-metadata-test.js
+++ b/packages/data/tests/unit/adapters/elide-metadata-test.js
@@ -109,6 +109,8 @@ module('Unit | Elide Metadata Adapter', function(hooks) {
               valueType: 'NUMBER',
               columnTags: ['DISPLAY'],
               defaultFormat: 'number',
+              columnType: 'field',
+              expression: null,
               __typename: 'Metric'
             },
             __typename: 'MetricEdge'
@@ -122,6 +124,8 @@ module('Unit | Elide Metadata Adapter', function(hooks) {
               valueType: 'NUMBER',
               columnTags: ['DISPLAY'],
               defaultFormat: 'number',
+              columnType: 'field',
+              expression: null,
               __typename: 'Metric'
             },
             __typename: 'MetricEdge'
@@ -145,6 +149,8 @@ module('Unit | Elide Metadata Adapter', function(hooks) {
               category: 'categoryOne',
               valueType: 'TEXT',
               columnTags: ['DISPLAY'],
+              columnType: 'field',
+              expression: null,
               __typename: 'Dimension'
             }
           }
@@ -168,6 +174,8 @@ module('Unit | Elide Metadata Adapter', function(hooks) {
               valueType: 'NUMBER',
               columnTags: ['DISPLAY'],
               defaultFormat: 'number',
+              columnType: 'field',
+              expression: null,
               __typename: 'Metric'
             },
             __typename: 'MetricEdge'
@@ -181,6 +189,8 @@ module('Unit | Elide Metadata Adapter', function(hooks) {
               valueType: 'NUMBER',
               columnTags: ['DISPLAY'],
               defaultFormat: 'number',
+              columnType: 'field',
+              expression: null,
               __typename: 'Metric'
             },
             __typename: 'MetricEdge'
@@ -228,6 +238,8 @@ module('Unit | Elide Metadata Adapter', function(hooks) {
                   valueType: 'NUMBER',
                   columnTags: ['DISPLAY'],
                   defaultFormat: 'number',
+                  columnType: 'field',
+                  expression: null,
                   __typename: 'Metric'
                 },
                 __typename: 'MetricEdge'
@@ -241,6 +253,8 @@ module('Unit | Elide Metadata Adapter', function(hooks) {
                   valueType: 'NUMBER',
                   columnTags: ['DISPLAY'],
                   defaultFormat: 'number',
+                  columnType: 'field',
+                  expression: null,
                   __typename: 'Metric'
                 },
                 __typename: 'MetricEdge'
@@ -258,6 +272,8 @@ module('Unit | Elide Metadata Adapter', function(hooks) {
                   category: 'categoryOne',
                   valueType: 'TEXT',
                   columnTags: ['DISPLAY'],
+                  columnType: 'field',
+                  expression: null,
                   __typename: 'Dimension'
                 },
                 __typename: 'DimensionEdge'

--- a/packages/data/tests/unit/serializers/elide-metadata-test.js
+++ b/packages/data/tests/unit/serializers/elide-metadata-test.js
@@ -31,7 +31,9 @@ module('Unit | Serializer | elide-metadata', function(hooks) {
                       category: 'cat1',
                       valueType: 'NUMBER',
                       columnTags: ['IMPORTANT'],
-                      defaultFormat: 'NONE'
+                      defaultFormat: 'NONE',
+                      columnType: 'field',
+                      expression: null
                     }
                   }
                 ]
@@ -45,7 +47,9 @@ module('Unit | Serializer | elide-metadata', function(hooks) {
                       description: 'Table A Dimension 1',
                       category: 'cat1',
                       valueType: 'TEXT',
-                      columnTags: ['IMPORTANT']
+                      columnTags: ['IMPORTANT'],
+                      columnType: 'field',
+                      expression: null
                     }
                   },
                   {
@@ -55,7 +59,9 @@ module('Unit | Serializer | elide-metadata', function(hooks) {
                       description: 'Table A Dimension 2',
                       category: 'cat1',
                       valueType: 'TEXT',
-                      columnTags: ['IMPORTANT']
+                      columnTags: ['IMPORTANT'],
+                      columnType: 'field',
+                      expression: null
                     }
                   }
                 ]
@@ -71,7 +77,9 @@ module('Unit | Serializer | elide-metadata', function(hooks) {
                       valueType: 'DATE',
                       columnTags: ['IMPORTANT'],
                       supportedGrains: ['day', 'week'],
-                      timeZone: 'UTC'
+                      timeZone: 'UTC',
+                      columnType: 'field',
+                      expression: null
                     }
                   }
                 ]
@@ -95,7 +103,9 @@ module('Unit | Serializer | elide-metadata', function(hooks) {
                       category: 'cat2',
                       valueType: 'NUMBER',
                       columnTags: ['IMPORTANT'],
-                      defaultFormat: 'NONE'
+                      defaultFormat: 'NONE',
+                      columnType: 'field',
+                      expression: null
                     }
                   },
                   {
@@ -106,7 +116,9 @@ module('Unit | Serializer | elide-metadata', function(hooks) {
                       category: 'cat2',
                       valueType: 'NUMBER',
                       columnTags: ['IMPORTANT'],
-                      defaultFormat: 'NONE'
+                      defaultFormat: 'NONE',
+                      columnType: 'field',
+                      expression: null
                     }
                   }
                 ]
@@ -120,7 +132,9 @@ module('Unit | Serializer | elide-metadata', function(hooks) {
                       description: 'Table B Dimension 1',
                       category: 'cat2',
                       valueType: 'TEXT',
-                      columnTags: ['IMPORTANT']
+                      columnTags: ['IMPORTANT'],
+                      columnType: 'field',
+                      expression: null
                     }
                   },
                   {
@@ -130,7 +144,9 @@ module('Unit | Serializer | elide-metadata', function(hooks) {
                       description: 'Table B Dimension 2',
                       category: 'cat2',
                       valueType: 'TEXT',
-                      columnTags: ['IMPORTANT']
+                      columnTags: ['IMPORTANT'],
+                      columnType: 'field',
+                      expression: null
                     }
                   }
                 ]
@@ -181,6 +197,8 @@ module('Unit | Serializer | elide-metadata', function(hooks) {
             valueType: 'NUMBER',
             tags: ['IMPORTANT'],
             defaultFormat: 'NONE',
+            type: 'field',
+            expression: null,
             source: 'dummy',
             tableId: 'tableA'
           },
@@ -192,6 +210,8 @@ module('Unit | Serializer | elide-metadata', function(hooks) {
             valueType: 'NUMBER',
             tags: ['IMPORTANT'],
             defaultFormat: 'NONE',
+            type: 'field',
+            expression: null,
             tableId: 'tableB',
             source: 'dummy'
           },
@@ -203,6 +223,8 @@ module('Unit | Serializer | elide-metadata', function(hooks) {
             valueType: 'NUMBER',
             tags: ['IMPORTANT'],
             defaultFormat: 'NONE',
+            type: 'field',
+            expression: null,
             tableId: 'tableB',
             source: 'dummy'
           }
@@ -215,6 +237,8 @@ module('Unit | Serializer | elide-metadata', function(hooks) {
             category: 'cat1',
             valueType: 'TEXT',
             tags: ['IMPORTANT'],
+            type: 'field',
+            expression: null,
             source: 'dummy',
             tableId: 'tableA'
           },
@@ -225,6 +249,8 @@ module('Unit | Serializer | elide-metadata', function(hooks) {
             category: 'cat1',
             valueType: 'TEXT',
             tags: ['IMPORTANT'],
+            type: 'field',
+            expression: null,
             source: 'dummy',
             tableId: 'tableA'
           },
@@ -235,6 +261,8 @@ module('Unit | Serializer | elide-metadata', function(hooks) {
             category: 'cat2',
             valueType: 'TEXT',
             tags: ['IMPORTANT'],
+            type: 'field',
+            expression: null,
             source: 'dummy',
             tableId: 'tableB'
           },
@@ -245,6 +273,8 @@ module('Unit | Serializer | elide-metadata', function(hooks) {
             category: 'cat2',
             valueType: 'TEXT',
             tags: ['IMPORTANT'],
+            type: 'field',
+            expression: null,
             source: 'dummy',
             tableId: 'tableB'
           }
@@ -257,6 +287,8 @@ module('Unit | Serializer | elide-metadata', function(hooks) {
             category: 'cat1',
             valueType: 'DATE',
             tags: ['IMPORTANT'],
+            type: 'field',
+            expression: null,
             supportedGrains: ['day', 'week'],
             timeZone: 'UTC',
             source: 'dummy',
@@ -289,7 +321,9 @@ module('Unit | Serializer | elide-metadata', function(hooks) {
             category: 'userMetrics',
             valueType: 'NUMBER',
             columnTags: ['IMPORTANT'],
-            defaultFormat: 'NONE'
+            defaultFormat: 'NONE',
+            columnType: 'field',
+            expression: null
           }
         },
         {
@@ -300,7 +334,9 @@ module('Unit | Serializer | elide-metadata', function(hooks) {
             category: 'userMetrics',
             valueType: 'NUMBER',
             columnTags: ['DISPLAY'],
-            defaultFormat: 'NONE'
+            defaultFormat: 'NONE',
+            columnType: 'field',
+            expression: null
           }
         }
       ]
@@ -318,7 +354,9 @@ module('Unit | Serializer | elide-metadata', function(hooks) {
           tags: ['IMPORTANT'],
           defaultFormat: 'NONE',
           source,
-          tableId
+          tableId,
+          type: 'field',
+          expression: null
         },
         {
           id: 'impressions',
@@ -329,7 +367,9 @@ module('Unit | Serializer | elide-metadata', function(hooks) {
           tags: ['DISPLAY'],
           defaultFormat: 'NONE',
           source,
-          tableId
+          tableId,
+          type: 'field',
+          expression: null
         }
       ],
       'Metric connection payload is normalized properly for a table'
@@ -354,7 +394,9 @@ module('Unit | Serializer | elide-metadata', function(hooks) {
             description: 'User Age',
             category: 'userDimensions',
             valueType: 'TEXT',
-            columnTags: ['IMPORTANT']
+            columnTags: ['IMPORTANT'],
+            columnType: 'field',
+            expression: null
           }
         },
         {
@@ -364,7 +406,9 @@ module('Unit | Serializer | elide-metadata', function(hooks) {
             description: 'User Gender',
             category: 'userDimensions',
             valueType: 'TEXT',
-            columnTags: ['DISPLAY']
+            columnTags: ['DISPLAY'],
+            columnType: 'field',
+            expression: null
           }
         }
       ]
@@ -381,7 +425,9 @@ module('Unit | Serializer | elide-metadata', function(hooks) {
           valueType: 'TEXT',
           tags: ['IMPORTANT'],
           source,
-          tableId
+          tableId,
+          type: 'field',
+          expression: null
         },
         {
           id: 'gender',
@@ -391,7 +437,9 @@ module('Unit | Serializer | elide-metadata', function(hooks) {
           valueType: 'TEXT',
           tags: ['DISPLAY'],
           source,
-          tableId
+          tableId,
+          type: 'field',
+          expression: null
         }
       ],
       'Dimension connection payload is normalized properly for a table'
@@ -421,7 +469,9 @@ module('Unit | Serializer | elide-metadata', function(hooks) {
             timeZone: {
               short: 'PST',
               long: 'Pacific Standard Time'
-            }
+            },
+            columnType: 'field',
+            expression: null
           }
         },
         {
@@ -436,7 +486,9 @@ module('Unit | Serializer | elide-metadata', function(hooks) {
             timeZone: {
               short: 'CST',
               long: 'Central Standard Time'
-            }
+            },
+            columnType: 'field',
+            expression: null
           }
         }
       ]
@@ -458,7 +510,9 @@ module('Unit | Serializer | elide-metadata', function(hooks) {
             long: 'Pacific Standard Time'
           },
           source,
-          tableId
+          tableId,
+          type: 'field',
+          expression: null
         },
         {
           id: 'orderMonth',
@@ -473,7 +527,9 @@ module('Unit | Serializer | elide-metadata', function(hooks) {
             long: 'Central Standard Time'
           },
           source,
-          tableId
+          tableId,
+          type: 'field',
+          expression: null
         }
       ],
       'Time Dimension connection payload is normalized properly for a table'


### PR DESCRIPTION
## Description
We discussed how we could make the types involved in loading metadata clearer.

## Proposed Changes

- Add a metadata payload interface and metadata interface for each metadata model that's serialized currently

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
