### PR TITLE
Fix: Remove sort when matching metric is removed

### DIFF
--- a/packages/reports/addon/consumers/request/sort.js
+++ b/packages/reports/addon/consumers/request/sort.js
@@ -98,12 +98,32 @@ export default ActionConsumer.extend({
      */
     [RequestActions.REMOVE_METRIC_FRAGMENT](route, metric) {
       // Find and remove any `sorts` attached to the metric and parameters
-      get(this, 'requestActionDispatcher').dispatch(
+      this.requestActionDispatcher.dispatch(
         RequestActions.REMOVE_SORT_WITH_PARAM,
         route,
         metric.metric,
         metric.parameters
       );
+    },
+
+    /**
+     * Remove all metric sorts of same base metric if a param is updated
+     * @action REMOVE_METRIC_FRAGMENT
+     * @param {Object} route - route that has a model that contains a request property
+     * @param {Object} metric - metric fragment model of metric that needs to be removed
+     */
+    [RequestActions.UPDATE_METRIC_FRAGMENT_WITH_PARAM](route, metric) {
+      this.requestActionDispatcher.dispatch(RequestActions.REMOVE_SORT_BY_METRIC_MODEL, route, metric.metric);
+    },
+
+    /**
+     * Remove all metric sorts of same base metric if a param is updated
+     * @action REMOVE_METRIC_FRAGMENT
+     * @param {Object} route - route that has a model that contains a request property
+     * @param {string} metric - base metric to be removed
+     */
+    [RequestActions.UPDATE_METRIC_PARAM](route, metric) {
+      this.requestActionDispatcher.dispatch(RequestActions.REMOVE_SORT, route, metric);
     }
   }
 });

--- a/packages/reports/addon/consumers/request/sort.js
+++ b/packages/reports/addon/consumers/request/sort.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import ActionConsumer from 'navi-core/consumers/action-consumer';
@@ -89,6 +89,21 @@ export default ActionConsumer.extend({
     [RequestActions.REMOVE_METRIC_WITH_PARAM](route, metric, parameters) {
       // Find and remove any `sorts` attached to the metric and parameters
       get(this, 'requestActionDispatcher').dispatch(RequestActions.REMOVE_SORT_WITH_PARAM, route, metric, parameters);
+    },
+
+    /**
+     * @action REMOVE_METRIC_FRAGMENT
+     * @param {Object} route - route that has a model that contains a request property
+     * @param {Object} metric - metric fragment model of metric that needs to be removed
+     */
+    [RequestActions.REMOVE_METRIC_FRAGMENT](route, metric) {
+      // Find and remove any `sorts` attached to the metric and parameters
+      get(this, 'requestActionDispatcher').dispatch(
+        RequestActions.REMOVE_SORT_WITH_PARAM,
+        route,
+        metric.metric,
+        metric.parameters
+      );
     }
   }
 });

--- a/packages/reports/tests/acceptance/column-config-test.js
+++ b/packages/reports/tests/acceptance/column-config-test.js
@@ -1233,7 +1233,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
   });
 
   test('Sort gets removed when metric is removed', async function(assert) {
-    assert.expect(3);
+    assert.expect(6);
     await visit('/reports/new');
 
     await clickItem('metric', 'Platform Revenue');
@@ -1252,6 +1252,28 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
 
     apiURL = await getRequestURL();
     assert.notOk(apiURL.searchParams.has('sort'), 'Sort is removed from request when metric is removed');
+
+    //test param changing
+    await visit('/reports/new');
+
+    await clickItem('metric', 'Platform Revenue');
+
+    await animationsSettled();
+    assert.deepEqual(getColumns(), ['Date Time (Day)', 'Platform Revenue (USD)'], 'The initial metrics was added');
+    await click('.navi-report__run-btn');
+
+    await click('.table-header-row .table-header-cell.metric .navi-table-sort-icon');
+
+    apiURL = await getRequestURL();
+    assert.equal(apiURL.searchParams.get('sort'), 'platformRevenue(currency=USD)|desc', 'Sort is included in request');
+
+    //removing metric from column config
+    await click('.navi-column-config-item__parameter-trigger');
+    await fillIn('.ember-power-select-search-input', 'Dollars');
+    await click(findAll('.ember-power-select-option')[1]);
+
+    apiURL = await getRequestURL();
+    assert.notOk(apiURL.searchParams.has('sort'), 'Sort is removed from request when metric params changed');
   });
 
   function getColumns() {

--- a/packages/reports/tests/acceptance/column-config-test.js
+++ b/packages/reports/tests/acceptance/column-config-test.js
@@ -1267,10 +1267,8 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
     apiURL = await getRequestURL();
     assert.equal(apiURL.searchParams.get('sort'), 'platformRevenue(currency=USD)|desc', 'Sort is included in request');
 
-    //removing metric from column config
-    await click('.navi-column-config-item__parameter-trigger');
-    await fillIn('.ember-power-select-search-input', 'Dollars');
-    await click(findAll('.ember-power-select-option')[1]);
+    //changing metric param
+    await selectChoose(findAll('.navi-column-config-item__parameter-trigger')[0], 'Dollars (CAD)');
 
     apiURL = await getRequestURL();
     assert.notOk(apiURL.searchParams.has('sort'), 'Sort is removed from request when metric params changed');


### PR DESCRIPTION
## Description

When removing a metric in the new column config, any matching sorts are not removed, causing Fili API errors

## Proposed Changes

- Add corresponding consumer for REMOVE_METRIC_FRAGMENT in sort consumer.
- When params change, remove all sorts with the base metric to reset the sorts for that metric.

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
