### PR TITLE
Build: Install python explicitly in build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,8 @@ jobs:
       name: 'NPM'
       script: bash ./scripts/npm-publish.sh
     - before_script:
-        - pyenv global 3.6
+        - pyenv install 3.6.10
+        - pyenv global 3.6.10
         - pip3 install travis-wait-improved
       script: travis-wait-improved --timeout 30m bash ./scripts/gh-pages-publish.sh
       name: 'GitHub Pages'


### PR DESCRIPTION

## Description


Currently, the build is breaking:

> $ pyenv global 3.6
> pyenv: version `3.6' not installed
> The command "pyenv global 3.6" failed and exited with 1 during .


https://travis-ci.com/github/yahoo/navi/jobs/353629118

## Proposed Changes

Build: Install python explicitly in build

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
