### PR TITLE
Update: Time Dimension's supported grains should be objects

### DIFF
--- a/packages/data/addon/gql/fragments/table.ts
+++ b/packages/data/addon/gql/fragments/table.ts
@@ -51,7 +51,13 @@ const fragment = gql`
           columnTags
           columnType
           expression
-          supportedGrains
+          supportedGrains {
+            edges {
+              node {
+                grain
+              }
+            }
+          }
           timeZone {
             short
           }

--- a/packages/data/addon/gql/schema.js
+++ b/packages/data/addon/gql/schema.js
@@ -116,8 +116,24 @@ const schema = gql`
     columnTags: [String!]
     columnType: ColumnType
     expression: String
-    supportedGrains: [TimeGrain]
+    supportedGrains: TimeDimensionGrainConnnection
     timeZone: TimeZone
+  }
+
+  type TimeDimensionGrainConnnection {
+    edges: [TimeDimensionGrainEdge!]!
+    pageInfo: PageInfo
+  }
+
+  type TimeDimensionGrainEdge {
+    node: TimeDimensionGrain
+    cursor: String!
+  }
+
+  type TimeDimensionGrain implements Node {
+    id: DeferredID!
+    expression: String
+    grain: TimeGrain
   }
 
   type metricFunction {


### PR DESCRIPTION
Resolves #

<!-- The above line will close the issue upon merge -->

## Description
Elide metadata schema has objects for supported grains of a time dimension

## Proposed Changes

- Make supportedGrains into a connection to TimeDimensionGrain nodes

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
