### PR TITLE
Update: Implement polling async request to populate results

### DIFF
--- a/packages/data/addon/adapters/elide-facts.ts
+++ b/packages/data/addon/adapters/elide-facts.ts
@@ -126,15 +126,14 @@ export default class ElideFacts extends EmberObject {
    * @param options
    */
   @task(function*(request: RequestV1, options: RequestOptions) {
-    //@ts-ignore
-    let asyncQueryPayload = yield this.createAsyncQueryRequest(request, options);
-    let asyncQuery = asyncQueryPayload?.asyncQuery.edges[0]?.node;
-    let result = asyncQuery?.result;
-    const id = asyncQuery?.id;
-
-    if (!id) {
-      throw Error('navi-data/elide-facts: AsyncQuery creation failed');
+    let asyncQueryPayload;
+    try {
+      //@ts-ignore
+      asyncQueryPayload = yield this.createAsyncQueryRequest(request, options);
+    } catch (e) {
+      return Promise.reject(e);
     }
+    let { result, id } = asyncQueryPayload.asyncQuery.edges[0].node;
 
     while (result === null) {
       //@ts-ignore

--- a/packages/data/addon/gql/mutations/async-facts-cancel.ts
+++ b/packages/data/addon/gql/mutations/async-facts-cancel.ts
@@ -4,7 +4,7 @@
  */
 import gql from 'graphql-tag';
 
-export const asyncFactsCancelMutationStr = `mutation($id: string) {
+export const asyncFactsCancelMutationStr = `mutation($id: String) {
   asyncQuery(op: UPDATE, ids: [$id], data: { status: CANCELLED }) {
     edges {
       node {

--- a/packages/data/addon/gql/mutations/async-facts.ts
+++ b/packages/data/addon/gql/mutations/async-facts.ts
@@ -5,7 +5,7 @@
 import gql from 'graphql-tag';
 
 export const asyncFactsMutationStr = `
-  mutation($id: string, $query: string) {
+  mutation($id: String, $query: String) {
     asyncQuery(op: UPSERT, data: { id: $id, query: $query, queryType: GRAPHQL_V1_0, status: QUEUED }) {
       edges {
         node {

--- a/packages/data/addon/gql/queries/async-facts.ts
+++ b/packages/data/addon/gql/queries/async-facts.ts
@@ -4,9 +4,9 @@
  */
 import gql from 'graphql-tag';
 
-const query = gql`
-  query($id: string, $query: string) {
-    asyncQuery(op: FETCH, ids: [$id], data: { query: $query }) {
+export const asyncFactsQueryStr = `
+  query($id: string) {
+    asyncQuery(op: FETCH, ids: [$id]) {
       edges {
         node {
           id
@@ -14,15 +14,18 @@ const query = gql`
           queryType
           status
           result {
-            id
+            httpStatus
             contentLength
             responseBody
-            status
           }
         }
       }
     }
   }
+`;
+
+const query = gql`
+  ${asyncFactsQueryStr}
 `;
 
 export default query;

--- a/packages/data/addon/gql/queries/async-facts.ts
+++ b/packages/data/addon/gql/queries/async-facts.ts
@@ -5,7 +5,7 @@
 import gql from 'graphql-tag';
 
 export const asyncFactsQueryStr = `
-  query($id: string) {
+  query($id: String) {
     asyncQuery(op: FETCH, ids: [$id]) {
       edges {
         node {

--- a/packages/data/addon/gql/schema.js
+++ b/packages/data/addon/gql/schema.js
@@ -177,7 +177,7 @@ const schema = gql`
     contentLength: Int
     createdOn: Date
     responseBody: String
-    status: Int
+    httpStatus: Int
     updatedOn: Date
     query(op: RelationshipOp = FETCH, data: AsyncQueryInput): AsyncQuery
   }
@@ -266,7 +266,7 @@ const schema = gql`
     contentLength: Int
     createdOn: Date
     responseBody: String
-    status: Int
+    httpStatus: Int
     updatedOn: Date
     query: AsyncQueryInput
   }


### PR DESCRIPTION
## Description

Navi currently has support for creating and canceling async requests, but without a way to populate results that don't come back within the synchronous response threshold, it's not very useful.

## Proposed Changes

- Expose results through a single method in the adapter `fetchDataForRequest`
- Add a fetchAsyncQueryData method for sending a single fetch
- Minor update to GQL query to match API definition

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
