### PR TITLE
Update: Deprecate ember concurrency decorators

### DIFF
--- a/packages/search/addon/components/navi-search-bar.js
+++ b/packages/search/addon/components/navi-search-bar.js
@@ -9,7 +9,7 @@ import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { restartableTask } from 'ember-concurrency-decorators';
+import { task } from 'ember-concurrency';
 import { timeout } from 'ember-concurrency';
 
 /**
@@ -77,13 +77,13 @@ export default class NaviSearchBarComponent extends Component {
    * @param {String} query
    * @returns {Array} results
    */
-  @restartableTask
-  *launchQuery(query) {
+  @(task(function*(query) {
     yield timeout(DEBOUNCE_MS);
     const results = yield this.searchProviderService.search.perform(query);
     if (results.length === 0 && query !== '') {
       return [EMPTY_RESULT];
     }
     return results;
-  }
+  }).restartable())
+  launchQuery;
 }

--- a/packages/search/addon/components/navi-search-bar.js
+++ b/packages/search/addon/components/navi-search-bar.js
@@ -9,8 +9,7 @@ import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { task } from 'ember-concurrency';
-import { timeout } from 'ember-concurrency';
+import { task, timeout } from 'ember-concurrency';
 
 /**
  * @constant EMPTY_RESULT – Empty result object

--- a/packages/search/addon/services/navi-search-provider.js
+++ b/packages/search/addon/services/navi-search-provider.js
@@ -8,7 +8,7 @@
 import Service from '@ember/service';
 import { getOwner } from '@ember/application';
 import config from 'ember-get-config';
-import { restartableTask } from 'ember-concurrency-decorators';
+import { task } from 'ember-concurrency';
 
 /* global requirejs */
 
@@ -42,8 +42,7 @@ export default class NaviSearchProviderService extends Service {
    * @returns {Array} array of objects that contain the search results,
    * the name of the result component as well as result ordering information
    */
-  @restartableTask
-  *search(query) {
+  @(task(function*(query) {
     const searchProviders = this._all();
     let results = [];
     for (const provider of searchProviders) {
@@ -53,5 +52,6 @@ export default class NaviSearchProviderService extends Service {
       }
     }
     return results;
-  }
+  }).restartable())
+  search;
 }

--- a/packages/search/addon/services/navi-search/navi-asset-search-provider.js
+++ b/packages/search/addon/services/navi-search/navi-asset-search-provider.js
@@ -7,7 +7,7 @@
 
 import { inject as service } from '@ember/service';
 import NaviBaseSearchProviderService from '../navi-base-search-provider';
-import { restartableTask } from 'ember-concurrency-decorators';
+import { task } from 'ember-concurrency';
 import { pluralize } from 'ember-inflector';
 import { getPartialMatchWeight } from 'navi-core/utils/search';
 
@@ -76,8 +76,7 @@ export default class NaviAssetSearchProviderService extends NaviBaseSearchProvid
    * @yields {Promise} promise with search query results
    * @returns {Object} Object containing component, title, and data to be displayed
    */
-  @restartableTask
-  *search(query) {
+  @(task(function*(query) {
     const types = ['report', 'dashboard'];
     const promises = [];
 
@@ -99,5 +98,6 @@ export default class NaviAssetSearchProviderService extends NaviBaseSearchProvid
           getPartialMatchWeight(resultB.title.toLowerCase(), query.toLowerCase())
       )
     };
-  }
+  }).restartable())
+  search;
 }

--- a/packages/search/addon/services/navi-search/navi-definition-search-provider.js
+++ b/packages/search/addon/services/navi-search/navi-definition-search-provider.js
@@ -27,6 +27,7 @@ export default class NaviDefinitionSearchProviderService extends NaviBaseSearchP
    * @param {String} query
    * @returns {Object} Object containing, component, title and data
    */
+  // eslint-disable-next-line require-yield
   @(task(function*(query) {
     const types = ['table', 'dimension', 'metric', 'time-dimension'];
     const kegData = [];

--- a/packages/search/addon/services/navi-search/navi-definition-search-provider.js
+++ b/packages/search/addon/services/navi-search/navi-definition-search-provider.js
@@ -7,7 +7,7 @@
 
 import { inject as service } from '@ember/service';
 import NaviBaseSearchProviderService from '../navi-base-search-provider';
-import { restartableTask } from 'ember-concurrency-decorators';
+import { task } from 'ember-concurrency';
 import { searchRecordsByFields } from 'navi-core/utils/search';
 
 export default class NaviDefinitionSearchProviderService extends NaviBaseSearchProviderService {
@@ -27,9 +27,7 @@ export default class NaviDefinitionSearchProviderService extends NaviBaseSearchP
    * @param {String} query
    * @returns {Object} Object containing, component, title and data
    */
-  @restartableTask
-  // eslint-disable-next-line require-yield
-  *search(query) {
+  @(task(function*(query) {
     const types = ['table', 'dimension', 'metric', 'time-dimension'];
     const kegData = [];
     let data = [];
@@ -44,5 +42,6 @@ export default class NaviDefinitionSearchProviderService extends NaviBaseSearchP
       title: 'Definition',
       data: data.slice(0, this.resultThreshold)
     };
-  }
+  }).restartable())
+  search;
 }

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -61,7 +61,6 @@
     "ember-cli-uglify": "^3.0.0",
     "ember-concurrency": "^1.1.5",
     "ember-composable-helpers": "^3.1.1",
-    "ember-concurrency-decorators": "^1.0.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.1",
     "ember-font-awesome": "^3.1.1",

--- a/packages/search/tests/dummy/app/services/navi-search/navi-sample-search-provider.js
+++ b/packages/search/tests/dummy/app/services/navi-search/navi-sample-search-provider.js
@@ -6,7 +6,7 @@
  */
 
 import NaviBaseSearchProviderService from '../navi-base-search-provider';
-import { keepLatestTask } from 'ember-concurrency-decorators';
+import { task } from 'ember-concurrency';
 import Response from 'ember-cli-mirage/response';
 
 export default class NaviSampleSearchProviderService extends NaviBaseSearchProviderService {
@@ -15,8 +15,7 @@ export default class NaviSampleSearchProviderService extends NaviBaseSearchProvi
    * @param {String} query
    * @returns {Object} Object containing results and dislay component
    */
-  @keepLatestTask
-  *search(query) {
+  @(task(function*(query) {
     let data = yield new Promise(function(resolve, reject) {
       let payload = [];
       if (query.toLowerCase().includes('sample')) {
@@ -31,5 +30,6 @@ export default class NaviSampleSearchProviderService extends NaviBaseSearchProvi
       title: 'Sample',
       data
     };
-  }
+  }).restartable())
+  search;
 }


### PR DESCRIPTION
Resolves #

<!-- The above line will close the issue upon merge -->

## Description
Deprecate ember concurrency decorators from navi-search in favor of native ember concurrency syntax

## Proposed Changes

-

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
