### PR TITLE
Update: Use get-shallow when using column id as key

### DIFF
--- a/packages/core/addon/helpers/get-shallow.ts
+++ b/packages/core/addon/helpers/get-shallow.ts
@@ -13,9 +13,7 @@
 import { helper } from '@ember/component/helper';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-type Params = [Dict<any>, string];
-export function getShallow(params: Params) {
-  const [obj, key] = params;
+export function getShallow([obj, key]: [Dict<any>, string]) {
   return obj[key];
 }
 

--- a/packages/core/addon/helpers/get-shallow.ts
+++ b/packages/core/addon/helpers/get-shallow.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2020, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ *
+ * A get helper that only goes one level deep. This is necessary for keys that contain "."
+ * e.g.
+ * obj = { 'foo.bar': 'baz' };
+ * {{get-shallow obj "foo.bar"}}
+ * -> 'baz'
+ * {{get obj "foo.bar"}}
+ * -> undefined
+ */
+import { helper } from '@ember/component/helper';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type params = [Dict<any>, string];
+export function getShallow(params: params) {
+  const [obj, key] = params;
+  return obj[key];
+}
+
+export default helper(getShallow);

--- a/packages/core/addon/helpers/get-shallow.ts
+++ b/packages/core/addon/helpers/get-shallow.ts
@@ -13,8 +13,8 @@
 import { helper } from '@ember/component/helper';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-type params = [Dict<any>, string];
-export function getShallow(params: params) {
+type Params = [Dict<any>, string];
+export function getShallow(params: Params) {
   const [obj, key] = params;
   return obj[key];
 }

--- a/packages/core/app/helpers/get-shallow.js
+++ b/packages/core/app/helpers/get-shallow.js
@@ -1,0 +1,1 @@
+export { default, getShallow } from 'navi-core/helpers/get-shallow';

--- a/packages/core/tests/integration/helpers/get-shallow-test.ts
+++ b/packages/core/tests/integration/helpers/get-shallow-test.ts
@@ -1,0 +1,32 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Helper | get-shallow', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    assert.expect(3);
+
+    this.set('object', {
+      'foo.bar': 'baz',
+      foo: {
+        bar: 'wrong'
+      },
+      buzz: 'bang'
+    });
+
+    this.set('key', 'foo.bar');
+
+    await render(hbs`{{get-shallow this.object this.key}}`);
+
+    assert.dom().hasText('baz', 'Key with period in it is used correctly');
+
+    this.set('key', 'buzz');
+    assert.dom().hasText('bang', 'Key without period in it is used correctly');
+
+    this.set('key', 'invalid');
+    assert.dom().hasText('', 'No value returned when key is not present on object');
+  });
+});

--- a/packages/reports/addon/templates/components/dimension-selector.hbs
+++ b/packages/reports/addon/templates/components/dimension-selector.hbs
@@ -35,7 +35,7 @@
             type="checkbox"
             class="grouped-list__item-checkbox"
             id={{concat "grouped-list-item-checkbox-" (dasherize item.name)}}
-            checked={{get this.itemsChecked item.id}}
+            checked={{get-shallow this.itemsChecked item.id}}
             {{on "change" (fn this.itemClicked item)}}
           >
           <label for={{concat "grouped-list-item-checkbox-" (dasherize item.name)}}
@@ -45,11 +45,11 @@
         </div>
       {{/if}}
     {{else}}
-      <div class="grouped-list__item-container {{if (and (get this.itemsChecked item.id) (feature-flag "enableRequestPreview")) "grouped-list__item-container--selected"}}">
+      <div class="grouped-list__item-container {{if (and (get-shallow this.itemsChecked item.id) (feature-flag "enableRequestPreview")) "grouped-list__item-container--selected"}}">
         <button class="grouped-list__item-label" {{on "click" (fn this.itemClicked item)}} role="button" type="button">
           <NaviIcon
-            @icon={{if (and (get this.itemsChecked item.id) (not (feature-flag "enableRequestPreview"))) "minus-circle" "plus-circle"}}
-            class="grouped-list__add-icon {{if (not (or (feature-flag "enableRequestPreview") (get this.itemsChecked item.id))) "grouped-list__add-icon--deselected"}}"
+            @icon={{if (and (get-shallow this.itemsChecked item.id) (not (feature-flag "enableRequestPreview"))) "minus-circle" "plus-circle"}}
+            class="grouped-list__add-icon {{if (not (or (feature-flag "enableRequestPreview") (get-shallow this.itemsChecked item.id))) "grouped-list__add-icon--deselected"}}"
           />
           {{item.name}}
         </button>
@@ -69,7 +69,7 @@
         <div class="grouped-list__icon-set">
           <NaviIcon
             @icon="filter"
-            class={{concat (if (get this.dimensionsFiltered item.id) "grouped-list__filter--active ") "grouped-list__filter"}}
+            class={{concat (if (get-shallow this.dimensionsFiltered item.id) "grouped-list__filter--active ") "grouped-list__filter"}}
             {{on "click" (fn this.onToggleDimFilter item)}}
           />
         </div>

--- a/packages/reports/addon/templates/components/metric-config.hbs
+++ b/packages/reports/addon/templates/components/metric-config.hbs
@@ -29,11 +29,11 @@
             @sortByField="description"
             as | param |
           >
-            <div class="grouped-list__item-container {{if (and (get parametersChecked (concat param.param "|" param.id)) (feature-flag "enableRequestPreview")) "grouped-list__item-container--selected"}}">
+            <div class="grouped-list__item-container {{if (and (get-shallow parametersChecked (concat param.param "|" param.id)) (feature-flag "enableRequestPreview")) "grouped-list__item-container--selected"}}">
               <button class="grouped-list__item-label" {{on "click" (fn this.paramToggled metric param)}} role="button" type="button">
                 <NaviIcon
-                  @icon={{if (and (get parametersChecked (concat param.param "|" param.id)) (not (feature-flag "enableRequestPreview"))) "minus-circle" "plus-circle"}}
-                  class="grouped-list__add-icon {{if (not (or (feature-flag "enableRequestPreview") (get parametersChecked (concat param.param "|" param.id)))) "grouped-list__add-icon--deselected"}}"
+                  @icon={{if (and (get-shallow parametersChecked (concat param.param "|" param.id)) (not (feature-flag "enableRequestPreview"))) "minus-circle" "plus-circle"}}
+                  class="grouped-list__add-icon {{if (not (or (feature-flag "enableRequestPreview") (get-shallow parametersChecked (concat param.param "|" param.id)))) "grouped-list__add-icon--deselected"}}"
                 />
                   {{! TODO: Simplify this when we normalize function arguments }}
                   {{if param.name param.name param.description}} ({{param.id}})
@@ -42,7 +42,7 @@
               <div class="grouped-list__icon-set metric-config__icon-set">
                 <NaviIcon
                   @icon="filter"
-                  class={{concat (if (get paramsFiltered (concat param.param "|" param.id)) "grouped-list__filter--active ") "grouped-list__filter"}}
+                  class={{concat (if (get-shallow paramsFiltered (concat param.param "|" param.id)) "grouped-list__filter--active ") "grouped-list__filter"}}
                   onclick={{action "paramFilterToggled" metric param}}
                 />
               </div>

--- a/packages/reports/addon/templates/components/metric-selector.hbs
+++ b/packages/reports/addon/templates/components/metric-selector.hbs
@@ -16,11 +16,11 @@
       @sortByField={{unless areMetricsFiltered "name"}}
       as | metric |
     >
-      <div class="grouped-list__item-container {{if (and (get this.metricsChecked metric.id) (feature-flag "enableRequestPreview")) "grouped-list__item-container--selected"}}">
+      <div class="grouped-list__item-container {{if (and (get-shallow this.metricsChecked metric.id) (feature-flag "enableRequestPreview")) "grouped-list__item-container--selected"}}">
         <button class="grouped-list__item-label" {{on "click" (fn this.metricClicked metric)}} role="button" type="button">
           <NaviIcon
-            @icon={{if (and (get this.metricsChecked metric.id) (not (feature-flag "enableRequestPreview"))) "minus-circle" "plus-circle"}}
-            class="grouped-list__add-icon {{if (not (or (feature-flag "enableRequestPreview") (get this.metricsChecked metric.id))) "grouped-list__add-icon--deselected"}}"
+            @icon={{if (and (get-shallow this.metricsChecked metric.id) (not (feature-flag "enableRequestPreview"))) "minus-circle" "plus-circle"}}
+            class="grouped-list__add-icon {{if (not (or (feature-flag "enableRequestPreview") (get-shallow this.metricsChecked metric.id))) "grouped-list__add-icon--deselected"}}"
           />
           {{metric.name}}
         </button>
@@ -50,7 +50,7 @@
           {{#if (can-having metric)}}
             <NaviIcon
               @icon="filter"
-              class={{concat (if (get this.metricsFiltered metric.id) "grouped-list__filter--active ") "grouped-list__filter"}}
+              class={{concat (if (get-shallow this.metricsFiltered metric.id) "grouped-list__filter--active ") "grouped-list__filter"}}
               {{on "click" (fn this.onToggleMetricFilter metric)}}
             >
               <EmberTooltip @side="right" @popperContainer="body" @effect="none">
@@ -61,7 +61,7 @@
                     Remove all
                   {{/if}}
                 {{else}}
-                  {{#if (get this.metricsFiltered metric.id)}}
+                  {{#if (get-shallow this.metricsFiltered metric.id)}}
                     Remove Filter
                   {{else}}
                     Add Filter


### PR DESCRIPTION
## Description
Elide is going to use a convention of `` `${table.id}.${columnId}` `` for its column ids. This causes problems when we try to use the basic `get` helper that is built-in to Ember since it sees that `.` in the middle of the id as a nested access indicator. 

## Proposed Changes

- Add a `get-shallow` helper that will allow us to use column ids as keys

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
