### PR TITLE
Update: Add type to all 2.0 fragments

### DIFF
--- a/packages/webservice/app/src/test/kotlin/com/yahoo/navi/ws/test/integration/RequestV2Test.kt
+++ b/packages/webservice/app/src/test/kotlin/com/yahoo/navi/ws/test/integration/RequestV2Test.kt
@@ -32,6 +32,7 @@ class RequestV2Test : IntegrationTest() {
         |   {
         |      "field": "product.id",
         |      "parameters": {},
+        |      "type": "dimension",
         |      "operator": "in",
         |      "values": [
         |        "access_manager"
@@ -40,6 +41,7 @@ class RequestV2Test : IntegrationTest() {
         |    {
         |      "field": "timeSpent",
         |      "parameters": {},
+        |      "type": "metric",
         |      "operator": "gt",
         |      "values": [
         |        3
@@ -48,6 +50,7 @@ class RequestV2Test : IntegrationTest() {
         |    { 
         |      "field": "dateTime",
         |      "parameters": {},
+        |      "type": "timeDimension",
         |      "operator": "bet",
         |      "values": [ "P1D", "current" ]
         |    }
@@ -58,18 +61,18 @@ class RequestV2Test : IntegrationTest() {
         |      "parameters": {
         |        "grain": "day"
         |      },
-        |      "type": "dimension",
+        |      "type": "timeDimension",
         |      "alias": "time"
         |    },
         |    {
         |      "field": "product",
         |      "parameters": {},
-        |
         |      "type": "dimension"
         |    },
         |    {
         |      "field": "spaceId.id",
-        |      "parameters": {}
+        |      "parameters": {},
+        |      "type": "dimension"
         |    },
         |    {
         |      "field": "timeSpent",
@@ -82,6 +85,7 @@ class RequestV2Test : IntegrationTest() {
         |    {
         |      "field": "dateTime",
         |      "parameters": {},
+        |      "type": "timeDimension",
         |      "direction": "desc"
         |    }
         |  ],
@@ -142,23 +146,26 @@ class RequestV2Test : IntegrationTest() {
 
                 .body("data.attributes.request.filters.size()", Is(3))
                 .body("data.attributes.request.filters[0].field", equalTo("product.id"))
+                .body("data.attributes.request.filters[0].type", equalTo("dimension"))
                 .body("data.attributes.request.filters[0].operator", equalTo("in"))
                 .body("data.attributes.request.filters[0].parameters", matchesJsonMap("{}"))
                 .body("data.attributes.request.filters[0].values", hasItems("access_manager"))
 
                 .body("data.attributes.request.filters[1].field", equalTo("timeSpent"))
                 .body("data.attributes.request.filters[1].operator", equalTo("gt"))
+                .body("data.attributes.request.filters[1].type", equalTo("metric"))
                 .body("data.attributes.request.filters[1].parameters", matchesJsonMap("{}"))
                 .body("data.attributes.request.filters[1].values", hasItems(3))
 
                 .body("data.attributes.request.filters[2].field", equalTo("dateTime"))
                 .body("data.attributes.request.filters[2].operator", equalTo("bet"))
+                .body("data.attributes.request.filters[2].type", equalTo("timeDimension"))
                 .body("data.attributes.request.filters[2].parameters", matchesJsonMap("{}"))
                 .body("data.attributes.request.filters[2].values", hasItems("P1D", "current"))
 
                 .body("data.attributes.request.columns[0].field", equalTo("dateTime"))
                 .body("data.attributes.request.columns[0].parameters", matchesJsonMap("{\"grain\":\"day\"}"))
-                .body("data.attributes.request.columns[0].type", equalTo("dimension"))
+                .body("data.attributes.request.columns[0].type", equalTo("timeDimension"))
                 .body("data.attributes.request.columns[0].alias", equalTo("time"))
 
                 .body("data.attributes.request.columns.size()", Is(4))
@@ -169,7 +176,7 @@ class RequestV2Test : IntegrationTest() {
 
                 .body("data.attributes.request.columns[2].field", equalTo("spaceId.id"))
                 .body("data.attributes.request.columns[2].parameters", matchesJsonMap("{}"))
-                .body("data.attributes.request.columns[2]", not(hasKey("type")))
+                .body("data.attributes.request.columns[2].type", equalTo("dimension"))
                 .body("data.attributes.request.columns[2]", not(hasKey("alias")))
 
                 .body("data.attributes.request.columns[3].field", equalTo("timeSpent"))
@@ -180,6 +187,7 @@ class RequestV2Test : IntegrationTest() {
                 .body("data.attributes.request.sorts.size()", Is(1))
                 .body("data.attributes.request.sorts[0].field", equalTo("dateTime"))
                 .body("data.attributes.request.sorts[0].parameters", matchesJsonMap("{}"))
+                .body("data.attributes.request.sorts[0].type", equalTo("timeDimension"))
                 .body("data.attributes.request.sorts[0].direction", equalTo("desc"))
     }
 
@@ -197,6 +205,7 @@ class RequestV2Test : IntegrationTest() {
                             "request": {
                                 "filters": [{
                                     "field": "foo",
+                                    "type": "metric",
                                     "operator": "gt",
                                     "values": [3, 3.156, -1]
                                 }],
@@ -225,6 +234,7 @@ class RequestV2Test : IntegrationTest() {
                 .assertThat()
                 .statusCode(HttpStatus.SC_OK)
                 .body("data.attributes.request.filters[0].values", hasItems(3, 3.156f, -1))
+                .body("data.attributes.request.filters[0].type", equalTo("metric"))
     }
 
     @Test
@@ -296,23 +306,26 @@ class RequestV2Test : IntegrationTest() {
 
                 .body("data.attributes.requests[0].filters.size()", Is(3))
                 .body("data.attributes.requests[0].filters[0].field", equalTo("product.id"))
+                .body("data.attributes.requests[0].filters[0].type", equalTo("dimension"))
                 .body("data.attributes.requests[0].filters[0].operator", equalTo("in"))
                 .body("data.attributes.requests[0].filters[0].parameters", matchesJsonMap("{}"))
                 .body("data.attributes.requests[0].filters[0].values", hasItems("access_manager"))
 
                 .body("data.attributes.requests[0].filters[1].field", equalTo("timeSpent"))
+                .body("data.attributes.requests[0].filters[1].type", equalTo("metric"))
                 .body("data.attributes.requests[0].filters[1].operator", equalTo("gt"))
                 .body("data.attributes.requests[0].filters[1].parameters", matchesJsonMap("{}"))
                 .body("data.attributes.requests[0].filters[1].values", hasItems(3))
 
                 .body("data.attributes.requests[0].filters[2].field", equalTo("dateTime"))
+                .body("data.attributes.requests[0].filters[2].type", equalTo("timeDimension"))
                 .body("data.attributes.requests[0].filters[2].operator", equalTo("bet"))
                 .body("data.attributes.requests[0].filters[2].parameters", matchesJsonMap("{}"))
                 .body("data.attributes.requests[0].filters[2].values", hasItems("P1D", "current"))
 
                 .body("data.attributes.requests[0].columns[0].field", equalTo("dateTime"))
                 .body("data.attributes.requests[0].columns[0].parameters", matchesJsonMap("{\"grain\":\"day\"}"))
-                .body("data.attributes.requests[0].columns[0].type", equalTo("dimension"))
+                .body("data.attributes.requests[0].columns[0].type", equalTo("timeDimension"))
                 .body("data.attributes.requests[0].columns[0].alias", equalTo("time"))
 
                 .body("data.attributes.requests[0].columns.size()", Is(4))
@@ -323,7 +336,7 @@ class RequestV2Test : IntegrationTest() {
 
                 .body("data.attributes.requests[0].columns[2].field", equalTo("spaceId.id"))
                 .body("data.attributes.requests[0].columns[2].parameters", matchesJsonMap("{}"))
-                .body("data.attributes.requests[0].columns[2]", not(hasKey("type")))
+                .body("data.attributes.requests[0].columns[2].type", equalTo("dimension"))
                 .body("data.attributes.requests[0].columns[2]", not(hasKey("alias")))
 
                 .body("data.attributes.requests[0].columns[3].field", equalTo("timeSpent"))
@@ -334,6 +347,7 @@ class RequestV2Test : IntegrationTest() {
                 .body("data.attributes.requests[0].sorts.size()", Is(1))
                 .body("data.attributes.requests[0].sorts[0].field", equalTo("dateTime"))
                 .body("data.attributes.requests[0].sorts[0].parameters", matchesJsonMap("{}"))
+                .body("data.attributes.requests[0].sorts[0].type", equalTo("timeDimension"))
                 .body("data.attributes.requests[0].sorts[0].direction", equalTo("desc"))
     }
 }

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/enums/ColumnType.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/enums/ColumnType.kt
@@ -5,5 +5,8 @@
 package com.yahoo.navi.ws.models.beans.enums
 
 enum class ColumnType {
-    dimension, metric, computed
+    dimension,
+    timeDimension,
+    metric,
+    computed
 }

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/request/v2/Filter.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/request/v2/Filter.kt
@@ -4,21 +4,24 @@
  */
 package com.yahoo.navi.ws.models.beans.fragments.request.v2
 
+import com.yahoo.navi.ws.models.beans.enums.ColumnType
 import org.hibernate.annotations.Parameter
 import org.hibernate.annotations.Type
 
 data class Filter(
     var field: String,
     @get: Type(type = "com.yahoo.navi.ws.models.types.JsonType", parameters = [
-      Parameter(name = "class", value = "kotlin.collections.HashMap")
-      ]) var parameters: Map<String, String>,
+        Parameter(name = "class", value = "kotlin.collections.HashMap")
+    ]) var parameters: Map<String, String>,
     var operator: String,
+    var type: ColumnType?,
     var values: Array<Any>
 ) {
     constructor() : this(
             "",
             emptyMap(),
             "",
+            null,
             emptyArray()
     )
 }

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/request/v2/Sort.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/request/v2/Sort.kt
@@ -4,6 +4,7 @@
  */
 package com.yahoo.navi.ws.models.beans.fragments.request.v2
 
+import com.yahoo.navi.ws.models.beans.enums.ColumnType
 import org.hibernate.annotations.Parameter
 import org.hibernate.annotations.Type
 
@@ -12,11 +13,13 @@ data class Sort(
     @get: Type(type = "com.yahoo.navi.ws.models.types.JsonType", parameters = [
         Parameter(name = "class", value = "kotlin.collections.HashMap")
     ]) var parameters: Map<String, String>,
+    var type: ColumnType?,
     var direction: String
 ) {
     constructor() : this(
             "",
             emptyMap(),
+            null,
             ""
     )
 }


### PR DESCRIPTION
## Description
In request 2.0 we want to have a distinguishable type for every column/filter/sort fragment so that they can more easily be looked up have correct behaviors

## Proposed Changes
- add `type` to all fragments in 2.0

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
