### PR TITLE
Build: Use python 3.6.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,8 +67,8 @@ jobs:
       name: 'NPM'
       script: bash ./scripts/npm-publish.sh
     - before_script:
-        - pyenv install 3.6.10
-        - pyenv global 3.6.10
+        - pyenv install 3.6.3
+        - pyenv global 3.6.3
         - pip3 install travis-wait-improved
       script: travis-wait-improved --timeout 30m bash ./scripts/gh-pages-publish.sh
       name: 'GitHub Pages'


### PR DESCRIPTION

## Description

The build is failing:

>$ pyenv install 3.6.10
python-build: definition not found: 3.6.10
See all available versions with `pyenv install --list'.
If the version you need is missing, try upgrading pyenv:

Other travis builds have successfully used 3.6.3

## Proposed Changes

-

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
