### PR TITLE
Fix: Gracefully handle spaces after comma

### DIFF
--- a/packages/data/addon/utils/metric.ts
+++ b/packages/data/addon/utils/metric.ts
@@ -137,7 +137,7 @@ export function parseMetricName(canonicalName: string): MetricObject {
     parameters = paramStr
       .split(',')
       .map(paramEntry => paramEntry.split('='))
-      .reduce((obj, [key, val]) => Object.assign({}, obj, { [key]: val }), {});
+      .reduce((obj, [key, val]) => Object.assign({}, obj, { [key.trim()]: val }), {});
   }
 
   // validation

--- a/packages/data/tests/unit/utils/metric-test.js
+++ b/packages/data/tests/unit/utils/metric-test.js
@@ -107,7 +107,7 @@ module('Unit - Utils - Metrics Utils', function() {
   });
 
   test('parse metric name into object', function(assert) {
-    assert.expect(6);
+    assert.expect(7);
 
     let metricString = 'base(param=paramVal)';
 
@@ -132,6 +132,16 @@ module('Unit - Utils - Metrics Utils', function() {
         parameters: { param1: 'paramVal1', param2: 'paramVal2' }
       },
       'Parser correctly constructs a metric object with multiple parameters'
+    );
+
+    metricString = 'base(param1=paramVal1, param2=paramVal2)';
+    assert.deepEqual(
+      parseMetricName(metricString),
+      {
+        metric: 'base',
+        parameters: { param1: 'paramVal1', param2: 'paramVal2' }
+      },
+      'Parser correctly constructs a metric object with multiple parameters even with a space'
     );
 
     metricString = '';


### PR DESCRIPTION
## Description
Quick fix to handle some extra spacing in metric parameters list

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
