### PR TITLE
Update: Performance improvements for navi-search

### DIFF
--- a/packages/search/addon/components/navi-search-bar.hbs
+++ b/packages/search/addon/components/navi-search-bar.hbs
@@ -5,9 +5,9 @@
       @keyUp={{fn this.onKeyUp dd}} @focusIn={{fn dd.actions.open}} data-ebd-id="{{dd.uniqueId}}-trigger" />
     <NaviIcon @icon="search" class="navi-search-bar__icon" />
   </div>
-  {{#if this.searchResults}}
+  {{#if (and this.launchQuery.lastSuccessful.value (not-eq this.searchQuery ""))}}
     <dd.content @class="navi-search-results navi-search-results--box navi-search-result-wrapper slide-fade">
-      <NaviSearchResult::Wrapper @searchResults={{this.searchResults}} @closeResults={{fn dd.actions.close event}} class="navi-search-results__item navi-search-results--box"/>
+      <NaviSearchResult::Wrapper @searchResults={{this.launchQuery.lastSuccessful.value}} @closeResults={{fn dd.actions.close event}} class="navi-search-results__item navi-search-results--box"/>
     </dd.content>
   {{/if}}
 </BasicDropdown>

--- a/packages/search/addon/components/navi-search-bar.js
+++ b/packages/search/addon/components/navi-search-bar.js
@@ -77,7 +77,7 @@ export default class NaviSearchBarComponent extends Component {
    * @returns {Array} results
    */
   @restartableTask
-  *launchQuery(query, event) {
+  *launchQuery(query) {
     let results;
     yield setTimeout(() => {}, DEBOUNCE_MS);
     results = yield this.searchProviderService.search.perform(query);

--- a/packages/search/addon/components/navi-search-bar.js
+++ b/packages/search/addon/components/navi-search-bar.js
@@ -74,6 +74,7 @@ export default class NaviSearchBarComponent extends Component {
   /**
    * @method launchQuery – Launch search task
    * @param {String} query
+   * @returns {Array} results
    */
   @restartableTask
   *launchQuery(query, event) {

--- a/packages/search/addon/components/navi-search-bar.js
+++ b/packages/search/addon/components/navi-search-bar.js
@@ -10,6 +10,7 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { restartableTask } from 'ember-concurrency-decorators';
+import { timeout } from 'ember-concurrency';
 
 /**
  * @constant EMPTY_RESULT – Empty result object
@@ -78,11 +79,10 @@ export default class NaviSearchBarComponent extends Component {
    */
   @restartableTask
   *launchQuery(query) {
-    let results;
-    yield setTimeout(() => {}, DEBOUNCE_MS);
-    results = yield this.searchProviderService.search.perform(query);
+    yield timeout(DEBOUNCE_MS);
+    const results = yield this.searchProviderService.search.perform(query);
     if (results.length === 0 && query !== '') {
-      results = [EMPTY_RESULT];
+      return [EMPTY_RESULT];
     }
     return results;
   }

--- a/packages/search/addon/services/navi-search-provider.js
+++ b/packages/search/addon/services/navi-search-provider.js
@@ -8,7 +8,7 @@
 import Service from '@ember/service';
 import { getOwner } from '@ember/application';
 import config from 'ember-get-config';
-import { keepLatestTask } from 'ember-concurrency-decorators';
+import { restartableTask } from 'ember-concurrency-decorators';
 
 /* global requirejs */
 
@@ -42,7 +42,7 @@ export default class NaviSearchProviderService extends Service {
    * @returns {Array} array of objects that contain the search results,
    * the name of the result component as well as result ordering information
    */
-  @keepLatestTask
+  @restartableTask
   *search(query) {
     const searchProviders = this._all();
     let results = [];

--- a/packages/search/addon/services/navi-search/navi-asset-search-provider.js
+++ b/packages/search/addon/services/navi-search/navi-asset-search-provider.js
@@ -7,7 +7,7 @@
 
 import { inject as service } from '@ember/service';
 import NaviBaseSearchProviderService from '../navi-base-search-provider';
-import { keepLatestTask } from 'ember-concurrency-decorators';
+import { restartableTask } from 'ember-concurrency-decorators';
 import { pluralize } from 'ember-inflector';
 
 export default class NaviAssetSearchProviderService extends NaviBaseSearchProviderService {
@@ -75,7 +75,7 @@ export default class NaviAssetSearchProviderService extends NaviBaseSearchProvid
    * @yields {Promise} promise with search query results
    * @returns {Object} Object containing component, title, and data to be displayed
    */
-  @keepLatestTask
+  @restartableTask
   *search(query) {
     const types = ['report', 'dashboard'];
     const promises = [];

--- a/packages/search/addon/services/navi-search/navi-definition-search-provider.js
+++ b/packages/search/addon/services/navi-search/navi-definition-search-provider.js
@@ -7,7 +7,7 @@
 
 import { inject as service } from '@ember/service';
 import NaviBaseSearchProviderService from '../navi-base-search-provider';
-import { keepLatestTask } from 'ember-concurrency-decorators';
+import { restartableTask } from 'ember-concurrency-decorators';
 import { searchRecordsByFields } from 'navi-core/utils/search';
 
 export default class NaviDefinitionSearchProviderService extends NaviBaseSearchProviderService {
@@ -27,7 +27,7 @@ export default class NaviDefinitionSearchProviderService extends NaviBaseSearchP
    * @param {String} query
    * @returns {Object} Object containing, component, title and data
    */
-  @keepLatestTask
+  @restartableTask
   // eslint-disable-next-line require-yield
   *search(query) {
     const types = ['table', 'dimension', 'metric', 'time-dimension'];

--- a/packages/search/app/styles/navi-search/components/navi-search-bar.less
+++ b/packages/search/app/styles/navi-search/components/navi-search-bar.less
@@ -69,8 +69,9 @@
 
 .navi-search-results {
   margin-top: 5px;
-  max-height: 80vh;
+  max-height: 90vh;
   overflow-x: auto;
+  z-index: 10;
 
   &--box {
     background: @denali-grey-100;


### PR DESCRIPTION
Resolves #

<!-- The above line will close the issue upon merge -->

## Description
Performance improvements for navi-search. 

## Proposed Changes

- Use restartableTask instead of keepLatestTask.
- Debounce queries from search bar.
- Use task's lastSuccessful value instead of keeping an extra tracked property.
- Update styles: make search result pane extend a little longer (after testing w/ Spotlight) and update z-index so search results appear over some page elements.

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
