### PR TITLE
Update: Open Date Time on new report

### DIFF
--- a/packages/reports/addon/components/navi-column-config.js
+++ b/packages/reports/addon/components/navi-column-config.js
@@ -114,7 +114,7 @@ class NaviColumnConfig extends Component {
         });
     }
 
-    return columns.length === 1 ? columns[0] : null;
+    return columns.length === 1 && column.type === 'timeDimension' ? columns[0] : null;
   }
 
   /**

--- a/packages/reports/addon/components/navi-column-config.js
+++ b/packages/reports/addon/components/navi-column-config.js
@@ -114,7 +114,7 @@ class NaviColumnConfig extends Component {
         });
     }
 
-    return columns.length === 1 && column.type === 'timeDimension' ? columns[0] : null;
+    return columns.length === 1 && columns[0].type === 'timeDimension' ? columns[0] : null;
   }
 
   /**

--- a/packages/reports/addon/components/navi-column-config.js
+++ b/packages/reports/addon/components/navi-column-config.js
@@ -21,13 +21,12 @@
  */
 import Component from '@ember/component';
 import layout from '../templates/components/navi-column-config';
-import { action, computed, set } from '@ember/object';
+import { action, computed } from '@ember/object';
 import { capitalize } from '@ember/string';
 import move from 'ember-animated/motions/move';
 import { easeOut, easeIn } from 'ember-animated/easings/cosine';
 import { layout as templateLayout, tagName } from '@ember-decorators/component';
 import { inject as service } from '@ember/service';
-import { later } from '@ember/runloop';
 
 @tagName('')
 @templateLayout(layout)
@@ -115,7 +114,7 @@ class NaviColumnConfig extends Component {
         });
     }
 
-    return null;
+    return columns.length === 1 ? columns[0] : null;
   }
 
   /**

--- a/packages/reports/addon/templates/components/navi-column-config/item.hbs
+++ b/packages/reports/addon/templates/components/navi-column-config/item.hbs
@@ -3,6 +3,7 @@
   class="navi-column-config-item navi-column-config-item--{{dasherize @column.type}}
     {{if this.isColumnConfigOpen "navi-column-config-item--open"}}
     {{if @isLastAdded "navi-column-config-item--last-added"}}"
+  data-name={{@column.name}}
   ...attributes
   {{did-insert this.setupElement}}
 >

--- a/packages/reports/tests/acceptance/column-config-test.js
+++ b/packages/reports/tests/acceptance/column-config-test.js
@@ -24,7 +24,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
   });
 
   test('Existing report loads correct columns', async function(assert) {
-    assert.expect(1);
+    assert.expect(2);
     await visit('reports/1/view');
 
     await animationsSettled();
@@ -33,10 +33,12 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
       ['Date Time (Day)', 'Property', 'Ad Clicks', 'Nav Link Clicks'],
       'Existing report loads columns correctly'
     );
+
+    assert.dom('.navi-column-config-item--open').doesNotExist('No columns are open when an existing report is loaded');
   });
 
   test('Creating new report shows column config if enableRequestPreview is on', async function(assert) {
-    assert.expect(4);
+    assert.expect(5);
     await visit('/reports/new');
 
     assert.ok(currentURL().endsWith('/edit'), 'We are on the edit report route');
@@ -48,6 +50,10 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
 
     await animationsSettled();
     assert.deepEqual(getColumns(), ['Date Time (Day)'], 'Initially only the date time is visible');
+
+    assert
+      .dom('.navi-column-config-item[data-name="dateTime"]')
+      .hasClass('navi-column-config-item--open', 'The date time is open on a new report');
   });
 
   test('Creating new report does not show column config without enableRequestPreview', async function(assert) {
@@ -94,7 +100,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
     assert.expect(12);
 
     await visit('/reports/new');
-    await click('.navi-report__run-btn');
+    await click('.navi-column-config-item[data-name="dateTime"] .navi-column-config-item__trigger');
     assert.deepEqual(getColumns(), ['Date Time (Day)'], 'Initially the only column is date time');
 
     //remove Date Time
@@ -164,7 +170,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
     assert.expect(28);
 
     await visit('/reports/new');
-    await click('.navi-report__run-btn');
+    await click('.navi-column-config-item[data-name="dateTime"] .navi-column-config-item__trigger');
     assert.deepEqual(getColumns(), ['Date Time (Day)'], 'Initially the only column is date time');
 
     //remove Date Time
@@ -368,7 +374,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
   test('adding - metrics', async function(assert) {
     assert.expect(3);
     await visit('/reports/new');
-    await click('.navi-report__run-btn');
+    await click('.navi-column-config-item[data-name="dateTime"] .navi-column-config-item__trigger');
 
     assert.deepEqual(getColumns(), ['Date Time (Day)'], 'Initially only the date time is visible');
     await clickItem('metric', 'Ad Clicks');
@@ -394,7 +400,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
   test('removing - metrics from start and end', async function(assert) {
     assert.expect(3);
     await visit('/reports/new');
-    await click('.navi-report__run-btn');
+    await click('.navi-column-config-item[data-name="dateTime"] .navi-column-config-item__trigger');
 
     await clickItem('metric', 'Ad Clicks');
     await clickItem('metric', 'Nav Link Clicks');
@@ -431,7 +437,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
   test('adding - dimensions', async function(assert) {
     assert.expect(3);
     await visit('/reports/new');
-    await click('.navi-report__run-btn');
+    await click('.navi-column-config-item[data-name="dateTime"] .navi-column-config-item__trigger');
 
     assert.deepEqual(getColumns(), ['Date Time (Day)'], 'Initially only the date time is visible');
     await clickItem('dimension', 'Age');
@@ -449,7 +455,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
   test('removing - dimensions from start and end', async function(assert) {
     assert.expect(3);
     await visit('/reports/new');
-    await click('.navi-report__run-btn');
+    await click('.navi-column-config-item[data-name="dateTime"] .navi-column-config-item__trigger');
 
     await clickItem('dimension', 'Age');
     await clickItem('dimension', 'Browser');
@@ -482,7 +488,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
   test('adding - metrics and dimensions', async function(assert) {
     assert.expect(2);
     await visit('/reports/new');
-    await click('.navi-report__run-btn');
+    await click('.navi-column-config-item[data-name="dateTime"] .navi-column-config-item__trigger');
 
     assert.deepEqual(getColumns(), ['Date Time (Day)'], 'Initially only the date time is visible');
     await clickItem('metric', 'Ad Clicks');
@@ -502,7 +508,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
   skip('config - renaming - date time', async function(assert) {
     assert.expect(4);
     await visit('/reports/new');
-    await click('.navi-report__run-btn');
+    await click('.navi-column-config-item[data-name="dateTime"] .navi-column-config-item__trigger');
 
     assert.deepEqual(getColumns(), ['Date Time (Day)'], 'Initially only the date time is visible');
 
@@ -522,7 +528,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
   skip('config - renaming - metrics', async function(assert) {
     assert.expect(7);
     await visit('/reports/new');
-    await click('.navi-report__run-btn');
+    await click('.navi-column-config-item[data-name="dateTime"] .navi-column-config-item__trigger');
 
     await clickItem('metric', 'Ad Clicks');
     await clickItem('metric', 'Nav Link Clicks');
@@ -573,7 +579,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
   skip('config - renaming - parameterized metrics', async function(assert) {
     assert.expect(7);
     await visit('/reports/new');
-    await click('.navi-report__run-btn');
+    await click('.navi-column-config-item[data-name="dateTime"] .navi-column-config-item__trigger');
 
     await clickItem('metric', 'Platform Revenue');
     await clickItem('metric', 'button click count');
@@ -624,7 +630,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
   skip('config - renaming - dimensions', async function(assert) {
     assert.expect(7);
     await visit('/reports/new');
-    await click('.navi-report__run-btn');
+    await click('.navi-column-config-item[data-name="dateTime"] .navi-column-config-item__trigger');
 
     await clickItem('dimension', 'Age');
     await clickItem('dimension', 'Browser');
@@ -667,7 +673,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
   test('config - parameters - metrics change first instance parameter', async function(assert) {
     assert.expect(2);
     await visit('/reports/new');
-    await click('.navi-report__run-btn');
+    await click('.navi-column-config-item[data-name="dateTime"] .navi-column-config-item__trigger');
 
     await clickItem('metric', 'Platform Revenue');
     await clickItem('metric', 'button click count');
@@ -692,7 +698,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
   test('config - parameters - metrics change last instance parameter', async function(assert) {
     assert.expect(2);
     await visit('/reports/new');
-    await click('.navi-report__run-btn');
+    await click('.navi-column-config-item[data-name="dateTime"] .navi-column-config-item__trigger');
 
     await clickItem('metric', 'Platform Revenue');
     await clickItem('metric', 'button click count');
@@ -717,7 +723,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
   test('config - clone - dimension', async function(assert) {
     assert.expect(2);
     await visit('/reports/new');
-    await click('.navi-report__run-btn');
+    await click('.navi-column-config-item[data-name="dateTime"] .navi-column-config-item__trigger');
 
     await clickItem('dimension', 'Age');
     await clickItem('dimension', 'Browser');
@@ -755,7 +761,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
   test('config - clone - metric', async function(assert) {
     assert.expect(2);
     await visit('/reports/new');
-    await click('.navi-report__run-btn');
+    await click('.navi-column-config-item[data-name="dateTime"] .navi-column-config-item__trigger');
 
     await clickItem('metric', 'Ad Clicks');
     await clickItem('metric', 'Nav Link Clicks');
@@ -804,7 +810,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
   test('config - clone - parameterized metric', async function(assert) {
     assert.expect(3);
     await visit('/reports/new');
-    await click('.navi-report__run-btn');
+    await click('.navi-column-config-item[data-name="dateTime"] .navi-column-config-item__trigger');
 
     await clickItem('metric', 'Platform Revenue');
     await clickItem('metric', 'Nav Link Clicks');
@@ -856,7 +862,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
   skip('config - duplicate columns - can configure multiple of the same base metrics', async function(assert) {
     assert.expect(2);
     await visit('/reports/new');
-    await click('.navi-report__run-btn');
+    await click('.navi-column-config-item[data-name="dateTime"] .navi-column-config-item__trigger');
 
     await clickItem('metric', 'Ad Clicks');
     await clickItem('metric', 'Nav Link Clicks');
@@ -884,7 +890,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
   skip('config - duplicate columns - can configure multiple of the same base dimension', async function(assert) {
     assert.expect(2);
     await visit('/reports/new');
-    await click('.navi-report__run-btn');
+    await click('.navi-column-config-item[data-name="dateTime"] .navi-column-config-item__trigger');
 
     await clickItem('dimension', 'Age');
     await clickItem('dimension', 'Browser');
@@ -908,7 +914,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
   test('config - filters - dimensions - expand on add', async function(assert) {
     assert.expect(8);
     await visit('/reports/new');
-    await click('.navi-report__run-btn');
+    await click('.navi-column-config-item[data-name="dateTime"] .navi-column-config-item__trigger');
 
     await clickItem('dimension', 'Age');
     await animationsSettled();
@@ -962,7 +968,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
   test('config - filters - metrics - expand on add', async function(assert) {
     assert.expect(8);
     await visit('/reports/new');
-    await click('.navi-report__run-btn');
+    await click('.navi-column-config-item[data-name="dateTime"] .navi-column-config-item__trigger');
 
     await clickItem('metric', 'Ad Clicks');
     await animationsSettled();
@@ -1014,7 +1020,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
   test('config - filters - parameterized metrics - expand on add', async function(assert) {
     assert.expect(8);
     await visit('/reports/new');
-    await click('.navi-report__run-btn');
+    await click('.navi-column-config-item[data-name="dateTime"] .navi-column-config-item__trigger');
 
     await clickItem('metric', 'Platform Revenue');
     await animationsSettled();
@@ -1067,7 +1073,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
   test('config - filters - parameterized metrics - different parameters make different filters', async function(assert) {
     assert.expect(6);
     await visit('/reports/new');
-    await click('.navi-report__run-btn');
+    await click('.navi-column-config-item[data-name="dateTime"] .navi-column-config-item__trigger');
 
     await clickItem('metric', 'Platform Revenue');
     await clickItem('metric', 'Platform Revenue');
@@ -1111,7 +1117,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
   test('config - filters - metrics - stay collapsed on remove', async function(assert) {
     assert.expect(4);
     await visit('/reports/new');
-    await click('.navi-report__run-btn');
+    await click('.navi-column-config-item[data-name="dateTime"] .navi-column-config-item__trigger');
 
     await clickItem('metric', 'Ad Clicks');
     await animationsSettled();
@@ -1142,7 +1148,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
   test('config - filters - parameterized metrics - stay collapsed on remove', async function(assert) {
     assert.expect(4);
     await visit('/reports/new');
-    await click('.navi-report__run-btn');
+    await click('.navi-column-config-item[data-name="dateTime"] .navi-column-config-item__trigger');
 
     await clickItem('metric', 'Platform Revenue');
     await animationsSettled();
@@ -1173,7 +1179,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
   test('config - filters - dimensions - stay collapsed on remove', async function(assert) {
     assert.expect(4);
     await visit('/reports/new');
-    await click('.navi-report__run-btn');
+    await click('.navi-column-config-item[data-name="dateTime"] .navi-column-config-item__trigger');
 
     await clickItem('dimension', 'Age');
     await animationsSettled();
@@ -1205,6 +1211,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
   test('config - parameterized metric - search parameters', async function(assert) {
     assert.expect(4);
     await visit('/reports/new');
+    await click('.navi-column-config-item[data-name="dateTime"] .navi-column-config-item__trigger');
 
     await clickItem('metric', 'Platform Revenue');
 

--- a/packages/reports/tests/integration/components/navi-column-config-test.js
+++ b/packages/reports/tests/integration/components/navi-column-config-test.js
@@ -133,7 +133,6 @@ module('Integration | Component | navi-column-config', function(hooks) {
       .dom('.navi-column-config-item__remove-icon')
       .isNotDisabled('remove button of date time column is not disabled');
 
-    await click('.navi-column-config-item__name[title="Date Time (Day)"]'); // open date time config
     await clickTrigger('.navi-column-config-item__parameter'); // open the time grain dropdown
     assert.deepEqual(
       findAll('.navi-column-config-item__parameter-dropdown .ember-power-select-option').map(el =>
@@ -371,7 +370,6 @@ module('Integration | Component | navi-column-config', function(hooks) {
       'Initial columns are added'
     );
 
-    await click('.navi-column-config-item__name[title="Date Time (Day)"]'); // open date time config
     assert.dom('.navi-column-config-base__clone-icon').exists({ count: 1 }, 'Date time config has clone icon');
     assert
       .dom('.navi-column-config-base__clone-icon')
@@ -410,6 +408,7 @@ module('Integration | Component | navi-column-config', function(hooks) {
       'Initial columns are added'
     );
 
+    await click('.navi-column-config-item__name[title="Date Time (Day)"]'); // close date time
     await click('.navi-column-config-item__name[title="Nav Link Clicks"]'); // open metric config
     assert.dom('.navi-column-config-base__clone-icon').exists({ count: 1 }, 'Metric config has clone icon');
     assert
@@ -467,6 +466,7 @@ module('Integration | Component | navi-column-config', function(hooks) {
       'Initial columns are added'
     );
 
+    await click('.navi-column-config-item__name[title="Date Time (Day)"]'); // close date time
     await click('.navi-column-config-item__name[title="Platform Revenue"]'); // open parameterized metric config
     assert.dom('.navi-column-config-base__clone-icon').exists({ count: 1 }, 'Metric config has clone icon');
     assert
@@ -524,6 +524,7 @@ module('Integration | Component | navi-column-config', function(hooks) {
       'Initial columns are added'
     );
 
+    await click('.navi-column-config-item__name[title="Date Time (Day)"]'); // close date time
     await click('.navi-column-config-item__name[title="Browser"]'); // open dimension config
     assert.dom('.navi-column-config-base__clone-icon').exists({ count: 1 }, 'Dimension config has clone icon');
     assert


### PR DESCRIPTION
## Description
With the new experience, we should show users how they can configure metrics/time grain by automatically opening the date time

## Proposed Changes
- Show the date time as being added when creating a new report

## Screenshots
![new-report](https://user-images.githubusercontent.com/12093492/81839365-0806d380-950d-11ea-939b-7fc2773ce082.gif)


## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
