### PR TITLE
Fix: Bar-chart missing class name

### DIFF
--- a/packages/core/addon/components/navi-visualizations/bar-chart.js
+++ b/packages/core/addon/components/navi-visualizations/bar-chart.js
@@ -20,7 +20,7 @@ export default class BarChart extends LineChart {
    * @property {Array} classNames - since bar-chart is a tagless wrapper component,
    * classes specified here are applied to the underlying c3-chart component
    */
-  classNames = ['bar-chart-widget'];
+  classNames = ['bar-chart-widget', 'line-chart-widget'];
 
   /**
    * @override


### PR DESCRIPTION
## Description

Bar chart is borked

## Proposed Changes

- Add line-chart-widget to classnames of bar chart since it extends from line-chart

## Screenshots

<img width="1081" alt="Screen Shot 2020-06-03 at 3 38 31 PM" src="https://user-images.githubusercontent.com/23023478/83686805-7b51b180-a5b0-11ea-9bbd-0fa2c76b20a8.png">
<img width="1081" alt="Screen Shot 2020-06-03 at 3 38 14 PM" src="https://user-images.githubusercontent.com/23023478/83686810-7c82de80-a5b0-11ea-87bc-8dec74166308.png">

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
