### PR TITLE
Update: Support Elide GraphQL

### DIFF
--- a/packages/webservice/app/build.gradle.kts
+++ b/packages/webservice/app/build.gradle.kts
@@ -15,10 +15,11 @@ repositories {
 
 dependencies {
     implementation(project(":models"))
-    implementation("com.yahoo.elide", "elide-spring-boot-starter", "5.0.0-pr10")
     implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("com.yahoo.elide", "elide-spring-boot-starter", "5.0.0-pr12")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("com.h2database", "h2", "1.3.176")
+    implementation("io.micrometer","micrometer-core", "1.5.1")
     testImplementation("org.springframework.boot:spring-boot-starter-test") {
         exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
     }

--- a/packages/webservice/app/src/main/resources/application.yaml
+++ b/packages/webservice/app/src/main/resources/application.yaml
@@ -4,7 +4,7 @@ elide:
     enabled: true
   graphql:
     path: /graphql/api/v1
-    enabled: false
+    enabled: true
   swagger:
     path: /doc
     enabled: true
@@ -33,3 +33,4 @@ logging:
   path: /tmp
 
 ---
+

--- a/packages/webservice/models/build.gradle.kts
+++ b/packages/webservice/models/build.gradle.kts
@@ -29,7 +29,7 @@ allOpen {
 }
 
 dependencies {
-    implementation("com.yahoo.elide", "elide-core", "5.0.0-pr10")
+    implementation("com.yahoo.elide", "elide-core", "5.0.0-pr12")
     implementation("javax.persistence", "javax.persistence-api", "2.2")
     implementation("org.hibernate", "hibernate-core", "5.4.15.Final")
 }

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/Asset.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/Asset.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 package com.yahoo.navi.ws.models.beans

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/Dashboard.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/Dashboard.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 package com.yahoo.navi.ws.models.beans

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/DashboardWidget.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/DashboardWidget.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 package com.yahoo.navi.ws.models.beans

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/HasAuthor.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/HasAuthor.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 package com.yahoo.navi.ws.models.beans

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/HasEditors.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/HasEditors.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 package com.yahoo.navi.ws.models.beans

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/Report.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/Report.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 package com.yahoo.navi.ws.models.beans

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/DashboardPresentation.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/DashboardPresentation.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 package com.yahoo.navi.ws.models.beans.fragments
@@ -13,12 +13,6 @@ import org.hibernate.annotations.TypeDef
 @TypeDef(typeClass = JsonType::class, name = "json")
 data class DashboardPresentation(
     var version: Int = 0,
-    var layout: List<Layout> = arrayListOf(),
+    var layout: List<Layout> = emptyList(),
     var columns: Int = 0
-) {
-    constructor() : this(
-            0,
-            arrayListOf<Layout>(),
-            0
-    )
-}
+)

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/DashboardWidgetVisualization.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/DashboardWidgetVisualization.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 package com.yahoo.navi.ws.models.beans.fragments
@@ -15,14 +15,8 @@ import org.hibernate.annotations.TypeDef
 data class DashboardWidgetVisualization(
     var type: String = "",
     var version: Int = 0,
-    @get:Type(type = "com.yahoo.navi.ws.models.types.JsonType", parameters = arrayOf(
-            Parameter(name = "class", value = "kotlin.collections.HashMap")
-    ))
+    @Type(type = "com.yahoo.navi.ws.models.types.JsonType", parameters = [
+        Parameter(name = "class", value = "java.util.HashMap")
+    ])
     var metadata: Map<Any, Any> = emptyMap()
-) {
-    constructor() : this(
-            "",
-            0,
-            emptyMap()
-    )
-}
+)

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/RequestV1.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/RequestV1.kt
@@ -18,27 +18,14 @@ import org.hibernate.annotations.TypeDef
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @TypeDef(typeClass = JsonType::class, name = "json")
 data class RequestV1(
-    var intervals: Array<Interval> = arrayOf(),
-    var filters: Array<Filter> = arrayOf(),
-    var dimensions: Array<Dimension> = arrayOf(),
-    var metrics: Array<Metric> = arrayOf(),
-    var logicalTable: LogicalTable,
-    var sort: Array<Sort> = arrayOf(),
-    var having: Array<Having> = arrayOf(),
+    var intervals: List<Interval> = emptyList(),
+    var filters: List<Filter> = emptyList(),
+    var dimensions: List<Dimension> = emptyList(),
+    var metrics: List<Metric> = emptyList(),
+    var logicalTable: LogicalTable = LogicalTable(),
+    var sort: List<Sort> = emptyList(),
+    var having: List<Having> = emptyList(),
     var dataSource: String? = null,
-    var bardVersion: String,
-    val requestVersion: String
-) : Request {
-    constructor() : this(
-        arrayOf<Interval>(),
-        arrayOf<Filter>(),
-        arrayOf<Dimension>(),
-        arrayOf<Metric>(),
-        LogicalTable("", ""),
-        arrayOf<Sort>(),
-        arrayOf<Having>(),
-        null,
-        "v1",
-        "v1"
-    )
-}
+    var bardVersion: String = "v1",
+    val requestVersion: String = "v1"
+) : Request

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/RequestV2.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/RequestV2.kt
@@ -14,21 +14,11 @@ import org.hibernate.annotations.TypeDef
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @TypeDef(typeClass = JsonType::class, name = "json")
 data class RequestV2(
-    var filters: Array<Filter>,
-    var columns: Array<Column>,
-    var table: String,
-    var sorts: Array<Sort>,
-    var limit: Int?,
-    var dataSource: String?,
-    val requestVersion: String
-) : Request {
-    constructor() : this(
-            emptyArray(),
-            emptyArray(),
-            "",
-            emptyArray(),
-            null,
-            null,
-            "2.0"
-    )
-}
+    var filters: List<Filter> = emptyList(),
+    var columns: List<Column> = emptyList(),
+    var table: String = "",
+    var sorts: List<Sort> = emptyList(),
+    var limit: Int? = null,
+    var dataSource: String? = null,
+    val requestVersion: String = "2.0"
+) : Request

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/Visualization.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/Visualization.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 package com.yahoo.navi.ws.models.beans.fragments
@@ -13,11 +13,9 @@ import org.hibernate.annotations.TypeDef
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @TypeDef(typeClass = JsonType::class, name = "json")
 data class Visualization(
-    var type: String,
-    var version: Int,
-    @get:Type(type = "com.yahoo.navi.ws.models.types.JsonType", parameters = [
-        (Parameter(name = "class", value = "kotlin.collections.HashMap"))
-    ]) var metadata: Map<Any, Any>
-) {
-    constructor() : this("", 1, emptyMap())
-}
+    var type: String = "",
+    var version: Int = 1,
+    @Type(type = "com.yahoo.navi.ws.models.types.JsonType", parameters = [
+        (Parameter(name = "class", value = "java.utils.HashMap"))
+    ]) var metadata: Map<Any, Any> = emptyMap()
+)

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/layout/Layout.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/layout/Layout.kt
@@ -1,17 +1,13 @@
 /**
- * Copyright 2019, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 package com.yahoo.navi.ws.models.beans.fragments.layout
 
 data class Layout(
-    var column: Int,
-    var row: Int,
-    var height: Int,
-    var width: Int,
-    var widgetId: Int
-) {
-    constructor() : this(
-            0, 0, 0, 0, 0
-    )
-}
+    var column: Int = 0,
+    var row: Int = 0,
+    var height: Int = 0,
+    var width: Int = 0,
+    var widgetId: Int = 0
+)

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/request/Dimension.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/request/Dimension.kt
@@ -1,11 +1,9 @@
 /**
- * Copyright 2019, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 package com.yahoo.navi.ws.models.beans.fragments.request
 
 data class Dimension(
-    var dimension: String
-) {
-    constructor() : this("")
-}
+    var dimension: String = ""
+)

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/request/Filter.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/request/Filter.kt
@@ -1,14 +1,12 @@
 /**
- * Copyright 2019, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 package com.yahoo.navi.ws.models.beans.fragments.request
 
 data class Filter(
-    var dimension: String,
-    var operator: String,
-    var values: Array<String>,
-    var field: String
-) {
-    constructor() : this("", "", arrayOf<String>(), "")
-}
+    var dimension: String = "",
+    var operator: String = "",
+    var values: List<String> = emptyList(),
+    var field: String = ""
+)

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/request/Having.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/request/Having.kt
@@ -1,13 +1,11 @@
 /**
- * Copyright 2019, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 package com.yahoo.navi.ws.models.beans.fragments.request
 
 data class Having(
-    var metric: String,
-    var operator: String,
-    var values: Array<Double>
-) {
-    constructor() : this("", "", arrayOf<Double>())
-}
+    var metric: String = "",
+    var operator: String = "",
+    var values: List<Double> = emptyList()
+)

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/request/Interval.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/request/Interval.kt
@@ -1,12 +1,10 @@
 /**
- * Copyright 2019, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 package com.yahoo.navi.ws.models.beans.fragments.request
 
 data class Interval(
-    var start: String,
-    var end: String
-) {
-    constructor() : this("", "")
-}
+    var start: String = "",
+    var end: String = ""
+)

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/request/LogicalTable.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/request/LogicalTable.kt
@@ -1,12 +1,10 @@
 /**
- * Copyright 2019, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 package com.yahoo.navi.ws.models.beans.fragments.request
 
 data class LogicalTable(
-    var table: String,
-    var timeGrain: String
-) {
-    constructor() : this("", "")
-}
+    var table: String = "",
+    var timeGrain: String = ""
+)

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/request/Metric.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/request/Metric.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 package com.yahoo.navi.ws.models.beans.fragments.request
@@ -8,11 +8,9 @@ import org.hibernate.annotations.Parameter
 import org.hibernate.annotations.Type
 
 data class Metric(
-    var metric: String,
+    var metric: String = "",
 
-    @get:Type(type = "com.yahoo.navi.ws.models.types.JsonType", parameters = [
-        Parameter(name = "class", value = "kotlin.collections.HashMap")
-    ]) var parameters: Map<String, String>
-) {
-    constructor() : this("", emptyMap())
-}
+    @Type(type = "com.yahoo.navi.ws.models.types.JsonType", parameters = [
+        Parameter(name = "class", value = "java.utils.HashMap")
+    ]) var parameters: Map<String, String> = emptyMap()
+)

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/request/Sort.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/request/Sort.kt
@@ -1,12 +1,10 @@
 /**
- * Copyright 2019, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 package com.yahoo.navi.ws.models.beans.fragments.request
 
 data class Sort(
-    var metric: String,
-    var direction: String
-) {
-    constructor() : this("", "")
-}
+    var metric: String = "",
+    var direction: String = ""
+)

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/request/v2/Column.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/request/v2/Column.kt
@@ -11,17 +11,10 @@ import org.hibernate.annotations.Type
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class Column(
-    var field: String,
-    @get: Type(type = "com.yahoo.navi.ws.models.types.JsonType", parameters = [
-        Parameter(name = "class", value = "kotlin.collections.HashMap")
-    ]) var parameters: Map<String, String>,
-    var type: ColumnType?,
-    var alias: String?
-) {
-    constructor() : this(
-            "",
-            emptyMap(),
-            null,
-            null
-    )
-}
+    var field: String = "",
+    @Type(type = "com.yahoo.navi.ws.models.types.JsonType", parameters = [
+        Parameter(name = "class", value = "java.utils.HashMap")
+    ]) var parameters: Map<String, String> = emptyMap(),
+    var type: ColumnType? = null,
+    var alias: String? = null
+)

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/request/v2/Filter.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/request/v2/Filter.kt
@@ -9,19 +9,11 @@ import org.hibernate.annotations.Parameter
 import org.hibernate.annotations.Type
 
 data class Filter(
-    var field: String,
-    @get: Type(type = "com.yahoo.navi.ws.models.types.JsonType", parameters = [
-        Parameter(name = "class", value = "kotlin.collections.HashMap")
-    ]) var parameters: Map<String, String>,
-    var operator: String,
-    var type: ColumnType?,
-    var values: Array<Any>
-) {
-    constructor() : this(
-            "",
-            emptyMap(),
-            "",
-            null,
-            emptyArray()
-    )
-}
+    var field: String = "",
+    @Type(type = "com.yahoo.navi.ws.models.types.JsonType", parameters = [
+        Parameter(name = "class", value = "java.utils.HashMap")
+    ]) var parameters: Map<String, String> = emptyMap(),
+    var operator: String = "",
+    var type: ColumnType? = null,
+    var values: List<Any> = emptyList()
+)

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/request/v2/Sort.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/request/v2/Sort.kt
@@ -9,17 +9,10 @@ import org.hibernate.annotations.Parameter
 import org.hibernate.annotations.Type
 
 data class Sort(
-    var field: String,
-    @get: Type(type = "com.yahoo.navi.ws.models.types.JsonType", parameters = [
-        Parameter(name = "class", value = "kotlin.collections.HashMap")
-    ]) var parameters: Map<String, String>,
-    var type: ColumnType?,
-    var direction: String
-) {
-    constructor() : this(
-            "",
-            emptyMap(),
-            null,
-            ""
-    )
-}
+    var field: String = "",
+    @Type(type = "com.yahoo.navi.ws.models.types.JsonType", parameters = [
+        Parameter(name = "class", value = "java.utils.HashMap")
+    ]) var parameters: Map<String, String> = emptyMap(),
+    var type: ColumnType? = null,
+    var direction: String = ""
+)


### PR DESCRIPTION
## Description

Update: Support Elide GraphQL

## Proposed Changes

 - Enable GraphQL
 - Update to Elide5-pr12
 - Use List instead of Array in fragments
 - Cleanup data class constructors

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
