### PR TITLE
Update: Support deserializing metadata objects from ids that contain "."

### DIFF
--- a/packages/core/addon/transforms/base-metadata-transform.js
+++ b/packages/core/addon/transforms/base-metadata-transform.js
@@ -4,6 +4,8 @@
  */
 
 import { inject as service } from '@ember/service';
+import { isPresent } from '@ember/utils';
+import config from 'ember-get-config';
 import DS from 'ember-data';
 
 export default DS.Transform.extend({
@@ -28,7 +30,7 @@ export default DS.Transform.extend({
   deserialize(serialized) {
     let namespace = null;
 
-    if (serialized.includes('.')) {
+    if (isPresent(config.navi.dataSources) && serialized.includes('.')) {
       const splitName = serialized.split('.');
       namespace = splitName.shift();
       serialized = splitName.join('.');

--- a/packages/core/addon/transforms/base-metadata-transform.js
+++ b/packages/core/addon/transforms/base-metadata-transform.js
@@ -30,8 +30,8 @@ export default DS.Transform.extend({
 
     if (serialized.includes('.')) {
       const splitName = serialized.split('.');
-      namespace = splitName[0];
-      serialized = splitName[1];
+      namespace = splitName.shift();
+      serialized = splitName.join('.');
     }
 
     return this.metadataService.getById(this.type, serialized, namespace);

--- a/packages/core/addon/transforms/dimension.js
+++ b/packages/core/addon/transforms/dimension.js
@@ -4,6 +4,8 @@
  */
 
 import BaseMetadataTransform from './base-metadata-transform';
+import { isPresent } from '@ember/utils';
+import config from 'ember-get-config';
 
 export default BaseMetadataTransform.extend({
   /**
@@ -24,7 +26,7 @@ export default BaseMetadataTransform.extend({
   deserialize(serialized) {
     let namespace = null;
 
-    if (serialized.includes('.')) {
+    if (isPresent(config.navi.dataSources) && serialized.includes('.')) {
       const splitName = serialized.split('.');
       namespace = splitName.shift();
       serialized = splitName.join('.');

--- a/packages/core/addon/transforms/dimension.js
+++ b/packages/core/addon/transforms/dimension.js
@@ -25,7 +25,9 @@ export default BaseMetadataTransform.extend({
     let namespace = null;
 
     if (serialized.includes('.')) {
-      [namespace, serialized] = serialized.split('.');
+      const splitName = serialized.split('.');
+      namespace = splitName.shift();
+      serialized = splitName.join('.');
     }
 
     // Lookup dimension id in time-dimensions if not found

--- a/packages/core/tests/unit/transforms/dimension-test.js
+++ b/packages/core/tests/unit/transforms/dimension-test.js
@@ -2,6 +2,8 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { settled } from '@ember/test-helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import Service from '@ember/service';
+import config from 'ember-get-config';
 
 let MetadataService;
 
@@ -18,14 +20,52 @@ module('Unit | Transform | Dimension', function(hooks) {
     assert.expect(3);
 
     await settled();
-    let transform = this.owner.lookup('transform:dimension'),
-      dim = MetadataService.getById('dimension', 'os');
+    const transform = this.owner.lookup('transform:dimension');
+    const dim = MetadataService.getById('dimension', 'os');
 
     assert.equal(transform.serialize(dim), 'os', 'Dimension is serialized to the name');
 
     assert.equal(transform.deserialize('os'), dim, 'Dimension is deserialized to the right object');
 
     assert.equal(transform.deserialize('dummy.os'), dim, 'Dimension with namespace is deserialized to right object');
+  });
+
+  test('deserialize with "." in id', function(assert) {
+    assert.expect(2);
+
+    const dataSources = config.navi.dataSources;
+
+    this.owner.unregister('service:bard-metadata');
+    this.owner.register(
+      'service:bard-metadata',
+      Service.extend({
+        getById(type, id) {
+          return { type, id };
+        }
+      })
+    );
+    const transform = this.owner.lookup('transform:dimension');
+
+    // Deserialize with no datasources defined in config
+    config.navi.dataSources = undefined;
+
+    assert.deepEqual(
+      transform.deserialize('foo.bar'),
+      { type: 'dimension', id: 'foo.bar' },
+      'Dimension with "." in id does not split on the "."'
+    );
+
+    // Deserialize with 2 datasources defined in config
+    config.navi.dataSources = dataSources;
+
+    assert.deepEqual(
+      transform.deserialize('dummy.foo.bar'),
+      { type: 'dimension', id: 'foo.bar' },
+      'Dimension with "." in id splits on the first "." when datasources are configured'
+    );
+
+    this.owner.unregister('service:bard-metadata');
+    this.owner.register('service:bard-metadata', MetadataService, { instantiate: false });
   });
 
   test('Do not cause crash when metadata is not available', function(assert) {

--- a/packages/core/tests/unit/transforms/metric-test.js
+++ b/packages/core/tests/unit/transforms/metric-test.js
@@ -2,6 +2,8 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { settled } from '@ember/test-helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import Service from '@ember/service';
+import config from 'ember-get-config';
 
 let MetadataService;
 
@@ -29,6 +31,44 @@ module('Unit | Transform | Metric', function(hooks) {
       metric,
       'namespaced metric is deserialized to the right object'
     );
+  });
+
+  test('deserialize with "." in id', function(assert) {
+    assert.expect(2);
+
+    const dataSources = config.navi.dataSources;
+
+    this.owner.unregister('service:bard-metadata');
+    this.owner.register(
+      'service:bard-metadata',
+      Service.extend({
+        getById(type, id) {
+          return { type, id };
+        }
+      })
+    );
+    const transform = this.owner.lookup('transform:metric');
+
+    // Deserialize with no datasources defined in config
+    config.navi.dataSources = undefined;
+
+    assert.deepEqual(
+      transform.deserialize('foo.bar'),
+      { type: 'metric', id: 'foo.bar' },
+      'Metric with "." in id does not split on the "."'
+    );
+
+    // Deserialize with 2 datasources defined in config
+    config.navi.dataSources = dataSources;
+
+    assert.deepEqual(
+      transform.deserialize('dummy.foo.bar'),
+      { type: 'metric', id: 'foo.bar' },
+      'Dimension with "." in id splits on the first "." when datasources are configured'
+    );
+
+    this.owner.unregister('service:bard-metadata');
+    this.owner.register('service:bard-metadata', MetadataService, { instantiate: false });
   });
 
   test('datetime test', async function(assert) {


### PR DESCRIPTION
Resolves #

<!-- The above line will close the issue upon merge -->

## Description
Reports saved with a metric or dimension with an id like `tableA.metric1` would not be successfully deserialized in the metadata transform due to the `.` character in the id.

## Proposed Changes

- Extract the namespace from before only the first `.` in the id.

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
