### PR TITLE
New: Elide-metadata-service to support fetching metadata through graphql

### DIFF
--- a/packages/data/addon/adapters/bard-facts-v2.ts
+++ b/packages/data/addon/adapters/bard-facts-v2.ts
@@ -15,7 +15,7 @@ import { configHost } from '../utils/adapter';
 
 const SORT_DIRECTIONS = ['desc', 'asc'];
 
-type RequestOptions = {
+export type RequestOptions = {
   clientId?: string;
   customHeaders?: Dict<string>;
   timeout?: number;

--- a/packages/data/addon/gql/fragments/table.js
+++ b/packages/data/addon/gql/fragments/table.js
@@ -40,6 +40,24 @@ const fragment = gql`
         }
       }
     }
+    timeDimensions {
+      edges {
+        node {
+          id
+          name
+          description
+          category
+          valueType
+          columnTags
+          columnType
+          expression
+          supportedGrains
+          timeZone {
+            short
+          }
+        }
+      }
+    }
   }
 `;
 

--- a/packages/data/addon/serializers/elide-metadata.ts
+++ b/packages/data/addon/serializers/elide-metadata.ts
@@ -45,10 +45,17 @@ type TableNode = {
   timeDimensions: Connection<TimeDimensionNode>;
 };
 
-type TablePayload = {
+export interface TablePayload {
   tables: Connection<TableNode>;
   source: string;
-};
+}
+
+export interface NormalizedMetadata {
+  tables: TableMetadataPayload[];
+  metrics: MetricMetadataPayload[];
+  dimensions: DimensionMetadataPayload[];
+  timeDimensions: TimeDimensionMetadataPayload[];
+}
 
 export default class ElideMetadataSerializer extends EmberObject {
   /**
@@ -59,7 +66,7 @@ export default class ElideMetadataSerializer extends EmberObject {
    * @param {string} source - datasource of the payload
    * @returns {Object} - normalized tables and their associated columns
    */
-  _normalizeTableConnection(tableConnection: Connection<TableNode>, source: string) {
+  _normalizeTableConnection(tableConnection: Connection<TableNode>, source: string): NormalizedMetadata {
     const edges = tableConnection.edges || [];
     let metrics: MetricMetadataPayload[] = [];
     let dimensions: DimensionMetadataPayload[] = [];
@@ -198,9 +205,18 @@ export default class ElideMetadataSerializer extends EmberObject {
    * @returns {Object} - normalized JSON object
    */
   normalize(payload: TablePayload) {
-    if (payload?.tables) {
+    if (this.isTablePayload(payload)) {
       return this._normalizeTableConnection(payload.tables, payload.source);
     }
     return payload;
+  }
+
+  /**
+   * Runtime typecheck that typescript can understand
+   * @param payload
+   * @return true if payload is an instance of TablePayload
+   */
+  isTablePayload(payload: TablePayload): payload is TablePayload {
+    return !!(payload as TablePayload).tables;
   }
 }

--- a/packages/data/addon/serializers/elide-metadata.ts
+++ b/packages/data/addon/serializers/elide-metadata.ts
@@ -215,8 +215,9 @@ export default class ElideMetadataSerializer extends EmberObject {
    * Runtime typecheck that typescript can understand
    * @param payload
    * @return true if payload is an instance of TablePayload
-   */
-  isTablePayload(payload: TablePayload): payload is TablePayload {
-    return !!(payload as TablePayload).tables;
+   * */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  isTablePayload(payload: any): payload is TablePayload {
+    return !!payload.tables;
   }
 }

--- a/packages/data/addon/services/elide-metadata.ts
+++ b/packages/data/addon/services/elide-metadata.ts
@@ -35,13 +35,13 @@ export default class ElideMetadata extends Service {
    * @private
    * @property {Object} adapter - the adapter object
    */
-  _adapter?: Adapter = undefined;
+  _adapter!: Readonly<Adapter>;
 
   /**
    * @private
    * @property {Object} serializer - the serializer object
    */
-  _serializer?: Serializer = undefined;
+  _serializer!: Readonly<Serializer>;
 
   /**
    * @private
@@ -81,7 +81,7 @@ export default class ElideMetadata extends Service {
 
       //normalize payload
       payload.source = dataSource;
-      const metadata = this._serializer?.normalize(payload);
+      const metadata = this._serializer.normalize(payload);
       this._loadMetadataIntoKeg(metadata, dataSource);
     }
   }
@@ -94,7 +94,7 @@ export default class ElideMetadata extends Service {
    * @returns {Promise} Payload for a given datasource or the default datasource
    */
   _fetchMetadata(options: MetadataRequestOptions = {}) {
-    return this._adapter?.fetchAll('table', options);
+    return this._adapter.fetchAll('table', options);
   }
 
   /**
@@ -184,7 +184,7 @@ export default class ElideMetadata extends Service {
    */
   fetchById(/*type: MetadataQueryType, id: string, namespace: string*/) {
     //TODO: Implement fetchById
-    return undefined;
+    assert('elide-metadata.fetchById must be defined before it can be called', false);
   }
 
   /**
@@ -241,10 +241,8 @@ export default class ElideMetadata extends Service {
    * @param metadata - Payload
    * @returns true if metadata is of type NormalizedMetadata
    */
-  isMetadataNormalized(metadata: NormalizedMetadata | TablePayload | undefined): metadata is NormalizedMetadata {
-    return Object.keys(metadata || {}).every(type =>
-      VALID_TYPES.includes(singularize(dasherize(type)) as MetadataType)
-    );
+  isMetadataNormalized(metadata: object | undefined): metadata is NormalizedMetadata {
+    return Object.keys(metadata || {}).every(type => this.isValidType(singularize(dasherize(type))));
   }
 
   /**
@@ -253,7 +251,7 @@ export default class ElideMetadata extends Service {
    * @returns true if type is MetadataType
    */
   isValidType(type: string): type is MetadataType {
-    return VALID_TYPES.includes(type as MetadataType);
+    return ((VALID_TYPES as unknown) as string[]).includes(type);
   }
 
   /**

--- a/packages/data/addon/services/elide-metadata.ts
+++ b/packages/data/addon/services/elide-metadata.ts
@@ -50,12 +50,12 @@ export default class ElideMetadata extends Service {
   @service('keg') _keg: TODO;
 
   /**
-   * @property {Array} loadedDataSources - list of data sources in which meta data has already been loaded
+   * @property loadedDataSources - list of data sources in which meta data has already been loaded
    */
   loadedDataSources: string[] = [];
 
   /**
-   * @method init
+   * @constructor
    */
   constructor() {
     super(...arguments);
@@ -70,7 +70,7 @@ export default class ElideMetadata extends Service {
    * @method loadMetadata
    * Fetches metadata from the bard WS using the metadata adapter and loads into keg
    *
-   * @param {Object} options - options object used by the adapter
+   * @param options - options object used by the adapter
    * @returns {Promise} promise that loads metadata
    */
   async loadMetadata(options: MetadataRequestOptions = {}) {
@@ -90,9 +90,8 @@ export default class ElideMetadata extends Service {
    * This method can be easily overridden to configure what metadata is loaded
    * @private
    * @method _fetchMetadata
-   * @param {Object} options
-   * @param {String} options.dataSourceName
-   * @returns {Promise<Object>} Payload for a given datasource or the default datasource
+   * @param options - optionally contains data source name
+   * @returns {Promise} Payload for a given datasource or the default datasource
    */
   _fetchMetadata(options: MetadataRequestOptions = {}) {
     return this._adapter?.fetchAll('table', options);
@@ -103,8 +102,8 @@ export default class ElideMetadata extends Service {
    * @private
    * Loads metadata based on type
    *
-   * @param {String} type - type of metadata, table, dimension, or metric
-   * @param {Array} metadataObjects - array of metadata objects
+   * @param type - type of metadata, table, dimension, time-dimension, or metric
+   * @param metadataObjects - array of metadata objects
    */
   _loadMetadataForType(type: MetadataType, metadataObjects: MetadataPayload[], namespace: string) {
     const owner = getOwner(this);
@@ -122,10 +121,11 @@ export default class ElideMetadata extends Service {
    * Loads normalized metadata POJO into the Keg
    * @private
    * @method _loadMetadataIntoKeg
-   * @param {Object} metadata - normalized metadata
-   * @param {String} dataSource
+   * @param metadata - normalized metadata
+   * @param dataSource
+   * @returns void
    */
-  _loadMetadataIntoKeg(metadata: NormalizedMetadata | TablePayload | undefined, dataSource: string) {
+  _loadMetadataIntoKeg(metadata: NormalizedMetadata | TablePayload | undefined, dataSource: string): void {
     if (!(this.isDestroyed || this.isDestroying) && this.isMetadataNormalized(metadata)) {
       //create metadata model objects and load into keg
       this._loadMetadataForType('table', metadata.tables, dataSource);
@@ -141,9 +141,9 @@ export default class ElideMetadata extends Service {
    * @method all
    * returns all metadata objects of type `type`
    *
-   * @param {String} type
-   * @param {String} namespace - optional, filters the result by namespace
-   * @returns {Promise} - array of all table metadata
+   * @param type
+   * @param namespace - optional, filters the result by namespace
+   * @returns {Promise<MetadataModel[]>} - array of all table metadata
    */
   all(type: MetadataType, namespace?: string) {
     assert('Type must be a valid navi-data model type', this.isValidType(type));
@@ -160,10 +160,10 @@ export default class ElideMetadata extends Service {
    * @method getById
    * Retrieves metadata based on type and id
    *
-   * @param {String} type
-   * @param {String} id
-   * @param {String} namespace - optional
-   * @returns {Object} metadata model object
+   * @param type
+   * @param id
+   * @param namespace - optional
+   * @returns {MetadataModel} metadata model object
    */
   getById(type: MetadataType, id: string, namespace?: string) {
     assert('Type must be a valid navi-data model type', this.isValidType(type));
@@ -191,10 +191,10 @@ export default class ElideMetadata extends Service {
    * @method findById
    * gets Metadata or fetches it if necessary
    *
-   * @param {String} type
-   * @param {String} id
-   * @param {String} namespace
-   * @returns {Promise}
+   * @param type
+   * @param id
+   * @param namespace
+   * @returns {Promise<MetadataModel>}
    */
   findById(type: MetadataType, id: string, namespace?: string) {
     //Get entity if already present in the keg

--- a/packages/data/addon/services/elide-metadata.ts
+++ b/packages/data/addon/services/elide-metadata.ts
@@ -35,13 +35,13 @@ export default class ElideMetadata extends Service {
    * @private
    * @property {Object} adapter - the adapter object
    */
-  _adapter!: Readonly<Adapter>;
+  readonly _adapter!: Adapter;
 
   /**
    * @private
    * @property {Object} serializer - the serializer object
    */
-  _serializer!: Readonly<Serializer>;
+  readonly _serializer!: Serializer;
 
   /**
    * @private

--- a/packages/data/addon/services/elide-metadata.ts
+++ b/packages/data/addon/services/elide-metadata.ts
@@ -1,0 +1,273 @@
+/**
+ * Copyright 2020, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ *
+ * Ember service that helps retrieve metadata from Elide WS through GraphQL
+ */
+import Service, { inject as service } from '@ember/service';
+import { MetadataRequestOptions, MetadataQueryType } from '../adapters/elide-metadata';
+import { TableMetadataPayload, TableMetadata } from '../models/metadata/table';
+import { MetricMetadataPayload } from '../models/metadata/metric';
+import { DimensionMetadataPayload } from '../models/metadata/dimension';
+import { TimeDimensionMetadataPayload } from '../models/metadata/time-dimension';
+import { getDefaultDataSourceName } from '../utils/adapter';
+import { dasherize } from '@ember/string';
+import { singularize } from 'ember-inflector';
+import { assign } from '@ember/polyfills';
+import { assert } from '@ember/debug';
+import GQLQueries from 'navi-data/gql/metadata-queries';
+import Serializer, { NormalizedMetadata, TablePayload } from '../serializers/elide-metadata';
+import Adapter from '../adapters/elide-metadata';
+
+import { setOwner, getOwner } from '@ember/application';
+
+const VALID_TYPES = <const>['table', 'metric', 'dimension', 'time-dimension'];
+
+type MetadataType = typeof VALID_TYPES[number];
+type MetadataPayload =
+  | TableMetadataPayload
+  | MetricMetadataPayload
+  | DimensionMetadataPayload
+  | TimeDimensionMetadataPayload;
+
+export default class ElideMetadata extends Service {
+  /**
+   * @private
+   * @property {Object} adapter - the adapter object
+   */
+  _adapter?: Adapter = undefined;
+
+  /**
+   * @private
+   * @property {Object} serializer - the serializer object
+   */
+  _serializer?: Serializer = undefined;
+
+  /**
+   * @private
+   * @property {Ember.Service} _keg - keg service
+   */
+  @service('keg') _keg: TODO;
+
+  /**
+   * @property {Array} loadedDataSources - list of data sources in which meta data has already been loaded
+   */
+  loadedDataSources: string[] = [];
+
+  /**
+   * @method init
+   */
+  constructor() {
+    super(...arguments);
+
+    //Instantiating the elide metadata adapter & serializer
+    const owner = getOwner(this);
+    this._adapter = owner.lookup('adapter:elide-metadata');
+    this._serializer = owner.lookup('serializer:elide-metadata');
+  }
+
+  /**
+   * @method loadMetadata
+   * Fetches metadata from the bard WS using the metadata adapter and loads into keg
+   *
+   * @param {Object} options - options object used by the adapter
+   * @returns {Promise} promise that loads metadata
+   */
+  async loadMetadata(options: MetadataRequestOptions = {}) {
+    const dataSource = options.dataSourceName || getDefaultDataSourceName();
+    //fetch metadata from WS if metadata not yet loaded
+    if (!this.loadedDataSources.includes(dataSource)) {
+      const payload = await this._fetchMetadata(options);
+
+      //normalize payload
+      payload.source = dataSource;
+      const metadata = this._serializer?.normalize(payload);
+      this._loadMetadataIntoKeg(metadata, dataSource);
+    }
+  }
+
+  /**
+   * This method can be easily overridden to configure what metadata is loaded
+   * @private
+   * @method _fetchMetadata
+   * @param {Object} options
+   * @param {String} options.dataSourceName
+   * @returns {Promise<Object>} Payload for a given datasource or the default datasource
+   */
+  _fetchMetadata(options: MetadataRequestOptions = {}) {
+    return this._adapter?.fetchAll('table', options);
+  }
+
+  /**
+   * @method _loadMetadataForType
+   * @private
+   * Loads metadata based on type
+   *
+   * @param {String} type - type of metadata, table, dimension, or metric
+   * @param {Array} metadataObjects - array of metadata objects
+   */
+  _loadMetadataForType(type: MetadataType, metadataObjects: MetadataPayload[], namespace: string) {
+    const owner = getOwner(this);
+    const metadata = metadataObjects.map(data => {
+      const payload = assign({}, data);
+
+      setOwner(payload, owner);
+      return payload;
+    });
+
+    return this._keg.pushMany(`metadata/${dasherize(type)}`, metadata, { namespace });
+  }
+
+  /**
+   * Loads normalized metadata POJO into the Keg
+   * @private
+   * @method _loadMetadataIntoKeg
+   * @param {Object} metadata - normalized metadata
+   * @param {String} dataSource
+   */
+  _loadMetadataIntoKeg(metadata: NormalizedMetadata | TablePayload | undefined, dataSource: string) {
+    if (!(this.isDestroyed || this.isDestroying) && this.isMetadataNormalized(metadata)) {
+      //create metadata model objects and load into keg
+      this._loadMetadataForType('table', metadata.tables, dataSource);
+      this._loadMetadataForType('dimension', metadata.dimensions, dataSource);
+      this._loadMetadataForType('time-dimension', metadata.timeDimensions, dataSource);
+      this._loadMetadataForType('metric', metadata.metrics, dataSource);
+
+      this.loadedDataSources.push(dataSource);
+    }
+  }
+
+  /**
+   * @method all
+   * returns all metadata objects of type `type`
+   *
+   * @param {String} type
+   * @param {String} namespace - optional, filters the result by namespace
+   * @returns {Promise} - array of all table metadata
+   */
+  all(type: MetadataType, namespace?: string) {
+    assert('Type must be a valid navi-data model type', this.isValidType(type));
+    assert('Metadata must be loaded before the operation can be performed', this.loadedDataSources.length > 0);
+
+    if (namespace) {
+      assert('Metadata must have the requested namespace loaded', this.loadedDataSources.includes(namespace));
+    }
+
+    return this._keg.all(`metadata/${type}`, namespace);
+  }
+
+  /**
+   * @method getById
+   * Retrieves metadata based on type and id
+   *
+   * @param {String} type
+   * @param {String} id
+   * @param {String} namespace - optional
+   * @returns {Object} metadata model object
+   */
+  getById(type: MetadataType, id: string, namespace?: string) {
+    assert('Type must be a valid navi-data model type', this.isValidType(type));
+    let source = namespace || getDefaultDataSourceName();
+    assert('Metadata must be loaded before the operation can be performed', this.loadedDataSources.includes(source));
+
+    return this._keg.getById(`metadata/${type}`, id, source);
+  }
+
+  /**
+   * @method fetchById
+   * Fetch metadata based on type and id
+   *
+   * @param type
+   * @param id
+   * @param namespace
+   * @returns fetched record
+   */
+  fetchById(/*type: MetadataQueryType, id: string, namespace: string*/) {
+    //TODO: Implement fetchById
+    return undefined;
+  }
+
+  /**
+   * @method findById
+   * gets Metadata or fetches it if necessary
+   *
+   * @param {String} type
+   * @param {String} id
+   * @param {String} namespace
+   * @returns {Promise}
+   */
+  findById(type: MetadataType, id: string, namespace?: string) {
+    //Get entity if already present in the keg
+    let dataSourceName = namespace || getDefaultDataSourceName();
+
+    // TODO: fallback to fetch when fetchById is supported
+    return Promise.resolve(this.getById(type, id, dataSourceName));
+  }
+
+  /**
+   * Convenience method to get a meta data field
+   * @param type
+   * @param id
+   * @param field
+   * @param defaultIfNone - (optional) default if meta data or field isn't found
+   * @param namespace
+   * @returns field if found otherwise defaultIfNone
+   */
+  getMetaField(
+    type: MetadataType,
+    id: string,
+    field: string,
+    defaultIfNone: string | null = null,
+    namespace: string | null = null
+  ) {
+    const dataSourceName = namespace || getDefaultDataSourceName();
+    const meta = this.getById(type, id, dataSourceName);
+    return meta?.[field] || defaultIfNone;
+  }
+
+  /**
+   * Convenience method to get namespace of a table
+   * @param {String} table
+   * @returns {string} - namespace
+   */
+  getTableNamespace(tableId: string) {
+    const items = this._keg.getBy('metadata/table', (recordTable: TableMetadata) => recordTable.id === tableId);
+
+    return items.length ? items[0].source : getDefaultDataSourceName();
+  }
+
+  /**
+   * Runtime typecheck that typescript can understand
+   * @param metadata - Payload
+   * @returns true if metadata is of type NormalizedMetadata
+   */
+  isMetadataNormalized(metadata: NormalizedMetadata | TablePayload | undefined): metadata is NormalizedMetadata {
+    return Object.keys(metadata || {}).every(type =>
+      VALID_TYPES.includes(singularize(dasherize(type)) as MetadataType)
+    );
+  }
+
+  /**
+   * Runtime typecheck that typescript can understand
+   * @param type - type name
+   * @returns true if type is MetadataType
+   */
+  isValidType(type: string): type is MetadataType {
+    return VALID_TYPES.includes(type as MetadataType);
+  }
+
+  /**
+   * Runtime typecheck that typescript can understand
+   * @param type - type name
+   * @return true if type is included in defined queries
+   */
+  isQueryableType(type: string): type is MetadataQueryType {
+    return Object.keys(GQLQueries).includes(type);
+  }
+}
+
+declare module '@ember/service' {
+  interface Registry {
+    'elide-metadata': ElideMetadata;
+  }
+}

--- a/packages/data/app/services/elide-metadata.js
+++ b/packages/data/app/services/elide-metadata.js
@@ -1,0 +1,1 @@
+export { default } from 'navi-data/services/elide-metadata';

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -37,6 +37,7 @@
     "ember-cli-mirage-graphql": "^0.3.1",
     "ember-cli-typescript": "^3.1.3",
     "ember-get-config": "0.2.4",
+    "graphql": "^14.6.0",
     "graphql-tag": "^2.10.1",
     "lodash-es": "^4.17.11",
     "papaparse": "^5.1.1"
@@ -79,7 +80,6 @@
     "eslint-plugin-node": "^11.0.0",
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-qunit": "^4.0.0",
-    "graphql": "^14.6.0",
     "loader.js": "^4.7.0",
     "qunit-dom": "^1.0.0",
     "typescript": "3.7.5"

--- a/packages/data/tests/dummy/mirage/factories/time-dimension.js
+++ b/packages/data/tests/dummy/mirage/factories/time-dimension.js
@@ -1,0 +1,26 @@
+import { Factory } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  index(i) {
+    return i;
+  },
+  id() {
+    return `timeDimension${this.index}`;
+  },
+  name() {
+    return `Time Dimension ${this.index}`;
+  },
+  description() {
+    return `This is time dimension ${this.index}`;
+  },
+  category: 'categoryOne',
+  valueType: 'TIME',
+  columnTags: () => ['DISPLAY'],
+  columnType: 'field',
+  expression: null,
+  supportedGrains: () => [],
+  timeZone: () => ({
+    short: 'UTC',
+    long: 'Universal Time Coordinated'
+  })
+});

--- a/packages/data/tests/dummy/mirage/scenarios/graphql-blockhead.js
+++ b/packages/data/tests/dummy/mirage/scenarios/graphql-blockhead.js
@@ -1,0 +1,9 @@
+export default function(server) {
+  const [table0, table1] = server.createList('table', 2);
+  server.createList('metric', 1, { table: table0 });
+  server.createList('metric', 1, { table: table1 });
+  server.createList('dimension', 2, { table: table0 });
+  server.createList('dimension', 3, { table: table1 });
+  server.createList('time-dimension', 1, { table: table0 });
+  server.createList('time-dimension', 1, { table: table1 });
+}

--- a/packages/data/tests/dummy/mirage/scenarios/graphql.js
+++ b/packages/data/tests/dummy/mirage/scenarios/graphql.js
@@ -1,10 +1,7 @@
 export default function(server) {
-  /*
-    Seed your development database using your factories.
-    This data will not be loaded in your tests.
-  */
   const [table0, table1] = server.createList('table', 2);
   server.createList('metric', 2, { table: table0 });
   server.createList('metric', 2, { table: table1 });
   server.create('dimension', { table: table0 });
+  server.create('time-dimension', { table: table1 });
 }

--- a/packages/data/tests/unit/adapters/elide-metadata-test.js
+++ b/packages/data/tests/unit/adapters/elide-metadata-test.js
@@ -77,6 +77,7 @@ module('Unit | Elide Metadata Adapter', function(hooks) {
       'cardinality',
       'metrics',
       'dimensions',
+      'timeDimensions',
       '__typename'
     ];
 
@@ -280,6 +281,10 @@ module('Unit | Elide Metadata Adapter', function(hooks) {
               }
             ],
             __typename: 'DimensionConnection'
+          },
+          timeDimensions: {
+            edges: [],
+            __typename: 'TimeDimensionConnection'
           },
           __typename: 'Table'
         }

--- a/packages/data/tests/unit/services/elide-metadata-test.ts
+++ b/packages/data/tests/unit/services/elide-metadata-test.ts
@@ -372,4 +372,25 @@ module('Unit | Service | elide-metadata', function(hooks) {
     //TODO: Implement this test when fetchById is supported
     assert.ok(false);
   });
+
+  test('getTableNamespace', async function(assert) {
+    assert.expect(3);
+
+    const Server = (this as MirageTestContext).server;
+    // Seed our mirage database
+    DummyScenario(Server);
+    await Service.loadMetadata({ dataSourceName: 'dummy' });
+    Server.db.emptyData();
+    BlockheadScenario(Server);
+    await Service.loadMetadata({ dataSourceName: 'blockhead' });
+
+    assert.equal(Service.getTableNamespace('table0'), 'dummy', 'Correct table namespace is shown');
+    assert.equal(
+      Service.getTableNamespace('table2'),
+      'blockhead',
+      'Correct table namespace is returned for non-default source'
+    );
+
+    assert.equal(Service.getTableNamespace('foo'), 'dummy', 'Default namespace returned when table not found');
+  });
 });

--- a/packages/data/tests/unit/services/elide-metadata-test.ts
+++ b/packages/data/tests/unit/services/elide-metadata-test.ts
@@ -1,0 +1,375 @@
+import { module, test } from 'qunit';
+import { setupTest, skip } from 'ember-qunit';
+//@ts-ignore
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { TestContext } from 'ember-test-helpers';
+import ElideMetadataService from 'navi-data/services/elide-metadata';
+import TableMetadataModel, { TableMetadata } from 'navi-data/models/metadata/table';
+import DimensionMetadataModel, { DimensionMetadata } from 'navi-data/models/metadata/dimension';
+import MetricMetadataModel, { MetricMetadata, MetricMetadataPayload } from 'navi-data/models/metadata/metric';
+import TimeDimensionMetadataModel, { TimeDimensionMetadata } from 'navi-data/models/metadata/time-dimension';
+import DummyScenario from 'dummy/mirage/scenarios/graphql';
+import BlockheadScenario from 'dummy/mirage/scenarios/graphql-blockhead';
+
+type MirageTestContext = TestContext & { server?: TODO };
+
+let Service: ElideMetadataService;
+
+module('Unit | Service | elide-metadata', function(hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function(this: MirageTestContext) {
+    Service = this.owner.lookup('service:elide-metadata');
+  });
+
+  test('it exists', function(assert) {
+    assert.ok(Service);
+  });
+
+  test('loadMetadata', async function(assert) {
+    // Seed our mirage database
+    DummyScenario((this as MirageTestContext).server);
+    await Service.loadMetadata();
+
+    const keg = Service._keg;
+
+    assert.deepEqual(
+      Object.keys(keg.idIndexes).sort(),
+      ['metadata/dimension', 'metadata/metric', 'metadata/table', 'metadata/time-dimension'],
+      'All the expected metadata types are loaded into the keg after load'
+    );
+
+    assert.deepEqual(keg.all('metadata/table').mapBy('id'), ['table0', 'table1'], 'All tables are loaded in the keg');
+
+    assert.deepEqual(keg.all('metadata/dimension').mapBy('id'), ['dimension0'], 'All dimensions are loaded in the keg');
+
+    assert.deepEqual(
+      keg.all('metadata/metric').mapBy('id'),
+      ['metric0', 'metric1', 'metric2', 'metric3'],
+      'All metrics are loaded in the keg'
+    );
+
+    assert.deepEqual(
+      keg.all('metadata/time-dimension').mapBy('id'),
+      ['timeDimension0'],
+      'All time-dimensions are loaded in the keg'
+    );
+
+    assert.deepEqual(Service.loadedDataSources, ['dummy'], 'One datasource should be loaded');
+  });
+
+  test('loadMetadata from multiple sources', async function(assert) {
+    const Server = (this as MirageTestContext).server;
+    // Seed our mirage database
+    DummyScenario(Server);
+    await Service.loadMetadata({ dataSourceName: 'dummy' });
+    Server.db.emptyData();
+    BlockheadScenario(Server);
+    await Service.loadMetadata({ dataSourceName: 'blockhead' });
+
+    const keg = Service._keg;
+
+    assert.deepEqual(
+      Object.keys(keg.idIndexes).sort(),
+      ['metadata/dimension', 'metadata/metric', 'metadata/table', 'metadata/time-dimension'],
+      'All the expected metadata types are loaded into the keg after load'
+    );
+
+    assert.deepEqual(
+      keg.all('metadata/table').map((table: TableMetadata) => ({ id: table.id, source: table.source })),
+      [
+        { id: 'table0', source: 'dummy' },
+        { id: 'table1', source: 'dummy' },
+        { id: 'table2', source: 'blockhead' },
+        { id: 'table3', source: 'blockhead' }
+      ],
+      'All tables are loaded in the keg'
+    );
+
+    assert.deepEqual(
+      keg.all('metadata/dimension').map((dim: DimensionMetadata) => ({ id: dim.id, source: dim.source })),
+      [
+        { id: 'dimension0', source: 'dummy' },
+        { id: 'dimension1', source: 'blockhead' },
+        { id: 'dimension2', source: 'blockhead' },
+        { id: 'dimension3', source: 'blockhead' },
+        { id: 'dimension4', source: 'blockhead' },
+        { id: 'dimension5', source: 'blockhead' }
+      ],
+      'All dimensions are loaded in the keg'
+    );
+
+    assert.deepEqual(
+      keg.all('metadata/metric').map((metric: MetricMetadata) => ({ id: metric.id, source: metric.source })),
+      [
+        { id: 'metric0', source: 'dummy' },
+        { id: 'metric1', source: 'dummy' },
+        { id: 'metric2', source: 'dummy' },
+        { id: 'metric3', source: 'dummy' },
+        { id: 'metric4', source: 'blockhead' },
+        { id: 'metric5', source: 'blockhead' }
+      ],
+      'All metrics are loaded in the keg'
+    );
+
+    assert.deepEqual(
+      keg.all('metadata/time-dimension').map((t: TimeDimensionMetadata) => ({ id: t.id, source: t.source })),
+      [
+        { id: 'timeDimension0', source: 'dummy' },
+        { id: 'timeDimension1', source: 'blockhead' },
+        { id: 'timeDimension2', source: 'blockhead' }
+      ],
+      'All time-dimensions are loaded in the keg'
+    );
+
+    assert.deepEqual(Service.loadedDataSources, ['dummy', 'blockhead'], 'Two datasources should be loaded');
+  });
+
+  test('loadMetadata after data loaded', async function(assert) {
+    assert.expect(1);
+
+    const result = await Service.loadMetadata();
+    assert.notOk(result, 'loadMetadata returns a promise that resolves to nothing when metadata is already loaded');
+  });
+
+  test('_loadMetadataForType', async function(assert) {
+    assert.expect(1);
+
+    let keg = this.owner.lookup('service:keg'),
+      testMetric: MetricMetadataPayload = {
+        id: 'foo',
+        description: 'foo',
+        name: 'Foo',
+        category: 'foo',
+        defaultFormat: 'bar',
+        tableId: 'baz',
+        source: 'dummy',
+        valueType: 'NUMBER',
+        type: 'field',
+        tags: []
+      };
+
+    await Service._loadMetadataForType('metric', [testMetric], 'dummy');
+
+    let record = keg.getById('metadata/metric', 'foo', 'dummy');
+
+    assert.deepEqual(
+      {
+        id: record.id,
+        description: record.description,
+        name: record.name,
+        category: record.category,
+        defaultFormat: record.defaultFormat,
+        tableId: record.tableId,
+        source: record.source,
+        valueType: record.valueType,
+        type: record.type,
+        tags: record.tags
+      },
+      testMetric,
+      'The testMetric has been pushed to the keg'
+    );
+  });
+
+  test('all method', async function(assert) {
+    assert.expect(12);
+
+    const Server = (this as MirageTestContext).server;
+    // Seed our mirage database
+    DummyScenario(Server);
+    await Service.loadMetadata({ dataSourceName: 'dummy' });
+    Server.db.emptyData();
+    BlockheadScenario(Server);
+    await Service.loadMetadata({ dataSourceName: 'blockhead' });
+
+    const allTables = Service.all('table');
+    assert.ok(
+      allTables.every((t: TableMetadataModel) => t instanceof TableMetadataModel),
+      'all method returns table metadata models'
+    );
+    assert.deepEqual(
+      allTables.mapBy('id'),
+      ['table0', 'table1', 'table2', 'table3'],
+      'All tables are returned for all datasources when no source is specified'
+    );
+
+    const allDimensions = Service.all('dimension');
+    assert.ok(
+      allDimensions.every((d: DimensionMetadataModel) => d instanceof DimensionMetadataModel),
+      'all method returns dimension metadata models'
+    );
+    assert.deepEqual(
+      allDimensions.mapBy('id'),
+      ['dimension0', 'dimension1', 'dimension2', 'dimension3', 'dimension4', 'dimension5'],
+      'all method returns all loaded dimensions for every source'
+    );
+
+    const allMetrics = Service.all('metric');
+    assert.ok(
+      allMetrics.every((m: MetricMetadataModel) => m instanceof MetricMetadataModel),
+      'all method returns metric metadata models'
+    );
+    assert.deepEqual(
+      allMetrics.mapBy('id'),
+      ['metric0', 'metric1', 'metric2', 'metric3', 'metric4', 'metric5'],
+      'all method returns all loaded metrics for every source'
+    );
+
+    const allTimeDimensions = Service.all('time-dimension');
+    assert.ok(
+      allTimeDimensions.every((d: TimeDimensionMetadataModel) => d instanceof TimeDimensionMetadataModel),
+      'all method returns time-dimension metadata models'
+    );
+    assert.deepEqual(
+      allTimeDimensions.mapBy('id'),
+      ['timeDimension0', 'timeDimension1', 'timeDimension2'],
+      'all method returns all loaded time-dimensions for every source'
+    );
+
+    const allDummyMetrics = Service.all('metric', 'dummy');
+    assert.ok(
+      allDummyMetrics.every((m: MetricMetadataModel) => m instanceof MetricMetadataModel),
+      'all method returns metric metadata models'
+    );
+    assert.deepEqual(
+      allDummyMetrics.mapBy('id'),
+      ['metric0', 'metric1', 'metric2', 'metric3'],
+      'all method returns all loaded metrics for only the specified source'
+    );
+
+    assert.throws(
+      () => {
+        // @ts-ignore
+        Service.all('foo');
+      },
+      new Error('Assertion Failed: Type must be a valid navi-data model type'),
+      'Service `all` method throws error when metadata type is invalid'
+    );
+
+    Service.set('loadedDataSources', []);
+
+    assert.throws(
+      () => {
+        Service.all('metric');
+      },
+      new Error('Assertion Failed: Metadata must be loaded before the operation can be performed'),
+      'Service `all` method throws error when metadata is not loaded'
+    );
+  });
+
+  test('getById', async function(assert) {
+    assert.expect(7);
+
+    const keg = this.owner.lookup('service:keg');
+    const Server = (this as MirageTestContext).server;
+    // Seed our mirage database
+    DummyScenario(Server);
+    await Service.loadMetadata();
+
+    assert.equal(
+      Service.getById('table', 'table1'),
+      keg.getById('metadata/table', 'table1', 'dummy'),
+      'Table1 is fetched from the keg using getById'
+    );
+
+    assert.equal(
+      Service.getById('dimension', 'dimension1'),
+      keg.getById('metadata/dimension', 'dimension1', 'dummy'),
+      'Dimension1 is fetched from the keg using getById'
+    );
+
+    assert.equal(
+      Service.getById('metric', 'metric0'),
+      keg.getById('metadata/metric', 'metric0', 'dummy'),
+      'Metric0 is fetched from the keg using getById'
+    );
+
+    assert.equal(
+      Service.getById('time-dimension', 'timeDimension0'),
+      keg.getById('metadata/time-dimension', 'timeDimension0', 'dummy'),
+      'Time Dimension 0 is fetched from the keg using getById'
+    );
+
+    //@ts-ignore
+    assert.equal(Service.getById('metric'), undefined, 'getById returns undefined when no id is passed');
+
+    assert.throws(
+      () => {
+        //@ts-ignore
+        Service.getById('foo');
+      },
+      new Error('Assertion Failed: Type must be a valid navi-data model type'),
+      'Service `getById` method throws error when metadata type is invalid'
+    );
+
+    Service.set('loadedDataSources', []);
+
+    assert.throws(
+      () => {
+        //@ts-ignore
+        Service.getById('metric');
+      },
+      new Error('Assertion Failed: Metadata must be loaded before the operation can be performed'),
+      'Service `getById` method throws error when metadata is not loaded'
+    );
+  });
+
+  test('findById', async function(assert) {
+    const keg = this.owner.lookup('service:keg');
+    const Server = (this as MirageTestContext).server;
+    // Seed our mirage database
+    DummyScenario(Server);
+    await Service.loadMetadata();
+
+    assert.equal(
+      await Service.findById('table', 'table1'),
+      keg.getById('metadata/table', 'table1', 'dummy'),
+      'Table1 is fetched from the keg using getById'
+    );
+
+    //TODO: Add tests when fetchById is implemented
+  });
+
+  test('getMetaField', async function(assert) {
+    assert.expect(5);
+    const Server = (this as MirageTestContext).server;
+    // Seed our mirage database
+    DummyScenario(Server);
+    await Service.loadMetadata({ dataSourceName: 'dummy' });
+    Server.db.emptyData();
+    BlockheadScenario(Server);
+    await Service.loadMetadata({ dataSourceName: 'blockhead' });
+
+    assert.equal(Service.getMetaField('metric', 'metric1', 'name'), 'Metric 1', 'gets field from requested metadata');
+
+    assert.equal(
+      Service.getMetaField('metric', 'metric5', 'name', undefined, 'blockhead'),
+      'Metric 5',
+      'gets field from requested metadata for a given datasource'
+    );
+
+    assert.equal(
+      Service.getMetaField('metric', 'metric5', 'name', 'foo', 'dummy'),
+      'foo',
+      'returns default when metadata is not found in given datasource'
+    );
+
+    assert.equal(
+      Service.getMetaField('metric', 'metric1', 'shortName', 'someDefault'),
+      'someDefault',
+      'returns default when field is not found'
+    );
+
+    assert.equal(
+      Service.getMetaField('metric', 'InvalidMetric', 'shortName', 'someDefault'),
+      'someDefault',
+      'returns default when metric is not found'
+    );
+  });
+
+  skip('fetchById', async function(assert) {
+    //TODO: Implement this test when fetchById is supported
+    assert.ok(false);
+  });
+});

--- a/packages/data/tests/unit/services/elide-metadata-test.ts
+++ b/packages/data/tests/unit/services/elide-metadata-test.ts
@@ -368,9 +368,17 @@ module('Unit | Service | elide-metadata', function(hooks) {
     );
   });
 
-  skip('fetchById', async function(assert) {
+  test('fetchById', async function(assert) {
+    assert.expect(1);
+
     //TODO: Implement this test when fetchById is supported
-    assert.ok(false);
+    assert.throws(
+      () => {
+        Service.fetchById();
+      },
+      new Error('Assertion Failed: elide-metadata.fetchById must be defined before it can be called'),
+      "Service `fetchById` method throws error because it's not implemented yet"
+    );
   });
 
   test('getTableNamespace', async function(assert) {

--- a/packages/data/types/global.d.ts
+++ b/packages/data/types/global.d.ts
@@ -6,6 +6,7 @@ declare module 'navi-data/templates/*' {
 }
 
 declare module 'ember-get-config';
+declare module 'ember-apollo-client';
 
 type Dict<T = string> = { [key: string]: T };
 type TODO<T = any> = T;


### PR DESCRIPTION
Resolves #770 

<!-- The above line will close the issue upon merge -->

## Description
We needed a service similar to bard-metadata in order to leverage our new adapter and serializer for graphql. 

The new service is intentionally not extending from the bard-metadata service even though they share a lot of similar functionality right now. In the future, there will be the opportunity for optimizations using the elide-metadata service that will change the implementation to be pretty different from the bard metadata flow.

## Proposed Changes

- Create Elide-metadata-service
- Typescript Elide-metadata adapter
- Add time dimensions to the graphql table query

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
