### PR TITLE
Update: Use autocomplete="new-password"

### DIFF
--- a/packages/core/addon/templates/components/power-select-search.hbs
+++ b/packages/core/addon/templates/components/power-select-search.hbs
@@ -6,7 +6,7 @@
     <NaviIcon @icon="search" />
     <input 
       type="search" 
-      autocomplete="off" 
+      autocomplete="new-password" 
       autocorrect="off" 
       autocapitalize="off" 
       spellcheck="false" 

--- a/packages/reports/addon/templates/components/power-select-bulk-import-trigger.hbs
+++ b/packages/reports/addon/templates/components/power-select-bulk-import-trigger.hbs
@@ -28,7 +28,7 @@
   {{#if searchEnabled}}
     {{!-- template-lint-disable no-positive-tabindex --}}
     <input type="search" class="ember-power-select-trigger-multiple-input"
-      autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
+      autocomplete="new-password" autocorrect="off" autocapitalize="off" spellcheck="false"
       id="ember-power-select-trigger-multiple-input-{{select.uniqueId}}"
       value={{select.searchText}}
       aria-controls={{listboxId}}

--- a/packages/reports/addon/templates/components/power-select-search-trigger.hbs
+++ b/packages/reports/addon/templates/components/power-select-search-trigger.hbs
@@ -3,7 +3,7 @@
 {{!-- template-lint-disable no-action --}}
 {{#if hasFocus}}
   <input type="search" class="ember-power-select-search-trigger {{elementId}}-input"
-    tabindex="0" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
+    tabindex="0" autocomplete="new-password" autocorrect="off" autocapitalize="off" spellcheck="false"
     placeholder={{placeholder}}
     oninput={{action "handleInput"}}
     onkeydown={{action "handleKeydown"}}


### PR DESCRIPTION
## Description

Having some issues with Chrome trying to be helpful and trying to autocomplete on our multiselect

## Proposed Changes

- [autocomplete="new-password"](https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#Preventing_autofilling_with_autocompletenew-password) to really suggest that the browser does not try to autocomplete

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
