### PR TITLE
Fix: Enable Request Preview disables metric-config

### DIFF
--- a/packages/reports/addon/components/metric-config.js
+++ b/packages/reports/addon/components/metric-config.js
@@ -161,19 +161,12 @@ class MetricConfig extends Component {
    * @param {Object} param
    */
   @action
-  paramToggled(metric, param, { target }) {
-    const enableRequestPreview = featureFlag('enableRequestPreview');
-    const actionName = !enableRequestPreview && this.parametersChecked[`${param.param}|${param.id}`] ? 'Remove' : 'Add';
+  paramToggled(metric, param) {
+    const actionName = this.parametersChecked[`${param.param}|${param.id}`] ? 'Remove' : 'Add';
     const handler = this[`on${actionName}ParameterizedMetric`];
 
     if (handler) {
-      if (featureFlag('enableRequestPreview')) {
-        const button = target.closest('button.grouped-list__item-label');
-        throttle(this, 'doParamToggled', handler, metric, param, button, THROTTLE_TIME);
-        BlurOnAnimationEnd(target, button);
-      } else {
-        this.doParamToggled(handler, metric, param, null);
-      }
+      this.doParamToggled(handler, metric, param, null);
     }
   }
 

--- a/packages/reports/addon/templates/components/metric-config.hbs
+++ b/packages/reports/addon/templates/components/metric-config.hbs
@@ -29,11 +29,11 @@
             @sortByField="description"
             as | param |
           >
-            <div class="grouped-list__item-container {{if (and (get-shallow parametersChecked (concat param.param "|" param.id)) (feature-flag "enableRequestPreview")) "grouped-list__item-container--selected"}}">
+            <div class="grouped-list__item-container {{if (get-shallow parametersChecked (concat param.param "|" param.id)) "grouped-list__item-container--selected"}}">
               <button class="grouped-list__item-label" {{on "click" (fn this.paramToggled metric param)}} role="button" type="button">
                 <NaviIcon
-                  @icon={{if (and (get-shallow parametersChecked (concat param.param "|" param.id)) (not (feature-flag "enableRequestPreview"))) "minus-circle" "plus-circle"}}
-                  class="grouped-list__add-icon {{if (not (or (feature-flag "enableRequestPreview") (get-shallow parametersChecked (concat param.param "|" param.id)))) "grouped-list__add-icon--deselected"}}"
+                  @icon={{if (get-shallow parametersChecked (concat param.param "|" param.id)) "minus-circle" "plus-circle"}}
+                  class="grouped-list__add-icon {{if (not (get-shallow parametersChecked (concat param.param "|" param.id))) "grouped-list__add-icon--deselected"}}"
                 />
                   {{! TODO: Simplify this when we normalize function arguments }}
                   {{if param.name param.name param.description}} ({{param.id}})

--- a/packages/reports/addon/templates/components/metric-selector.hbs
+++ b/packages/reports/addon/templates/components/metric-selector.hbs
@@ -38,7 +38,7 @@
         </NaviIcon>
 
         <div class="grouped-list__icon-set {{if (not (can-having metric)) "grouped-list__icon-set--no-filter"}}">
-          {{#if (and (get metric "hasParameters") (not (feature-flag "enableRequestPreview")))}}
+          {{#if (and metric.hasParameters (not (feature-flag "enableRequestPreview")))}}
             <MetricConfig
               @metric={{metric}}
               @request={{@request}}

--- a/packages/reports/addon/templates/components/metric-selector.hbs
+++ b/packages/reports/addon/templates/components/metric-selector.hbs
@@ -38,7 +38,7 @@
         </NaviIcon>
 
         <div class="grouped-list__icon-set {{if (not (can-having metric)) "grouped-list__icon-set--no-filter"}}">
-          {{#if (get metric "hasParameters")}}
+          {{#if (and (get metric "hasParameters") (not (feature-flag "enableRequestPreview")))}}
             <MetricConfig
               @metric={{metric}}
               @request={{@request}}

--- a/packages/reports/tests/acceptance/column-config-test.js
+++ b/packages/reports/tests/acceptance/column-config-test.js
@@ -1350,7 +1350,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
     );
 
     await click(findAll('.grouped-list__group-header').filter(el => el.textContent.includes('Revenue'))[0]);
-    assert.dom('.metric-config').doesNotExist();
+    assert.dom('.metric-config').doesNotExist('Metric config is not visible when request preview is enabled');
   });
 
   test('Sort gets removed when metric is removed', async function(assert) {

--- a/packages/reports/tests/acceptance/column-config-test.js
+++ b/packages/reports/tests/acceptance/column-config-test.js
@@ -3,7 +3,7 @@ import { findAll, visit, click, fillIn, blur, currentURL, find } from '@ember/te
 import { setupApplicationTest } from 'ember-qunit';
 import config from 'ember-get-config';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { clickItem, clickMetricConfigTrigger } from 'navi-reports/test-support/report-builder';
+import { clickItem } from 'navi-reports/test-support/report-builder';
 import { setupAnimationTest, animationsSettled } from 'ember-animated/test-support';
 import { selectChoose } from 'ember-power-select/test-support';
 
@@ -176,7 +176,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
   });
 
   test('accordion behavior and highlighting last added item', async function(assert) {
-    assert.expect(42);
+    assert.expect(40);
 
     await visit('/reports/new');
     assert.deepEqual(getColumns(), ['Date Time (Day)'], 'Initially the only column is date time');
@@ -421,22 +421,6 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
     assert
       .dom('.navi-column-config-item--last-added')
       .doesNotExist('No column is highlighted after removing the parameterized metric');
-
-    //add a parameterized metric from metric config
-    const closeConfig = await clickMetricConfigTrigger('Platform Revenue');
-    await clickItem('metricConfig', 'Dollars', 'CAD');
-    await animationsSettled();
-    await closeConfig();
-    assert.deepEqual(
-      findAll('.navi-column-config-item').map(el => el.classList.contains('navi-column-config-item--open')),
-      [false, false, false, false, true],
-      'Only Platform Revenue (CAD) is open'
-    );
-    assert.deepEqual(
-      findAll('.navi-column-config-item').map(el => el.classList.contains('navi-column-config-item--last-added')),
-      [false, false, false, false, true],
-      'Only Platform Revenue (CAD) is highlighted'
-    );
   });
 
   test('adding, removing and changing - date time', async function(assert) {
@@ -1337,7 +1321,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
   });
 
   test('config - parameterized metric - search parameters', async function(assert) {
-    assert.expect(4);
+    assert.expect(5);
     await visit('/reports/new');
 
     await clickItem('metric', 'Platform Revenue');
@@ -1364,6 +1348,9 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
       ['Date Time (Day)', 'Platform Revenue (CAD)'],
       'Clicking the filtered option changes the metrics parameter'
     );
+
+    await click(findAll('.grouped-list__group-header').filter(el => el.textContent.includes('Revenue'))[0]);
+    assert.dom('.metric-config').doesNotExist();
   });
 
   test('Sort gets removed when metric is removed', async function(assert) {

--- a/packages/reports/tests/acceptance/metric-parameters-test.js
+++ b/packages/reports/tests/acceptance/metric-parameters-test.js
@@ -90,65 +90,6 @@ module('Acceptance | navi-report - metric parameters', function(hooks) {
     config.navi.FEATURES.enableRequestPreview = originalFeatureFlag;
   });
 
-  test('adding and removing metrics - enableRequestPreview', async function(assert) {
-    assert.expect(7);
-
-    const originalFeatureFlag = config.navi.FEATURES.enableRequestPreview;
-
-    config.navi.FEATURES.enableRequestPreview = true;
-
-    await visit('/reports/1/view');
-
-    //adding a metric with default params
-    await clickItem('metric', 'Platform Revenue');
-    await clickMetricConfigTrigger('Platform Revenue');
-
-    assert.deepEqual(
-      await getAllSelected('metricConfig'),
-      ['Dollars (USD)'],
-      'Only the default parameter for the metric is selected'
-    );
-
-    let metricConfigItem = await getItem('metricConfig', 'Dollars', 'USD');
-
-    assert.ok(metricConfigItem.item.querySelector('.fa-plus-circle'), 'Selected param still has a plus icon');
-
-    //clicking same param again
-    await clickItem('metricConfig', 'Dollars', 'USD');
-
-    assert.deepEqual(
-      await getAllSelected('metricConfig'),
-      ['Dollars (USD)'],
-      'Selection is unchanged after clicking an already added param'
-    );
-
-    metricConfigItem = await getItem('metricConfig', 'Dollars', 'USD');
-
-    assert.ok(
-      metricConfigItem.item.querySelector('.fa-plus-circle'),
-      'Param still has a plus icon after secondary click'
-    );
-
-    metricConfigItem = await getItem('metricConfig', 'Euro');
-
-    assert.ok(metricConfigItem.item.querySelector('.fa-plus-circle'), 'An unselected param has a plus icon');
-
-    //adding another param for the same metric
-    await clickItem('metricConfig', 'Euro');
-
-    assert.deepEqual(
-      await getAllSelected('metricConfig'),
-      ['Dollars (USD)', 'Euro (EUR)'],
-      'Adding another parameter changes selected items'
-    );
-
-    metricConfigItem = await getItem('metricConfig', 'Euro');
-
-    assert.ok(metricConfigItem.item.querySelector('.fa-plus-circle'), 'Second param still has a plus icon');
-
-    config.navi.FEATURES.enableRequestPreview = originalFeatureFlag;
-  });
-
   test('auto open metric config', async function(assert) {
     assert.expect(3);
 


### PR DESCRIPTION
## Description

Disable metric config gear menu when request preview is on: It obstructs column preview and doesn't give enough functionality

## Proposed Changes

- Removes gear icon when the enableRequestPreview flag is on

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
