### PR TITLE
Update: Column config - scroll to and highlight most recently added column

### DIFF
--- a/packages/dashboards/addon/templates/dashboards/dashboard/widgets/widget.hbs
+++ b/packages/dashboards/addon/templates/dashboards/dashboard/widgets/widget.hbs
@@ -121,9 +121,9 @@
           @lastAddedColumn={{this.lastAddedColumn}}
           @report={{this.model}}
           @openFilters={{route-action "openFilters"}}
-          @onRemoveTimeDimension={{queue (set this.lastAddedColumn null) (update-report-action "REMOVE_TIME_GRAIN")}}
-          @onRemoveDimension={{queue (set this.lastAddedColumn null) (update-report-action "REMOVE_DIMENSION_FRAGMENT")}}
-          @onRemoveMetric={{queue (set this.lastAddedColumn null) (update-report-action "REMOVE_METRIC_FRAGMENT")}}
+          @onRemoveTimeDimension={{queue (fn this.updateLastAddedColumn null) (update-report-action "REMOVE_TIME_GRAIN")}}
+          @onRemoveDimension={{queue (fn this.updateLastAddedColumn null) (update-report-action "REMOVE_DIMENSION_FRAGMENT")}}
+          @onRemoveMetric={{queue (fn this.updateLastAddedColumn null) (update-report-action "REMOVE_METRIC_FRAGMENT")}}
           @onAddDimension={{queue (fn this.updateLastAddedColumn "dimension") (update-report-action "ADD_DIMENSION")}}
           @onAddMetric={{queue (fn this.updateLastAddedColumn "metric") (update-report-action "ADD_METRIC")}}
           @onAddMetricWithParameter={{queue (fn this.updateLastAddedColumn "metric") (update-report-action "ADD_METRIC_WITH_PARAM")}}
@@ -191,7 +191,7 @@
         <button
           type="button"
           class="btn btn-secondary navi-report-widget__revert-btn"
-          onclick={{queue (set this.lastAddedColumn null) (route-action "revertChanges" @model)}}
+          onclick={{queue (fn this.updateLastAddedColumn null) (route-action "revertChanges" @model)}}
         >
           Revert Changes
         </button>

--- a/packages/dashboards/addon/templates/dashboards/dashboard/widgets/widget.hbs
+++ b/packages/dashboards/addon/templates/dashboards/dashboard/widgets/widget.hbs
@@ -111,21 +111,22 @@
       @disabled={{this.isRunningReport}}
       @isFiltersCollapsed={{this.isFiltersCollapsed}}
       @onUpdateFiltersCollapsed={{toggle "isFiltersCollapsed" this}}
-      @onBeforeAddItem={{fn this.updateColumnDrawerOpen true}}
+      @onBeforeAddItem={{this.onBeforeAddItem}}
       as |builder|
     >
       {{#if (feature-flag "enableRequestPreview")}}
         <NaviColumnConfig
           class="{{if this.isRunningReport "navi-column-config--disabled"}}"
           @isOpen={{this.isColumnDrawerOpen}}
+          @lastAddedColumn={{this.lastAddedColumn}}
           @report={{this.model}}
           @openFilters={{route-action "openFilters"}}
-          @onRemoveTimeDimension={{update-report-action "REMOVE_TIME_GRAIN"}}
-          @onRemoveDimension={{update-report-action "REMOVE_DIMENSION_FRAGMENT"}}
-          @onRemoveMetric={{update-report-action "REMOVE_METRIC_FRAGMENT"}}
-          @onAddDimension={{update-report-action "ADD_DIMENSION"}}
-          @onAddMetric={{update-report-action "ADD_METRIC"}}
-          @onAddMetricWithParameter={{update-report-action "ADD_METRIC_WITH_PARAM"}}
+          @onRemoveTimeDimension={{queue (set this.lastAddedColumn null) (update-report-action "REMOVE_TIME_GRAIN")}}
+          @onRemoveDimension={{queue (set this.lastAddedColumn null) (update-report-action "REMOVE_DIMENSION_FRAGMENT")}}
+          @onRemoveMetric={{queue (set this.lastAddedColumn null) (update-report-action "REMOVE_METRIC_FRAGMENT")}}
+          @onAddDimension={{queue (fn this.updateLastAddedColumn "dimension") (update-report-action "ADD_DIMENSION")}}
+          @onAddMetric={{queue (fn this.updateLastAddedColumn "metric") (update-report-action "ADD_METRIC")}}
+          @onAddMetricWithParameter={{queue (fn this.updateLastAddedColumn "metric") (update-report-action "ADD_METRIC_WITH_PARAM")}}
           @onToggleDimFilter={{update-report-action "TOGGLE_DIM_FILTER"}}
           @onToggleMetricFilter={{update-report-action "TOGGLE_METRIC_FILTER"}}
           @onToggleParameterizedMetricFilter={{update-report-action "TOGGLE_PARAMETERIZED_METRIC_FILTER"}}
@@ -190,7 +191,7 @@
         <button
           type="button"
           class="btn btn-secondary navi-report-widget__revert-btn"
-          onclick={{route-action "revertChanges" @model}}
+          onclick={{queue (set this.lastAddedColumn null) (route-action "revertChanges" @model)}}
         >
           Revert Changes
         </button>

--- a/packages/reports/addon/components/navi-column-config.js
+++ b/packages/reports/addon/components/navi-column-config.js
@@ -63,6 +63,7 @@ class NaviColumnConfig extends Component {
         name,
         displayName: this.getDisplayName(dimension, 'dimension', visualization),
         isFiltered: filteredDimensions.includes(name),
+        isRemovable: true,
         fragment: dimension
       };
     });
@@ -74,6 +75,7 @@ class NaviColumnConfig extends Component {
         name,
         displayName: this.getDisplayName(metric, 'metric', visualization),
         isFiltered: filteredMetrics.includes(name),
+        isRemovable: true,
         fragment: metric
       };
     });
@@ -86,6 +88,7 @@ class NaviColumnConfig extends Component {
         name: 'dateTime',
         displayName: this.getDisplayName(timeGrainObject, 'timeDimension', visualization),
         isFiltered: true,
+        isRemovable: timeGrains.find(grain => grain.id === 'all') ? true : false,
         fragment: 'dateTime',
         timeGrain,
         timeGrains: timeGrains.filter(grain => grain.id !== 'all')

--- a/packages/reports/addon/components/navi-column-config.js
+++ b/packages/reports/addon/components/navi-column-config.js
@@ -21,7 +21,7 @@
  */
 import Component from '@ember/component';
 import layout from '../templates/components/navi-column-config';
-import { action, computed } from '@ember/object';
+import { action, computed, set } from '@ember/object';
 import { capitalize } from '@ember/string';
 import move from 'ember-animated/motions/move';
 import { easeOut, easeIn } from 'ember-animated/easings/cosine';
@@ -210,11 +210,11 @@ class NaviColumnConfig extends Component {
    * @param {Object} column - contains type and name of column to remove from request
    */
   @action
-  removeColumn(column, { componentElement }) {
+  removeColumn(column) {
     const { type, fragment } = column;
     const removalHandler = this[`onRemove${capitalize(type)}`];
     if (removalHandler) {
-      componentElement.classList.add('navi-column-config-item--removing');
+      set(column, 'isRemoving', true);
       later(() => removalHandler(fragment), 200);
     }
   }

--- a/packages/reports/addon/components/navi-column-config.js
+++ b/packages/reports/addon/components/navi-column-config.js
@@ -106,13 +106,13 @@ class NaviColumnConfig extends Component {
     const { columns, lastAddedColumn } = this;
 
     if (lastAddedColumn) {
-      for (let i = columns.length - 1; i >= 0; i--) {
-        const column = columns[i];
-        const columnName = column.type === 'timeDimension' ? 'dateTime' : column.fragment[column.type].id;
-        if (column.type === lastAddedColumn.type && columnName === lastAddedColumn.name) {
-          return column;
-        }
-      }
+      return columns
+        .slice()
+        .reverse()
+        .find(column => {
+          const columnName = column.type === 'timeDimension' ? 'dateTime' : column.fragment[column.type].id;
+          return column.type === lastAddedColumn.type && columnName === lastAddedColumn.name;
+        });
     }
 
     return null;
@@ -219,10 +219,7 @@ class NaviColumnConfig extends Component {
   removeColumn(column) {
     const { type, fragment } = column;
     const removalHandler = this[`onRemove${capitalize(type)}`];
-    if (removalHandler) {
-      set(column, 'isRemoving', true);
-      later(() => removalHandler(fragment), 200);
-    }
+    removalHandler?.(fragment);
   }
 
   /**

--- a/packages/reports/addon/components/navi-column-config.js
+++ b/packages/reports/addon/components/navi-column-config.js
@@ -95,7 +95,10 @@ class NaviColumnConfig extends Component {
     return columns;
   }
 
-  @computed('columns', 'lastAddedColumn')
+  /**
+   * @property {Object} lastAddedItem - the column that has been added last
+   */
+  @computed('columns.[]', 'lastAddedColumn')
   get lastAddedItem() {
     const { columns, lastAddedColumn } = this;
 

--- a/packages/reports/addon/components/navi-column-config/item.js
+++ b/packages/reports/addon/components/navi-column-config/item.js
@@ -15,7 +15,7 @@ import { set, action } from '@ember/object';
 import { layout as templateLayout, tagName } from '@ember-decorators/component';
 import layout from '../../templates/components/navi-column-config/item';
 import { A as arr } from '@ember/array';
-import { debounce } from '@ember/runloop';
+import { debounce, next } from '@ember/runloop';
 
 @tagName('')
 @templateLayout(layout)
@@ -75,6 +75,13 @@ class NaviColumnConfigItemComponent extends Component {
   @action
   setupElement(element) {
     this.componentElement = element;
+
+    if (this.isLastAdded) {
+      set(this, 'isColumnConfigOpen', true);
+      next(() => {
+        element.parentElement.scrollTop = element.offsetTop - element.parentElement.offsetTop;
+      });
+    }
   }
 }
 

--- a/packages/reports/addon/components/navi-column-config/item.js
+++ b/packages/reports/addon/components/navi-column-config/item.js
@@ -78,9 +78,11 @@ class NaviColumnConfigItemComponent extends Component {
     this.componentElement = element;
 
     if (this.isLastAdded) {
-      set(this, 'isColumnConfigOpen', true);
+      if (this.column.type !== 'dimension') {
+        set(this, 'isColumnConfigOpen', true);
+      }
       next(() => {
-        element.parentElement.scrollTop = element.offsetTop - element.parentElement.offsetTop;
+        this.componentElement.scrollIntoView(true);
       });
     }
   }

--- a/packages/reports/addon/components/navi-column-config/item.js
+++ b/packages/reports/addon/components/navi-column-config/item.js
@@ -82,7 +82,7 @@ class NaviColumnConfigItemComponent extends Component {
         set(this, 'isColumnConfigOpen', true);
       }
       next(() => {
-        this.componentElement.scrollIntoView(true);
+        element.parentElement.scrollTop = element.offsetTop - element.parentElement.offsetTop;
       });
     }
   }

--- a/packages/reports/addon/components/navi-column-config/item.js
+++ b/packages/reports/addon/components/navi-column-config/item.js
@@ -69,7 +69,8 @@ class NaviColumnConfigItemComponent extends Component {
   }
 
   /**
-   * Stores element reference after render
+   * Stores element reference after render.
+   * If the column was just added, open the config and scroll to element
    * @param element - element inserted
    */
   @action

--- a/packages/reports/addon/controllers/reports/report.js
+++ b/packages/reports/addon/controllers/reports/report.js
@@ -37,7 +37,7 @@ export default class ReportsReportController extends Controller {
   modifiedRequest = null;
 
   /**
-   * @property {Object} lastAddedColumn
+   * @property {Object} lastAddedColumn - the column that has been added last
    */
   lastAddedColumn = null;
 
@@ -119,9 +119,27 @@ export default class ReportsReportController extends Controller {
     }
   }
 
+  /**
+   * Updates the last added column
+   * @param {String} type - the added column type
+   * @param {Object} fragment - the added request fragment
+   * @param {String} fragment.id - fragment id
+   */
   @action
-  updateLastAddedColumn(reportBuilder, type, { id }) {
+  updateLastAddedColumn(type, { id }) {
     set(this, 'lastAddedColumn', { type, name: type === 'timeDimension' ? 'dateTime' : id });
+  }
+
+  /**
+   * Opens the column config drawer and updates the last added column
+   * @param {ReportBuilderComponent} reportBuilder - The report builder component
+   * @param {String} columnType - the added column type
+   * @param {Object} fragment - the added request fragment
+   */
+  @action
+  onBeforeAddItem(reportBuilder, columnType, fragment) {
+    this.send('updateColumnDrawerOpen', true, reportBuilder);
+    this.send('updateLastAddedColumn', columnType, fragment);
   }
 
   /**

--- a/packages/reports/addon/controllers/reports/report.js
+++ b/packages/reports/addon/controllers/reports/report.js
@@ -37,6 +37,11 @@ export default class ReportsReportController extends Controller {
   modifiedRequest = null;
 
   /**
+   * @property {Object} lastAddedColumn
+   */
+  lastAddedColumn = null;
+
+  /**
    * @property {String} reportState - state of the the report
    */
   get reportState() {
@@ -99,6 +104,10 @@ export default class ReportsReportController extends Controller {
     const { isColumnDrawerOpen } = this;
     set(this, 'isColumnDrawerOpen', isOpen);
 
+    if (!isOpen) {
+      set(this, 'lastAddedColumn', null);
+    }
+
     if (isOpen !== isColumnDrawerOpen) {
       const visualizationElement = reportBuilder.element.querySelector('.report-view');
       if (visualizationElement) {
@@ -108,6 +117,11 @@ export default class ReportsReportController extends Controller {
         this.onFadeEnd = null;
       }
     }
+  }
+
+  @action
+  updateLastAddedColumn(reportBuilder, type, { id }) {
+    set(this, 'lastAddedColumn', { type, name: type === 'timeDimension' ? 'dateTime' : id });
   }
 
   /**

--- a/packages/reports/addon/controllers/reports/report.js
+++ b/packages/reports/addon/controllers/reports/report.js
@@ -123,11 +123,10 @@ export default class ReportsReportController extends Controller {
    * Updates the last added column
    * @param {String} type - the added column type
    * @param {Object} fragment - the added request fragment
-   * @param {String} fragment.id - fragment id
    */
   @action
-  updateLastAddedColumn(type, { id }) {
-    set(this, 'lastAddedColumn', { type, name: type === 'timeDimension' ? 'dateTime' : id });
+  updateLastAddedColumn(type, fragment) {
+    set(this, 'lastAddedColumn', !type ? null : { type, name: type === 'timeDimension' ? 'dateTime' : fragment.id });
   }
 
   /**
@@ -138,8 +137,8 @@ export default class ReportsReportController extends Controller {
    */
   @action
   onBeforeAddItem(reportBuilder, columnType, fragment) {
-    this.send('updateColumnDrawerOpen', true, reportBuilder);
-    this.send('updateLastAddedColumn', columnType, fragment);
+    this.updateColumnDrawerOpen(true, reportBuilder);
+    this.updateLastAddedColumn(columnType, fragment);
   }
 
   /**

--- a/packages/reports/addon/routes/reports/report.js
+++ b/packages/reports/addon/routes/reports/report.js
@@ -76,7 +76,8 @@ export default Route.extend({
     controller.setProperties({
       showSaveAs: false,
       isFiltersCollapsed: false,
-      modifiedRequest: null
+      modifiedRequest: null,
+      lastAddedColumn: null
     });
   },
 

--- a/packages/reports/addon/templates/components/dimension-selector.hbs
+++ b/packages/reports/addon/templates/components/dimension-selector.hbs
@@ -5,7 +5,7 @@
   @selected={{this.selectedColumnsAndFilters}}
   @title="Dimensions"
   @contentClass="navi-list-selector__content--dimension"
-  class="{{if (feature-flag "enableRequestPreview") "navi-list-selector__request_preview"}}"
+  class="{{if (feature-flag "enableRequestPreview") "navi-list-selector--request-preview"}}"
   as | items areItemsFiltered |
 >
   <GroupedList

--- a/packages/reports/addon/templates/components/metric-selector.hbs
+++ b/packages/reports/addon/templates/components/metric-selector.hbs
@@ -42,7 +42,7 @@
             <MetricConfig
               @metric={{metric}}
               @request={{@request}}
-              @onAddParameterizedMetric={{update-report-action "ADD_METRIC_WITH_PARAM"}}
+              @onAddParameterizedMetric={{@onAddMetricWithParameter}}
               @onRemoveParameterizedMetric={{update-report-action "REMOVE_METRIC_WITH_PARAM"}}
               @onToggleParameterizedMetricFilter={{queue (update-report-action "TOGGLE_PARAMETERIZED_METRIC_FILTER") (action (optional @onToggleParameterizedMetricFilter))}}
             />

--- a/packages/reports/addon/templates/components/metric-selector.hbs
+++ b/packages/reports/addon/templates/components/metric-selector.hbs
@@ -6,7 +6,7 @@
     @selected={{this.selectedMetrics}}
     @title="Metrics"
     @contentClass="navi-list-selector__content--metric"
-    class="{{if (feature-flag "enableRequestPreview") "navi-list-selector__request_preview"}}"
+    class="{{if (feature-flag "enableRequestPreview") "navi-list-selector--request-preview"}}"
     as | metrics areMetricsFiltered |
   >
     <GroupedList

--- a/packages/reports/addon/templates/components/navi-column-config.hbs
+++ b/packages/reports/addon/templates/components/navi-column-config.hbs
@@ -1,18 +1,19 @@
 {{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 <AnimatedContainer class="navi-column-config" ...attributes {{did-insert this.setupElement}}>
-  {{#animated-if @isOpen use=this.drawerTransition duration=200 }}
+  {{#animated-if @isOpen use=this.drawerTransition duration=200}}
     <div class="navi-column-config__panel">
       <h3 class="navi-column-config__title">Columns</h3>
       <ul class="navi-column-config__columns">
-        {{#animated-each items=this.columns use=this.transition key="fragment" duration=200 as |column|}}
+        {{#each this.columns key="fragment" as |column|}}
           <NaviColumnConfig::Item
             @column={{column}}
+            @isLastAdded={{eq column this.lastAddedItem}}
             @visualization={{@report.visualization}}
             @onRemoveColumn={{fn this.removeColumn column}}
             @cloneColumn={{fn this.cloneColumn column}}
             @toggleColumnFilter={{fn this.toggleColumnFilter column}}
           />
-        {{/animated-each}}
+        {{/each}}
       </ul>
     </div>
   {{/animated-if}}

--- a/packages/reports/addon/templates/components/navi-column-config/item.hbs
+++ b/packages/reports/addon/templates/components/navi-column-config/item.hbs
@@ -6,42 +6,38 @@
   ...attributes
   {{did-insert this.setupElement}}
 >
-  <AnimatedContainer>
-    {{#animated-if (not @column.isRemoving) use=fade}}
-      <div class="navi-column-config-item__header">
-        <button
-          type="button"
-          aria-label="delete {{dasherize @column.type}} {{@column.displayName}}"
-          class="navi-column-config-item__remove-icon {{unless @column.isRemovable "navi-column-config-item__remove-icon--disabled"}}"
-          disabled={{not @column.isRemovable}}
-          {{on "click" @onRemoveColumn}}>
-          <NaviIcon @icon="minus-circle" />
-        </button>
+  <div class="navi-column-config-item__header">
+    <button
+      type="button"
+      aria-label="delete {{dasherize @column.type}} {{@column.displayName}}"
+      class="navi-column-config-item__remove-icon {{unless @column.isRemovable "navi-column-config-item__remove-icon--disabled"}}"
+      disabled={{not @column.isRemovable}}
+      {{on "click" @onRemoveColumn}}>
+      <NaviIcon @icon="minus-circle" />
+    </button>
 
-        <span class="navi-column-config-item__type-icon"></span>
+    <span class="navi-column-config-item__type-icon"></span>
 
-        <button
-          class="navi-column-config-item__trigger"
-          type="button"
-          {{on "click" (toggle "isColumnConfigOpen" this)}}
-        >
-          <span title="{{@column.displayName}}" class="navi-column-config-item__name">{{@column.displayName}}</span>
-          <NaviIcon
-            class="navi-column-config-item__dropdown-icon"
-            @icon="angle-right"
-          />
-        </button>
-      </div>
+    <button
+      class="navi-column-config-item__trigger"
+      type="button"
+      {{on "click" (toggle "isColumnConfigOpen" this)}}
+    >
+      <span title="{{@column.displayName}}" class="navi-column-config-item__name">{{@column.displayName}}</span>
+      <NaviIcon
+        class="navi-column-config-item__dropdown-icon"
+        @icon="angle-right"
+      />
+    </button>
+  </div>
 
-      {{#if this.isColumnConfigOpen}}
-        <NaviColumnConfig::Base
-          @column={{@column}}
-          @metadata={{@visualization.metadata}}
-          @cloneColumn={{@cloneColumn}}
-          @toggleColumnFilter={{@toggleColumnFilter}}
-          @onUpdateColumnName={{this.updateColumnName}}
-        />
-      {{/if}}
-    {{/animated-if}}
-  </AnimatedContainer>
+  {{#if this.isColumnConfigOpen}}
+    <NaviColumnConfig::Base
+      @column={{@column}}
+      @metadata={{@visualization.metadata}}
+      @cloneColumn={{@cloneColumn}}
+      @toggleColumnFilter={{@toggleColumnFilter}}
+      @onUpdateColumnName={{this.updateColumnName}}
+    />
+  {{/if}}
 </li>

--- a/packages/reports/addon/templates/components/navi-column-config/item.hbs
+++ b/packages/reports/addon/templates/components/navi-column-config/item.hbs
@@ -1,6 +1,6 @@
 {{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 <li
-  class="navi-column-config-item navi-column-config-item--{{dasherize @column.type}} {{if this.isColumnConfigOpen "navi-column-config-item--open"}}"
+  class="navi-column-config-item navi-column-config-item--{{dasherize @column.type}} {{if this.isColumnConfigOpen "navi-column-config-item--open"}} {{if @isLastAdded "navi-column-config-item--last-added"}}"
   ...attributes
   {{did-insert this.setupElement}}
 >
@@ -9,7 +9,7 @@
       type="button"
       aria-label="delete {{dasherize @column.type}} {{@column.displayName}}"
       class="navi-column-config-item__remove-icon"
-      {{on "click" @onRemoveColumn}}>
+      {{on "click" (fn @onRemoveColumn this)}}>
       <NaviIcon @icon="minus-circle" />
     </button>
 

--- a/packages/reports/addon/templates/components/navi-column-config/item.hbs
+++ b/packages/reports/addon/templates/components/navi-column-config/item.hbs
@@ -1,40 +1,46 @@
 {{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 <li
-  class="navi-column-config-item navi-column-config-item--{{dasherize @column.type}} {{if this.isColumnConfigOpen "navi-column-config-item--open"}} {{if @isLastAdded "navi-column-config-item--last-added"}}"
+  class="navi-column-config-item navi-column-config-item--{{dasherize @column.type}}
+    {{if this.isColumnConfigOpen "navi-column-config-item--open"}}
+    {{if @isLastAdded "navi-column-config-item--last-added"}}"
   ...attributes
   {{did-insert this.setupElement}}
 >
-  <div class="navi-column-config-item__header">
-    <button
-      type="button"
-      aria-label="delete {{dasherize @column.type}} {{@column.displayName}}"
-      class="navi-column-config-item__remove-icon"
-      {{on "click" (fn @onRemoveColumn this)}}>
-      <NaviIcon @icon="minus-circle" />
-    </button>
+  <AnimatedContainer>
+    {{#animated-if (not @column.isRemoving) use=fade}}
+      <div class="navi-column-config-item__header">
+        <button
+          type="button"
+          aria-label="delete {{dasherize @column.type}} {{@column.displayName}}"
+          class="navi-column-config-item__remove-icon"
+          {{on "click" @onRemoveColumn}}>
+          <NaviIcon @icon="minus-circle" />
+        </button>
 
-    <span class="navi-column-config-item__type-icon"></span>
+        <span class="navi-column-config-item__type-icon"></span>
 
-    <button
-      class="navi-column-config-item__trigger"
-      type="button"
-      {{on "click" (toggle "isColumnConfigOpen" this)}}
-    >
-      <span title="{{@column.displayName}}" class="navi-column-config-item__name">{{@column.displayName}}</span>
-      <NaviIcon
-        class="navi-column-config-item__dropdown-icon"
-        @icon="angle-right"
-      />
-    </button>
-  </div>
+        <button
+          class="navi-column-config-item__trigger"
+          type="button"
+          {{on "click" (toggle "isColumnConfigOpen" this)}}
+        >
+          <span title="{{@column.displayName}}" class="navi-column-config-item__name">{{@column.displayName}}</span>
+          <NaviIcon
+            class="navi-column-config-item__dropdown-icon"
+            @icon="angle-right"
+          />
+        </button>
+      </div>
 
-  {{#if this.isColumnConfigOpen}}
-    <NaviColumnConfig::Base
-      @column={{@column}}
-      @metadata={{@visualization.metadata}}
-      @cloneColumn={{@cloneColumn}}
-      @toggleColumnFilter={{@toggleColumnFilter}}
-      @onUpdateColumnName={{this.updateColumnName}}
-    />
-  {{/if}}
+      {{#if this.isColumnConfigOpen}}
+        <NaviColumnConfig::Base
+          @column={{@column}}
+          @metadata={{@visualization.metadata}}
+          @cloneColumn={{@cloneColumn}}
+          @toggleColumnFilter={{@toggleColumnFilter}}
+          @onUpdateColumnName={{this.updateColumnName}}
+        />
+      {{/if}}
+    {{/animated-if}}
+  </AnimatedContainer>
 </li>

--- a/packages/reports/addon/templates/components/navi-column-config/item.hbs
+++ b/packages/reports/addon/templates/components/navi-column-config/item.hbs
@@ -12,7 +12,8 @@
         <button
           type="button"
           aria-label="delete {{dasherize @column.type}} {{@column.displayName}}"
-          class="navi-column-config-item__remove-icon"
+          class="navi-column-config-item__remove-icon {{unless @column.isRemovable "navi-column-config-item__remove-icon--disabled"}}"
+          disabled={{not @column.isRemovable}}
           {{on "click" @onRemoveColumn}}>
           <NaviIcon @icon="minus-circle" />
         </button>

--- a/packages/reports/addon/templates/components/report-builder.hbs
+++ b/packages/reports/addon/templates/components/report-builder.hbs
@@ -13,8 +13,8 @@
       <DimensionSelector
         class="report-builder__container report-builder__dimension-selector{{if @disabled " report-builder__container--disabled"}}"
         @request={{this.request}}
-        @onAddTimeGrain={{queue (fn (optional @onBeforeAddItem) this) (update-report-action "ADD_TIME_GRAIN")}}
-        @onAddDimension={{queue (fn (optional @onBeforeAddItem) this) (update-report-action "ADD_DIMENSION")}}
+        @onAddTimeGrain={{queue (fn @onBeforeAddItem this "timeDimension") (update-report-action "ADD_TIME_GRAIN")}}
+        @onAddDimension={{queue (fn @onBeforeAddItem this "dimension") (update-report-action "ADD_DIMENSION")}}
         @onRemoveTimeGrain={{update-report-action "REMOVE_TIME_GRAIN"}}
         @onRemoveDimension={{update-report-action "REMOVE_DIMENSION"}}
         @onToggleDimFilter={{queue (update-report-action "TOGGLE_DIM_FILTER") (action "onToggleDimFilter")}}
@@ -22,8 +22,8 @@
       <MetricSelector
         class="report-builder__container report-builder__metric-selector{{if @disabled " report-builder__container--disabled"}}"
         @request={{this.request}}
-        @onAddMetric={{queue (fn (optional @onBeforeAddItem) this) (update-report-action "ADD_METRIC")}}
-        @onAddMetricWithParameter={{queue (fn (optional @onBeforeAddItem) this) (update-report-action "ADD_METRIC_WITH_PARAM")}}
+        @onAddMetric={{queue (fn @onBeforeAddItem this "metric") (update-report-action "ADD_METRIC")}}
+        @onAddMetricWithParameter={{queue (fn @onBeforeAddItem this "metric") (update-report-action "ADD_METRIC_WITH_PARAM")}}
         @onRemoveMetric={{update-report-action "REMOVE_METRIC"}}
         @onToggleMetricFilter={{queue (update-report-action "TOGGLE_METRIC_FILTER") (action "onToggleMetricFilter")}}
         @onToggleParameterizedMetricFilter={{action "onToggleParameterizedMetricFilter"}}

--- a/packages/reports/addon/templates/components/report-builder.hbs
+++ b/packages/reports/addon/templates/components/report-builder.hbs
@@ -13,8 +13,8 @@
       <DimensionSelector
         class="report-builder__container report-builder__dimension-selector{{if @disabled " report-builder__container--disabled"}}"
         @request={{this.request}}
-        @onAddTimeGrain={{queue (fn @onBeforeAddItem this "timeDimension") (update-report-action "ADD_TIME_GRAIN")}}
-        @onAddDimension={{queue (fn @onBeforeAddItem this "dimension") (update-report-action "ADD_DIMENSION")}}
+        @onAddTimeGrain={{queue (fn (optional @onBeforeAddItem) this "timeDimension") (update-report-action "ADD_TIME_GRAIN")}}
+        @onAddDimension={{queue (fn (optional @onBeforeAddItem) this "dimension") (update-report-action "ADD_DIMENSION")}}
         @onRemoveTimeGrain={{update-report-action "REMOVE_TIME_GRAIN"}}
         @onRemoveDimension={{update-report-action "REMOVE_DIMENSION"}}
         @onToggleDimFilter={{queue (update-report-action "TOGGLE_DIM_FILTER") (action "onToggleDimFilter")}}
@@ -22,8 +22,8 @@
       <MetricSelector
         class="report-builder__container report-builder__metric-selector{{if @disabled " report-builder__container--disabled"}}"
         @request={{this.request}}
-        @onAddMetric={{queue (fn @onBeforeAddItem this "metric") (update-report-action "ADD_METRIC")}}
-        @onAddMetricWithParameter={{queue (fn @onBeforeAddItem this "metric") (update-report-action "ADD_METRIC_WITH_PARAM")}}
+        @onAddMetric={{queue (fn (optional @onBeforeAddItem) this "metric") (update-report-action "ADD_METRIC")}}
+        @onAddMetricWithParameter={{queue (fn (optional @onBeforeAddItem) this "metric") (update-report-action "ADD_METRIC_WITH_PARAM")}}
         @onRemoveMetric={{update-report-action "REMOVE_METRIC"}}
         @onToggleMetricFilter={{queue (update-report-action "TOGGLE_METRIC_FILTER") (action "onToggleMetricFilter")}}
         @onToggleParameterizedMetricFilter={{action "onToggleParameterizedMetricFilter"}}

--- a/packages/reports/addon/templates/components/report-builder.hbs
+++ b/packages/reports/addon/templates/components/report-builder.hbs
@@ -1,5 +1,5 @@
 {{!-- Copyright 2019, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
-<div class="report-builder__side">
+<div class="report-builder__side {{if (feature-flag "enableRequestPreview") "report-builder__side--request-preview"}}">
   {{#if (or (gt allTables.length 1) (not hasValidLogicalTable))}}
     <NaviTableSelect
       class={{concat "report-builder__container report-builder__container--table" (if disabled " report-builder__container--disabled" "")}}

--- a/packages/reports/addon/templates/reports/report.hbs
+++ b/packages/reports/addon/templates/reports/report.hbs
@@ -42,7 +42,7 @@
       @disabled={{this.isRunningReport}}
       @isFiltersCollapsed={{this.isFiltersCollapsed}}
       @onUpdateFiltersCollapsed={{set this.isFiltersCollapsed _}}
-      @onBeforeAddItem={{queue (fn this.updateColumnDrawerOpen true) this.updateLastAddedColumn}}
+      @onBeforeAddItem={{this.onBeforeAddItem}}
       as |builder|
     >
       {{#if (feature-flag "enableRequestPreview")}}
@@ -55,9 +55,9 @@
           @onRemoveTimeDimension={{queue (set this.lastAddedColumn null) (update-report-action "REMOVE_TIME_GRAIN")}}
           @onRemoveDimension={{queue (set this.lastAddedColumn null) (update-report-action "REMOVE_DIMENSION_FRAGMENT")}}
           @onRemoveMetric={{queue (set this.lastAddedColumn null) (update-report-action "REMOVE_METRIC_FRAGMENT")}}
-          @onAddDimension={{queue (fn this.updateLastAddedColumn builder "dimension") (update-report-action "ADD_DIMENSION")}}
-          @onAddMetric={{queue (fn this.updateLastAddedColumn builder "metric") (update-report-action "ADD_METRIC")}}
-          @onAddMetricWithParameter={{queue (fn this.updateLastAddedColumn builder "metric") (update-report-action "ADD_METRIC_WITH_PARAM")}}
+          @onAddDimension={{queue (fn this.updateLastAddedColumn "dimension") (update-report-action "ADD_DIMENSION")}}
+          @onAddMetric={{queue (fn this.updateLastAddedColumn "metric") (update-report-action "ADD_METRIC")}}
+          @onAddMetricWithParameter={{queue (fn this.updateLastAddedColumn "metric") (update-report-action "ADD_METRIC_WITH_PARAM")}}
           @onToggleDimFilter={{update-report-action "TOGGLE_DIM_FILTER"}}
           @onToggleMetricFilter={{update-report-action "TOGGLE_METRIC_FILTER"}}
           @onToggleParameterizedMetricFilter={{update-report-action "TOGGLE_PARAMETERIZED_METRIC_FILTER"}}

--- a/packages/reports/addon/templates/reports/report.hbs
+++ b/packages/reports/addon/templates/reports/report.hbs
@@ -52,9 +52,9 @@
           @lastAddedColumn={{this.lastAddedColumn}}
           @report={{this.model}}
           @openFilters={{route-action "openFilters"}}
-          @onRemoveTimeDimension={{queue (set this.lastAddedColumn null) (update-report-action "REMOVE_TIME_GRAIN")}}
-          @onRemoveDimension={{queue (set this.lastAddedColumn null) (update-report-action "REMOVE_DIMENSION_FRAGMENT")}}
-          @onRemoveMetric={{queue (set this.lastAddedColumn null) (update-report-action "REMOVE_METRIC_FRAGMENT")}}
+          @onRemoveTimeDimension={{queue (fn this.updateLastAddedColumn null) (update-report-action "REMOVE_TIME_GRAIN")}}
+          @onRemoveDimension={{queue (fn this.updateLastAddedColumn null) (update-report-action "REMOVE_DIMENSION_FRAGMENT")}}
+          @onRemoveMetric={{queue (fn this.updateLastAddedColumn null) (update-report-action "REMOVE_METRIC_FRAGMENT")}}
           @onAddDimension={{queue (fn this.updateLastAddedColumn "dimension") (update-report-action "ADD_DIMENSION")}}
           @onAddMetric={{queue (fn this.updateLastAddedColumn "metric") (update-report-action "ADD_METRIC")}}
           @onAddMetricWithParameter={{queue (fn this.updateLastAddedColumn "metric") (update-report-action "ADD_METRIC_WITH_PARAM")}}
@@ -125,7 +125,7 @@
         <NaviButton
           class="navi-report__revert-btn"
           @type="secondary"
-          @onClick={{queue (set this.lastAddedColumn null) (route-action "revertChanges" model)}}
+          @onClick={{queue (fn this.updateLastAddedColumn null) (route-action "revertChanges" model)}}
         >
           Revert
         </NaviButton>

--- a/packages/reports/addon/templates/reports/report.hbs
+++ b/packages/reports/addon/templates/reports/report.hbs
@@ -42,21 +42,22 @@
       @disabled={{this.isRunningReport}}
       @isFiltersCollapsed={{this.isFiltersCollapsed}}
       @onUpdateFiltersCollapsed={{set this.isFiltersCollapsed _}}
-      @onBeforeAddItem={{fn this.updateColumnDrawerOpen true}}
+      @onBeforeAddItem={{queue (fn this.updateColumnDrawerOpen true) this.updateLastAddedColumn}}
       as |builder|
     >
       {{#if (feature-flag "enableRequestPreview")}}
         <NaviColumnConfig
           class="{{if this.isRunningReport "navi-column-config--disabled"}}"
           @isOpen={{this.isColumnDrawerOpen}}
+          @lastAddedColumn={{this.lastAddedColumn}}
           @report={{this.model}}
           @openFilters={{route-action "openFilters"}}
-          @onRemoveTimeDimension={{update-report-action "REMOVE_TIME_GRAIN"}}
-          @onRemoveDimension={{update-report-action "REMOVE_DIMENSION_FRAGMENT"}}
-          @onRemoveMetric={{update-report-action "REMOVE_METRIC_FRAGMENT"}}
-          @onAddDimension={{update-report-action "ADD_DIMENSION"}}
-          @onAddMetric={{update-report-action "ADD_METRIC"}}
-          @onAddMetricWithParameter={{update-report-action "ADD_METRIC_WITH_PARAM"}}
+          @onRemoveTimeDimension={{queue (set this.lastAddedColumn null) (update-report-action "REMOVE_TIME_GRAIN")}}
+          @onRemoveDimension={{queue (set this.lastAddedColumn null) (update-report-action "REMOVE_DIMENSION_FRAGMENT")}}
+          @onRemoveMetric={{queue (set this.lastAddedColumn null) (update-report-action "REMOVE_METRIC_FRAGMENT")}}
+          @onAddDimension={{queue (fn this.updateLastAddedColumn builder "dimension") (update-report-action "ADD_DIMENSION")}}
+          @onAddMetric={{queue (fn this.updateLastAddedColumn builder "metric") (update-report-action "ADD_METRIC")}}
+          @onAddMetricWithParameter={{queue (fn this.updateLastAddedColumn builder "metric") (update-report-action "ADD_METRIC_WITH_PARAM")}}
           @onToggleDimFilter={{update-report-action "TOGGLE_DIM_FILTER"}}
           @onToggleMetricFilter={{update-report-action "TOGGLE_METRIC_FILTER"}}
           @onToggleParameterizedMetricFilter={{update-report-action "TOGGLE_PARAMETERIZED_METRIC_FILTER"}}
@@ -124,7 +125,7 @@
         <NaviButton
           class="navi-report__revert-btn"
           @type="secondary"
-          @onClick={{route-action "revertChanges" model}}
+          @onClick={{queue (set this.lastAddedColumn null) (route-action "revertChanges" model)}}
         >
           Revert
         </NaviButton>

--- a/packages/reports/app/styles/navi-reports/components/navi-column-config.less
+++ b/packages/reports/app/styles/navi-reports/components/navi-column-config.less
@@ -43,6 +43,7 @@
   &__columns {
     flex: 1;
     overflow-y: auto;
+    scroll-behavior: smooth;
   }
 
   &--disabled {

--- a/packages/reports/app/styles/navi-reports/components/navi-column-config.less
+++ b/packages/reports/app/styles/navi-reports/components/navi-column-config.less
@@ -43,6 +43,7 @@
   &__columns {
     flex: 1;
     overflow-y: auto;
+    padding-bottom: 100px;
     scroll-behavior: smooth;
   }
 

--- a/packages/reports/app/styles/navi-reports/components/navi-column-config/item.less
+++ b/packages/reports/app/styles/navi-reports/components/navi-column-config/item.less
@@ -124,32 +124,17 @@
   }
 
   @keyframes navi-column-config-item-pulse-once {
-    0% {
+    0%,
+    100% {
       background-color: @navi-white;
     }
     50% {
       background-color: @denali-brand-200;
     }
-    100% {
-      background-color: @navi-white;
-    }
   }
 
   &--last-added {
     animation: navi-column-config-item-pulse-once 0.75s;
-  }
-
-  @keyframes navi-column-config-item-fade-out {
-    0% {
-      opacity: 1;
-    }
-    100% {
-      opacity: 0;
-    }
-  }
-
-  &--removing {
-    animation: navi-column-config-item-fade-out 0.3s;
   }
 
   &__parameter {

--- a/packages/reports/app/styles/navi-reports/components/navi-column-config/item.less
+++ b/packages/reports/app/styles/navi-reports/components/navi-column-config/item.less
@@ -123,6 +123,35 @@
     }
   }
 
+  @keyframes navi-column-config-item-pulse-once {
+    0% {
+      background-color: @navi-white;
+    }
+    50% {
+      background-color: @denali-brand-200;
+    }
+    100% {
+      background-color: @navi-white;
+    }
+  }
+
+  &--last-added {
+    animation: navi-column-config-item-pulse-once 0.75s;
+  }
+
+  @keyframes navi-column-config-item-fade-out {
+    0% {
+      opacity: 1;
+    }
+    100% {
+      opacity: 0;
+    }
+  }
+
+  &--removing {
+    animation: navi-column-config-item-fade-out 0.3s;
+  }
+
   &__parameter {
     &-trigger {
       &,

--- a/packages/reports/app/styles/navi-reports/components/report-builder.less
+++ b/packages/reports/app/styles/navi-reports/components/report-builder.less
@@ -140,7 +140,7 @@
     min-height: 0;
     overflow: hidden;
 
-    .navi-list-selector__request_preview .navi-list-selector__title::after {
+    .navi-list-selector--request-preview .navi-list-selector__title::after {
       background-color: @denali-graph-orange;
       border-radius: 50%;
       content: '';
@@ -170,7 +170,7 @@
     min-height: 0;
     overflow: hidden;
 
-    .navi-list-selector__request_preview .navi-list-selector__title::after {
+    .navi-list-selector--request-preview .navi-list-selector__title::after {
       background-color: @denali-graph-purple;
       border-radius: 1px;
       content: '';

--- a/packages/reports/tests/acceptance/column-config-test.js
+++ b/packages/reports/tests/acceptance/column-config-test.js
@@ -160,6 +160,105 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
       .exists('Column config drawer is still open after adding another parameterized metric');
   });
 
+  test('highlights last added/cloned item', async function(assert) {
+    assert.expect(15);
+
+    await visit('/reports/new');
+    await click('.navi-report__run-btn');
+    assert.deepEqual(getColumns(), ['Date Time (Day)'], 'Initially the only column is date time');
+
+    //remove Date Time
+    await click('.navi-column-config-item__remove-icon');
+
+    //add back Date Time
+    await clickItem('timeGrain', 'Date Time');
+    await animationsSettled();
+    assert.dom('.navi-column-config-item').hasClass('navi-column-config-item--open', 'Date time config is open');
+    assert
+      .dom('.navi-column-config-item')
+      .hasClass('navi-column-config-item--last-added', 'Date time column is highlighted');
+
+    //close the config
+    await click('.navi-column-config-item__name[title="Date Time (Day)"]');
+
+    //add a dimension
+    await clickItem('dimension', 'Age');
+    await animationsSettled();
+    assert.deepEqual(
+      findAll('.navi-column-config-item').map(el => el.classList.contains('navi-column-config-item--open')),
+      [false, true],
+      'Only Age dimension is open'
+    );
+    assert.deepEqual(
+      findAll('.navi-column-config-item').map(el => el.classList.contains('navi-column-config-item--last-added')),
+      [false, true],
+      'Only Age dimension is highlighted'
+    );
+
+    //add another dimension
+    await clickItem('dimension', 'Browser');
+    await animationsSettled();
+    assert.deepEqual(
+      findAll('.navi-column-config-item').map(el => el.classList.contains('navi-column-config-item--open')),
+      [false, true, true],
+      'Age and Browser dimensions are open'
+    );
+    assert.deepEqual(
+      findAll('.navi-column-config-item').map(el => el.classList.contains('navi-column-config-item--last-added')),
+      [false, false, true],
+      'Only Browser dimension is highlighted'
+    );
+
+    //close open configs
+    await click('.navi-column-config-item__name[title="Age"]');
+    await click('.navi-column-config-item__name[title="Browser"]');
+
+    //add same dimension again
+    await clickItem('dimension', 'Browser');
+    await animationsSettled();
+    assert.deepEqual(
+      findAll('.navi-column-config-item').map(el => el.classList.contains('navi-column-config-item--open')),
+      [false, false, false, true],
+      'Only most recently added dimension is open'
+    );
+    assert.deepEqual(
+      findAll('.navi-column-config-item').map(el => el.classList.contains('navi-column-config-item--last-added')),
+      [false, false, false, true],
+      'Only most recently added dimension is highlighted'
+    );
+
+    //clone
+    await click('.navi-column-config-base__clone-icon');
+    await animationsSettled();
+    assert.deepEqual(
+      findAll('.navi-column-config-item').map(el => el.classList.contains('navi-column-config-item--open')),
+      [false, false, false, true, true],
+      'Original and cloned dimensions are open'
+    );
+    assert.deepEqual(
+      findAll('.navi-column-config-item').map(el => el.classList.contains('navi-column-config-item--last-added')),
+      [false, false, false, false, true],
+      'Only cloned dimension is highlighted'
+    );
+
+    //close open configs
+    await click(findAll('.navi-column-config-item__name[title="Browser"]')[1]);
+    await click(findAll('.navi-column-config-item__name[title="Browser"]')[2]);
+
+    //remove last added column
+    await click(findAll('.navi-column-config-item__remove-icon')[4]);
+    assert.dom('.navi-column-config-item--open').doesNotExist('No column is open after removing');
+    assert.dom('.navi-column-config-item--last-added').doesNotExist('No column is highlighted after removing');
+
+    //save, revert
+    await click('.navi-report__save-btn');
+    await clickItem('dimension', 'Browser');
+    await animationsSettled();
+    await click('.navi-report__revert-btn');
+    assert.dom('.navi-column-config-item--open').doesNotExist('No column is open after reverting');
+    assert.dom('.navi-column-config-item--last-added').doesNotExist('No column is highlighted after reverting');
+  });
+
   test('adding, removing and changing - date time', async function(assert) {
     assert.expect(7);
     await visit('reports/1/view');
@@ -170,11 +269,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
 
     assert.dom('.filter-builder__subject').hasText('Date Time (All)', 'Deselecting day changes time grain to all');
     await animationsSettled();
-    assert.deepEqual(
-      getColumns(),
-      ['Property', 'Ad Clicks', 'Nav Link Clicks'],
-      'Date Time is removed after selecting All timegrain'
-    );
+    assert.deepEqual(getColumns(), ['Property', 'Ad Clicks', 'Nav Link Clicks'], 'Date Time is removed');
 
     await clickItem('dimension', 'Date Time');
     await animationsSettled();
@@ -185,8 +280,6 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
       ['Date Time (Day)', 'Property', 'Ad Clicks', 'Nav Link Clicks'],
       'A Date Time (Day) column is added'
     );
-
-    await click('.navi-column-config-item__name[title="Date Time (Day)"]');
     await selectChoose('.navi-column-config-item__parameter-trigger', 'Week');
 
     assert
@@ -514,8 +607,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
       'The initial parameterized metrics were added'
     );
 
-    await click('.navi-column-config-item__name[title="Platform Revenue (USD)"]');
-    await selectChoose('.navi-column-config-item__parameter-trigger', 'Dollars (CAD)');
+    await selectChoose(findAll('.navi-column-config-item__parameter-trigger')[0], 'Dollars (CAD)');
 
     assert.deepEqual(
       getColumns(),
@@ -540,8 +632,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
       'The initial parameterized metrics were added'
     );
 
-    await click(findAll('.navi-column-config-item__name[title="Platform Revenue (USD)"]')[1]);
-    await selectChoose('.navi-column-config-item__parameter-trigger', 'Dollars (CAD)');
+    await selectChoose(findAll('.navi-column-config-item__parameter-trigger')[2], 'Dollars (CAD)');
 
     assert.deepEqual(
       getColumns(),
@@ -561,10 +652,8 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
     await animationsSettled();
     assert.deepEqual(getColumns(), ['Date Time (Day)', 'Age', 'Browser'], 'The initial dimensions were added');
 
-    await click('.navi-column-config-item__name[title="Age"]');
     await click('.navi-column-config-base__clone-icon');
     await animationsSettled();
-    await click('.navi-column-config-item__name[title="Age"]');
 
     assert.deepEqual(getColumns(), ['Date Time (Day)', 'Age', 'Browser', 'Age'], 'The dimension can be cloned');
 
@@ -604,10 +693,8 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
       'The initial metrics were added'
     );
 
-    await click('.navi-column-config-item__name[title="Ad Clicks"]');
     await click('.navi-column-config-base__clone-icon');
     await animationsSettled();
-    await click('.navi-column-config-item__name[title="Ad Clicks"]');
 
     assert.deepEqual(
       getColumns(),
@@ -655,10 +742,8 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
       'The initial metrics were added'
     );
 
-    await click('.navi-column-config-item__name[title="Platform Revenue (USD)"]');
     await click('.navi-column-config-base__clone-icon');
     await animationsSettled();
-    await click('.navi-column-config-item__name[title="Platform Revenue (USD)"]');
 
     assert.deepEqual(
       getColumns(),
@@ -762,7 +847,6 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
       .dom('.report-builder__container--filters')
       .hasClass('report-builder__container--filters--collapsed', 'Filters are collapsed after click');
 
-    await click('.navi-column-config-item__name[title="Age"]');
     await click('.navi-column-config-base__filter-icon');
 
     assert
@@ -785,7 +869,6 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
     await clickItem('dimension', 'Age');
     await animationsSettled();
 
-    await click(findAll('.navi-column-config-item__name[title="Age"]')[1]);
     assert.dom('.navi-column-config-base__filter-icon--active').exists({ count: 2 }, 'Both filter icons are active');
 
     await click(findAll('.navi-column-config-base__filter-icon')[1]);
@@ -816,7 +899,6 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
       .dom('.report-builder__container--filters')
       .hasClass('report-builder__container--filters--collapsed', 'Filters are collapsed after click');
 
-    await click('.navi-column-config-item__name[title="Ad Clicks"]');
     await click('.navi-column-config-base__filter-icon');
 
     assert
@@ -839,7 +921,6 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
     await clickItem('metric', 'Ad Clicks');
     await animationsSettled();
 
-    await click(findAll('.navi-column-config-item__name[title="Ad Clicks"]')[1]);
     assert.dom('.navi-column-config-base__filter-icon--active').exists({ count: 2 }, 'Both filter icons are active');
 
     await click(findAll('.navi-column-config-base__filter-icon')[1]);
@@ -870,7 +951,6 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
       .dom('.report-builder__container--filters')
       .hasClass('report-builder__container--filters--collapsed', 'Filters are collapsed after click');
 
-    await click('.navi-column-config-item__name[title="Platform Revenue (USD)"]');
     await click('.navi-column-config-base__filter-icon');
 
     assert
@@ -893,7 +973,6 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
     await clickItem('metric', 'Platform Revenue');
     await animationsSettled();
 
-    await click(findAll('.navi-column-config-item__name[title="Platform Revenue (USD)"]')[1]);
     assert.dom('.navi-column-config-base__filter-icon--active').exists({ count: 2 }, 'Both filter icons are active');
 
     await click(findAll('.navi-column-config-base__filter-icon')[1]);
@@ -918,7 +997,6 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
     await clickItem('metric', 'Platform Revenue');
     await animationsSettled();
 
-    await click('.navi-column-config-item__name[title="Platform Revenue (USD)"]');
     await click('.navi-column-config-base__filter-icon');
 
     assert.deepEqual(
@@ -926,8 +1004,6 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
       ['Date Time (Day)', 'Platform Revenue (USD)'],
       'Metric filter is added'
     );
-
-    await click(findAll('.navi-column-config-item__name[title="Platform Revenue (USD)"]')[1]);
 
     assert.dom('.navi-column-config-base__filter-icon--active').exists({ count: 2 }, 'Both filter icons are active');
 
@@ -969,7 +1045,6 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
       .doesNotHaveClass('report-builder__container--filters--collapsed', 'Filters are open by default');
     await click('.report-builder__container-header__filters-toggle-icon');
 
-    await click('.navi-column-config-item__name[title="Ad Clicks"]');
     await click('.navi-column-config-base__filter-icon');
 
     assert
@@ -1001,7 +1076,6 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
       .doesNotHaveClass('report-builder__container--filters--collapsed', 'Filters are open by default');
     await click('.report-builder__container-header__filters-toggle-icon');
 
-    await click('.navi-column-config-item__name[title="Platform Revenue (USD)"]');
     await click('.navi-column-config-base__filter-icon');
 
     assert
@@ -1033,7 +1107,6 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
       .doesNotHaveClass('report-builder__container--filters--collapsed', 'Filters are open by default');
     await click('.report-builder__container-header__filters-toggle-icon');
 
-    await click('.navi-column-config-item__name[title="Age"]');
     await click('.navi-column-config-base__filter-icon');
 
     assert
@@ -1061,7 +1134,6 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
     await animationsSettled();
     assert.deepEqual(getColumns(), ['Date Time (Day)', 'Platform Revenue (USD)'], 'The initial metrics was added');
 
-    await click('.navi-column-config-item__name[title="Platform Revenue (USD)"]');
     await click('.navi-column-config-item__parameter-trigger');
     assert.strictEqual(
       findAll('.ember-power-select-option').map(el => el.textContent.trim()).length,

--- a/packages/reports/tests/acceptance/column-config-test.js
+++ b/packages/reports/tests/acceptance/column-config-test.js
@@ -161,7 +161,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
   });
 
   test('highlights last added/cloned item', async function(assert) {
-    assert.expect(29);
+    assert.expect(28);
 
     await visit('/reports/new');
     await click('.navi-report__run-btn');
@@ -184,11 +184,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
     //add a dimension
     await clickItem('dimension', 'Age');
     await animationsSettled();
-    assert.deepEqual(
-      findAll('.navi-column-config-item').map(el => el.classList.contains('navi-column-config-item--open')),
-      [false, true],
-      'Only Age dimension is open'
-    );
+    assert.dom('.navi-column-config-item--open').doesNotExist('No column is open - dimensions do not open when added');
     assert.deepEqual(
       findAll('.navi-column-config-item').map(el => el.classList.contains('navi-column-config-item--last-added')),
       [false, true],
@@ -199,28 +195,14 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
     await clickItem('dimension', 'Browser');
     await animationsSettled();
     assert.deepEqual(
-      findAll('.navi-column-config-item').map(el => el.classList.contains('navi-column-config-item--open')),
-      [false, true, true],
-      'Age and Browser dimensions are open'
-    );
-    assert.deepEqual(
       findAll('.navi-column-config-item').map(el => el.classList.contains('navi-column-config-item--last-added')),
       [false, false, true],
       'Only Browser dimension is highlighted'
     );
 
-    //close open configs
-    await click('.navi-column-config-item__name[title="Age"]');
-    await click('.navi-column-config-item__name[title="Browser"]');
-
     //add same dimension again
     await clickItem('dimension', 'Browser');
     await animationsSettled();
-    assert.deepEqual(
-      findAll('.navi-column-config-item').map(el => el.classList.contains('navi-column-config-item--open')),
-      [false, false, false, true],
-      'Only most recently added Browser dimension is open'
-    );
     assert.deepEqual(
       findAll('.navi-column-config-item').map(el => el.classList.contains('navi-column-config-item--last-added')),
       [false, false, false, true],
@@ -228,12 +210,13 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
     );
 
     //clone dimension
+    await click(findAll('.navi-column-config-item__name[title="Browser"]')[1]);
     await click('.navi-column-config-base__clone-icon');
     await animationsSettled();
     assert.deepEqual(
       findAll('.navi-column-config-item').map(el => el.classList.contains('navi-column-config-item--open')),
-      [false, false, false, true, true],
-      'Original and cloned dimensions are open'
+      [false, false, false, true, false],
+      'Original dimension is still open, cloned one is closed'
     );
     assert.deepEqual(
       findAll('.navi-column-config-item').map(el => el.classList.contains('navi-column-config-item--last-added')),
@@ -241,9 +224,9 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
       'Only cloned dimension is highlighted'
     );
 
-    //close open configs
+    //close open config
     await click(findAll('.navi-column-config-item__name[title="Browser"]')[1]);
-    await click(findAll('.navi-column-config-item__name[title="Browser"]')[2]);
+    assert.dom('.navi-column-config-item--open').doesNotExist('No column is open');
 
     //remove last added column
     await click(findAll('.navi-column-config-item__remove-icon')[4]);
@@ -742,6 +725,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
     await animationsSettled();
     assert.deepEqual(getColumns(), ['Date Time (Day)', 'Age', 'Browser'], 'The initial dimensions were added');
 
+    await click('.navi-column-config-item__name[title="Age"]');
     await click('.navi-column-config-base__clone-icon');
     await animationsSettled();
 
@@ -937,6 +921,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
       .dom('.report-builder__container--filters')
       .hasClass('report-builder__container--filters--collapsed', 'Filters are collapsed after click');
 
+    await click('.navi-column-config-item__name[title="Age"]');
     await click('.navi-column-config-base__filter-icon');
 
     assert
@@ -959,6 +944,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
     await clickItem('dimension', 'Age');
     await animationsSettled();
 
+    await click(findAll('.navi-column-config-item__name[title="Age"]')[1]);
     assert.dom('.navi-column-config-base__filter-icon--active').exists({ count: 2 }, 'Both filter icons are active');
 
     await click(findAll('.navi-column-config-base__filter-icon')[1]);
@@ -1197,6 +1183,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
       .doesNotHaveClass('report-builder__container--filters--collapsed', 'Filters are open by default');
     await click('.report-builder__container-header__filters-toggle-icon');
 
+    await click('.navi-column-config-item__name[title="Age"]');
     await click('.navi-column-config-base__filter-icon');
 
     assert

--- a/packages/reports/tests/integration/components/navi-column-config-test.js
+++ b/packages/reports/tests/integration/components/navi-column-config-test.js
@@ -368,6 +368,7 @@ module('Integration | Component | navi-column-config', function(hooks) {
       .hasAttribute('aria-disabled', 'true', 'Date time config filter icon has aria-disabled="true" attribute');
     await click('.navi-column-config-base__filter-icon');
     await click('.navi-column-config-item__remove-icon');
+    await animationsSettled();
   });
 
   test('Header config buttons - metric', async function(assert) {
@@ -424,6 +425,7 @@ module('Integration | Component | navi-column-config', function(hooks) {
       .hasClass('navi-column-config-base__filter-icon--active', 'Metric config filter is active if there is a having');
 
     await click(findAll('.navi-column-config-item__remove-icon')[1]);
+    await animationsSettled();
   });
 
   test('Header config buttons - parameterized metric', async function(assert) {
@@ -480,6 +482,7 @@ module('Integration | Component | navi-column-config', function(hooks) {
       .hasClass('navi-column-config-base__filter-icon--active', 'Metric config filter is active if there is a having');
 
     await click(findAll('.navi-column-config-item__remove-icon')[1]);
+    await animationsSettled();
   });
 
   test('Header config buttons - dimension', async function(assert) {
@@ -539,5 +542,61 @@ module('Integration | Component | navi-column-config', function(hooks) {
       );
 
     await click(findAll('.navi-column-config-item__remove-icon')[1]);
+    await animationsSettled();
+  });
+
+  test('last added column', async function(assert) {
+    assert.expect(6);
+
+    this.set('lastAddedColumn', { type: 'dimension', name: 'foo' });
+    addItem('dimension', 'browser');
+    await render(
+      hbs`<NaviColumnConfig @report={{this.report}} @lastAddedColumn={{this.lastAddedColumn}} @isOpen={{true}} />`
+    );
+
+    await animationsSettled();
+    let elements = findAll('.navi-column-config-item');
+    assert.deepEqual(
+      elements.map(el => el.classList.contains('navi-column-config-item--last-added')),
+      [false, false],
+      'No column has the `last-added` class'
+    );
+    assert.deepEqual(
+      elements.map(el => el.classList.contains('navi-column-config-item--open')),
+      [false, false],
+      'No column is open'
+    );
+
+    this.set('lastAddedColumn', { type: 'dimension', name: 'browser' });
+    await render(
+      hbs`<NaviColumnConfig @report={{this.report}} @lastAddedColumn={{this.lastAddedColumn}} @isOpen={{true}} />`
+    );
+
+    await animationsSettled();
+    elements = findAll('.navi-column-config-item');
+    assert.deepEqual(
+      elements.map(el => el.classList.contains('navi-column-config-item--last-added')),
+      [false, true],
+      'Last added column has the correct class'
+    );
+    assert.deepEqual(
+      elements.map(el => el.classList.contains('navi-column-config-item--open')),
+      [false, true],
+      'Last added column is open'
+    );
+
+    addItem('dimension', 'browser');
+    await animationsSettled();
+    elements = findAll('.navi-column-config-item');
+    assert.deepEqual(
+      elements.map(el => el.classList.contains('navi-column-config-item--last-added')),
+      [false, false, true],
+      'Only the most recently added column has the correct class'
+    );
+    assert.deepEqual(
+      elements.map(el => el.classList.contains('navi-column-config-item--open')),
+      [false, true, true],
+      'Previously added column is still open as well as the most recently added one'
+    );
   });
 });

--- a/packages/reports/tests/integration/components/navi-column-config-test.js
+++ b/packages/reports/tests/integration/components/navi-column-config-test.js
@@ -567,57 +567,85 @@ module('Integration | Component | navi-column-config', function(hooks) {
   });
 
   test('last added column', async function(assert) {
-    assert.expect(6);
+    assert.expect(11);
 
     this.set('lastAddedColumn', { type: 'dimension', name: 'foo' });
     addItem('dimension', 'browser');
+    addItem('metric', 'adClicks');
     await render(
       hbs`<NaviColumnConfig @report={{this.report}} @lastAddedColumn={{this.lastAddedColumn}} @isOpen={{true}} />`
     );
 
     await animationsSettled();
+    assert.dom('.navi-column-config-item--last-added').doesNotExist('No column has the `last-added` class');
+    assert.dom('.navi-column-config-item--open').doesNotExist('No column is open');
+
+    this.set('lastAddedColumn', { type: 'timeDimension', name: 'dateTime' });
+    await render(
+      hbs`<NaviColumnConfig @report={{this.report}} @lastAddedColumn={{this.lastAddedColumn}} @isOpen={{true}} />`
+    );
+    await animationsSettled();
     let elements = findAll('.navi-column-config-item');
     assert.deepEqual(
       elements.map(el => el.classList.contains('navi-column-config-item--last-added')),
-      [false, false],
-      'No column has the `last-added` class'
+      [true, false, false],
+      'Date time column has the correct class'
     );
     assert.deepEqual(
       elements.map(el => el.classList.contains('navi-column-config-item--open')),
-      [false, false],
-      'No column is open'
+      [true, false, false],
+      'Date time column is open'
     );
 
     this.set('lastAddedColumn', { type: 'dimension', name: 'browser' });
     await render(
       hbs`<NaviColumnConfig @report={{this.report}} @lastAddedColumn={{this.lastAddedColumn}} @isOpen={{true}} />`
     );
-
     await animationsSettled();
-    elements = findAll('.navi-column-config-item');
+    assert.dom('.navi-column-config-item--open').doesNotExist('No column is open - dimensions are not open when added');
     assert.deepEqual(
-      elements.map(el => el.classList.contains('navi-column-config-item--last-added')),
-      [false, true],
-      'Last added column has the correct class'
-    );
-    assert.deepEqual(
-      elements.map(el => el.classList.contains('navi-column-config-item--open')),
-      [false, true],
-      'Last added column is open'
+      findAll('.navi-column-config-item').map(el => el.classList.contains('navi-column-config-item--last-added')),
+      [false, true, false],
+      'Last added dimensnion column has the correct class'
     );
 
     addItem('dimension', 'browser');
     await animationsSettled();
+    assert.deepEqual(
+      findAll('.navi-column-config-item').map(el => el.classList.contains('navi-column-config-item--last-added')),
+      [false, false, true, false],
+      'Only the most recently added column has the correct class'
+    );
+
+    this.set('lastAddedColumn', { type: 'metric', name: 'adClicks' });
+    await render(
+      hbs`<NaviColumnConfig @report={{this.report}} @lastAddedColumn={{this.lastAddedColumn}} @isOpen={{true}} />`
+    );
+    await animationsSettled();
     elements = findAll('.navi-column-config-item');
     assert.deepEqual(
       elements.map(el => el.classList.contains('navi-column-config-item--last-added')),
-      [false, false, true],
-      'Only the most recently added column has the correct class'
+      [false, false, false, true],
+      'Last added metric column has the correct class'
     );
     assert.deepEqual(
       elements.map(el => el.classList.contains('navi-column-config-item--open')),
-      [false, true, true],
-      'Previously added column is still open as well as the most recently added one'
+      [false, false, false, true],
+      'Last added metric column is open'
+    );
+
+    addItem('metric', 'adClicks');
+    await animationsSettled();
+    elements = findAll('.navi-column-config-item');
+    assert.deepEqual(
+      elements.map(el => el.classList.contains('navi-column-config-item--last-added')),
+      [false, false, false, false, true],
+      'Only last added metric column has the correct class'
+    );
+    assert.deepEqual(
+      elements.map(el => el.classList.contains('navi-column-config-item--open')),
+      [false, false, false, true, true],
+      'Previously added metric is open as well as the last added one'
     );
   });
 });

--- a/packages/reports/tests/integration/components/navi-column-config-test.js
+++ b/packages/reports/tests/integration/components/navi-column-config-test.js
@@ -112,7 +112,7 @@ module('Integration | Component | navi-column-config', function(hooks) {
   });
 
   test('time grain - switching and removing', async function(assert) {
-    assert.expect(4);
+    assert.expect(8);
 
     await render(hbs`<NaviColumnConfig @report={{this.report}} @isOpen={{true}} />`);
 
@@ -122,6 +122,16 @@ module('Integration | Component | navi-column-config', function(hooks) {
       ['Date Time (Day)'],
       'The date time column is initially added and set to day'
     );
+
+    assert
+      .dom('.navi-column-config-item__remove-icon')
+      .doesNotHaveClass(
+        'navi-column-config-item__remove-icon--disabled',
+        'remove button of date time column does not have disabled class'
+      );
+    assert
+      .dom('.navi-column-config-item__remove-icon')
+      .isNotDisabled('remove button of date time column is not disabled');
 
     await click('.navi-column-config-item__name[title="Date Time (Day)"]'); // open date time config
     await clickTrigger('.navi-column-config-item__parameter'); // open the time grain dropdown
@@ -148,6 +158,17 @@ module('Integration | Component | navi-column-config', function(hooks) {
       [],
       'The date time column is removed when timegrain is set to all'
     );
+
+    this.set('report.request.logicalTable.table', { timeGrainIds: ['day'], timeGrains: [{ id: 'day', name: 'Day' }] });
+    this.set('report.request.logicalTable.timeGrain', 'day');
+    await animationsSettled();
+    assert
+      .dom('.navi-column-config-item__remove-icon')
+      .hasClass(
+        'navi-column-config-item__remove-icon--disabled',
+        'remove button of date time column has disabled class'
+      );
+    assert.dom('.navi-column-config-item__remove-icon').isDisabled('remove button of date time column is disabled');
   });
 
   test('metrics - adding', async function(assert) {


### PR DESCRIPTION
## Description

When adding or cloning a column, open and highlight the item and scroll to it.

## Proposed Changes

- Add a controller property `lastAddedColumn` that will save last added column type and id
- Reset it when removing a column, reverting unsaved changes or navigating away
- the `navi-column-config` component will pass a `isLastAdded` argument to each item
- if `true`, the item will be scrolled to, have a highlighted background and config will be open
- had to switch back to a regular `each` loop since `animated-each` causes scrolling to flicker. Instead, added `animated-if` for fade and collapse effect when removing a column
- disable removing a date time column when no `all` time grain in metadata

## Screenshots

![May-05-2020 16-32-33](https://user-images.githubusercontent.com/13946669/81125811-2148c800-8eee-11ea-841c-bb43bcb818bf.gif)

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
