### PR TITLE
Fact data interfaces

### DIFF
--- a/packages/data/addon/adapters/bard-facts-v2.ts
+++ b/packages/data/addon/adapters/bard-facts-v2.ts
@@ -145,10 +145,10 @@ export default class BardFactsAdapter extends EmberObject implements NaviFactAda
    * @return sort param value
    */
   _buildSortParam(request: RequestV2, aliasFunction: AliasFn = a => a): string | undefined {
-    const { sort } = request;
+    const { sorts } = request;
 
-    if (sort.length) {
-      return sort
+    if (sorts.length) {
+      return sorts
         .map(sortField => {
           const field = aliasFunction(sortField.field);
           const direction = sortField.direction || 'desc';

--- a/packages/data/addon/adapters/bard-facts-v2.ts
+++ b/packages/data/addon/adapters/bard-facts-v2.ts
@@ -12,52 +12,10 @@ import { assign } from '@ember/polyfills';
 import EmberObject from '@ember/object';
 import { canonicalizeMetric, serializeParameters, getAliasedMetrics, canonicalizeAlias } from '../utils/metric';
 import { configHost } from '../utils/adapter';
+import NaviFactAdapter, { Filter, Parameters, RequestOptions, RequestV2, SORT_DIRECTIONS } from './fact-interface';
 
-const SORT_DIRECTIONS = ['desc', 'asc'];
-
-export type RequestOptions = {
-  clientId?: string;
-  customHeaders?: Dict<string>;
-  timeout?: number;
-  page?: number;
-  perPage?: number;
-  format?: string;
-  cache?: boolean;
-  queryParams?: Dict<string>;
-  dataSourceName?: string;
-};
-type Query = RequestOptions & Dict<string | number | boolean>;
-type SortDirection = typeof SORT_DIRECTIONS[number];
-type ColumnType = 'metric' | 'dimension' | 'timeDimension';
-type Parameters = Dict<string>;
-type Column = {
-  field: string;
-  parameters: Parameters;
-  type: ColumnType;
-  alias: string;
-};
-type Filter = {
-  field: string;
-  parameters: Parameters;
-  type: ColumnType;
-  operator: string;
-  values: string[];
-};
-type Sort = {
-  field: string;
-  parameters: Parameters;
-  direction: SortDirection;
-};
-// TODO: Remove V2 once V1 is no longer in use
-type RequestV2 = {
-  filters: Filter[];
-  columns: Column[];
-  table: string;
-  sort: Sort[];
-  limit: TODO<string>;
-  requestVersion: '2.0';
-};
-type AliasFn = (column: string) => string;
+export type Query = RequestOptions & Dict<string | number | boolean>;
+export type AliasFn = (column: string) => string;
 
 /**
  * @function formatDimensionFieldName
@@ -96,7 +54,7 @@ export function serializeFilters(filters: Filter[]): string {
     .join(',');
 }
 
-export default class BardFactsAdapter extends EmberObject {
+export default class BardFactsAdapter extends EmberObject implements NaviFactAdapter {
   /**
    * @property namespace
    */

--- a/packages/data/addon/adapters/bard-facts.ts
+++ b/packages/data/addon/adapters/bard-facts.ts
@@ -13,7 +13,7 @@ import { assign } from '@ember/polyfills';
 import EmberObject, { getWithDefault } from '@ember/object';
 import { canonicalizeMetric, getAliasedMetrics, canonicalizeAlias } from '../utils/metric';
 import { configHost } from '../utils/adapter';
-import NaviFactAdapter, { RequestV1, RequestOptions, SORT_DIRECTIONS } from './fact-interface';
+import NaviFactAdapter, { RequestV1, RequestOptions, SORT_DIRECTIONS, SortDirection } from './fact-interface';
 import { AliasFn, Query } from './bard-facts-v2';
 
 /**
@@ -129,7 +129,7 @@ export default class BardFactsAdapter extends EmberObject implements NaviFactAda
 
     if (sort && sort.length) {
       return sort
-        .map((sortMetric: { metric: string; direction: string }) => {
+        .map((sortMetric: { metric: string; direction: SortDirection }) => {
           const metric = aliasFunction(sortMetric.metric);
           const direction = getWithDefault(sortMetric, 'direction', 'desc');
 

--- a/packages/data/addon/adapters/bard-facts.ts
+++ b/packages/data/addon/adapters/bard-facts.ts
@@ -25,7 +25,7 @@ import { AliasFn, Query } from './bard-facts-v2';
  * @param {String} filter.operator - the type of filter operator
  * @param {Array<String|number>} filter.values - the values to pass to the operator
  */
-export function serializeFilters(filters: TODO[]) {
+export function serializeFilters(filters: TODO[]): string {
   return filters
     .map(filter => {
       const { dimension, field, operator, values } = filter;

--- a/packages/data/addon/adapters/fact-interface.ts
+++ b/packages/data/addon/adapters/fact-interface.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2020, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+
+export type RequestV1 = TODO;
+
+export type RequestOptions = {
+  clientId?: string;
+  customHeaders?: Dict<string>;
+  timeout?: number;
+  page?: number;
+  perPage?: number;
+  format?: string;
+  cache?: boolean;
+  queryParams?: Dict<string>;
+  dataSourceName?: string;
+};
+
+export const SORT_DIRECTIONS = ['desc', 'asc'];
+
+export type Parameters = Dict<string>;
+
+export type SortDirection = typeof SORT_DIRECTIONS[number];
+
+export type ColumnType = 'metric' | 'dimension' | 'timeDimension';
+
+export type Column = {
+  field: string;
+  parameters: Parameters;
+  type: ColumnType;
+  alias: string;
+};
+
+export type Filter = {
+  field: string;
+  parameters: Parameters;
+  type: ColumnType;
+  operator: string;
+  values: string[];
+};
+
+export type Sort = {
+  field: string;
+  parameters: Parameters;
+  direction: SortDirection;
+};
+
+// TODO: Remove V2 once V1 is no longer in use
+export type RequestV2 = {
+  filters: Filter[];
+  columns: Column[];
+  table: string;
+  sort: Sort[];
+  limit: TODO<string>;
+  requestVersion: '2.0';
+};
+
+export default interface NaviFactAdapter {
+  fetchDataForRequest(request: RequestV1, options: RequestOptions): Promise<TODO>;
+  urlForFindQuery(request: RequestV1, options: RequestOptions): string;
+}

--- a/packages/data/addon/adapters/fact-interface.ts
+++ b/packages/data/addon/adapters/fact-interface.ts
@@ -43,6 +43,7 @@ export type Filter = {
 export type Sort = {
   field: string;
   parameters: Parameters;
+  type: ColumnType;
   direction: SortDirection;
 };
 

--- a/packages/data/addon/adapters/fact-interface.ts
+++ b/packages/data/addon/adapters/fact-interface.ts
@@ -29,7 +29,7 @@ export type Column = {
   field: string;
   parameters: Parameters;
   type: ColumnType;
-  alias: string;
+  alias?: string;
 };
 
 export type Filter = {
@@ -52,8 +52,9 @@ export type RequestV2 = {
   filters: Filter[];
   columns: Column[];
   table: string;
-  sort: Sort[];
-  limit: TODO<string>;
+  dataSource: string;
+  sorts: Sort[];
+  limit?: TODO<string>;
   requestVersion: '2.0';
 };
 

--- a/packages/data/addon/models/navi-facts.ts
+++ b/packages/data/addon/models/navi-facts.ts
@@ -6,22 +6,24 @@
  */
 
 import EmberObject from '@ember/object';
+import { ResponseV1 } from 'navi-data/serializers/fact-interface';
+import { RequestV1 } from 'navi-data/adapters/fact-interface';
 
 export default class NaviFacts extends EmberObject {
   /**
-   * @property {Object} request - the request object
+   * @property {RequestV1} request - the request object
    */
-  request = undefined;
+  request: RequestV1;
 
   /**
-   * @property {Object} response - response for request
+   * @property {ResponseV1} response - response for request
    */
-  response = undefined;
+  response?: ResponseV1;
 
   /**
    * @property {Service} _factsService - instance of the facts service passed in on create
    */
-  _factService = undefined;
+  _factService: TODO;
 
   /**
    * @method next

--- a/packages/data/addon/serializers/bard-facts.ts
+++ b/packages/data/addon/serializers/bard-facts.ts
@@ -9,14 +9,13 @@ import EmberObject from '@ember/object';
 import NaviFactSerializer, { ResponseV1 } from './fact-interface';
 
 export default class BardFactsSerializer extends EmberObject implements NaviFactSerializer {
-  normalize(payload: ResponseV1): ResponseV1 | undefined {
+  normalize(payload?: ResponseV1): ResponseV1 | undefined {
     if (payload) {
       return {
         rows: payload.rows,
         meta: payload.meta || {}
       };
-    } else {
-      return undefined;
     }
+    return undefined;
   }
 }

--- a/packages/data/addon/serializers/bard-facts.ts
+++ b/packages/data/addon/serializers/bard-facts.ts
@@ -6,19 +6,17 @@
  */
 
 import EmberObject from '@ember/object';
+import NaviFactSerializer, { ResponseV1 } from './fact-interface';
 
-export default class BardFactsSerializer extends EmberObject {
-  /**
-   * @method normalize - normalizes the JSON response
-   * @param response {Object} - JSON response object
-   * @returns {Object} - normalized JSON object
-   */
-  normalize(payload) {
+export default class BardFactsSerializer extends EmberObject implements NaviFactSerializer {
+  normalize(payload: ResponseV1): ResponseV1 | undefined {
     if (payload) {
       return {
         rows: payload.rows,
         meta: payload.meta || {}
       };
+    } else {
+      return undefined;
     }
   }
 }

--- a/packages/data/addon/serializers/fact-interface.ts
+++ b/packages/data/addon/serializers/fact-interface.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright 2020, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+
+export interface ResponseV1 {
+  rows: Array<object>;
+  meta: {
+    pagination?: { currentPage: number; rowsPerPage: number; perPage: number; numberOfResults: number };
+  };
+}
+
+export default interface NaviFactSerializer {
+  normalize(payload: ResponseV1): ResponseV1 | undefined;
+}

--- a/packages/data/addon/serializers/fact-interface.ts
+++ b/packages/data/addon/serializers/fact-interface.ts
@@ -11,5 +11,5 @@ export interface ResponseV1 {
 }
 
 export default interface NaviFactSerializer {
-  normalize(payload: ResponseV1): ResponseV1 | undefined;
+  normalize(payload?: ResponseV1): ResponseV1 | undefined;
 }

--- a/packages/data/addon/services/navi-facts.ts
+++ b/packages/data/addon/services/navi-facts.ts
@@ -67,7 +67,7 @@ export default class NaviFactsService extends Service {
    * @param {Object} [options.customHeaders] - hash of header names and values
    * @returns {Promise} - Promise with the bard response model object
    */
-  fetch(this: NaviFactsService, request: RequestV1, options: RequestOptions) {
+  fetch(this: NaviFactsService, request: RequestV1, options: RequestOptions): Promise<NaviFactsModel> {
     const type = config.navi.dataSources[0].type;
     const adapter = this._adapterFor(type);
     const serializer = this._serializerFor(type);
@@ -87,7 +87,7 @@ export default class NaviFactsService extends Service {
    * @param {Object} request
    * @return {Promise|null} returns the promise with the next set of results or null
    */
-  fetchNext(this: NaviFactsService, response: ResponseV1, request: RequestV1): Promise<TODO> | null {
+  fetchNext(this: NaviFactsService, response: ResponseV1, request: RequestV1): Promise<NaviFactsModel> | null {
     if (response.meta.pagination) {
       const { perPage, numberOfResults, currentPage } = response.meta.pagination;
       const totalPages = numberOfResults / perPage;
@@ -108,7 +108,7 @@ export default class NaviFactsService extends Service {
    * @param {Object} request
    * @return {Promise|null} returns the promise with the previous set of results or null
    */
-  fetchPrevious(this: NaviFactsService, response: ResponseV1, request: RequestV1): Promise<TODO> | null {
+  fetchPrevious(this: NaviFactsService, response: ResponseV1, request: RequestV1): Promise<NaviFactsModel> | null {
     if (response.meta.pagination) {
       const { rowsPerPage, currentPage } = response.meta.pagination;
       if (currentPage > 1) {

--- a/packages/data/addon/services/navi-facts.ts
+++ b/packages/data/addon/services/navi-facts.ts
@@ -8,17 +8,20 @@
 import Service from '@ember/service';
 import { getOwner } from '@ember/application';
 import NaviFactsModel from 'navi-data/models/navi-facts';
+//@ts-ignore
 import RequestBuilder from 'navi-data/builder/request';
 import config from 'ember-get-config';
+import NaviFactAdapter, { RequestV1, RequestOptions } from 'navi-data/adapters/fact-interface';
+import NaviFactSerializer, { ResponseV1 } from 'navi-data/serializers/fact-interface';
 
 export default class NaviFactsService extends Service {
   /**
    * @method _adapterFor
    *
    * @param {String} type
-   * @returns {Adapter} adpater instance for type
+   * @returns {Adapter} adapter instance for type
    */
-  _adapterFor(type = 'bard-facts') {
+  _adapterFor(type = 'bard-facts'): NaviFactAdapter {
     return getOwner(this).lookup(`adapter:${type}`);
   }
 
@@ -28,7 +31,7 @@ export default class NaviFactsService extends Service {
    * @param {String} type
    * @returns {Serializer} serializer instance for type
    */
-  _serializerFor(type = 'bard-facts') {
+  _serializerFor(type = 'bard-facts'): NaviFactSerializer {
     return getOwner(this).lookup(`serializer:${type}`);
   }
 
@@ -39,7 +42,7 @@ export default class NaviFactsService extends Service {
    * @param {Object} baseRequest - existing request to start from
    * @returns {Object} request builder interface
    */
-  request(baseRequest) {
+  request(baseRequest: RequestV1) {
     return RequestBuilder.create(baseRequest);
   }
 
@@ -49,9 +52,9 @@ export default class NaviFactsService extends Service {
    * @param {Object} [options] - options object
    * @returns {String} - url for the request
    */
-  getURL(request, options) {
-    const type = config.navi.dataSources[0].type,
-      adapter = this._adapterFor(type);
+  getURL(request: RequestV1, options: RequestOptions) {
+    const type = config.navi.dataSources[0].type;
+    const adapter = this._adapterFor(type);
     return adapter.urlForFindQuery(request, options);
   }
 
@@ -64,10 +67,10 @@ export default class NaviFactsService extends Service {
    * @param {Object} [options.customHeaders] - hash of header names and values
    * @returns {Promise} - Promise with the bard response model object
    */
-  fetch(request, options) {
-    const type = config.navi.dataSources[0].type,
-      adapter = this._adapterFor(type),
-      serializer = this._serializerFor(type);
+  fetch(this: NaviFactsService, request: RequestV1, options: RequestOptions) {
+    const type = config.navi.dataSources[0].type;
+    const adapter = this._adapterFor(type);
+    const serializer = this._serializerFor(type);
 
     return adapter.fetchDataForRequest(request, options).then(payload => {
       return NaviFactsModel.create({
@@ -84,19 +87,16 @@ export default class NaviFactsService extends Service {
    * @param {Object} request
    * @return {Promise|null} returns the promise with the next set of results or null
    */
-  fetchNext(response, request) {
+  fetchNext(this: NaviFactsService, response: ResponseV1, request: RequestV1): Promise<TODO> | null {
     if (response.meta.pagination) {
       const { perPage, numberOfResults, currentPage } = response.meta.pagination;
-
       const totalPages = numberOfResults / perPage;
 
       if (currentPage < totalPages) {
-        let options = {
+        return this.fetch(request, {
           page: currentPage + 1,
           perPage: perPage
-        };
-
-        return this.fetch(request, options);
+        });
       }
     }
     return null;
@@ -108,18 +108,16 @@ export default class NaviFactsService extends Service {
    * @param {Object} request
    * @return {Promise|null} returns the promise with the previous set of results or null
    */
-  fetchPrevious(response, request) {
+  fetchPrevious(this: NaviFactsService, response: ResponseV1, request: RequestV1): Promise<TODO> | null {
     if (response.meta.pagination) {
-      if (response.meta.pagination.currentPage > 1) {
-        const options = {
-          page: response.meta.pagination.currentPage - 1,
-          perPage: response.meta.pagination.rowsPerPage
-        };
-
-        return this.fetch(request, options);
+      const { rowsPerPage, currentPage } = response.meta.pagination;
+      if (currentPage > 1) {
+        return this.fetch(request, {
+          page: currentPage - 1,
+          perPage: rowsPerPage
+        });
       }
     }
-
     return null;
   }
 }

--- a/packages/data/package-lock.json
+++ b/packages/data/package-lock.json
@@ -2227,9 +2227,9 @@
       },
       "dependencies": {
         "@babel/helper-plugin-utils": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-          "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+          "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA=="
         }
       }
     },
@@ -3096,9 +3096,9 @@
       "dev": true
     },
     "@types/ember": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@types/ember/-/ember-3.1.2.tgz",
-      "integrity": "sha512-Z4jxklUlnoWEkenLaMDDmzguL3UUcAIaCiu28nNYlIovWTGmvKuJgUKSqd+03j4jjzaz+yz0fepM408XULew/A==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@types/ember/-/ember-3.16.0.tgz",
+      "integrity": "sha512-9TBWidO/9ydThgh0Fy7y2DNX7Pb8REoV7tYK+HBFZ2iyc1TwXTNt15gVz0cCyorvsve2OS+vt5wzYvlqgSGlwg==",
       "dev": true,
       "requires": {
         "@types/ember__application": "*",
@@ -3123,9 +3123,9 @@
       }
     },
     "@types/ember-qunit": {
-      "version": "3.4.8",
-      "resolved": "https://registry.npmjs.org/@types/ember-qunit/-/ember-qunit-3.4.8.tgz",
-      "integrity": "sha512-eAFYXit9vIXLiJiLzmI3Y37+AprHX0aVkgkC9cZzOLPAFeTSJ9T6Mso0o9EvrlAeFe/opg9uGp/QUgbX7X7IAw==",
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/@types/ember-qunit/-/ember-qunit-3.4.9.tgz",
+      "integrity": "sha512-XFe9EK9CVo431TJjS2a/bEcdRBCWFZeDYvYwZEDAlAVvVj9oApAX3bU4OEu9R9xHe6UhyvsgSa7dEr1tComRFQ==",
       "dev": true,
       "requires": {
         "@types/ember": "*",
@@ -3133,9 +3133,9 @@
       }
     },
     "@types/ember-test-helpers": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/ember-test-helpers/-/ember-test-helpers-1.0.7.tgz",
-      "integrity": "sha512-qxBdoXv+cW4J907s9CftS6qrgkkXWROT6I1TV2yW5eErCMu9YvPU7X8z4qFQ/ZVZOgoT5lVnsgYX1a36RJE8xw==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/ember-test-helpers/-/ember-test-helpers-1.0.8.tgz",
+      "integrity": "sha512-tkFfW4fblFfXxJboCodVaw2PVjFIvSzhO+m/cXqunRyN4VffC6gcaPMnfJYQ68h25jLMDyuTrks9SsnITjs3pg==",
       "dev": true,
       "requires": {
         "@types/ember": "*",
@@ -3145,9 +3145,9 @@
       }
     },
     "@types/ember__application": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@types/ember__application/-/ember__application-3.0.8.tgz",
-      "integrity": "sha512-+Swh9w3s921nrbzYWbVl9W+zGIjel8LNvczVhtUdmss7PMii/yzU52/41a+VoesfO/1zfIkG3KJpvBBob5mTvw==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@types/ember__application/-/ember__application-3.16.0.tgz",
+      "integrity": "sha512-iudEJJmax99sLJCqmIwt3pM3ZuU6QHScH9ksg1pznwAjDGD3eAXYW6USYcK4KZwEIbXyX86KBBcjwg///Ae5JQ==",
       "dev": true,
       "requires": {
         "@types/ember__application": "*",
@@ -3157,9 +3157,9 @@
       }
     },
     "@types/ember__array": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/ember__array/-/ember__array-3.0.6.tgz",
-      "integrity": "sha512-cLIpWjOYCDtqKk+YlsrT5Bf4qAxThYngOk9vHzzBxPqmbTY/E5zRsyxbYIuDmeOPiyWVJ6qliBomnTVdgZK0cA==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@types/ember__array/-/ember__array-3.16.0.tgz",
+      "integrity": "sha512-Ks6ZsNLUuhMUn5sZORc/unyQyD4No2l97f9O6fQ4QeL61PR2r0eSU7MvdAkZOdX0rezwaOcxp8Vo8sngNFnXrA==",
       "dev": true,
       "requires": {
         "@types/ember__array": "*",
@@ -3167,9 +3167,9 @@
       }
     },
     "@types/ember__component": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@types/ember__component/-/ember__component-3.0.7.tgz",
-      "integrity": "sha512-IC919wn7OfDFAGVgwWA26QRvyPk/XTJJh/inlFwwHuOUmysQ0hB2KOGgU8nSWfL8aIoNH99HB3oyIAH2tM9gQg==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@types/ember__component/-/ember__component-3.16.0.tgz",
+      "integrity": "sha512-MnzHTGQ6ic9/wT72Ho3BybEajKFkJOakeYSriVLFQTxbaLwm8RNDrZNPHWGT4FEl6dEf90+2SBJHFagbIPAhng==",
       "dev": true,
       "requires": {
         "@types/ember__component": "*",
@@ -3178,18 +3178,18 @@
       }
     },
     "@types/ember__controller": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@types/ember__controller/-/ember__controller-3.0.8.tgz",
-      "integrity": "sha512-AgBA3T3nPa14OyTLCtR2FJyoRtKvR5lbzvvYli2z1smCJEdmyvNuGk71sgJNai57SW7la93HQS+g6d18VZgEKw==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@types/ember__controller/-/ember__controller-3.16.0.tgz",
+      "integrity": "sha512-LSM4ybqq46ptUkVMkAZA37IGLcoKVsYQ01uLn1JjE+dGQDKDnRxB5x3o/J1KM24H1eb3ZoYj0WckJgINUJVMxw==",
       "dev": true,
       "requires": {
         "@types/ember__object": "*"
       }
     },
     "@types/ember__debug": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@types/ember__debug/-/ember__debug-3.0.7.tgz",
-      "integrity": "sha512-GtS8vwt0t1KwzFvOllKCJ0k8gGzhohsCjlfeksmR1rnMuzb/tiuKKXWOP5UszTRg+OK68bSzZMuw1SQKFAZE4w==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@types/ember__debug/-/ember__debug-3.16.0.tgz",
+      "integrity": "sha512-z34EhS2gpo7CeJQXenbIdX301uTkyZ3YI6JQ+sxE2iw/sKxJbxPfBEB6FDiFyec0SXuvic0wSBLROKM2kJBnkg==",
       "dev": true,
       "requires": {
         "@types/ember__debug": "*",
@@ -3198,9 +3198,9 @@
       }
     },
     "@types/ember__engine": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/ember__engine/-/ember__engine-3.0.5.tgz",
-      "integrity": "sha512-RfmgcNuwj6OJzsJejj9Zu/4td5xHHIj/Mydk0dYqBLoNFp/BKVMhYwuxOHZLkcF/Vy36R33UJ8zIklZuYli1SA==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@types/ember__engine/-/ember__engine-3.16.0.tgz",
+      "integrity": "sha512-1UOR4jG8NLwnw4pUe3MOvfIJ6rX2RYr9zr9KiLyOYVIQ9lQxfXB6L+U5gf0dUewnWy7h58iZ01FlPGrlwKm2vg==",
       "dev": true,
       "requires": {
         "@types/ember__engine": "*",
@@ -3208,15 +3208,15 @@
       }
     },
     "@types/ember__error": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/ember__error/-/ember__error-3.0.4.tgz",
-      "integrity": "sha512-GBYIuZBanzMgai6sfZAzgxe5PPIABBR7IkZEzu/pzSxeZl26TkurK1IlwP+L3RKet+2Fw2r4Cfsw5O2vRUsv1Q==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@types/ember__error/-/ember__error-3.16.0.tgz",
+      "integrity": "sha512-inHhs9w2bEmJql0ddVXeWyqkzPbmyxcJ1Pe+UFf9aYWnLr0S7sZPzSQX4l+tGEjf8BCQvoMLk7TdujIj1LAoRA==",
       "dev": true
     },
     "@types/ember__object": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@types/ember__object/-/ember__object-3.1.3.tgz",
-      "integrity": "sha512-4B9XK76TIuWCgGEgwbcGbmaIH2R2C5+BXg1zgGYagxnoLl/TCCKYwtSaUm3/z/z3l5Yk+4PA2MZeXBQmPKMC6A==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@types/ember__object/-/ember__object-3.12.0.tgz",
+      "integrity": "sha512-jFPpkg2rMgCYdjT9PQ8S4UfKGNjRFKXw25C75draHcCWYiiXQxIOjZhirm+F4I8s1NbHbwHCN55h+bdpCNb22w==",
       "dev": true,
       "requires": {
         "@types/ember__object": "*",
@@ -3224,15 +3224,15 @@
       }
     },
     "@types/ember__polyfills": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@types/ember__polyfills/-/ember__polyfills-3.0.7.tgz",
-      "integrity": "sha512-aQUI0HTIlTroMrQrfu533pBiNm39v5O6ec2bNcfDRFhKYVRVCaI88llH/QssRCUywrPdnQnLpUJFF95JNk0rUQ==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@types/ember__polyfills/-/ember__polyfills-3.12.0.tgz",
+      "integrity": "sha512-2HX4vsvHQbodVdw5z0xmOyocRH56e/MetmUf6EJTjWSE9GX5Ry/VE4FZ6nhYzzrVuPOECj5fJ7kSaI5KugBHfg==",
       "dev": true
     },
     "@types/ember__routing": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/@types/ember__routing/-/ember__routing-3.0.12.tgz",
-      "integrity": "sha512-uguCrJdycNJtLrdgiu3bfqpcQ4dhCCrS7wB5CyTAvy0SNcqfRBxGOlPUBzgljxPYCtQ1kIqJpmoPorG56hTi0A==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@types/ember__routing/-/ember__routing-3.16.0.tgz",
+      "integrity": "sha512-fPtYLVLl1oLg0zQNM58LsmDfw+R6DdNxKM71DT8V3tyW7CbhkYDKlkiAioykFQpoCGxnaRa49Pa15hBF/siZuw==",
       "dev": true,
       "requires": {
         "@types/ember__component": "*",
@@ -3243,51 +3243,51 @@
       }
     },
     "@types/ember__runloop": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@types/ember__runloop/-/ember__runloop-3.0.7.tgz",
-      "integrity": "sha512-mi1GquXQDtAvc5yww8QgUgOIb+SBZnSyffx6bvv1POjpQSvb5/sYEyEGGTg2nbjArB9zhOtg9CfCj6llOchdjA==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@types/ember__runloop/-/ember__runloop-3.16.0.tgz",
+      "integrity": "sha512-E8RVmsYsbugR2xonreCBX3LTp3rYxJ9dmVE13g/AulZcf2x+RB5H43wvK4lKeg1j+OPY3LBs04CmyaEBHn+xSg==",
       "dev": true,
       "requires": {
         "@types/ember__runloop": "*"
       }
     },
     "@types/ember__service": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/ember__service/-/ember__service-3.0.6.tgz",
-      "integrity": "sha512-UA1QEDQylGgxdLHr03uMOeX5idW6fqsqHUvPjCjTvxmJlIHCcejJ/qwXtZRri4GsLfMlMJowJQVxRm29WwdScg==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@types/ember__service/-/ember__service-3.16.0.tgz",
+      "integrity": "sha512-yOY3tO1xuo53a+UpfvYeXsZRsU8KVSv1odeoU6mN/WRACbNsD1WvYcolsQ/9TPynt5djEvHEHOR2WwQBIvN+1A==",
       "dev": true,
       "requires": {
         "@types/ember__object": "*"
       }
     },
     "@types/ember__string": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@types/ember__string/-/ember__string-3.0.8.tgz",
-      "integrity": "sha512-xOGHilXWx/talkpGhgRL+FEQJAImwe97JXcFTFD2rELbh0slL/HI7rSvBeWCPKp75cflNHUCr1N943iTGt5J0g==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@types/ember__string/-/ember__string-3.16.0.tgz",
+      "integrity": "sha512-zmOuSnvS+xKr7kqyRkc9xghWsqqTcP//9soK2KWVhzQltosmpNdkoy+M2upaSZAzhL7wqiUzX99F1ZMDCkwknQ==",
       "dev": true,
       "requires": {
         "@types/ember__template": "*"
       }
     },
     "@types/ember__template": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/ember__template/-/ember__template-3.0.1.tgz",
-      "integrity": "sha512-6hYGNLvYhwv+XvRFXeObMu8Fr2h3tslb+YQNE2UKU81ul8AJZ+utZuGpEVZ221sa49HWm220yNVuOFeQcC4PhA==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@types/ember__template/-/ember__template-3.16.0.tgz",
+      "integrity": "sha512-OVr29pQtbyLVJW6h7+wdkeXLHx00p4CY28znsEgO0X2EeF5xyBhmyhTZOWrGbiTU17+Zs9d4KStt5f1Bq4Wgow==",
       "dev": true
     },
     "@types/ember__test": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/ember__test/-/ember__test-3.0.6.tgz",
-      "integrity": "sha512-q5BmDF0NZ3nXUAy8da/dXDfVZMsHxNj6vqONBoq/GLGS5kxNJNXiYsa5NG5BVXv1Gd4fIT6lySlX5x/yUqtYdA==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@types/ember__test/-/ember__test-3.16.0.tgz",
+      "integrity": "sha512-kYenxB1B3LAqMlzY15ER1oJVDBZJLDIYAcIaTJ56V2FU1B2SBHoiAttId/QQs84oElYIYycm1FWGqMgRrk9UpA==",
       "dev": true,
       "requires": {
         "@types/ember__application": "*"
       }
     },
     "@types/ember__test-helpers": {
-      "version": "0.7.10",
-      "resolved": "https://registry.npmjs.org/@types/ember__test-helpers/-/ember__test-helpers-0.7.10.tgz",
-      "integrity": "sha512-e+NVsScAO+BcWCki9CuepScJ4akiKORrFyYaEvpoRSyyM5UpvY4Ov175hXxcNFv5JSyIvPUvhZtOH2W3BlLHhA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@types/ember__test-helpers/-/ember__test-helpers-1.7.0.tgz",
+      "integrity": "sha512-8pd+KNnus948oAQh0pdpP4SioaBTJDqn+H4FkBjphZf+VzFZMVbJoDtDqCcBH/d2Cr2gXPd4RDjZRprg/bRVLQ==",
       "dev": true,
       "requires": {
         "@types/ember": "*",
@@ -3297,9 +3297,9 @@
       }
     },
     "@types/ember__utils": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/ember__utils/-/ember__utils-3.0.4.tgz",
-      "integrity": "sha512-JmX5VPRmvAKHzLGBLXPqupcGLEeqvTVjIdsg09WRn+QvEOlVUzLgl/DM9uaOXXmp+aZUhNKtz2skmsxxu/ac2w==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@types/ember__utils/-/ember__utils-3.16.0.tgz",
+      "integrity": "sha512-fd0q5d+8/XqoH7H51UmdT9wQA6SGW/fB/1yNSD57NHHiVkkT1GUHhPHWCLjnZHtWIM5cS0+gZeCPGou7qOM/6g==",
       "dev": true
     },
     "@types/eslint-visitor-keys": {
@@ -3344,9 +3344,9 @@
       "dev": true
     },
     "@types/jquery": {
-      "version": "3.3.34",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.34.tgz",
-      "integrity": "sha512-lW9vsVL53Xu/Nj4gi2hNmHGc4u3KKghjqTkAlO0kF5GIOPxbqqnQpgqJBzmn3yXLrPqHb6cmNJ6URnS23Vtvbg==",
+      "version": "3.3.38",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.38.tgz",
+      "integrity": "sha512-nkDvmx7x/6kDM5guu/YpXkGZ/Xj/IwGiLDdKM99YA5Vag7pjGyTJ8BNUh/6hxEn/sEu5DKtyRgnONJ7EmOoKrA==",
       "dev": true,
       "requires": {
         "@types/sizzle": "*"
@@ -11255,9 +11255,9 @@
       }
     },
     "ember-cli-typescript": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-3.1.3.tgz",
-      "integrity": "sha512-bFi15H60L9TLYfn9XUzi+RAP1gTWHFtVdSy9IHvxXHlCvTlFZ+2rfuugr/f8reQLz9gvJccKc5TyRD7v+uhx0Q==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-3.1.4.tgz",
+      "integrity": "sha512-HJ73kL45OGRmIkPhBNFt31I1SGUvdZND+LCH21+qpq3pPlFpJG8GORyXpP+2ze8PbnITNLzwe5AwUrpyuRswdQ==",
       "requires": {
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.4.4",
         "@babel/plugin-proposal-optional-chaining": "^7.6.0",
@@ -14919,9 +14919,9 @@
       },
       "dependencies": {
         "cross-spawn": {
-          "version": "7.0.2",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.2.tgz",
-          "integrity": "sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==",
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
           "requires": {
             "path-key": "^3.1.0",
             "shebang-command": "^2.0.0",
@@ -22490,9 +22490,9 @@
       }
     },
     "typescript": {
-      "version": "3.7.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
-      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.5.tgz",
+      "integrity": "sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==",
       "dev": true
     },
     "typescript-memoize": {

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -35,7 +35,7 @@
     "ember-cli-htmlbars": "^4.2.2",
     "ember-cli-mirage": "~1.1.6",
     "ember-cli-mirage-graphql": "^0.3.1",
-    "ember-cli-typescript": "^3.1.3",
+    "ember-cli-typescript": "^3.1.4",
     "ember-get-config": "0.2.4",
     "faker": "^4.1.0",
     "graphql": "^14.6.0",
@@ -47,9 +47,9 @@
   "devDependencies": {
     "@babel/preset-typescript": "^7.8.3",
     "@ember/optional-features": "^1.3.0",
-    "@types/ember": "^3.1.2",
-    "@types/ember-qunit": "^3.4.8",
-    "@types/ember__test-helpers": "^0.7.10",
+    "@types/ember": "^3.16.0",
+    "@types/ember-qunit": "^3.4.9",
+    "@types/ember__test-helpers": "^1.7.0",
     "@types/lodash-es": "^4.17.3",
     "@types/papaparse": "^5.0.3",
     "@types/qunit": "^2.9.1",
@@ -84,7 +84,7 @@
     "eslint-plugin-qunit": "^4.0.0",
     "loader.js": "^4.7.0",
     "qunit-dom": "^1.0.0",
-    "typescript": "3.7.5"
+    "typescript": "^3.9.5"
   },
   "engines": {
     "node": "10.* || >= 12"

--- a/packages/data/tests/unit/adapters/bard-facts-v2-test.js
+++ b/packages/data/tests/unit/adapters/bard-facts-v2-test.js
@@ -82,7 +82,7 @@ const TestRequest = {
         type: 'dimension'
       }
     ],
-    sort: []
+    sorts: []
   },
   Response = {
     rows: [
@@ -373,7 +373,7 @@ module('Unit | Bard Facts V2 Adapter', function(hooks) {
     assert.expect(7);
 
     let singleSort = {
-      sort: [
+      sorts: [
         {
           field: 'm1',
           parameters: {},
@@ -388,7 +388,7 @@ module('Unit | Bard Facts V2 Adapter', function(hooks) {
     );
 
     let sortNoDirection = {
-      sort: [
+      sorts: [
         {
           field: 'm1'
         }
@@ -401,7 +401,7 @@ module('Unit | Bard Facts V2 Adapter', function(hooks) {
     );
 
     let manySorts = {
-      sort: [
+      sorts: [
         {
           field: 'm1',
           direction: 'asc'
@@ -421,7 +421,7 @@ module('Unit | Bard Facts V2 Adapter', function(hooks) {
     assert.equal(
       Adapter._buildSortParam(
         {
-          sort: [
+          sorts: [
             {
               field: 'a',
               direction: 'asc'
@@ -437,7 +437,7 @@ module('Unit | Bard Facts V2 Adapter', function(hooks) {
     assert.equal(
       Adapter._buildSortParam(
         {
-          sort: [
+          sorts: [
             {
               field: 'a',
               direction: 'asc'
@@ -454,11 +454,11 @@ module('Unit | Bard Facts V2 Adapter', function(hooks) {
       'sort param with aliases mixed with non aliases work'
     );
 
-    let emptySorts = { sort: [] };
+    let emptySorts = { sorts: [] };
     assert.equal(Adapter._buildSortParam(emptySorts), undefined, '_buildSortParam returns undefined with empty sort');
 
     let invalidSort = {
-      sort: [
+      sorts: [
         { field: 'valid1' },
         { field: 'valid2', direction: 'asc' },
         { field: 'valid3', direction: 'desc' },
@@ -633,7 +633,7 @@ module('Unit | Bard Facts V2 Adapter', function(hooks) {
       '_buildQuery sets non default format if format is set in the options object'
     );
 
-    let sortRequest = assign({}, TestRequest, { sort: [{ field: 'm1' }] });
+    let sortRequest = assign({}, TestRequest, { sorts: [{ field: 'm1' }] });
     assert.deepEqual(
       Adapter._buildQuery(sortRequest),
       {
@@ -647,7 +647,7 @@ module('Unit | Bard Facts V2 Adapter', function(hooks) {
       '_buildQuery correctly built the query object for a request with sort'
     );
 
-    sortRequest = assign({}, TestRequest, { sort: [{ field: 'a' }] });
+    sortRequest = assign({}, TestRequest, { sorts: [{ field: 'a' }] });
     assert.deepEqual(
       Adapter._buildQuery(sortRequest),
       {
@@ -821,7 +821,7 @@ module('Unit | Bard Facts V2 Adapter', function(hooks) {
 
     let requestWithSort = assign({}, TestRequest, {
       filters: [{ field: 'dateTime', type: 'timeDimension', operator: 'bet', values: ['2015-01-03', '2015-01-04'] }],
-      sort: [{ field: 'm1' }, { field: 'm2' }]
+      sorts: [{ field: 'm1' }, { field: 'm2' }]
     });
     assert.equal(
       decodeURIComponent(Adapter.urlForFindQuery(requestWithSort)),


### PR DESCRIPTION
## Description

This PR adds fact interfaces for the adapter and serializer. This is in preparation of the elide set. I took a stab at organizing some types and interfaces. I am open to suggestions, but I don't think we need to get it perfect in the short term. Most likely we will see the patterns as we move forward, plus it is pretty easy to move them around (VSCode is pretty good at that).

## Proposed Changes

- Bumps ember-cli-typescript to  3.1.4
- Adds fact adapter and serializer interfaces
- JS -> TS some files
- Move Request V2 types

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
