### PR TITLE
Update: Add threshold to limit definition results

### DIFF
--- a/packages/search/addon/services/navi-search/navi-definition-search-provider.js
+++ b/packages/search/addon/services/navi-search/navi-definition-search-provider.js
@@ -36,7 +36,7 @@ export default class NaviDefinitionSearchProviderService extends NaviBaseSearchP
 
     if (query?.length > 0) {
       types.forEach(type => kegData.push(...this.metadataService.all(type)));
-      data = searchRecordsByFields(kegData, query, ['id', 'name', 'description']);
+      data = searchRecordsByFields(kegData, query, ['id', 'name', 'description'], 10);
     }
 
     return {


### PR DESCRIPTION
Resolves #

<!-- The above line will close the issue upon merge -->

## Description
Add a relevance threshold to limit the number of results fetch by the definition search provider.

## Proposed Changes

-

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
