### PR TITLE
Update: Add focusOut hook on navi-search

### DIFF
--- a/packages/search/addon/components/navi-search-bar.hbs
+++ b/packages/search/addon/components/navi-search-bar.hbs
@@ -1,8 +1,8 @@
 {{! Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. }}
-<BasicDropdown @tagName="div" @matchTriggerWidth={{true}} @verticalPosition="below" @class="navi-search" ...attributes as |dd|>
+<BasicDropdown @tagName="div" @matchTriggerWidth={{true}} @verticalPosition="below" @renderInPlace={{true}} @class="navi-search" ...attributes as |dd|>
   <div class="navi-search-bar">
     <Input @type="text" @value={{this.searchQuery}} @placeholder="Search" @class="navi-search-bar__input"
-      @keyUp={{fn this.onKeyUp dd}} @focusIn={{fn dd.actions.open}} data-ebd-id="{{dd.uniqueId}}-trigger" />
+      @keyUp={{fn this.onKeyUp dd}} @focusIn={{fn dd.actions.open}} @focusOut={{@focusOut}} data-ebd-id="{{dd.uniqueId}}-trigger" />
     <NaviIcon @icon="search" class="navi-search-bar__icon" />
   </div>
   {{#if (and this.launchQuery.lastSuccessful.value (not-eq this.searchQuery ""))}}

--- a/packages/search/tests/integration/components/navi-search-bar-test.js
+++ b/packages/search/tests/integration/components/navi-search-bar-test.js
@@ -1,9 +1,10 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, fillIn, triggerKeyEvent } from '@ember/test-helpers';
+import { blur, render, fillIn, triggerKeyEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { set } from '@ember/object';
 
 module('Integration | Component | navi-search-bar', function(hooks) {
   setupRenderingTest(hooks);
@@ -69,5 +70,18 @@ module('Integration | Component | navi-search-bar', function(hooks) {
     await triggerKeyEvent('.navi-search-bar__input', 'keyup', 13);
 
     assert.dom('.navi-search-results').doesNotExist('Nothing happens if you search with empty query');
+  });
+
+  test('pass focusOut function', async function(assert) {
+    assert.expect(1);
+
+    const focusOut = function() {
+      assert.ok(true, 'focus out function called');
+    };
+    set(this, 'focusOut', focusOut);
+
+    await render(hbs`<NaviSearchBar @focusOut={{this.focusOut}} />`);
+
+    blur('.navi-search-bar__input');
   });
 });


### PR DESCRIPTION
Resolves #

<!-- The above line will close the issue upon merge -->

## Description
Add focusOut hook on navi-search

## Proposed Changes

- Add a hook for when the search bar is out of focus. Can be used to say collapse a nav bar when the search loses focus
- Render search results under the navi-search div instead of the root of the body.

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
