### PR TITLE
Update: Add tootlip support for metric parameters.

### DIFF
--- a/packages/data/addon/mirage/fixtures/bard-meta-metrics.js
+++ b/packages/data/addon/mirage/fixtures/bard-meta-metrics.js
@@ -141,10 +141,11 @@ export default {
       parameters: {
         type: {
           type: 'enum',
+          description: 'Gives the metric power to have directionality',
           values: [
-            { id: 'l', description: 'Left' },
-            { id: 'r', description: 'Right' },
-            { id: 'm', description: 'Middle' }
+            { id: 'l', name: 'Left' },
+            { id: 'r', name: 'Right' },
+            { id: 'm', name: 'Middle' }
           ],
           defaultValue: 'l'
         },

--- a/packages/data/addon/serializers/metadata/metric-function.js
+++ b/packages/data/addon/serializers/metadata/metric-function.js
@@ -16,11 +16,12 @@ import EmberObject from '@ember/object';
 export function constructFunctionArguments(parameters) {
   return Object.keys(parameters).map(param => {
     const paramObj = parameters[param];
-    const { type, defaultValue, values, dimensionName } = paramObj;
+    const { type, defaultValue, values, dimensionName, description } = paramObj;
 
     return {
       id: param,
       name: param,
+      description,
       valueType: 'TEXT',
       type: 'ref', // It will always be ref for our case because all our parameters have their valid values defined in a dimension or enum
       expression: type === 'dimension' ? `dimension:${dimensionName}` : INTRINSIC_VALUE_EXPRESSION,

--- a/packages/data/tests/unit/serializers/bard-metadata-test.js
+++ b/packages/data/tests/unit/serializers/bard-metadata-test.js
@@ -402,6 +402,7 @@ module('Unit | Bard Metadata Serializer', function(hooks) {
         id: 'currency',
         name: 'currency',
         valueType: 'TEXT',
+        description: undefined,
         type: 'ref',
         expression: 'dimension:displayCurrency',
         _localValues: null,

--- a/packages/data/tests/unit/serializers/metadata/metric-function-test.js
+++ b/packages/data/tests/unit/serializers/metadata/metric-function-test.js
@@ -8,6 +8,7 @@ const FunctionArguments = [
     id: 'currency',
     name: 'currency',
     valueType: 'TEXT',
+    description: undefined,
     type: 'ref',
     expression: 'dimension:displayCurrency',
     _localValues: null,
@@ -16,6 +17,7 @@ const FunctionArguments = [
   {
     id: 'type',
     name: 'type',
+    description: undefined,
     valueType: 'TEXT',
     type: 'ref',
     expression: 'self',
@@ -70,6 +72,7 @@ module('Unit | Metric Function Serializer', function(hooks) {
                 id: 'EUR'
               }
             ],
+            description: undefined,
             defaultValue: 'USD'
           }
         ]

--- a/packages/reports/addon/components/navi-column-config/metric.js
+++ b/packages/reports/addon/components/navi-column-config/metric.js
@@ -44,7 +44,7 @@ class NaviColumnConfigMetricComponent extends Component {
     if (!metric.hasParameters) {
       return [];
     }
-    return metric.arguments.map(arg => arg.id);
+    return metric.arguments.map(arg => arg);
   }
 
   /**
@@ -53,14 +53,14 @@ class NaviColumnConfigMetricComponent extends Component {
   @computed('column.fragment.parameters.{}', 'allParameters')
   get currentParameters() {
     const { metricParameters, allParameters } = this;
+    const metricParameterIds = metricParameters.map(param => param.id);
     const selectedParamIds = this.column.fragment.parameters || {};
 
     return allParameters.then(vals => {
-      const selected = metricParameters.reduce((selectedParams, paramId) => {
+      const selected = metricParameterIds.reduce((selectedParams, paramId) => {
         selectedParams[paramId] = vals[paramId].find(param => param.id === selectedParamIds[paramId]);
         return selectedParams;
       }, {});
-
       return selected;
     });
   }

--- a/packages/reports/addon/components/navi-column-config/metric.js
+++ b/packages/reports/addon/components/navi-column-config/metric.js
@@ -44,7 +44,7 @@ class NaviColumnConfigMetricComponent extends Component {
     if (!metric.hasParameters) {
       return [];
     }
-    return metric.arguments.map(arg => arg);
+    return metric.arguments;
   }
 
   /**

--- a/packages/reports/addon/templates/components/metric-config.hbs
+++ b/packages/reports/addon/templates/components/metric-config.hbs
@@ -35,7 +35,8 @@
                   @icon={{if (and (get parametersChecked (concat param.param "|" param.id)) (not (feature-flag "enableRequestPreview"))) "minus-circle" "plus-circle"}}
                   class="grouped-list__add-icon {{if (not (or (feature-flag "enableRequestPreview") (get parametersChecked (concat param.param "|" param.id)))) "grouped-list__add-icon--deselected"}}"
                 />
-                {{param.description}} ({{param.id}})
+                  {{! TODO: Simplify this when we normalize function arguments }}
+                  {{if param.name param.name param.description}} ({{param.id}})
               </button>
 
               <div class="grouped-list__icon-set metric-config__icon-set">

--- a/packages/reports/addon/templates/components/navi-column-config/metric.hbs
+++ b/packages/reports/addon/templates/components/navi-column-config/metric.hbs
@@ -1,23 +1,32 @@
 {{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 {{#each this.metricParameters as |param|}}
   <div class="navi-column-config-base__option navi-column-config-item__parameter">
-    <label for="{{this.classId}}-{{param}}" class="navi-column-config-item__parameter-label navi-column-config-base__option-label">{{capitalize param}} Type</label>
-    {{#let (get (await this.allParameters) param) as |allParams|}}
+    <label for="{{this.classId}}-{{param.id}}" class="navi-column-config-item__parameter-label navi-column-config-base__option-label">{{capitalize param.name}} Type 
+      {{#if param.description}}
+        <NaviIcon @icon="question-circle-o">
+          <EmberTooltip @side="right" @popperContainer="body" @effect="none">
+            {{param.description}}
+          </EmberTooltip>
+        </NaviIcon>
+      {{/if}}
+    </label>
+    {{#let (get (await this.allParameters) param.id) as |allParams|}}
       <PowerSelect
         @triggerClass="navi-column-config-item__parameter-trigger navi-column-config-base__option-input"
-        @triggerId="{{this.classId}}-{{param}}"
+        @triggerId="{{this.classId}}-{{param.id}}"
         @dropdownClass="navi-column-config-item__parameter-dropdown"
-        @selected={{get (await this.currentParameters) param}}
-        @searchField="description"
-        @searchPlaceholder="Search {{capitalize param}}"
+        @selected={{get (await this.currentParameters) param.id}}
+        @searchField={{if allParams.firstObject.name "name" "description"}}
+        @searchPlaceholder="Search {{capitalize param.name}}"
         @options={{allParams}}
         @onchange={{this.updateMetricParam}}
-        as | param |
+        as | arg |
       >
-        {{#if (eq (get (filter-by "description" param.description allParams) "length") 1)}}
-          {{param.description}}
+        {{! TODO: Simplify this when we normalize function arguments }}
+        {{#if (eq (get (filter-by (if arg.name "name" "description") (if arg.name arg.name arg.description) allParams) "length") 1)}}
+          {{if arg.name arg.name arg.description}}
         {{else}}
-          {{param.description}} ({{param.id}})
+          {{if arg.name arg.name arg.description}} ({{arg.id}})
         {{/if}}
       </PowerSelect>
     {{/let}}

--- a/packages/reports/tests/integration/components/navi-column-config/metric-test.js
+++ b/packages/reports/tests/integration/components/navi-column-config/metric-test.js
@@ -1,11 +1,12 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click, findAll, getContext } from '@ember/test-helpers';
+import { render, click, findAll, getContext, triggerEvent } from '@ember/test-helpers';
 import { A as arr } from '@ember/array';
 import { helper as buildHelper } from '@ember/component/helper';
 import { selectChoose } from 'ember-power-select/test-support/helpers';
 import hbs from 'htmlbars-inline-precompile';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { assertTooltipContent } from 'ember-tooltips/test-support/dom';
 
 let MetadataService;
 
@@ -61,7 +62,7 @@ module('Integration | Component | navi-column-config/metric', function(hooks) {
   }
 
   test('Configuring multiple parameters', async function(assert) {
-    assert.expect(3);
+    assert.expect(6);
 
     this.column = await getMetricColumn('multipleParamMetric', {
       type: 'l',
@@ -83,6 +84,13 @@ module('Integration | Component | navi-column-config/metric', function(hooks) {
       'Mulitple parameters values are filled in with selected values'
     );
 
+    await click('.navi-column-config-item__parameter-trigger.ember-power-select-trigger');
+    assert.deepEqual(
+      findAll('.ember-power-select-option').map(el => el.textContent.trim()),
+      ['Left', 'Right', 'Middle'],
+      'Param values with name key show up correctly'
+    );
+
     await selectChoose('.navi-column-config-item__parameter', 'Right');
     await selectChoose(findAll('.navi-column-config-item__parameter')[1], 'Daily Average');
     await selectChoose(findAll('.navi-column-config-item__parameter')[2], '13-17');
@@ -94,6 +102,17 @@ module('Integration | Component | navi-column-config/metric', function(hooks) {
       ['Right', 'Daily Average', '13-17', 'Euro', 'Drams'],
       'A selected parameter can be changed and a null valued parameter can be changed'
     );
+
+    assert
+      .dom('.ember-tooltip-target')
+      .exists({ count: 1 }, 'Description tooltip shows once for the one parameter that has a description');
+
+    await triggerEvent('.ember-tooltip-target', 'mouseenter');
+
+    assertTooltipContent(assert, {
+      targetSelector: '.ember-tooltip-target',
+      contentString: 'Gives the metric power to have directionality'
+    });
   });
 
   test('Configuring null parameter', async function(assert) {


### PR DESCRIPTION
- also allow param arguments with name over description.

## Description

Allows description to be a property of metric function parameters that can be used as tooltip helpers.

Allows the shape of metric function parameter arguments to be `{id, name}` as well as support `{id, description}`

## Proposed Changes

- Add description property to metric function parameters.
- If said description exists show tooltip help next to parameter in metric config
- Add support to use `name` rather than `description` if the values have a `name` param. 

FUTURE TODO: Normalize all function arguments to `{name, id, description}` shape. even if arguments come from external sources like a dimension.

## Screenshots

![Screen Shot 2020-05-22 at 4 15 25 PM](https://user-images.githubusercontent.com/99422/82710019-7fdca880-9c47-11ea-881d-3d50d9a1e8f3.png)

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
