### PR TITLE
Update: GraphQL metadata queries more inline with Elide implementation

### DIFF
--- a/packages/data/addon/adapters/elide-metadata.ts
+++ b/packages/data/addon/adapters/elide-metadata.ts
@@ -49,7 +49,7 @@ export default class GraphQLMetadataAdapter extends EmberObject {
     const queryOptions = Object.assign({}, options, { query });
     if (id) {
       queryOptions.variables = Object.assign(queryOptions.variables || {}, {
-        id
+        ids: [id]
       });
     }
 

--- a/packages/data/addon/gql/queries/table.ts
+++ b/packages/data/addon/gql/queries/table.ts
@@ -6,9 +6,13 @@ import gql from 'graphql-tag';
 import TableFragment from '../fragments/table';
 
 const query = gql`
-  query($id: DeferredID!) {
-    table(id: $id) {
-      ...TableFragment
+  query($ids: [String!]) {
+    table(ids: $ids) {
+      edges {
+        node {
+          ...TableFragment
+        }
+      }
     }
   }
   ${TableFragment}

--- a/packages/data/addon/gql/queries/tables.ts
+++ b/packages/data/addon/gql/queries/tables.ts
@@ -7,7 +7,7 @@ import TableFragment from '../fragments/table';
 
 const query = gql`
   query {
-    tables {
+    table {
       edges {
         node {
           ...TableFragment

--- a/packages/data/addon/gql/schema.js
+++ b/packages/data/addon/gql/schema.js
@@ -185,6 +185,15 @@ const schema = gql`
     field
   }
 
+  enum RelationshipOp {
+    FETCH
+    DELETE
+    UPSERT
+    REPLACE
+    REMOVE
+    UPDATE
+  }
+
   type TimeZone { # modeled after java.util.TimeZone
     long: String
     short: String
@@ -199,8 +208,14 @@ const schema = gql`
   }
 
   type Query {
-    tables: TableConnection
-    table(id: DeferredID!): Table
+    table(
+      op: RelationshipOp
+      ids: [String]
+      filter: String
+      sort: String
+      first: String
+      after: String
+    ): TableConnection
   }
 `;
 

--- a/packages/data/addon/mirage/handlers/graphql.js
+++ b/packages/data/addon/mirage/handlers/graphql.js
@@ -7,12 +7,13 @@ import schema from 'navi-data/gql/schema';
 
 const OPTIONS = {
   argsMap: {
+    // We have to use undefined as the type key because ember-cli-mirage-graphql does not define the type property for edges and connections
     undefined: {
       ids(records, _, ids) {
         return Array.isArray(ids) ? records.filter(record => ids.includes(record.id)) : records;
       }
     }
   }
-}; // Options possibly added in the future
+};
 
 export default createGraphQLHandler(schema, OPTIONS);

--- a/packages/data/addon/mirage/handlers/graphql.js
+++ b/packages/data/addon/mirage/handlers/graphql.js
@@ -5,6 +5,14 @@
 import createGraphQLHandler from 'ember-cli-mirage-graphql/handler';
 import schema from 'navi-data/gql/schema';
 
-const OPTIONS = {}; // Options possibly added in the future
+const OPTIONS = {
+  argsMap: {
+    undefined: {
+      ids(records, _, ids) {
+        return Array.isArray(ids) ? records.filter(record => ids.includes(record.id)) : records;
+      }
+    }
+  }
+}; // Options possibly added in the future
 
 export default createGraphQLHandler(schema, OPTIONS);

--- a/packages/data/addon/serializers/elide-metadata.ts
+++ b/packages/data/addon/serializers/elide-metadata.ts
@@ -51,7 +51,7 @@ type TableNode = {
 };
 
 export interface TablePayload {
-  tables: Connection<TableNode>;
+  table: Connection<TableNode>;
   source: string;
 }
 
@@ -211,7 +211,7 @@ export default class ElideMetadataSerializer extends EmberObject {
    */
   normalize(payload: TablePayload) {
     if (this.isTablePayload(payload)) {
-      return this._normalizeTableConnection(payload.tables, payload.source);
+      return this._normalizeTableConnection(payload.table, payload.source);
     }
     return payload;
   }
@@ -223,6 +223,6 @@ export default class ElideMetadataSerializer extends EmberObject {
    * */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   isTablePayload(payload: any): payload is TablePayload {
-    return !!payload.tables;
+    return !!payload.table;
   }
 }

--- a/packages/data/tests/unit/adapters/elide-metadata-test.js
+++ b/packages/data/tests/unit/adapters/elide-metadata-test.js
@@ -51,7 +51,7 @@ module('Unit | Elide Metadata Adapter', function(hooks) {
       const { operationName, variables, query } = JSON.parse(requestBody);
 
       assert.notOk(operationName, 'No operation name specified');
-      assert.deepEqual(variables, { id: 'foo' }, 'id variable is passed in options');
+      assert.deepEqual(variables, { ids: ['foo'] }, 'id variable is passed in options');
       assert.equal(
         removeTypeNameField(query),
         gqlQuery,
@@ -81,7 +81,7 @@ module('Unit | Elide Metadata Adapter', function(hooks) {
       '__typename'
     ];
 
-    const { tables: tableConnection } = await Adapter.fetchAll('table');
+    const { table: tableConnection } = await Adapter.fetchAll('table');
     const tables = tableConnection.edges.map(edge => edge.node);
 
     // Test that all fields specified in the query are included in the result and none of them are null as they should be populated by the factories
@@ -223,70 +223,78 @@ module('Unit | Elide Metadata Adapter', function(hooks) {
       result,
       {
         table: {
-          id: 'table0',
-          name: 'Table 0',
-          description: 'This is Table 0',
-          category: 'categoryOne',
-          cardinality: 'SMALL',
-          metrics: {
-            edges: [
-              {
-                node: {
-                  id: 'metric0',
-                  name: 'Metric 0',
-                  description: 'This is metric 0',
-                  category: 'categoryOne',
-                  valueType: 'NUMBER',
-                  columnTags: ['DISPLAY'],
-                  defaultFormat: 'number',
-                  columnType: 'field',
-                  expression: null,
-                  __typename: 'Metric'
+          __typename: 'TableConnection',
+          edges: [
+            {
+              __typename: 'TableEdge',
+              node: {
+                id: 'table0',
+                name: 'Table 0',
+                description: 'This is Table 0',
+                category: 'categoryOne',
+                cardinality: 'SMALL',
+                metrics: {
+                  edges: [
+                    {
+                      node: {
+                        id: 'metric0',
+                        name: 'Metric 0',
+                        description: 'This is metric 0',
+                        category: 'categoryOne',
+                        valueType: 'NUMBER',
+                        columnTags: ['DISPLAY'],
+                        defaultFormat: 'number',
+                        columnType: 'field',
+                        expression: null,
+                        __typename: 'Metric'
+                      },
+                      __typename: 'MetricEdge'
+                    },
+                    {
+                      node: {
+                        id: 'metric1',
+                        name: 'Metric 1',
+                        description: 'This is metric 1',
+                        category: 'categoryOne',
+                        valueType: 'NUMBER',
+                        columnTags: ['DISPLAY'],
+                        defaultFormat: 'number',
+                        columnType: 'field',
+                        expression: null,
+                        __typename: 'Metric'
+                      },
+                      __typename: 'MetricEdge'
+                    }
+                  ],
+                  __typename: 'MetricConnection'
                 },
-                __typename: 'MetricEdge'
-              },
-              {
-                node: {
-                  id: 'metric1',
-                  name: 'Metric 1',
-                  description: 'This is metric 1',
-                  category: 'categoryOne',
-                  valueType: 'NUMBER',
-                  columnTags: ['DISPLAY'],
-                  defaultFormat: 'number',
-                  columnType: 'field',
-                  expression: null,
-                  __typename: 'Metric'
+                dimensions: {
+                  edges: [
+                    {
+                      node: {
+                        id: 'dimension0',
+                        name: 'Dimension 0',
+                        description: 'This is dimension 0',
+                        category: 'categoryOne',
+                        valueType: 'TEXT',
+                        columnTags: ['DISPLAY'],
+                        columnType: 'field',
+                        expression: null,
+                        __typename: 'Dimension'
+                      },
+                      __typename: 'DimensionEdge'
+                    }
+                  ],
+                  __typename: 'DimensionConnection'
                 },
-                __typename: 'MetricEdge'
+                timeDimensions: {
+                  edges: [],
+                  __typename: 'TimeDimensionConnection'
+                },
+                __typename: 'Table'
               }
-            ],
-            __typename: 'MetricConnection'
-          },
-          dimensions: {
-            edges: [
-              {
-                node: {
-                  id: 'dimension0',
-                  name: 'Dimension 0',
-                  description: 'This is dimension 0',
-                  category: 'categoryOne',
-                  valueType: 'TEXT',
-                  columnTags: ['DISPLAY'],
-                  columnType: 'field',
-                  expression: null,
-                  __typename: 'Dimension'
-                },
-                __typename: 'DimensionEdge'
-              }
-            ],
-            __typename: 'DimensionConnection'
-          },
-          timeDimensions: {
-            edges: [],
-            __typename: 'TimeDimensionConnection'
-          },
-          __typename: 'Table'
+            }
+          ]
         }
       },
       'The expected table is returned with all requested fields'

--- a/packages/data/tests/unit/serializers/elide-metadata-test.js
+++ b/packages/data/tests/unit/serializers/elide-metadata-test.js
@@ -12,7 +12,7 @@ module('Unit | Serializer | elide-metadata', function(hooks) {
 
   test('normalize', function(assert) {
     const tableConnectionPayload = {
-      tables: {
+      table: {
         edges: [
           {
             node: {


### PR DESCRIPTION
## Description

The GraphQL metadata queries defined in navi-data do not quite match up with what is implemented in the API.

## Proposed Changes

- use `table` query for all table requests
- add all filter arguments that are currently supported in elide
- override ember-cli-mirage-graphql argsMap to handle the `ids` filter argument

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
