### PR TITLE
Update: Search results show scrollbar

### DIFF
--- a/packages/search/app/styles/navi-search/components/navi-search-bar.less
+++ b/packages/search/app/styles/navi-search/components/navi-search-bar.less
@@ -66,6 +66,8 @@
 
 .navi-search-results {
   margin-top: 5px;
+  max-height: 80vh;
+  overflow-x: auto;
 
   &--box {
     background: @denali-grey-100;

--- a/packages/search/app/styles/navi-search/components/navi-search-bar.less
+++ b/packages/search/app/styles/navi-search/components/navi-search-bar.less
@@ -13,7 +13,10 @@
     appearance: none;
     background: @denali-grey-100;
     border: none;
+    border-color: @denali-grey-500;
     border-radius: 4px;
+    border-style: solid;
+    border-width: 1px;
     box-shadow: none;
     color: @denali-grey-800;
     flex: 1 0 auto;


### PR DESCRIPTION
Resolves #

<!-- The above line will close the issue upon merge -->

## Description
Show scrollbar instead of extending the size of the search result pane. Also, add a border around the search bar.

## Proposed Changes

-

## Screenshots
<img width="1132" alt="Screen Shot 2020-05-03 at 5 17 50 PM" src="https://user-images.githubusercontent.com/1649445/80927248-16f9c300-8d62-11ea-895d-ca42690e0965.png">
<img width="1415" alt="Screen Shot 2020-05-03 at 5 17 09 PM 1" src="https://user-images.githubusercontent.com/1649445/80927254-1a8d4a00-8d62-11ea-9f0a-2fc2d64309b0.png">



## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
