### PR TITLE
Show more results support for display components

### DIFF
--- a/packages/search/addon/components/navi-search-result/asset.hbs
+++ b/packages/search/addon/components/navi-search-result/asset.hbs
@@ -16,7 +16,7 @@
   </tbody>
 </table>
 {{#if this.hasMoreResults}}
-  <button {{on "click" (toggle "showTop" this)}} class="navi-search-result-options__button">
+  <button {{on "click" (toggle "showTop" this)}} class="navi-search-result-options__show-button">
     {{if this.showTop "Show more" "Show less"}}
   </button>
 {{/if}}

--- a/packages/search/addon/components/navi-search-result/asset.hbs
+++ b/packages/search/addon/components/navi-search-result/asset.hbs
@@ -15,3 +15,8 @@
     {{/each}}
   </tbody>
 </table>
+{{#if this.hasMoreResults}}
+  <button {{on "click" (toggle "showTop" this)}} class="navi-search-result-options__button">
+    {{if this.showTop "Show more" "Show less"}}
+  </button>
+{{/if}}

--- a/packages/search/addon/components/navi-search-result/asset.js
+++ b/packages/search/addon/components/navi-search-result/asset.js
@@ -5,16 +5,27 @@
  * A component that displays results for reports and dashboards
  */
 
-import Component from '@glimmer/component';
+import NaviBaseSearchResultComponent from './base';
 import { pluralize } from 'ember-inflector';
 import { set } from '@ember/object';
 
-export default class NaviAssetSearchResultComponent extends Component {
+/**
+ * @constant NUM_TOP
+ */
+const NUM_TOP = 5;
+
+export default class NaviAssetSearchResultComponent extends NaviBaseSearchResultComponent {
+  /**
+   * @override
+   * @property {number} numberOfTopResults
+   */
+  numberOfTopResults = NUM_TOP;
+
   /**
    * @property {Array} results
    */
   get results() {
-    return this.args.data?.map(value => {
+    return this.data?.map(value => {
       set(value, 'route', this._getRouteFor(value));
       set(value, 'type', value.constructor?.modelName);
       set(value, 'icon', value.type === 'report' ? 'file-text' : 'bar-chart');

--- a/packages/search/addon/components/navi-search-result/base.ts
+++ b/packages/search/addon/components/navi-search-result/base.ts
@@ -7,6 +7,9 @@
 
 import Component from '@glimmer/component';
 
+/**
+ * @interface Args
+ */
 interface Args {
   data: Array<Object>;
 }

--- a/packages/search/addon/components/navi-search-result/base.ts
+++ b/packages/search/addon/components/navi-search-result/base.ts
@@ -6,6 +6,7 @@
  */
 
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 
 /**
  * @interface Args
@@ -14,4 +15,31 @@ interface Args {
   data: Array<Object>;
 }
 
-export default class NaviBaseSearchResultComponent extends Component<Args> {}
+export default class NaviBaseSearchResultComponent extends Component<Args> {
+  /**
+   * @property {Boolean} showTop
+   */
+  @tracked showTop: Boolean = true;
+
+  /**
+   * @property {number} numberOfTopResults
+   */
+  numberOfTopResults: number = 10;
+
+  /**
+   * @property {Boolean} hasMoreResults
+   */
+  get hasMoreResults(): Boolean {
+    return this.args?.data.length > this.numberOfTopResults;
+  }
+
+  /**
+   * @property {Array} results
+   */
+  get data(): Array<Object> {
+    if (this.showTop && this.hasMoreResults) {
+      return this.args?.data.slice(0, this.numberOfTopResults);
+    }
+    return this.args?.data;
+  }
+}

--- a/packages/search/addon/components/navi-search-result/base.ts
+++ b/packages/search/addon/components/navi-search-result/base.ts
@@ -24,7 +24,7 @@ export default class NaviBaseSearchResultComponent extends Component<Args> {
   /**
    * @property {number} numberOfTopResults
    */
-  numberOfTopResults: number = 10;
+  @tracked numberOfTopResults: number = 10;
 
   /**
    * @property {Boolean} hasMoreResults

--- a/packages/search/addon/components/navi-search-result/base.ts
+++ b/packages/search/addon/components/navi-search-result/base.ts
@@ -1,0 +1,14 @@
+/**
+ * Copyright 2020, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ *
+ * Base search result component
+ */
+
+import Component from '@glimmer/component';
+
+interface Args {
+  data: Array<Object>;
+}
+
+export default class NaviBaseSearchResultComponent extends Component<Args> {}

--- a/packages/search/addon/components/navi-search-result/base.ts
+++ b/packages/search/addon/components/navi-search-result/base.ts
@@ -12,14 +12,14 @@ import { tracked } from '@glimmer/tracking';
  * @interface Args
  */
 interface Args {
-  data: Array<Object>;
+  data: Array<TODO>;
 }
 
 export default class NaviBaseSearchResultComponent extends Component<Args> {
   /**
-   * @property {Boolean} showTop
+   * @property {boolean} showTop
    */
-  @tracked showTop: Boolean = true;
+  @tracked showTop: boolean = true;
 
   /**
    * @property {number} numberOfTopResults
@@ -27,9 +27,9 @@ export default class NaviBaseSearchResultComponent extends Component<Args> {
   @tracked numberOfTopResults: number = 10;
 
   /**
-   * @property {Boolean} hasMoreResults
+   * @property {boolean} hasMoreResults
    */
-  get hasMoreResults(): Boolean {
+  get hasMoreResults(): boolean {
     return this.args?.data.length > this.numberOfTopResults;
   }
 

--- a/packages/search/addon/components/navi-search-result/definition.hbs
+++ b/packages/search/addon/components/navi-search-result/definition.hbs
@@ -12,7 +12,7 @@
                 {{/if}}
                 <p class="navi-search-definition-result__item-description">
                   {{#if result.description}}
-                  {{result.description}}
+                    {{result.description}}
                   {{else}}
                     {{extendedResult.description}}
                   {{/if}}

--- a/packages/search/addon/components/navi-search-result/definition.hbs
+++ b/packages/search/addon/components/navi-search-result/definition.hbs
@@ -1,7 +1,7 @@
 {{! Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. }}
 <table class="navi-search-results__item navi-search-results__item--definition" ...attributes>
   <tbody class="navi-search-results__item-body">
-    {{#each this.results as |result|}}
+    {{#each this.data as |result|}}
       {{#let (await result.extended) as |extendedResult|}}
         {{#if (or result.description extendedResult.description)}}
           <tr class="navi-search-definition-result">
@@ -22,12 +22,10 @@
         {{/if}}
       {{/let}}
     {{/each}}
-    {{#if this.hasMoreResults}}
-      <tr {{on "click" (toggle "showTop" this)}} class="navi-search-definition-options">
-        <td class="navi-search-definition-options__button">
-          {{if this.showTop "Show more" "Show less"}}
-        </td>
-      </tr>
-    {{/if}}
   </tbody>
 </table>
+{{#if this.hasMoreResults}}
+  <button {{on "click" (toggle "showTop" this)}} class="navi-search-result-options__button">
+    {{if this.showTop "Show more" "Show less"}}
+  </button>
+{{/if}}

--- a/packages/search/addon/components/navi-search-result/definition.hbs
+++ b/packages/search/addon/components/navi-search-result/definition.hbs
@@ -25,7 +25,7 @@
   </tbody>
 </table>
 {{#if this.hasMoreResults}}
-  <button {{on "click" (toggle "showTop" this)}} class="navi-search-result-options__button">
+  <button {{on "click" (toggle "showTop" this)}} class="navi-search-result-options__show-button">
     {{if this.showTop "Show more" "Show less"}}
   </button>
 {{/if}}

--- a/packages/search/addon/components/navi-search-result/definition.hbs
+++ b/packages/search/addon/components/navi-search-result/definition.hbs
@@ -2,23 +2,25 @@
 <table class="navi-search-results__item navi-search-results__item--definition" ...attributes>
   <tbody class="navi-search-results__item-body">
     {{#each @data as |result|}}
-      <tr class="navi-search-definition-result">
-        <td class="navi-search-definition-result__item navi-search-results__item--cell">
-            <h5 class="navi-search-definition-result__item-name">{{result.name}}</h5>
-            {{#if this.hasMultipleDataSources}}
-              <em class="navi-search-definition-result__item-source">Source: {{result.source}}</em>
-            {{/if}}
-            <p class="navi-search-definition-result__item-description">
-              {{#if result.description}}
-               {{result.description}}
-              {{else}}
-                {{#let (await result.extended) as |extendedResult|}}
-                  {{extendedResult.description}}
-                {{/let}}
-              {{/if}}
-            </p>
-        </td>
-      </tr>
+      {{#let (await result.extended) as |extendedResult|}}
+        {{#if (or result.description extendedResult.description)}}
+          <tr class="navi-search-definition-result">
+            <td class="navi-search-definition-result__item navi-search-results__item--cell">
+                <h5 class="navi-search-definition-result__item-name">{{result.name}}</h5>
+                {{#if this.hasMultipleDataSources}}
+                  <em class="navi-search-definition-result__item-source">Source: {{result.source}}</em>
+                {{/if}}
+                <p class="navi-search-definition-result__item-description">
+                  {{#if result.description}}
+                  {{result.description}}
+                  {{else}}
+                    {{extendedResult.description}}
+                  {{/if}}
+                </p>
+            </td>
+          </tr>
+        {{/if}}
+      {{/let}}
     {{/each}}
   </tbody>
 </table>

--- a/packages/search/addon/components/navi-search-result/definition.hbs
+++ b/packages/search/addon/components/navi-search-result/definition.hbs
@@ -1,7 +1,7 @@
 {{! Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. }}
 <table class="navi-search-results__item navi-search-results__item--definition" ...attributes>
   <tbody class="navi-search-results__item-body">
-    {{#each @data as |result|}}
+    {{#each this.results as |result|}}
       {{#let (await result.extended) as |extendedResult|}}
         {{#if (or result.description extendedResult.description)}}
           <tr class="navi-search-definition-result">

--- a/packages/search/addon/components/navi-search-result/definition.hbs
+++ b/packages/search/addon/components/navi-search-result/definition.hbs
@@ -22,5 +22,12 @@
         {{/if}}
       {{/let}}
     {{/each}}
+    {{#if this.hasMoreResults}}
+      <tr {{on "click" (toggle "showTop" this)}} class="navi-search-definition-options">
+        <td class="navi-search-definition-options__button">
+          {{if this.showTop "Show more" "Show less"}}
+        </td>
+      </tr>
+    {{/if}}
   </tbody>
 </table>

--- a/packages/search/addon/components/navi-search-result/definition.ts
+++ b/packages/search/addon/components/navi-search-result/definition.ts
@@ -12,7 +12,7 @@ import { inject as service } from '@ember/service';
 /**
  * @constant NUM_TOP
  */
-const NUM_TOP:number = 2;
+const NUM_TOP: number = 2;
 
 export default class NaviDefinitionSearchResultComponent extends NaviBaseSearchResultComponent {
   /**

--- a/packages/search/addon/components/navi-search-result/definition.ts
+++ b/packages/search/addon/components/navi-search-result/definition.ts
@@ -26,9 +26,9 @@ export default class NaviDefinitionSearchResultComponent extends NaviBaseSearchR
   numberOfTopResults: number = NUM_TOP;
 
   /**
-   * @property {Boolean} hasMultipleDataSources
+   * @property {boolean} hasMultipleDataSources
    */
-  get hasMultipleDataSources(): Boolean {
+  get hasMultipleDataSources(): boolean {
     return this.metadataService.loadedDataSources.length > 1;
   }
 }

--- a/packages/search/addon/components/navi-search-result/definition.ts
+++ b/packages/search/addon/components/navi-search-result/definition.ts
@@ -33,10 +33,17 @@ export default class NaviDefinitionSearchResultComponent extends NaviBaseSearchR
   }
 
   /**
+   * @property {Boolean} hasMoreResults
+   */
+  get hasMoreResults(): Boolean {
+    return this.args?.data.length > NUM_TOP;
+  }
+
+  /**
    * @property {Array} results
    */
   get results(): Array<Object> {
-    if (this.showTop) {
+    if (this.showTop && this.hasMoreResults) {
       return this.args?.data.slice(0, NUM_TOP);
     }
     return this.args?.data;

--- a/packages/search/addon/components/navi-search-result/definition.ts
+++ b/packages/search/addon/components/navi-search-result/definition.ts
@@ -6,7 +6,6 @@
  */
 
 import NaviBaseSearchResultComponent from './base';
-import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 
 /**
@@ -21,31 +20,15 @@ export default class NaviDefinitionSearchResultComponent extends NaviBaseSearchR
   @service('bard-metadata') metadataService!: TODO;
 
   /**
-   * @property {Boolean} showTop
+   * @override
+   * @property {number} numberOfTopResults
    */
-  @tracked showTop: Boolean = true;
+  numberOfTopResults: number = NUM_TOP;
 
   /**
    * @property {Boolean} hasMultipleDataSources
    */
   get hasMultipleDataSources(): Boolean {
     return this.metadataService.loadedDataSources.length > 1;
-  }
-
-  /**
-   * @property {Boolean} hasMoreResults
-   */
-  get hasMoreResults(): Boolean {
-    return this.args?.data.length > NUM_TOP;
-  }
-
-  /**
-   * @property {Array} results
-   */
-  get results(): Array<Object> {
-    if (this.showTop && this.hasMoreResults) {
-      return this.args?.data.slice(0, NUM_TOP);
-    }
-    return this.args?.data;
   }
 }

--- a/packages/search/addon/components/navi-search-result/definition.ts
+++ b/packages/search/addon/components/navi-search-result/definition.ts
@@ -5,19 +5,40 @@
  * A component that displays results for definitions
  */
 
-import Component from '@glimmer/component';
+import NaviBaseSearchResultComponent from './base';
+import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 
-export default class NaviDefinitionSearchResultComponent extends Component {
+/**
+ * @constant NUM_TOP
+ */
+const NUM_TOP = 2;
+
+export default class NaviDefinitionSearchResultComponent extends NaviBaseSearchResultComponent {
   /**
    * @property {Ember.Service} metadataService
    */
   @service('bard-metadata') metadataService!: TODO;
 
   /**
+   * @property {Boolean} showTop
+   */
+  @tracked showTop: Boolean = true;
+
+  /**
    * @property {Boolean} hasMultipleDataSources
    */
-  get hasMultipleDataSources() {
+  get hasMultipleDataSources(): Boolean {
     return this.metadataService.loadedDataSources.length > 1;
+  }
+
+  /**
+   * @property {Array} results
+   */
+  get results(): Array<Object> {
+    if (this.showTop) {
+      return this.args?.data.slice(0, NUM_TOP);
+    }
+    return this.args?.data;
   }
 }

--- a/packages/search/addon/components/navi-search-result/definition.ts
+++ b/packages/search/addon/components/navi-search-result/definition.ts
@@ -12,7 +12,7 @@ import { inject as service } from '@ember/service';
 /**
  * @constant NUM_TOP
  */
-const NUM_TOP = 2;
+const NUM_TOP:number = 2;
 
 export default class NaviDefinitionSearchResultComponent extends NaviBaseSearchResultComponent {
   /**

--- a/packages/search/addon/services/navi-base-search-provider.js
+++ b/packages/search/addon/services/navi-base-search-provider.js
@@ -10,6 +10,11 @@ import { assert } from '@ember/debug';
 
 export default class NaviBaseSearchProviderService extends Service {
   /**
+   * @property {number} resultThreshold
+   */
+  resultThreshold = 10;
+
+  /**
    * @method search
    * @returns {Array} array of search results
    */

--- a/packages/search/addon/services/navi-search/navi-definition-search-provider.js
+++ b/packages/search/addon/services/navi-search/navi-definition-search-provider.js
@@ -10,6 +10,11 @@ import NaviBaseSearchProviderService from '../navi-base-search-provider';
 import { keepLatestTask } from 'ember-concurrency-decorators';
 import { searchRecordsByFields } from 'navi-core/utils/search';
 
+/**
+ * @constant RESULT_THRESHOLD
+ */
+const RESULT_THRESHOLD = 10;
+
 export default class NaviDefinitionSearchProviderService extends NaviBaseSearchProviderService {
   /**
    * @property {Ember.Service} metadataService
@@ -42,7 +47,7 @@ export default class NaviDefinitionSearchProviderService extends NaviBaseSearchP
     return {
       component: this._displayComponentName,
       title: 'Definition',
-      data
+      data: data.slice(0, RESULT_THRESHOLD)
     };
   }
 }

--- a/packages/search/addon/services/navi-search/navi-definition-search-provider.js
+++ b/packages/search/addon/services/navi-search/navi-definition-search-provider.js
@@ -10,11 +10,6 @@ import NaviBaseSearchProviderService from '../navi-base-search-provider';
 import { keepLatestTask } from 'ember-concurrency-decorators';
 import { searchRecordsByFields } from 'navi-core/utils/search';
 
-/**
- * @constant RESULT_THRESHOLD
- */
-const RESULT_THRESHOLD = 10;
-
 export default class NaviDefinitionSearchProviderService extends NaviBaseSearchProviderService {
   /**
    * @property {Ember.Service} metadataService
@@ -47,7 +42,7 @@ export default class NaviDefinitionSearchProviderService extends NaviBaseSearchP
     return {
       component: this._displayComponentName,
       title: 'Definition',
-      data: data.slice(0, RESULT_THRESHOLD)
+      data: data.slice(0, this.resultThreshold)
     };
   }
 }

--- a/packages/search/addon/services/navi-search/navi-definition-search-provider.js
+++ b/packages/search/addon/services/navi-search/navi-definition-search-provider.js
@@ -36,7 +36,7 @@ export default class NaviDefinitionSearchProviderService extends NaviBaseSearchP
 
     if (query?.length > 0) {
       types.forEach(type => kegData.push(...this.metadataService.all(type)));
-      data = searchRecordsByFields(kegData, query, ['id', 'name', 'description']);
+      data = searchRecordsByFields(kegData, query, ['id', 'name', 'description'], 10);
     }
 
     return {

--- a/packages/search/addon/services/navi-search/navi-definition-search-provider.js
+++ b/packages/search/addon/services/navi-search/navi-definition-search-provider.js
@@ -36,7 +36,7 @@ export default class NaviDefinitionSearchProviderService extends NaviBaseSearchP
 
     if (query?.length > 0) {
       types.forEach(type => kegData.push(...this.metadataService.all(type)));
-      data = searchRecordsByFields(kegData, query, ['id', 'name', 'description'], 10);
+      data = searchRecordsByFields(kegData, query, ['id', 'name', 'description']);
     }
 
     return {

--- a/packages/search/app/styles/navi-search/common/common.less
+++ b/packages/search/app/styles/navi-search/common/common.less
@@ -33,3 +33,30 @@
     cursor: not-allowed;
   }
 }
+
+.navi-search-result-options {
+  &__button {
+    align-items: center;
+    background: rgba(0, 0, 0, 0);
+    border: none;
+    border-radius: 4px;
+    box-sizing: border-box;
+    color: #016eff;
+    cursor: pointer;
+    display: inline-flex;
+    font-size: inherit;
+    height: 36px;
+    justify-content: center;
+    margin: 0px;
+    min-width: 120px;
+    outline: 0;
+    padding: 0px 10px;
+    padding-bottom: 1px;
+    transition: background 300ms;
+  }
+
+  &__button:hover {
+    background: rgba(0, 76, 179, 0.26);
+    color: #004cb3 !important;
+  }
+}

--- a/packages/search/app/styles/navi-search/common/common.less
+++ b/packages/search/app/styles/navi-search/common/common.less
@@ -35,7 +35,7 @@
 }
 
 .navi-search-result-options {
-  &__button {
+  &__show-button {
     align-items: center;
     background: rgba(0, 0, 0, 0);
     border: none;
@@ -55,7 +55,7 @@
     transition: background 300ms;
   }
 
-  &__button:hover {
+  &__show-button:hover {
     background: rgba(@denali-brand-400, 0.26);
     color: @denali-brand-400;
   }

--- a/packages/search/app/styles/navi-search/common/common.less
+++ b/packages/search/app/styles/navi-search/common/common.less
@@ -41,7 +41,7 @@
     border: none;
     border-radius: 4px;
     box-sizing: border-box;
-    color: #016eff;
+    color: @denali-brand-400;
     cursor: pointer;
     display: inline-flex;
     font-size: inherit;
@@ -56,7 +56,7 @@
   }
 
   &__button:hover {
-    background: rgba(0, 76, 179, 0.26);
-    color: #004cb3 !important;
+    background: rgba(@denali-brand-400, 0.26);
+    color: @denali-brand-400;
   }
 }

--- a/packages/search/app/styles/navi-search/components/navi-definition-search-result.less
+++ b/packages/search/app/styles/navi-search/components/navi-definition-search-result.less
@@ -18,3 +18,15 @@
     margin-block-end: 0;
   }
 }
+
+.navi-search-definition-options {
+  &__button {
+    background: #cce2ff;
+    border-radius: 4px;
+    color: #303030;
+    cursor: pointer;
+    display: inline-block;
+    margin-top: 15px;
+    padding: 4px 6px;
+  }
+}

--- a/packages/search/app/styles/navi-search/components/navi-definition-search-result.less
+++ b/packages/search/app/styles/navi-search/components/navi-definition-search-result.less
@@ -18,15 +18,3 @@
     margin-block-end: 0;
   }
 }
-
-.navi-search-definition-options {
-  &__button {
-    background: #cce2ff;
-    border-radius: 4px;
-    color: #303030;
-    cursor: pointer;
-    display: inline-block;
-    margin-top: 15px;
-    padding: 4px 6px;
-  }
-}

--- a/packages/search/package-lock.json
+++ b/packages/search/package-lock.json
@@ -1583,7 +1583,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@glimmer/component/-/component-1.0.0.tgz",
       "integrity": "sha512-1ERZYNLZRuC8RYbcfkJeAWn3Ly7W2VdoHLQIHCmhQH/m7ubkNOdLQcTnUzje7OnRUs9EJ6DjfoN57XRX9Ux4rA==",
-      "dev": true,
       "requires": {
         "@glimmer/di": "^0.1.9",
         "@glimmer/env": "^0.1.7",
@@ -1604,7 +1603,6 @@
           "version": "7.5.5",
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.5.5.tgz",
           "integrity": "sha512-pehKf4m640myZu5B2ZviLaiBlxMCjSZ1qTEO459AXKX5GnPueyulJeCqZFs1nz/Ya2dDzXQ1NxZ/kKNWyD4h6w==",
-          "dev": true,
           "requires": {
             "@babel/helper-create-class-features-plugin": "^7.5.5",
             "@babel/helper-plugin-utils": "^7.0.0",
@@ -1615,7 +1613,6 @@
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-3.0.2.tgz",
           "integrity": "sha512-ZyPAwrOdlCddduFbsMyyFzJUrvW6b04pMvDiAQZrCwghlvgowJDY+EfoXn+eR1RRA5nmGHJ+B68T63VnpRiT1A==",
-          "dev": true,
           "requires": {
             "broccoli-plugin": "^1.3.0",
             "merge-trees": "^2.0.0"
@@ -1625,7 +1622,6 @@
           "version": "7.0.2",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.2.tgz",
           "integrity": "sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==",
-          "dev": true,
           "requires": {
             "path-key": "^3.1.0",
             "shebang-command": "^2.0.0",
@@ -1636,7 +1632,6 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -1645,7 +1640,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-3.0.0.tgz",
           "integrity": "sha512-lo5YArbJzJi5ssvaGqTt6+FnhTALnSvYVuxM7lfyL1UCMudyNJ94ovH5C7n5il7ATd6WsNiAPRUO/v+s5Jq/aA==",
-          "dev": true,
           "requires": {
             "@babel/plugin-transform-typescript": "~7.5.0",
             "ansi-to-html": "^0.6.6",
@@ -1664,7 +1658,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/execa/-/execa-2.1.0.tgz",
           "integrity": "sha512-Y/URAVapfbYy2Xp/gb6A0E7iR8xeqOCXsuuaoMn7A5PzrXUK84E1gyiEfq0wQd/GHA6GsoHWwhNq8anb0mleIw==",
-          "dev": true,
           "requires": {
             "cross-spawn": "^7.0.0",
             "get-stream": "^5.0.0",
@@ -1681,7 +1674,6 @@
           "version": "8.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
           "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-          "dev": true,
           "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^4.0.0",
@@ -1692,7 +1684,6 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
           "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
-          "dev": true,
           "requires": {
             "pump": "^3.0.0"
           }
@@ -1700,14 +1691,12 @@
         "is-stream": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-          "dev": true
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
         },
         "matcher-collection": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
           "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
-          "dev": true,
           "requires": {
             "@types/minimatch": "^3.0.3",
             "minimatch": "^3.0.2"
@@ -1717,7 +1706,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-2.0.0.tgz",
           "integrity": "sha512-5xBbmqYBalWqmhYm51XlohhkmVOua3VAUrrWh8t9iOkaLpS6ifqm/UVuUjQCeDVJ9Vx3g2l6ihfkbLSTeKsHbw==",
-          "dev": true,
           "requires": {
             "fs-updater": "^1.0.4",
             "heimdalljs": "^0.2.5"
@@ -1727,7 +1715,6 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
           "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
-          "dev": true,
           "requires": {
             "path-key": "^3.0.0"
           }
@@ -1735,26 +1722,22 @@
         "p-finally": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
-          "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
-          "dev": true
+          "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw=="
         },
         "path-key": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-          "dev": true
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
         },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         },
         "shebang-command": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
           "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-          "dev": true,
           "requires": {
             "shebang-regex": "^3.0.0"
           }
@@ -1762,14 +1745,12 @@
         "shebang-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-          "dev": true
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
         },
         "walk-sync": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.0.2.tgz",
           "integrity": "sha512-dCZkrxfHjPn7tIvdYrX3uMD/R0beVrHpA8lROQ5wWrl8psJgR6xwCkwqTFes0dNujbS2o/ITpvSYgIFsLsf13A==",
-          "dev": true,
           "requires": {
             "@types/minimatch": "^3.0.3",
             "ensure-posix-path": "^1.1.0",
@@ -1780,7 +1761,6 @@
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
           "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-          "dev": true,
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -1790,8 +1770,7 @@
     "@glimmer/di": {
       "version": "0.1.11",
       "resolved": "https://registry.npmjs.org/@glimmer/di/-/di-0.1.11.tgz",
-      "integrity": "sha1-poeMB6E6LCx2/N5ZilyXY3v8QoA=",
-      "dev": true
+      "integrity": "sha1-poeMB6E6LCx2/N5ZilyXY3v8QoA="
     },
     "@glimmer/env": {
       "version": "0.1.7",
@@ -1832,11 +1811,24 @@
         }
       }
     },
+    "@glimmer/tracking": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@glimmer/tracking/-/tracking-1.0.0.tgz",
+      "integrity": "sha512-OuF04ihYD/Rjvf++Rf7MzJVnawMSax/SZXEj4rlsQoMRwtQafgtkWjlFBcbBNQkJ3rev1zzfNN+3mdD2BFIaNg==",
+      "requires": {
+        "@glimmer/env": "^0.1.7",
+        "@glimmer/validator": "^0.44.0"
+      }
+    },
     "@glimmer/util": {
       "version": "0.44.0",
       "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.44.0.tgz",
-      "integrity": "sha512-duAsm30uVK9jSysElCbLyU6QQYO2X9iLDLBIBUcCqck9qN1o3tK2qWiHbGK5d6g8E2AJ4H88UrfElkyaJlGrwg==",
-      "dev": true
+      "integrity": "sha512-duAsm30uVK9jSysElCbLyU6QQYO2X9iLDLBIBUcCqck9qN1o3tK2qWiHbGK5d6g8E2AJ4H88UrfElkyaJlGrwg=="
+    },
+    "@glimmer/validator": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@glimmer/validator/-/validator-0.44.0.tgz",
+      "integrity": "sha512-i01plR0EgFVz69GDrEuFgq1NheIjZcyTy3c7q+w7d096ddPVeVcRzU3LKaqCfovvLJ+6lJx40j45ecycASUUyw=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
@@ -7561,8 +7553,7 @@
     "ember-cli-get-component-path-option": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ember-cli-get-component-path-option/-/ember-cli-get-component-path-option-1.0.0.tgz",
-      "integrity": "sha1-DXtZVVni+QUKvtgE8djv8bCLx3E=",
-      "dev": true
+      "integrity": "sha1-DXtZVVni+QUKvtgE8djv8bCLx3E="
     },
     "ember-cli-htmlbars": {
       "version": "4.2.3",
@@ -7688,8 +7679,7 @@
     "ember-cli-is-package-missing": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ember-cli-is-package-missing/-/ember-cli-is-package-missing-1.0.0.tgz",
-      "integrity": "sha1-bmGEyvuSY13ZPKbJRrEEKS1OM5A=",
-      "dev": true
+      "integrity": "sha1-bmGEyvuSY13ZPKbJRrEEKS1OM5A="
     },
     "ember-cli-less": {
       "version": "2.0.4",
@@ -7948,7 +7938,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ember-cli-normalize-entity-name/-/ember-cli-normalize-entity-name-1.0.0.tgz",
       "integrity": "sha1-CxT3vLxZmqEXtf3cgeT9A8S61bc=",
-      "dev": true,
       "requires": {
         "silent-error": "^1.0.0"
       }

--- a/packages/search/package-lock.json
+++ b/packages/search/package-lock.json
@@ -8538,6 +8538,68 @@
         "semver": "^5.4.1"
       }
     },
+    "ember-composable-helpers": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ember-composable-helpers/-/ember-composable-helpers-3.2.0.tgz",
+      "integrity": "sha512-OBnwpDkeOnDBMGQ/96B7TUy3e3wR1dqmAJ8+zDQTEjWrrCztKFg2dNGzCJchN1AD1i4FS4B/9iloAnn1pPWw8w==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.0.0",
+        "broccoli-funnel": "2.0.1",
+        "ember-cli-babel": "^7.1.0",
+        "resolve": "^1.10.0"
+      },
+      "dependencies": {
+        "broccoli-funnel": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.1.tgz",
+          "integrity": "sha512-C8Lnp9TVsSSiZMGEF16C0dCiNg2oJqUKwuZ1K4kVC6qRPG/2Cj/rtB5kRCC9qEbwqhX71bDbfHROx0L3J7zXQg==",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "fs-tree-diff": {
+          "version": "0.5.9",
+          "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz",
+          "integrity": "sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==",
+          "dev": true,
+          "requires": {
+            "heimdalljs-logger": "^0.1.7",
+            "object-assign": "^4.1.0",
+            "path-posix": "^1.0.0",
+            "symlink-or-copy": "^1.1.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
     "ember-concurrency": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/ember-concurrency/-/ember-concurrency-1.1.7.tgz",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -60,6 +60,7 @@
     "ember-cli-typescript-blueprints": "^3.0.0",
     "ember-cli-uglify": "^3.0.0",
     "ember-concurrency": "^1.1.5",
+    "ember-composable-helpers": "^3.1.1",
     "ember-concurrency-decorators": "^1.0.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.1",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -23,6 +23,8 @@
     "postpublish": "ember ts:clean"
   },
   "dependencies": {
+    "@glimmer/component": "^1.0.0",
+    "@glimmer/tracking": "^1.0.0",
     "ember-auto-import": "^1.5.3",
     "ember-cli-babel": "^7.17.2",
     "ember-cli-htmlbars": "^4.2.0",
@@ -37,7 +39,6 @@
   "devDependencies": {
     "@babel/preset-typescript": "^7.8.3",
     "@ember/optional-features": "^1.3.0",
-    "@glimmer/component": "^1.0.0",
     "@types/ember": "^3.1.2",
     "@types/ember-data": "^3.1.11",
     "@types/ember-qunit": "^3.4.8",

--- a/packages/search/tests/integration/components/navi-search-result/asset-test.js
+++ b/packages/search/tests/integration/components/navi-search-result/asset-test.js
@@ -101,7 +101,7 @@ module('Integration | Component | navi-search-result-asset', function(hooks) {
       'Show more button is shown.'
     );
     assert.deepEqual(
-      findAll('.navi-search-asset-result__item').map(result => result.textContent.trim()),
+      findAll('.navi-search-asset-result__item').map(el => el.textContent.trim()),
       ['Revenue report 1', 'Revenue Dashboard 1', 'Revenue report 2', 'Revenue Dashboard 2', 'Revenue report 3'],
       'Displayed correct search result.'
     );

--- a/packages/search/tests/integration/components/navi-search-result/asset-test.js
+++ b/packages/search/tests/integration/components/navi-search-result/asset-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click, find, findAll } from '@ember/test-helpers';
+import { render, click, findAll } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { set } from '@ember/object';
 
@@ -95,11 +95,7 @@ module('Integration | Component | navi-search-result-asset', function(hooks) {
     await render(hbs`<NaviSearchResult::Asset @data={{this.data}} @closeResults={{fn this.closeResults}} />`);
 
     assert.dom('.navi-search-asset-result').exists({ count: 5 }, '5 results are displayed');
-    assert.equal(
-      find('.navi-search-result-options__button').textContent.trim(),
-      'Show more',
-      'Show more button is shown.'
-    );
+    assert.dom('.navi-search-result-options__button').hasText('Show more', 'Show more button is shown.');
     assert.deepEqual(
       findAll('.navi-search-asset-result__item').map(el => el.textContent.trim()),
       ['Revenue report 1', 'Revenue Dashboard 1', 'Revenue report 2', 'Revenue Dashboard 2', 'Revenue report 3'],
@@ -109,11 +105,7 @@ module('Integration | Component | navi-search-result-asset', function(hooks) {
     await click('.navi-search-result-options__button');
 
     assert.dom('.navi-search-asset-result').exists({ count: 6 }, '6 results are displayed');
-    assert.equal(
-      find('.navi-search-result-options__button').textContent.trim(),
-      'Show less',
-      'Show less button is shown.'
-    );
+    assert.dom('.navi-search-result-options__button').hasText('Show less', 'Show less button is shown.');
     assert.deepEqual(
       findAll('.navi-search-asset-result__item').map(result => result.textContent.trim()),
       [
@@ -130,11 +122,7 @@ module('Integration | Component | navi-search-result-asset', function(hooks) {
     await click('.navi-search-result-options__button');
 
     assert.dom('.navi-search-asset-result').exists({ count: 5 }, '5 results are displayed');
-    assert.equal(
-      find('.navi-search-result-options__button').textContent.trim(),
-      'Show more',
-      'Show more button is shown.'
-    );
+    assert.dom('.navi-search-result-options__button').hasText('Show more', 'Show more button is shown.');
     assert.deepEqual(
       findAll('.navi-search-asset-result__item').map(result => result.textContent.trim()),
       ['Revenue report 1', 'Revenue Dashboard 1', 'Revenue report 2', 'Revenue Dashboard 2', 'Revenue report 3'],

--- a/packages/search/tests/integration/components/navi-search-result/asset-test.js
+++ b/packages/search/tests/integration/components/navi-search-result/asset-test.js
@@ -95,17 +95,17 @@ module('Integration | Component | navi-search-result-asset', function(hooks) {
     await render(hbs`<NaviSearchResult::Asset @data={{this.data}} @closeResults={{fn this.closeResults}} />`);
 
     assert.dom('.navi-search-asset-result').exists({ count: 5 }, '5 results are displayed');
-    assert.dom('.navi-search-result-options__button').hasText('Show more', 'Show more button is shown.');
+    assert.dom('.navi-search-result-options__show-button').hasText('Show more', 'Show more button is shown.');
     assert.deepEqual(
       findAll('.navi-search-asset-result__item').map(el => el.textContent.trim()),
       ['Revenue report 1', 'Revenue Dashboard 1', 'Revenue report 2', 'Revenue Dashboard 2', 'Revenue report 3'],
       'Displayed correct search result.'
     );
 
-    await click('.navi-search-result-options__button');
+    await click('.navi-search-result-options__show-button');
 
     assert.dom('.navi-search-asset-result').exists({ count: 6 }, '6 results are displayed');
-    assert.dom('.navi-search-result-options__button').hasText('Show less', 'Show less button is shown.');
+    assert.dom('.navi-search-result-options__show-button').hasText('Show less', 'Show less button is shown.');
     assert.deepEqual(
       findAll('.navi-search-asset-result__item').map(result => result.textContent.trim()),
       [
@@ -119,10 +119,10 @@ module('Integration | Component | navi-search-result-asset', function(hooks) {
       'Displayed correct search result.'
     );
 
-    await click('.navi-search-result-options__button');
+    await click('.navi-search-result-options__show-button');
 
     assert.dom('.navi-search-asset-result').exists({ count: 5 }, '5 results are displayed');
-    assert.dom('.navi-search-result-options__button').hasText('Show more', 'Show more button is shown.');
+    assert.dom('.navi-search-result-options__show-button').hasText('Show more', 'Show more button is shown.');
     assert.deepEqual(
       findAll('.navi-search-asset-result__item').map(result => result.textContent.trim()),
       ['Revenue report 1', 'Revenue Dashboard 1', 'Revenue report 2', 'Revenue Dashboard 2', 'Revenue report 3'],

--- a/packages/search/tests/integration/components/navi-search-result/asset-test.js
+++ b/packages/search/tests/integration/components/navi-search-result/asset-test.js
@@ -1,22 +1,14 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, findAll } from '@ember/test-helpers';
+import { render, click, find, findAll } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { set } from '@ember/object';
 
 module('Integration | Component | navi-search-result-asset', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
-    assert.expect(1);
-
-    await render(hbs`<NaviSearchResult::Asset />`);
-
-    assert.equal(this.element.textContent.trim(), '');
-  });
-
   test('displays results', async function(assert) {
-    assert.expect(2);
+    assert.expect(3);
 
     const data = [
       {
@@ -40,11 +32,112 @@ module('Integration | Component | navi-search-result-asset', function(hooks) {
     await render(hbs`<NaviSearchResult::Asset @data={{this.data}} @closeResults={{fn this.closeResults}} />`);
 
     assert.dom('.navi-search-asset-result').exists({ count: 2 }, '2 results are displayed');
-    let results = findAll('.navi-search-asset-result__item');
-    let expectedResults = ['Revenue report 1', 'Revenue Dashboard'];
     assert.deepEqual(
-      results.map(result => result.textContent.trim()),
-      expectedResults,
+      findAll('.navi-search-asset-result__item').map(result => result.textContent.trim()),
+      ['Revenue report 1', 'Revenue Dashboard'],
+      'Displayed correct search result.'
+    );
+    assert
+      .dom('.navi-search-defition-options__button')
+      .doesNotExist('Show more button is not displayed when there are few results');
+  });
+
+  test('show more results', async function(assert) {
+    assert.expect(9);
+
+    const data = [
+      {
+        title: 'Revenue report 1',
+        modelId: 7,
+        constructor: {
+          modelName: 'report'
+        }
+      },
+      {
+        title: 'Revenue Dashboard 1',
+        modelId: 4,
+        constructor: {
+          modelName: 'dashboard'
+        }
+      },
+      {
+        title: 'Revenue report 2',
+        modelId: 7,
+        constructor: {
+          modelName: 'report'
+        }
+      },
+      {
+        title: 'Revenue Dashboard 2',
+        modelId: 4,
+        constructor: {
+          modelName: 'dashboard'
+        }
+      },
+      {
+        title: 'Revenue report 3',
+        modelId: 7,
+        constructor: {
+          modelName: 'report'
+        }
+      },
+      {
+        title: 'Revenue Dashboard 3',
+        modelId: 4,
+        constructor: {
+          modelName: 'dashboard'
+        }
+      }
+    ];
+    set(this, 'data', data);
+    set(this, 'closeResults', () => undefined);
+
+    await render(hbs`<NaviSearchResult::Asset @data={{this.data}} @closeResults={{fn this.closeResults}} />`);
+
+    assert.dom('.navi-search-asset-result').exists({ count: 5 }, '5 results are displayed');
+    assert.equal(
+      find('.navi-search-result-options__button').textContent.trim(),
+      'Show more',
+      'Show more button is shown.'
+    );
+    assert.deepEqual(
+      findAll('.navi-search-asset-result__item').map(result => result.textContent.trim()),
+      ['Revenue report 1', 'Revenue Dashboard 1', 'Revenue report 2', 'Revenue Dashboard 2', 'Revenue report 3'],
+      'Displayed correct search result.'
+    );
+
+    await click('.navi-search-result-options__button');
+
+    assert.dom('.navi-search-asset-result').exists({ count: 6 }, '6 results are displayed');
+    assert.equal(
+      find('.navi-search-result-options__button').textContent.trim(),
+      'Show less',
+      'Show less button is shown.'
+    );
+    assert.deepEqual(
+      findAll('.navi-search-asset-result__item').map(result => result.textContent.trim()),
+      [
+        'Revenue report 1',
+        'Revenue Dashboard 1',
+        'Revenue report 2',
+        'Revenue Dashboard 2',
+        'Revenue report 3',
+        'Revenue Dashboard 3'
+      ],
+      'Displayed correct search result.'
+    );
+
+    await click('.navi-search-result-options__button');
+
+    assert.dom('.navi-search-asset-result').exists({ count: 5 }, '5 results are displayed');
+    assert.equal(
+      find('.navi-search-result-options__button').textContent.trim(),
+      'Show more',
+      'Show more button is shown.'
+    );
+    assert.deepEqual(
+      findAll('.navi-search-asset-result__item').map(result => result.textContent.trim()),
+      ['Revenue report 1', 'Revenue Dashboard 1', 'Revenue report 2', 'Revenue Dashboard 2', 'Revenue report 3'],
       'Displayed correct search result.'
     );
   });

--- a/packages/search/tests/integration/components/navi-search-result/definition-test.js
+++ b/packages/search/tests/integration/components/navi-search-result/definition-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, findAll } from '@ember/test-helpers';
+import { render, find, findAll, click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { set } from '@ember/object';
 import Service from '@ember/service';
@@ -133,5 +133,105 @@ module('Integration | Component | definition', function(hooks) {
 
     await render(hbs`<NaviSearchResult::Definition @data={{this.data}} />`);
     assert.dom('.navi-search-definition-result').doesNotExist('No results are displayed');
+  });
+
+  test('show more results', async function(assert) {
+    assert.expect(12);
+    const data = [
+      {
+        id: 'pageViews',
+        name: 'Page Views',
+        description: 'The number of views of a page.'
+      },
+      {
+        id: 'impressions',
+        name: 'Impressions',
+        description: 'Number of times a user saw the ad.'
+      },
+      {
+        id: 'revenue',
+        name: 'Revenue',
+        description: 'How much money were made.'
+      }
+    ];
+    set(this, 'data', data);
+
+    await render(hbs`<NaviSearchResult::Definition @data={{this.data}} />`);
+
+    assert.dom('.navi-search-definition-result').exists({ count: 2 }, 'Two results are displayed');
+    assert.equal(
+      find('.navi-search-definition-options__button').textContent.trim(),
+      'Show more',
+      'Show less button is shown.'
+    );
+
+    assert.deepEqual(
+      findAll('.navi-search-definition-result__item-name').map(el => el.textContent.trim()),
+      ['Page Views', 'Impressions'],
+      'definition titles are shown correctly'
+    );
+    assert.deepEqual(
+      findAll('.navi-search-definition-result__item-description').map(el => el.textContent.trim()),
+      ['The number of views of a page.', 'Number of times a user saw the ad.'],
+      'definition descriptions are shown correctly'
+    );
+
+    await click('.navi-search-definition-options__button');
+
+    assert.dom('.navi-search-definition-result').exists({ count: 3 }, 'Three results are displayed');
+    assert.equal(
+      find('.navi-search-definition-options__button').textContent.trim(),
+      'Show less',
+      'Show less button is shown.'
+    );
+
+    assert.deepEqual(
+      findAll('.navi-search-definition-result__item-name').map(el => el.textContent.trim()),
+      ['Page Views', 'Impressions', 'Revenue'],
+      'definition titles are shown correctly'
+    );
+    assert.deepEqual(
+      findAll('.navi-search-definition-result__item-description').map(el => el.textContent.trim()),
+      ['The number of views of a page.', 'Number of times a user saw the ad.', 'How much money were made.'],
+      'definition descriptions are shown correctly'
+    );
+
+    await click('.navi-search-definition-options__button');
+
+    assert.dom('.navi-search-definition-result').exists({ count: 2 }, 'Two results are displayed');
+    assert.equal(
+      find('.navi-search-definition-options__button').textContent.trim(),
+      'Show more',
+      'Show less button is shown.'
+    );
+
+    assert.deepEqual(
+      findAll('.navi-search-definition-result__item-name').map(el => el.textContent.trim()),
+      ['Page Views', 'Impressions'],
+      'definition titles are shown correctly'
+    );
+    assert.deepEqual(
+      findAll('.navi-search-definition-result__item-description').map(el => el.textContent.trim()),
+      ['The number of views of a page.', 'Number of times a user saw the ad.'],
+      'definition descriptions are shown correctly'
+    );
+  });
+
+  test('few returned results', async function(assert) {
+    assert.expect(2);
+    const data = [
+      {
+        id: 'pageViews',
+        name: 'Page Views',
+        description: 'The number of views of a page.'
+      }
+    ];
+    set(this, 'data', data);
+
+    await render(hbs`<NaviSearchResult::Definition @data={{this.data}} />`);
+    assert.dom('.navi-search-definition-result').exists({ count: 1 }, 'One results are displayed');
+    assert
+      .dom('.navi-search-defition-options__button')
+      .doesNotExist('Show more button is not displayed when there are few results');
   });
 });

--- a/packages/search/tests/integration/components/navi-search-result/definition-test.js
+++ b/packages/search/tests/integration/components/navi-search-result/definition-test.js
@@ -127,4 +127,19 @@ module('Integration | Component | definition', function(hooks) {
       'definitions sources are shown correctly'
     );
   });
+
+  test('result without a description', async function(assert) {
+    assert.expect(1);
+
+    const data = [
+      {
+        id: 'pageViews',
+        name: 'Page Views'
+      }
+    ];
+    set(this, 'data', data);
+
+    await render(hbs`<NaviSearchResult::Definition @data={{this.data}} />`);
+    assert.dom('.navi-search-definition-result').doesNotExist('No results are displayed');
+  });
 });

--- a/packages/search/tests/integration/components/navi-search-result/definition-test.js
+++ b/packages/search/tests/integration/components/navi-search-result/definition-test.js
@@ -16,14 +16,6 @@ module('Integration | Component | definition', function(hooks) {
     this.owner.register('service:bard-metadata', MetadataServiceStub);
   });
 
-  test('it renders', async function(assert) {
-    assert.expect(1);
-
-    await render(hbs`<NaviSearchResult::Definition />`);
-
-    assert.equal(this.element.textContent.trim(), '');
-  });
-
   test('displays results', async function(assert) {
     assert.expect(3);
 

--- a/packages/search/tests/integration/components/navi-search-result/definition-test.js
+++ b/packages/search/tests/integration/components/navi-search-result/definition-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, find, findAll, click } from '@ember/test-helpers';
+import { render, findAll, click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { set } from '@ember/object';
 import Service from '@ember/service';
@@ -135,6 +135,25 @@ module('Integration | Component | definition', function(hooks) {
     assert.dom('.navi-search-definition-result').doesNotExist('No results are displayed');
   });
 
+  test('result without a description in extended', async function(assert) {
+    assert.expect(1);
+
+    const data = [
+      {
+        id: 'pageViews',
+        name: 'Page Views',
+        extended: Promise.resolve({
+          id: 'pageViews',
+          name: 'Page Views'
+        })
+      }
+    ];
+    set(this, 'data', data);
+
+    await render(hbs`<NaviSearchResult::Definition @data={{this.data}} />`);
+    assert.dom('.navi-search-definition-result').doesNotExist('No results are displayed');
+  });
+
   test('show more results', async function(assert) {
     assert.expect(12);
     const data = [
@@ -159,11 +178,7 @@ module('Integration | Component | definition', function(hooks) {
     await render(hbs`<NaviSearchResult::Definition @data={{this.data}} />`);
 
     assert.dom('.navi-search-definition-result').exists({ count: 2 }, 'Two results are displayed');
-    assert.equal(
-      find('.navi-search-result-options__button').textContent.trim(),
-      'Show more',
-      'Show less button is shown.'
-    );
+    assert.dom('.navi-search-result-options__button').hasText('Show more', 'Show more button is shown.');
 
     assert.deepEqual(
       findAll('.navi-search-definition-result__item-name').map(el => el.textContent.trim()),
@@ -179,11 +194,7 @@ module('Integration | Component | definition', function(hooks) {
     await click('.navi-search-result-options__button');
 
     assert.dom('.navi-search-definition-result').exists({ count: 3 }, 'Three results are displayed');
-    assert.equal(
-      find('.navi-search-result-options__button').textContent.trim(),
-      'Show less',
-      'Show less button is shown.'
-    );
+    assert.dom('.navi-search-result-options__button').hasText('Show less', 'Show less button is shown.');
 
     assert.deepEqual(
       findAll('.navi-search-definition-result__item-name').map(el => el.textContent.trim()),
@@ -199,11 +210,7 @@ module('Integration | Component | definition', function(hooks) {
     await click('.navi-search-result-options__button');
 
     assert.dom('.navi-search-definition-result').exists({ count: 2 }, 'Two results are displayed');
-    assert.equal(
-      find('.navi-search-result-options__button').textContent.trim(),
-      'Show more',
-      'Show less button is shown.'
-    );
+    assert.dom('.navi-search-result-options__button').hasText('Show more', 'Show more button is shown.');
 
     assert.deepEqual(
       findAll('.navi-search-definition-result__item-name').map(el => el.textContent.trim()),

--- a/packages/search/tests/integration/components/navi-search-result/definition-test.js
+++ b/packages/search/tests/integration/components/navi-search-result/definition-test.js
@@ -178,7 +178,7 @@ module('Integration | Component | definition', function(hooks) {
     await render(hbs`<NaviSearchResult::Definition @data={{this.data}} />`);
 
     assert.dom('.navi-search-definition-result').exists({ count: 2 }, 'Two results are displayed');
-    assert.dom('.navi-search-result-options__button').hasText('Show more', 'Show more button is shown.');
+    assert.dom('.navi-search-result-options__show-button').hasText('Show more', 'Show more button is shown.');
 
     assert.deepEqual(
       findAll('.navi-search-definition-result__item-name').map(el => el.textContent.trim()),
@@ -191,10 +191,10 @@ module('Integration | Component | definition', function(hooks) {
       'definition descriptions are shown correctly'
     );
 
-    await click('.navi-search-result-options__button');
+    await click('.navi-search-result-options__show-button');
 
     assert.dom('.navi-search-definition-result').exists({ count: 3 }, 'Three results are displayed');
-    assert.dom('.navi-search-result-options__button').hasText('Show less', 'Show less button is shown.');
+    assert.dom('.navi-search-result-options__show-button').hasText('Show less', 'Show less button is shown.');
 
     assert.deepEqual(
       findAll('.navi-search-definition-result__item-name').map(el => el.textContent.trim()),
@@ -207,10 +207,10 @@ module('Integration | Component | definition', function(hooks) {
       'definition descriptions are shown correctly'
     );
 
-    await click('.navi-search-result-options__button');
+    await click('.navi-search-result-options__show-button');
 
     assert.dom('.navi-search-definition-result').exists({ count: 2 }, 'Two results are displayed');
-    assert.dom('.navi-search-result-options__button').hasText('Show more', 'Show more button is shown.');
+    assert.dom('.navi-search-result-options__show-button').hasText('Show more', 'Show more button is shown.');
 
     assert.deepEqual(
       findAll('.navi-search-definition-result__item-name').map(el => el.textContent.trim()),

--- a/packages/search/tests/integration/components/navi-search-result/definition-test.js
+++ b/packages/search/tests/integration/components/navi-search-result/definition-test.js
@@ -160,7 +160,7 @@ module('Integration | Component | definition', function(hooks) {
 
     assert.dom('.navi-search-definition-result').exists({ count: 2 }, 'Two results are displayed');
     assert.equal(
-      find('.navi-search-definition-options__button').textContent.trim(),
+      find('.navi-search-result-options__button').textContent.trim(),
       'Show more',
       'Show less button is shown.'
     );
@@ -176,11 +176,11 @@ module('Integration | Component | definition', function(hooks) {
       'definition descriptions are shown correctly'
     );
 
-    await click('.navi-search-definition-options__button');
+    await click('.navi-search-result-options__button');
 
     assert.dom('.navi-search-definition-result').exists({ count: 3 }, 'Three results are displayed');
     assert.equal(
-      find('.navi-search-definition-options__button').textContent.trim(),
+      find('.navi-search-result-options__button').textContent.trim(),
       'Show less',
       'Show less button is shown.'
     );
@@ -196,11 +196,11 @@ module('Integration | Component | definition', function(hooks) {
       'definition descriptions are shown correctly'
     );
 
-    await click('.navi-search-definition-options__button');
+    await click('.navi-search-result-options__button');
 
     assert.dom('.navi-search-definition-result').exists({ count: 2 }, 'Two results are displayed');
     assert.equal(
-      find('.navi-search-definition-options__button').textContent.trim(),
+      find('.navi-search-result-options__button').textContent.trim(),
       'Show more',
       'Show less button is shown.'
     );
@@ -229,7 +229,7 @@ module('Integration | Component | definition', function(hooks) {
     set(this, 'data', data);
 
     await render(hbs`<NaviSearchResult::Definition @data={{this.data}} />`);
-    assert.dom('.navi-search-definition-result').exists({ count: 1 }, 'One results are displayed');
+    assert.dom('.navi-search-definition-result').exists({ count: 1 }, 'One result is displayed');
     assert
       .dom('.navi-search-defition-options__button')
       .doesNotExist('Show more button is not displayed when there are few results');


### PR DESCRIPTION
Resolves #

<!-- The above line will close the issue upon merge -->

## Description
Show more results support for display components

## Proposed Changes

- Limit results returned by the provider
- Show more button for when you have a lot of results
- Only show definition result if it has a description property
- Typescript updates

## Screenshots
![ezgif-4-b48633de01fc](https://user-images.githubusercontent.com/1649445/81225173-6af8e780-8fae-11ea-92e8-c77a601b8cd5.gif)




## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
