### PR TITLE
Update: GraphQL Request URI Prefix

### DIFF
--- a/packages/data/addon/services/navi-metadata-apollo.js
+++ b/packages/data/addon/services/navi-metadata-apollo.js
@@ -6,7 +6,7 @@ export default class NaviMetadataApolloService extends ApolloService {
   /**
    * @property {String}
    */
-  namespace = 'v1/graphql';
+  namespace = 'graphql';
 
   /**
    * @override

--- a/packages/data/tests/dummy/mirage/config.js
+++ b/packages/data/tests/dummy/mirage/config.js
@@ -7,8 +7,9 @@ export default function() {
 
   // Mock bard facts + metadata
   for (let dataSource of config.navi.dataSources) {
+    this.urlPrefix = dataSource.uri;
+    GraphQL.call(this);
     this.urlPrefix = `${dataSource.uri}/v1`;
     BardMeta.call(this);
-    GraphQL.call(this);
   }
 }

--- a/packages/data/tests/unit/adapters/elide-metadata-test.js
+++ b/packages/data/tests/unit/adapters/elide-metadata-test.js
@@ -26,7 +26,7 @@ module('Unit | Elide Metadata Adapter', function(hooks) {
 
     const gqlQuery = print(GQLQueries.table.all).trim(); //GQL Query as string
 
-    this.server.post('https://data.naviapp.io/v1/graphql', (schema, { requestBody }) => {
+    this.server.post('https://data.naviapp.io/graphql', (schema, { requestBody }) => {
       const { operationName, variables, query } = JSON.parse(requestBody);
 
       assert.notOk(operationName, 'No operation name specified');
@@ -47,7 +47,7 @@ module('Unit | Elide Metadata Adapter', function(hooks) {
 
     const gqlQuery = print(GQLQueries.table.single).trim(); //GQL Query as string
 
-    this.server.post('https://data.naviapp.io/v1/graphql', (schema, { requestBody }) => {
+    this.server.post('https://data.naviapp.io/graphql', (schema, { requestBody }) => {
       const { operationName, variables, query } = JSON.parse(requestBody);
 
       assert.notOk(operationName, 'No operation name specified');

--- a/packages/data/tests/unit/services/navi-metadata-apollo-test.js
+++ b/packages/data/tests/unit/services/navi-metadata-apollo-test.js
@@ -8,10 +8,6 @@ module('Unit | Service | navi-metadata-apollo', function(hooks) {
   // Replace this with your real tests.
   test('_buildURLPath', function(assert) {
     const service = this.owner.lookup('service:navi-metadata-apollo');
-    assert.equal(
-      service._buildURLPath(),
-      `${config.navi.dataSources[0].uri}/v1/graphql`,
-      'URL path is built correctly'
-    );
+    assert.equal(service._buildURLPath(), `${config.navi.dataSources[0].uri}/graphql`, 'URL path is built correctly');
   });
 });


### PR DESCRIPTION
## Description
`v1` in the URI prefix is not needed for GraphQL requests

## Proposed Changes

- Remove v1 from URI prefix for GraphQL

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
