### PR TITLE
Update: Throttle and highlight clicks on metric/dimension selections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,9 @@ script:
     npx lerna exec --scope ${PACKAGE} ember ts:precompile;
     PRECOMPILE_RESULT=$?;
     npx lerna exec --scope ${PACKAGE} ember ts:clean;
+    if [[ "${PRECOMPILE_RESULT}" -gt 0 ]]; then
     exit $PRECOMPILE_RESULT;
+    fi
     fi
   - if [[ "${PACKAGE}" == "navi-webservice" ]]; then
     pushd packages/webservice && ./gradlew check && popd;

--- a/packages/core/app/styles/navi-core/variables/animations.less
+++ b/packages/core/app/styles/navi-core/variables/animations.less
@@ -2,7 +2,8 @@
  * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
-@import 'colors';
-@import 'fonts';
-@import 'size';
-@import 'animations';
+@keyframes navi-pulse-once {
+  50% {
+    background-color: @denali-brand-200;
+  }
+}

--- a/packages/reports/addon/components/dimension-selector.js
+++ b/packages/reports/addon/components/dimension-selector.js
@@ -206,7 +206,7 @@ export default class DimensionSelector extends Component {
    * @param {Node} target - DOM Node for clicked dimension
    */
   doItemClicked(item, target) {
-    target.focus(); // firefox does not focus a button on click in MacOS specifically
+    target && target.focus(); // firefox does not focus a button on click in MacOS specifically
     const type = item.dateTimeDimension ? 'TimeGrain' : 'Dimension';
     const enableRequestPreview = featureFlag('enableRequestPreview');
 
@@ -234,11 +234,13 @@ export default class DimensionSelector extends Component {
    */
   @action
   itemClicked(item, { target }) {
-    const button =
-      target.closest('button.grouped-list__item-label') || target.closest('input.grouped-list__item-checkbox');
+    const button = target.closest('button.grouped-list__item-label');
 
-    throttle(this, 'doItemClicked', item, button, THROTTLE_TIME);
-
-    BlurOnAnimationEnd(target, button);
+    if (featureFlag('enableRequestPreview')) {
+      throttle(this, 'doItemClicked', item, button, THROTTLE_TIME);
+      BlurOnAnimationEnd(target, button);
+    } else {
+      this.doItemClicked(item, null);
+    }
   }
 }

--- a/packages/reports/addon/components/dimension-selector.js
+++ b/packages/reports/addon/components/dimension-selector.js
@@ -25,6 +25,35 @@ import { getDefaultTimeGrain } from 'navi-reports/utils/request-table';
 
 export const THROTTLE_TIME = 750; // milliseconds
 
+const ANIMATIONS = {
+  animation: 'animationend',
+  OAnimation: 'oAnimationEnd',
+  MozAnimation: 'animationend',
+  WebkitAnimation: 'webkitAnimationEnd'
+};
+
+/**
+ * Blur button at the end of the target's animation
+ * @param {Element} target - grouped-list__item-container--selected element for the clicked item that will play the animation
+ * @param {Element} button - grouped-list__item-label element that is the button that fired off the action
+ */
+export function BlurOnAnimationEnd(target, button) {
+  const listItemContainer = target.closest('.grouped-list__item-container--selected');
+  if (listItemContainer) {
+    // Detect the end of the css animation depending on browser and blur the button
+    let animationEndEvent;
+    for (let animation in ANIMATIONS) {
+      if (listItemContainer.style[animation] != undefined) {
+        animationEndEvent = ANIMATIONS[animation];
+      }
+    }
+
+    if (animationEndEvent) {
+      listItemContainer.addEventListener(animationEndEvent, () => button.blur(), { once: true });
+    }
+  }
+}
+
 export default class DimensionSelector extends Component {
   layout = layout;
 
@@ -210,12 +239,6 @@ export default class DimensionSelector extends Component {
 
     throttle(this, 'doItemClicked', item, button, THROTTLE_TIME);
 
-    const listItemContainer = target.closest('.grouped-list__item-container--selected');
-    if (listItemContainer) {
-      // Detect the end of the css animation and blur the button
-      ['animationend', 'webkitAnimationEnd', 'oAnimationEnd', 'MSAnimationEnd'].forEach(ev => {
-        listItemContainer.addEventListener(ev, button.blur());
-      });
-    }
+    BlurOnAnimationEnd(target, button);
   }
 }

--- a/packages/reports/addon/components/dimension-selector.js
+++ b/packages/reports/addon/components/dimension-selector.js
@@ -234,9 +234,8 @@ export default class DimensionSelector extends Component {
    */
   @action
   itemClicked(item, { target }) {
-    const button = target.closest('button.grouped-list__item-label');
-
     if (featureFlag('enableRequestPreview')) {
+      const button = target.closest('button.grouped-list__item-label');
       throttle(this, 'doItemClicked', item, button, THROTTLE_TIME);
       BlurOnAnimationEnd(target, button);
     } else {

--- a/packages/reports/addon/components/metric-config.js
+++ b/packages/reports/addon/components/metric-config.js
@@ -14,22 +14,22 @@
 import Component from '@ember/component';
 import layout from '../templates/components/metric-config';
 import { inject as service } from '@ember/service';
-import { computed, get, observer, set } from '@ember/object';
+import { computed, get, set, action } from '@ember/object';
+import { throttle } from '@ember/runloop';
+import { BlurOnAnimationEnd, THROTTLE_TIME } from './dimension-selector';
 import { A as arr } from '@ember/array';
 import { featureFlag } from 'navi-core/helpers/feature-flag';
+import { layout as templateLayout, tagName } from '@ember-decorators/component';
+import { observes } from '@ember-decorators/object';
 
-export default Component.extend({
-  layout,
-
-  /**
-   * @property {Array} classNames
-   */
-  classNames: ['metric-config'],
-
+@tagName('')
+@templateLayout(layout)
+class MetricConfig extends Component {
   /**
    * @property {Service} parameterService - metric parameter service
    */
-  parameterService: service('metric-parameter'),
+  @service('metric-parameter')
+  parameterService;
 
   /**
    * @method calculatePosition
@@ -45,13 +45,14 @@ export default Component.extend({
       };
 
     return { style };
-  },
+  }
 
   /**
    * @observer _fetchAllParams
    * creates a hash of promises for all metric parameter values and sets the appropriate properties
    */
-  _fetchAllParams: observer('metric', function() {
+  @observes('metric')
+  _fetchAllParams() {
     const fetchParamsPromise = this.parameterService.fetchAllParams(this.metric);
 
     set(this, 'parametersPromise', fetchParamsPromise);
@@ -59,7 +60,7 @@ export default Component.extend({
       set(this, 'allParametersMap', result);
       set(this, 'allParameters', Object.values(result));
     });
-  }),
+  }
 
   /**
    * @property {Object} allParametersMap - parameters map of param type and id to parameter object
@@ -68,17 +69,18 @@ export default Component.extend({
    *    ...
    *  }
    */
-  allParametersMap: undefined,
+  allParametersMap;
 
   /**
    * @property {Array} allParameters - parameter value array
    */
-  allParameters: undefined,
+  allParameters;
 
   /**
    * @property {Array} selectedParams - selected param objects
    */
-  selectedParams: computed('request.metrics.[]', 'metric', 'allParametersMap', function() {
+  @computed('request.metrics.[]', 'metric', 'allParametersMap')
+  get selectedParams() {
     let selectedMetrics = arr(get(this, 'request.metrics')).filterBy('metric', get(this, 'metric')),
       selectedMetricParams = arr(selectedMetrics).mapBy('parameters'),
       allParametersMap = get(this, 'allParametersMap') || {};
@@ -100,23 +102,25 @@ export default Component.extend({
         return allParametersMap[`${key}|${value}`];
       })
       .filter(e => !!e); //filter out bad or outdated parameters
-  }),
+  }
 
   /**
    * @property {Array} parametersChecked - list of all parameters checked
    */
-  parametersChecked: computed('selectedParams', function() {
+  @computed('selectedParams')
+  get parametersChecked() {
     return get(this, 'selectedParams').reduce((list, param) => {
       list[`${get(param, 'param')}|${get(param, 'id')}`] = true;
       return list;
     }, {});
-  }),
+  }
 
-  /*
+  /**
    * @property {Object} paramsFiltered - having -> boolean mapping denoting presence of metric param
    *                                         in request havings
    */
-  paramsFiltered: computed('request.having.[]', 'metric', function() {
+  @computed('request.having.[]', 'metric')
+  get paramsFiltered() {
     return arr(get(this, 'request.having'))
       .filterBy('metric.metric.id', this.metric?.id)
       .reduce((list, having) => {
@@ -128,39 +132,63 @@ export default Component.extend({
 
         return list;
       }, {});
-  }),
+  }
 
-  actions: {
-    /*
-     * @action triggerFetch
-     * trigger parameter value fetch
-     */
-    triggerFetch() {
-      this._fetchAllParams();
-    },
+  /**
+   * @action Call the supplied handler to add the metric with param and focus the clicked button
+   * @param {Function} handler
+   * @param {String} metric
+   * @param {Object} param
+   * @param {Element} target
+   */
+  doParamToggled(handler, metric, param, target) {
+    target && target.focus();
+    handler(metric, { [param.param]: param.id });
+  }
 
-    /*
-     * @action paramToggled
-     * @param {Object} metric
-     * @param {Object} param
-     */
-    paramToggled(metric, param) {
-      const enableRequestPreview = featureFlag('enableRequestPreview');
-      const action = !enableRequestPreview && this.parametersChecked[`${param.param}|${param.id}`] ? 'Remove' : 'Add';
-      const handler = this[`on${action}ParameterizedMetric`];
+  /**
+   * @action triggerFetch
+   * trigger parameter value fetch
+   */
+  @action
+  triggerFetch() {
+    this._fetchAllParams();
+  }
 
-      if (handler) handler(metric, { [param.param]: param.id });
-    },
+  /**
+   * @action paramToggled - throttle the adding of metrics when requestPreview is enabled
+   * @param {Object} metric
+   * @param {Object} param
+   */
+  @action
+  paramToggled(metric, param, { target }) {
+    const enableRequestPreview = featureFlag('enableRequestPreview');
+    const actionName = !enableRequestPreview && this.parametersChecked[`${param.param}|${param.id}`] ? 'Remove' : 'Add';
+    const handler = this[`on${actionName}ParameterizedMetric`];
 
-    /*
-     * @action paramFilterToggled
-     * @param {Object} metric
-     * @param {Object} param
-     */
-    paramFilterToggled(metric, param) {
-      const handler = get(this, 'onToggleParameterizedMetricFilter');
+    const button = target.closest('button.grouped-list__item-label');
 
-      if (handler) handler(metric, { [get(param, 'param')]: get(param, 'id') });
+    if (handler) {
+      if (featureFlag('enableRequestPreview')) {
+        throttle(this, 'doParamToggled', handler, metric, param, button, THROTTLE_TIME);
+        BlurOnAnimationEnd(target, button);
+      } else {
+        this.doParamToggled(handler, metric, param, null);
+      }
     }
   }
-});
+
+  /**
+   * @action paramFilterToggled
+   * @param {Object} metric
+   * @param {Object} param
+   */
+  @action
+  paramFilterToggled(metric, param) {
+    const handler = get(this, 'onToggleParameterizedMetricFilter');
+
+    if (handler) handler(metric, { [get(param, 'param')]: get(param, 'id') });
+  }
+}
+
+export default MetricConfig;

--- a/packages/reports/addon/components/metric-config.js
+++ b/packages/reports/addon/components/metric-config.js
@@ -166,10 +166,9 @@ class MetricConfig extends Component {
     const actionName = !enableRequestPreview && this.parametersChecked[`${param.param}|${param.id}`] ? 'Remove' : 'Add';
     const handler = this[`on${actionName}ParameterizedMetric`];
 
-    const button = target.closest('button.grouped-list__item-label');
-
     if (handler) {
       if (featureFlag('enableRequestPreview')) {
+        const button = target.closest('button.grouped-list__item-label');
         throttle(this, 'doParamToggled', handler, metric, param, button, THROTTLE_TIME);
         BlurOnAnimationEnd(target, button);
       } else {

--- a/packages/reports/addon/components/metric-selector.js
+++ b/packages/reports/addon/components/metric-selector.js
@@ -22,7 +22,7 @@ import layout from '../templates/components/metric-selector';
 import { run } from '@ember/runloop';
 import { featureFlag } from 'navi-core/helpers/feature-flag';
 import { layout as templateLayout, tagName } from '@ember-decorators/component';
-import { THROTTLE_TIME } from './dimension-selector';
+import { THROTTLE_TIME, BlurOnAnimationEnd } from './dimension-selector';
 
 @templateLayout(layout)
 @tagName('')
@@ -129,13 +129,7 @@ class MetricSelectorComponent extends Component {
 
     throttle(this, 'doMetricClicked', metric, button, THROTTLE_TIME);
 
-    const listItemContainer = target.closest('.grouped-list__item-container--selected');
-    if (listItemContainer) {
-      // Detect the end of the css animation and blur the button
-      ['animationend', 'webkitAnimationEnd', 'oAnimationEnd', 'MSAnimationEnd'].forEach(ev => {
-        listItemContainer.addEventListener(ev, button.blur());
-      });
-    }
+    BlurOnAnimationEnd(target, button);
   }
 }
 

--- a/packages/reports/addon/components/metric-selector.js
+++ b/packages/reports/addon/components/metric-selector.js
@@ -125,9 +125,8 @@ class MetricSelectorComponent extends Component {
    */
   @action
   metricClicked(metric, { target }) {
-    const button = target.closest('button.grouped-list__item-label');
-
     if (featureFlag('enableRequestPreview')) {
+      const button = target.closest('button.grouped-list__item-label');
       throttle(this, 'doMetricClicked', metric, button, THROTTLE_TIME);
       BlurOnAnimationEnd(target, button);
     } else {

--- a/packages/reports/addon/components/metric-selector.js
+++ b/packages/reports/addon/components/metric-selector.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Usage:
@@ -105,7 +105,7 @@ class MetricSelectorComponent extends Component {
    * @param {Node} target - DOM Node for clicked metric
    */
   doMetricClicked(metric, target) {
-    target.focus(); // firefox does not focus a button on click in MacOS specifically
+    target && target.focus(); // firefox does not focus a button on click in MacOS specifically
     const enableRequestPreview = featureFlag('enableRequestPreview'),
       actionName = !enableRequestPreview && get(this, 'metricsChecked')[get(metric, 'id')] ? 'Remove' : 'Add',
       handler = this[`on${actionName}Metric`];
@@ -127,9 +127,12 @@ class MetricSelectorComponent extends Component {
   metricClicked(metric, { target }) {
     const button = target.closest('button.grouped-list__item-label');
 
-    throttle(this, 'doMetricClicked', metric, button, THROTTLE_TIME);
-
-    BlurOnAnimationEnd(target, button);
+    if (featureFlag('enableRequestPreview')) {
+      throttle(this, 'doMetricClicked', metric, button, THROTTLE_TIME);
+      BlurOnAnimationEnd(target, button);
+    } else {
+      this.doMetricClicked(metric, null);
+    }
   }
 }
 

--- a/packages/reports/addon/templates/components/dimension-selector.hbs
+++ b/packages/reports/addon/templates/components/dimension-selector.hbs
@@ -21,6 +21,7 @@
           <button class="grouped-list__item-label"
             role="button"
             aria-disabled="{{not (is-empty this.selectedTimeGrain)}}"
+            type="button"
             {{on "click" (fn this.itemClicked item)}}>
             <NaviIcon
               @icon="plus-circle"

--- a/packages/reports/addon/templates/components/dimension-selector.hbs
+++ b/packages/reports/addon/templates/components/dimension-selector.hbs
@@ -46,7 +46,7 @@
       {{/if}}
     {{else}}
       <div class="grouped-list__item-container {{if (and (get this.itemsChecked item.id) (feature-flag "enableRequestPreview")) "grouped-list__item-container--selected"}}">
-        <button class="grouped-list__item-label" {{on "click" (fn this.itemClicked item)}} role="button">
+        <button class="grouped-list__item-label" {{on "click" (fn this.itemClicked item)}} role="button" type="button">
           <NaviIcon
             @icon={{if (and (get this.itemsChecked item.id) (not (feature-flag "enableRequestPreview"))) "minus-circle" "plus-circle"}}
             class="grouped-list__add-icon {{if (not (or (feature-flag "enableRequestPreview") (get this.itemsChecked item.id))) "grouped-list__add-icon--deselected"}}"

--- a/packages/reports/addon/templates/components/dimension-selector.hbs
+++ b/packages/reports/addon/templates/components/dimension-selector.hbs
@@ -18,7 +18,7 @@
     {{#if item.dateTimeDimension}}
       {{#if (feature-flag "enableRequestPreview")}}
         <div class="grouped-list__item-container {{if this.selectedTimeGrain "grouped-list__item-container--selected grouped-list__item-container--disabled"}}">
-          <span class="grouped-list__item-label"
+          <button class="grouped-list__item-label"
             role="button"
             aria-disabled="{{not (is-empty this.selectedTimeGrain)}}"
             {{on "click" (fn this.itemClicked item)}}>
@@ -27,7 +27,7 @@
               class="grouped-list__add-icon"
             />
             {{item.name}}
-          </span>
+          </button>
         </div>
       {{else}}
         <div class="grouped-list__item-checkbox-container">
@@ -46,13 +46,13 @@
       {{/if}}
     {{else}}
       <div class="grouped-list__item-container {{if (and (get this.itemsChecked item.id) (feature-flag "enableRequestPreview")) "grouped-list__item-container--selected"}}">
-        <span class="grouped-list__item-label" {{on "click" (fn this.itemClicked item)}} role="button">
+        <button class="grouped-list__item-label" {{on "click" (fn this.itemClicked item)}} role="button">
           <NaviIcon
             @icon={{if (and (get this.itemsChecked item.id) (not (feature-flag "enableRequestPreview"))) "minus-circle" "plus-circle"}}
             class="grouped-list__add-icon {{if (not (or (feature-flag "enableRequestPreview") (get this.itemsChecked item.id))) "grouped-list__add-icon--deselected"}}"
           />
           {{item.name}}
-        </span>
+        </button>
 
         <NaviIcon @icon="question-circle-o" class="grouped-list__item-info">
           <EmberTooltip @side="right" @popperContainer="body" @effect="none">

--- a/packages/reports/addon/templates/components/metric-config.hbs
+++ b/packages/reports/addon/templates/components/metric-config.hbs
@@ -1,55 +1,57 @@
-{{!-- Copyright 2019, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
-<BasicDropdown
-  @calculatePosition={{calculatePosition}}
-  as |dd|
->
-  <dd.trigger @class="metric-config__dropdown-trigger" @onMouseDown={{action "triggerFetch"}}>
-    <NaviIcon @icon="cog" class="metric-config__trigger-icon" />
-  </dd.trigger>
+{{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+<div class="metric-config" ...attributes>
+  <BasicDropdown
+    @calculatePosition={{calculatePosition}}
+    as |dd|
+  >
+    <dd.trigger @class="metric-config__dropdown-trigger" @onMouseDown={{action "triggerFetch"}}>
+      <NaviIcon @icon="cog" class="metric-config__trigger-icon" />
+    </dd.trigger>
 
-  <dd.content @class="metric-config__dropdown-container">
-    {{#if (is-pending parametersPromise)}}
-      <NaviLoader />
-    {{else if (is-rejected parametersPromise)}}
-      <div class="metric-config__error-msg">OOPS! Something went wrong. Please try refreshing the page.</div>
-    {{else}}
-      <NaviListSelector
-        @items={{this.allParameters}}
-        @searchField="description"
-        @selected={{this.selectedParams}}
-        @title={{this.metric.name}}
-        @contentClass="navi-list-selector__content--metric-config"
-        as | params |
-      >
-        <GroupedList
-          @items={{params}}
-          @shouldOpenAllGroups={{true}}
-          @groupByField="param"
-          @sortByField="description"
-          as | param |
+    <dd.content @class="metric-config__dropdown-container">
+      {{#if (is-pending parametersPromise)}}
+        <NaviLoader />
+      {{else if (is-rejected parametersPromise)}}
+        <div class="metric-config__error-msg">OOPS! Something went wrong. Please try refreshing the page.</div>
+      {{else}}
+        <NaviListSelector
+          @items={{this.allParameters}}
+          @searchField="description"
+          @selected={{this.selectedParams}}
+          @title={{this.metric.name}}
+          @contentClass="navi-list-selector__content--metric-config"
+          as | params |
         >
-          <div class="grouped-list__item-container {{if (and (get parametersChecked (concat param.param "|" param.id)) (feature-flag "enableRequestPreview")) "grouped-list__item-container--selected"}}">
-            <span class="grouped-list__item-label" onclick={{action "paramToggled" metric param}} role="button">
-              <NaviIcon
-                @icon={{if (and (get parametersChecked (concat param.param "|" param.id)) (not (feature-flag "enableRequestPreview"))) "minus-circle" "plus-circle"}}
-                class="grouped-list__add-icon {{if (not (or (feature-flag "enableRequestPreview") (get parametersChecked (concat param.param "|" param.id)))) "grouped-list__add-icon--deselected"}}"
-              />
-              {{param.description}} ({{param.id}})
-            </span>
+          <GroupedList
+            @items={{params}}
+            @shouldOpenAllGroups={{true}}
+            @groupByField="param"
+            @sortByField="description"
+            as | param |
+          >
+            <div class="grouped-list__item-container {{if (and (get parametersChecked (concat param.param "|" param.id)) (feature-flag "enableRequestPreview")) "grouped-list__item-container--selected"}}">
+              <button class="grouped-list__item-label" {{on "click" (fn this.paramToggled metric param)}} role="button" type="button">
+                <NaviIcon
+                  @icon={{if (and (get parametersChecked (concat param.param "|" param.id)) (not (feature-flag "enableRequestPreview"))) "minus-circle" "plus-circle"}}
+                  class="grouped-list__add-icon {{if (not (or (feature-flag "enableRequestPreview") (get parametersChecked (concat param.param "|" param.id)))) "grouped-list__add-icon--deselected"}}"
+                />
+                {{param.description}} ({{param.id}})
+              </button>
 
-            <div class="grouped-list__icon-set metric-config__icon-set">
-              <NaviIcon
-                @icon="filter"
-                class={{concat (if (get paramsFiltered (concat param.param "|" param.id)) "grouped-list__filter--active ") "grouped-list__filter"}}
-                onclick={{action "paramFilterToggled" metric param}}
-              />
+              <div class="grouped-list__icon-set metric-config__icon-set">
+                <NaviIcon
+                  @icon="filter"
+                  class={{concat (if (get paramsFiltered (concat param.param "|" param.id)) "grouped-list__filter--active ") "grouped-list__filter"}}
+                  onclick={{action "paramFilterToggled" metric param}}
+                />
+              </div>
             </div>
-          </div>
-        </GroupedList>
-      </NaviListSelector>
-      <div class="metric-config__footer">
-        <div class="metric-config__done-btn btn btn-primary" role="button" onclick={{action dd.actions.close}}>Done</div>
-      </div>
-    {{/if}}
-  </dd.content>
-</BasicDropdown>
+          </GroupedList>
+        </NaviListSelector>
+        <div class="metric-config__footer">
+          <div class="metric-config__done-btn btn btn-primary" role="button" onclick={{action dd.actions.close}}>Done</div>
+        </div>
+      {{/if}}
+    </dd.content>
+  </BasicDropdown>
+</div>

--- a/packages/reports/addon/templates/components/metric-selector.hbs
+++ b/packages/reports/addon/templates/components/metric-selector.hbs
@@ -17,7 +17,7 @@
       as | metric |
     >
       <div class="grouped-list__item-container {{if (and (get this.metricsChecked metric.id) (feature-flag "enableRequestPreview")) "grouped-list__item-container--selected"}}">
-        <button class="grouped-list__item-label" {{on "click" (fn this.metricClicked metric)}} role="button">
+        <button class="grouped-list__item-label" {{on "click" (fn this.metricClicked metric)}} role="button" type="button">
           <NaviIcon
             @icon={{if (and (get this.metricsChecked metric.id) (not (feature-flag "enableRequestPreview"))) "minus-circle" "plus-circle"}}
             class="grouped-list__add-icon {{if (not (or (feature-flag "enableRequestPreview") (get this.metricsChecked metric.id))) "grouped-list__add-icon--deselected"}}"

--- a/packages/reports/addon/templates/components/metric-selector.hbs
+++ b/packages/reports/addon/templates/components/metric-selector.hbs
@@ -17,13 +17,13 @@
       as | metric |
     >
       <div class="grouped-list__item-container {{if (and (get this.metricsChecked metric.id) (feature-flag "enableRequestPreview")) "grouped-list__item-container--selected"}}">
-        <span class="grouped-list__item-label" {{on "click" (fn this.metricClicked metric)}} role="button">
+        <button class="grouped-list__item-label" {{on "click" (fn this.metricClicked metric)}} role="button">
           <NaviIcon
             @icon={{if (and (get this.metricsChecked metric.id) (not (feature-flag "enableRequestPreview"))) "minus-circle" "plus-circle"}}
             class="grouped-list__add-icon {{if (not (or (feature-flag "enableRequestPreview") (get this.metricsChecked metric.id))) "grouped-list__add-icon--deselected"}}"
           />
           {{metric.name}}
-        </span>
+        </button>
 
         <NaviIcon @icon="question-circle-o" class="grouped-list__item-info">
           <EmberTooltip @side="right" @popperContainer="body" @effect="none">

--- a/packages/reports/app/styles/navi-reports/components/grouped-list.less
+++ b/packages/reports/app/styles/navi-reports/components/grouped-list.less
@@ -35,12 +35,12 @@
 
   &__item {
     display: flex;
-    margin-left: 15px;
     font-size: @font-size-mid;
+    margin-left: 15px;
 
     &-label {
-      font: inherit;
       display: block;
+      font: inherit;
       padding: 0;
 
       &:hover {

--- a/packages/reports/app/styles/navi-reports/components/grouped-list.less
+++ b/packages/reports/app/styles/navi-reports/components/grouped-list.less
@@ -49,6 +49,10 @@
           opacity: unset;
         }
       }
+
+      &::-moz-focus-inner {
+        border: 0; // prevents dotted outline when button is focused
+      }
     }
 
     &-container {

--- a/packages/reports/app/styles/navi-reports/components/grouped-list.less
+++ b/packages/reports/app/styles/navi-reports/components/grouped-list.less
@@ -39,6 +39,10 @@
     font-size: @font-size-mid;
 
     &-label {
+      font: inherit;
+      display: block;
+      padding: 0;
+
       &:hover {
         .grouped-list__add-icon {
           color: @denali-link-hover;
@@ -55,6 +59,10 @@
 
       &--selected {
         background-color: @denali-brand-100;
+
+        &:focus-within {
+          animation: navi-pulse-once 0.75s;
+        }
       }
 
       &--disabled {
@@ -121,9 +129,11 @@
       width: 5px;
     }
 
-    span&-label {
+    button&-label {
+      align-items: unset;
       cursor: pointer;
       margin: 0 3px;
+      text-align: left;
     }
 
     &-info {

--- a/packages/reports/app/styles/navi-reports/components/navi-column-config/item.less
+++ b/packages/reports/app/styles/navi-reports/components/navi-column-config/item.less
@@ -123,18 +123,8 @@
     }
   }
 
-  @keyframes navi-column-config-item-pulse-once {
-    0%,
-    100% {
-      background-color: @navi-white;
-    }
-    50% {
-      background-color: @denali-brand-200;
-    }
-  }
-
   &--last-added {
-    animation: navi-column-config-item-pulse-once 0.75s;
+    animation: navi-pulse-once 0.75s;
   }
 
   &__parameter {

--- a/packages/reports/tests/acceptance/column-config-test.js
+++ b/packages/reports/tests/acceptance/column-config-test.js
@@ -1275,7 +1275,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
     assert.equal(apiURL.searchParams.get('sort'), 'platformRevenue(currency=USD)|desc', 'Sort is included in request');
 
     //changing metric param
-    await selectChoose(findAll('.navi-column-config-item__parameter-trigger')[0], 'Dollars (CAD)');
+    await selectChoose(findAll('.navi-column-config-item__parameter-trigger')[1], 'Dollars (CAD)');
 
     apiURL = await getRequestURL();
     assert.notOk(apiURL.searchParams.has('sort'), 'Sort is removed from request when metric params changed');

--- a/packages/search/addon/components/navi-search-bar.hbs
+++ b/packages/search/addon/components/navi-search-bar.hbs
@@ -7,7 +7,7 @@
   </div>
   {{#if (and this.launchQuery.lastSuccessful.value (not-eq this.searchQuery ""))}}
     <dd.content @class="navi-search-results navi-search-results--box navi-search-result-wrapper slide-fade">
-      <NaviSearchResult::Wrapper @searchResults={{this.launchQuery.lastSuccessful.value}} @closeResults={{fn dd.actions.close event}} class="navi-search-results__item navi-search-results--box"/>
+      <NaviSearchResult::Wrapper @searchResults={{this.launchQuery.lastSuccessful.value}} @closeResults={{fn dd.actions.close this.event}} class="navi-search-results__item navi-search-results--box"/>
     </dd.content>
   {{/if}}
 </BasicDropdown>

--- a/packages/search/addon/components/navi-search-result/asset.hbs
+++ b/packages/search/addon/components/navi-search-result/asset.hbs
@@ -16,7 +16,7 @@
   </tbody>
 </table>
 {{#if this.hasMoreResults}}
-  <button {{on "click" (toggle "showTop" this)}} class="navi-search-result-options__show-button">
+  <button {{on "click" (toggle "showTop" this)}} class="navi-search-result-options__show-button" type="button">
     {{if this.showTop "Show more" "Show less"}}
   </button>
 {{/if}}

--- a/packages/search/addon/components/navi-search-result/definition.hbs
+++ b/packages/search/addon/components/navi-search-result/definition.hbs
@@ -25,7 +25,7 @@
   </tbody>
 </table>
 {{#if this.hasMoreResults}}
-  <button {{on "click" (toggle "showTop" this)}} class="navi-search-result-options__show-button">
+  <button {{on "click" (toggle "showTop" this)}} class="navi-search-result-options__show-button" type="button">
     {{if this.showTop "Show more" "Show less"}}
   </button>
 {{/if}}

--- a/packages/search/tests/integration/components/navi-search-bar-test.js
+++ b/packages/search/tests/integration/components/navi-search-bar-test.js
@@ -82,6 +82,6 @@ module('Integration | Component | navi-search-bar', function(hooks) {
 
     await render(hbs`<NaviSearchBar @focusOut={{this.focusOut}} />`);
 
-    blur('.navi-search-bar__input');
+    await blur('.navi-search-bar__input');
   });
 });

--- a/packages/search/tests/integration/components/navi-search-bar-test.js
+++ b/packages/search/tests/integration/components/navi-search-bar-test.js
@@ -1,7 +1,7 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { blur, render, fillIn, triggerKeyEvent } from '@ember/test-helpers';
+import { blur, render, fillIn, triggerKeyEvent, focus } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { set } from '@ember/object';
@@ -74,14 +74,16 @@ module('Integration | Component | navi-search-bar', function(hooks) {
 
   test('pass focusOut function', async function(assert) {
     assert.expect(1);
+    const done = assert.async();
 
-    const focusOut = function() {
+    set(this, 'focusOut', () => {
       assert.ok(true, 'focus out function called');
-    };
-    set(this, 'focusOut', focusOut);
+      done();
+    });
 
     await render(hbs`<NaviSearchBar @focusOut={{this.focusOut}} />`);
 
-    await blur('.navi-search-bar__input');
+    await focus('input'); // focus the input first because otherwise the focusout event doesn't always fire
+    await blur('input');
   });
 });


### PR DESCRIPTION
## Description
Users find it hard to tell when they've added a metric or dimension in the new column config, so they end up adding the same metric/dimension multiple times.

## Proposed Changes

- Highlight a clicked metric/dimension so that users have some feedback that something has happened
- Throttle clicks on metrics/dimensions to prevent unintentional additions/deletions

## Screenshots

It doesn't show in the gif, but selected metrics/dimensions still have a light `@denali-brand-100` background color.
![May-15-2020 02-26-49](https://user-images.githubusercontent.com/23023478/82023229-91c0b900-9653-11ea-8cec-2ab19e4dae74.gif)

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
