### PR TITLE
Update: Don't rerun request after reordering table columns

### DIFF
--- a/packages/reports/addon/controllers/reports/report/view.js
+++ b/packages/reports/addon/controllers/reports/report/view.js
@@ -7,6 +7,12 @@ import { isEqual, omit } from 'lodash-es';
 import Controller, { inject as controller } from '@ember/controller';
 import { canonicalizeMetric } from 'navi-data/utils/metric';
 
+/**
+ * @param {Object} request
+ * @returns {Array} canonicalized metrics sorted alphabetically
+ */
+const sortedMetrics = request => (request.metrics || []).map(metric => canonicalizeMetric(metric)).sort();
+
 export default class ReportViewController extends Controller {
   /*
    * @property {Controller} reportController
@@ -20,14 +26,13 @@ export default class ReportViewController extends Controller {
   get hasRequestRun() {
     const { modifiedRequest } = this.reportController;
     const { request } = this.model;
-    const metricsKeys = request => (request.metrics || []).map(metric => canonicalizeMetric(metric)).sort();
 
     if (!modifiedRequest) {
       //no changes have been made yet
       return true;
     }
 
-    if (!isEqual(metricsKeys(request), metricsKeys(modifiedRequest))) {
+    if (!isEqual(sortedMetrics(request), sortedMetrics(modifiedRequest))) {
       //changes in metrics outside of order
       return false;
     }

--- a/packages/reports/addon/controllers/reports/report/view.js
+++ b/packages/reports/addon/controllers/reports/report/view.js
@@ -37,7 +37,7 @@ export default class ReportViewController extends Controller {
       return false;
     }
 
-    if (!isEqual(omit(request 'metrics'), omit(modifiedRequest,, 'metrics'))) {
+    if (!isEqual(omit(request, 'metrics'), omit(modifiedRequest, 'metrics'))) {
       //changes in request outside of metrics
       return false;
     }

--- a/packages/reports/addon/controllers/reports/report/view.js
+++ b/packages/reports/addon/controllers/reports/report/view.js
@@ -37,7 +37,7 @@ export default class ReportViewController extends Controller {
       return false;
     }
 
-    if (!isEqual(omit(modifiedRequest, 'metrics'), omit(request, 'metrics'))) {
+    if (!isEqual(omit(request 'metrics'), omit(modifiedRequest,, 'metrics'))) {
       //changes in request outside of metrics
       return false;
     }

--- a/packages/reports/addon/routes/reports/report.js
+++ b/packages/reports/addon/routes/reports/report.js
@@ -114,9 +114,9 @@ export default Route.extend({
    * @override
    */
   deactivate() {
-    let model = this.currentModel;
+    const model = this.modelFor(this.routeName);
     // https://github.com/emberjs/ember.js/issues/16820
-    if (!this.isDestroying && !get(model, 'isNew') && get(model, 'hasDirtyAttributes')) {
+    if (!this.isDestroying && !model.isNew && model.hasDirtyAttributes) {
       this.send('revertChanges', model);
     }
   },
@@ -209,7 +209,7 @@ export default Route.extend({
      */
     updateTitle(title) {
       if (!isEmpty(title)) {
-        set(this.currentModel, 'title', title);
+        set(this.modelFor(this.routeName), 'title', title);
       }
     },
 
@@ -238,9 +238,9 @@ export default Route.extend({
      * @param {Object} metadataUpdates
      */
     onUpdateVisualizationConfig(metadataUpdates) {
-      let metadata = get(this, 'currentModel.visualization.metadata');
+      const metadata = this.modelFor(this.routeName).visualization?.metadata;
 
-      set(this.currentModel, 'visualization.metadata', merge({}, metadata, metadataUpdates));
+      set(this.modelFor(this.routeName), 'visualization.metadata', merge({}, metadata, metadataUpdates));
     },
 
     /**
@@ -258,10 +258,10 @@ export default Route.extend({
        *TODO validate actionType is a valid report action
        */
       if (actionType) {
-        get(this, 'updateReportActionDispatcher').dispatch(actionType, this, ...args);
+        this.updateReportActionDispatcher.dispatch(actionType, this, ...args);
       }
 
-      this.send('setModifiedRequest', this.currentModel.get('request').serialize());
+      this.send('setModifiedRequest', this.modelFor(this.routeName).request.serialize());
     },
 
     /**

--- a/packages/reports/tests/acceptance/report-test.js
+++ b/packages/reports/tests/acceptance/report-test.js
@@ -2141,6 +2141,31 @@ module('Acceptance | Navi Report', function(hooks) {
     );
   });
 
+  test('reordering metrics does not rerun the request', async function(assert) {
+    assert.expect(1);
+    await visit('/reports/2');
+
+    server.urlPrefix = `${config.navi.dataSources[0].uri}/v1`;
+    server.get('/data/*path', () => {
+      assert.ok(false, 'Request was rerun');
+    });
+
+    await reorder(
+      'mouse',
+      '.table-header-row-vc--view .table-header-cell',
+      '.table-header-row-vc--view .metric:contains(Nav Clicks)',
+      '.table-header-row-vc--view .dimension:contains(Property)',
+      '.table-header-row-vc--view .metric:contains(Ad Clicks)',
+      '.table-header-row-vc--view .dateTime'
+    );
+
+    assert.deepEqual(
+      findAll('.table-header-row-vc--view .table-header-cell__title').map(el => el.innerText.trim()),
+      ['Nav Clicks', 'Property', 'Ad Clicks', 'Date'],
+      'The headers are reordered as specified by the reorder'
+    );
+  });
+
   test('adding metrics to reordered table keeps order', async function(assert) {
     assert.expect(2);
     await visit('/reports/2');

--- a/packages/reports/tests/acceptance/report-test.js
+++ b/packages/reports/tests/acceptance/report-test.js
@@ -2167,8 +2167,14 @@ module('Acceptance | Navi Report', function(hooks) {
   });
 
   test('adding metrics to reordered table keeps order', async function(assert) {
-    assert.expect(2);
+    assert.expect(3);
     await visit('/reports/2');
+
+    assert.deepEqual(
+      findAll('.table-header-row-vc--view .table-header-cell__title').map(el => el.innerText.trim()),
+      ['Date', 'Property', 'Ad Clicks', 'Nav Clicks'],
+      'The headers are ordered correctly'
+    );
 
     await reorder(
       'mouse',

--- a/packages/reports/tests/unit/routes/reports/report-test.js
+++ b/packages/reports/tests/unit/routes/reports/report-test.js
@@ -1,7 +1,6 @@
 import { run } from '@ember/runloop';
 import { resolve, reject } from 'rsvp';
 import { A } from '@ember/array';
-import { get } from '@ember/object';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
@@ -107,14 +106,16 @@ module('Unit | Route | reports/report', function(hooks) {
   test('deactivate method', function(assert) {
     assert.expect(1);
 
-    let mockReport = {
+    const mockReport = {
         hasDirtyAttributes: true,
         rollbackAttributes() {
           assert.ok(true, 'Route model is asked to rollback');
         }
       },
       route = this.owner.factoryFor('route:reports/report').create({
-        currentModel: mockReport,
+        modelFor() {
+          return mockReport;
+        },
         routeName: 'reports.report'
       });
 
@@ -163,15 +164,17 @@ module('Unit | Route | reports/report', function(hooks) {
         title: 'Default Title'
       },
       route = this.owner.factoryFor('route:reports/report').create({
-        currentModel: mockReport
+        modelFor() {
+          return mockReport;
+        }
       });
 
-    assert.equal(get(route, 'currentModel.title'), 'Default Title', '`Default Title` is the current report title');
+    assert.equal(route.modelFor(route.routeName).title, 'Default Title', '`Default Title` is the current report title');
 
     route.send('updateTitle', 'Edited Title');
 
     assert.equal(
-      get(route, 'currentModel.title'),
+      route.modelFor(route.routeName).title,
       'Edited Title',
       'Title of the report is updated with `Edited Title`'
     );


### PR DESCRIPTION
## Description

There's no need to rerun the request after reordering table columns.

## Proposed Changes

Reordering metric columns changes the order of the metrics fragment array.
Change `hasRequestRun` method to return true if the only diff is the order of metrics, otherwise false.

## Screenshots

![May-29-2020 15-23-17](https://user-images.githubusercontent.com/13946669/83310304-6647dd80-a1c0-11ea-8153-3ee5e2d6a3a1.gif)

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
