### PR TITLE
Update: Pluralize sorts in request 2.0

### DIFF
--- a/packages/webservice/app/src/test/kotlin/com/yahoo/navi/ws/test/integration/RequestV2Test.kt
+++ b/packages/webservice/app/src/test/kotlin/com/yahoo/navi/ws/test/integration/RequestV2Test.kt
@@ -78,7 +78,7 @@ class RequestV2Test : IntegrationTest() {
         |    }
         |  ],
         |  "table": "certifiedAudience",
-        |  "sort": [
+        |  "sorts": [
         |    {
         |      "field": "dateTime",
         |      "parameters": {},
@@ -177,10 +177,10 @@ class RequestV2Test : IntegrationTest() {
                 .body("data.attributes.request.columns[3].type", equalTo("metric"))
                 .body("data.attributes.request.columns[3]", not(hasKey("alias")))
 
-                .body("data.attributes.request.sort.size()", Is(1))
-                .body("data.attributes.request.sort[0].field", equalTo("dateTime"))
-                .body("data.attributes.request.sort[0].parameters", matchesJsonMap("{}"))
-                .body("data.attributes.request.sort[0].direction", equalTo("desc"))
+                .body("data.attributes.request.sorts.size()", Is(1))
+                .body("data.attributes.request.sorts[0].field", equalTo("dateTime"))
+                .body("data.attributes.request.sorts[0].parameters", matchesJsonMap("{}"))
+                .body("data.attributes.request.sorts[0].direction", equalTo("desc"))
     }
 
     @Test
@@ -331,9 +331,9 @@ class RequestV2Test : IntegrationTest() {
                 .body("data.attributes.requests[0].columns[3].type", equalTo("metric"))
                 .body("data.attributes.requests[0].columns[3]", not(hasKey("alias")))
 
-                .body("data.attributes.requests[0].sort.size()", Is(1))
-                .body("data.attributes.requests[0].sort[0].field", equalTo("dateTime"))
-                .body("data.attributes.requests[0].sort[0].parameters", matchesJsonMap("{}"))
-                .body("data.attributes.requests[0].sort[0].direction", equalTo("desc"))
+                .body("data.attributes.requests[0].sorts.size()", Is(1))
+                .body("data.attributes.requests[0].sorts[0].field", equalTo("dateTime"))
+                .body("data.attributes.requests[0].sorts[0].parameters", matchesJsonMap("{}"))
+                .body("data.attributes.requests[0].sorts[0].direction", equalTo("desc"))
     }
 }

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/RequestV2.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/RequestV2.kt
@@ -17,7 +17,7 @@ data class RequestV2(
     var filters: Array<Filter>,
     var columns: Array<Column>,
     var table: String,
-    var sort: Array<Sort>,
+    var sorts: Array<Sort>,
     var limit: Int?,
     var dataSource: String?,
     val requestVersion: String


### PR DESCRIPTION
## Description
In request 2.0, sort refers to a collection

## Proposed Changes
- pluralize sorts to clarify it is a collection

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
