### PR TITLE
Fix: Credentials not being sent with graphql requests

### DIFF
--- a/packages/data/addon/services/navi-metadata-apollo.js
+++ b/packages/data/addon/services/navi-metadata-apollo.js
@@ -40,7 +40,7 @@ export default class NaviMetadataApolloService extends ApolloService {
 
     return Object.assign({}, defaultOptions, {
       apiURL: this._buildURLPath(),
-      credentials: 'include'
+      requestCredentials: 'include'
     });
   }
 


### PR DESCRIPTION
## Description
GraphQL requests were being sent without cookies because the credentials config key is wrong.

it should be `requestCredentials` 
https://github.com/ember-graphql/ember-apollo-client/blob/master/README.md#runtime-configuration

## Proposed Changes

- Use correct key to ensure cookies are sent

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
