### PR TITLE
Update: SupportedGrains serialize as objects

### DIFF
--- a/packages/data/addon/models/metadata/time-dimension.ts
+++ b/packages/data/addon/models/metadata/time-dimension.ts
@@ -4,14 +4,19 @@
  */
 import DimensionMetadataModel, { DimensionMetadata, DimensionMetadataPayload } from './dimension';
 
+interface TimeDimensionGrain {
+  id: string;
+  expression: string;
+  grain: string;
+}
 // Shape of public properties on model
 export interface TimeDimensionMetadata extends DimensionMetadata {
-  supportedGrains: string[];
+  supportedGrains: TimeDimensionGrain[];
   timeZone: TODO;
 }
 // Shape passed to model constructor
 export interface TimeDimensionMetadataPayload extends DimensionMetadataPayload {
-  supportedGrains: string[];
+  supportedGrains: TimeDimensionGrain[];
   timeZone: TODO;
 }
 
@@ -20,7 +25,7 @@ export default class TimeDimensionMetadataModel extends DimensionMetadataModel
   /**
    * @property {string[]} supportedGrains
    */
-  supportedGrains!: string[];
+  supportedGrains!: TimeDimensionGrain[];
 
   /**
    * @property {string} timeZone

--- a/packages/data/addon/serializers/elide-metadata.ts
+++ b/packages/data/addon/serializers/elide-metadata.ts
@@ -31,8 +31,13 @@ type ColumnNode = {
 type MetricNode = ColumnNode & { defaultFormat: string };
 type DimensionNode = ColumnNode;
 type TimeDimensionNode = DimensionNode & {
-  supportedGrains: string[];
+  supportedGrains: Connection<TimeDimensionGrainNode>;
   timeZone: string;
+};
+type TimeDimensionGrainNode = {
+  id: string;
+  expression: string;
+  grain: string;
 };
 type TableNode = {
   id: string;
@@ -191,7 +196,9 @@ export default class ElideMetadataSerializer extends EmberObject {
         tableId,
         source,
         tags: node.columnTags,
-        supportedGrains: node.supportedGrains,
+        supportedGrains: node.supportedGrains.edges.map((edge: Edge<TimeDimensionGrainNode>) => {
+          return edge.node;
+        }),
         timeZone: node.timeZone,
         type: node.columnType,
         expression: node.expression

--- a/packages/data/addon/serializers/elide-metadata.ts
+++ b/packages/data/addon/serializers/elide-metadata.ts
@@ -196,9 +196,7 @@ export default class ElideMetadataSerializer extends EmberObject {
         tableId,
         source,
         tags: node.columnTags,
-        supportedGrains: node.supportedGrains.edges.map((edge: Edge<TimeDimensionGrainNode>) => {
-          return edge.node;
-        }),
+        supportedGrains: node.supportedGrains.edges.map(edge => edge.node),
         timeZone: node.timeZone,
         type: node.columnType,
         expression: node.expression

--- a/packages/data/tests/unit/serializers/elide-metadata-test.js
+++ b/packages/data/tests/unit/serializers/elide-metadata-test.js
@@ -76,7 +76,12 @@ module('Unit | Serializer | elide-metadata', function(hooks) {
                       category: 'cat1',
                       valueType: 'DATE',
                       columnTags: ['IMPORTANT'],
-                      supportedGrains: ['day', 'week'],
+                      supportedGrains: {
+                        edges: [
+                          { node: { id: 'day', grain: 'DAY', expression: '' } },
+                          { node: { id: 'week', grain: 'WEEK', expression: '' } }
+                        ]
+                      },
                       timeZone: 'UTC',
                       columnType: 'field',
                       expression: null
@@ -289,7 +294,10 @@ module('Unit | Serializer | elide-metadata', function(hooks) {
             tags: ['IMPORTANT'],
             type: 'field',
             expression: null,
-            supportedGrains: ['day', 'week'],
+            supportedGrains: [
+              { id: 'day', grain: 'DAY', expression: '' },
+              { id: 'week', grain: 'WEEK', expression: '' }
+            ],
             timeZone: 'UTC',
             source: 'dummy',
             tableId: 'tableA'
@@ -465,7 +473,13 @@ module('Unit | Serializer | elide-metadata', function(hooks) {
             category: 'userDimensions',
             valueType: 'DATE',
             columnTags: ['DISPLAY'],
-            supportedGrains: ['day', 'week', 'month'],
+            supportedGrains: {
+              edges: [
+                { node: { id: 'day', grain: 'DAY', expression: '' } },
+                { node: { id: 'week', grain: 'WEEK', expression: '' } },
+                { node: { id: 'month', grain: 'MONTH', expression: '' } }
+              ]
+            },
             timeZone: {
               short: 'PST',
               long: 'Pacific Standard Time'
@@ -482,7 +496,9 @@ module('Unit | Serializer | elide-metadata', function(hooks) {
             category: 'userDimensions',
             valueType: 'DATE',
             columnTags: ['DISPLAY'],
-            supportedGrains: ['month'],
+            supportedGrains: {
+              edges: [{ node: { id: 'month', grain: 'MONTH', expression: '' } }]
+            },
             timeZone: {
               short: 'CST',
               long: 'Central Standard Time'
@@ -504,7 +520,11 @@ module('Unit | Serializer | elide-metadata', function(hooks) {
           category: 'userDimensions',
           valueType: 'DATE',
           tags: ['DISPLAY'],
-          supportedGrains: ['day', 'week', 'month'],
+          supportedGrains: [
+            { id: 'day', grain: 'DAY', expression: '' },
+            { id: 'week', grain: 'WEEK', expression: '' },
+            { id: 'month', grain: 'MONTH', expression: '' }
+          ],
           timeZone: {
             short: 'PST',
             long: 'Pacific Standard Time'
@@ -521,7 +541,7 @@ module('Unit | Serializer | elide-metadata', function(hooks) {
           category: 'userDimensions',
           valueType: 'DATE',
           tags: ['DISPLAY'],
-          supportedGrains: ['month'],
+          supportedGrains: [{ id: 'month', grain: 'MONTH', expression: '' }],
           timeZone: {
             short: 'CST',
             long: 'Central Standard Time'


### PR DESCRIPTION
## Description
Supported Grains need to be serialized as objects into the time dimension model

## Proposed Changes

- Normalize support grains connection into objects

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
