### PR TITLE
Fix: Quick fix default name time-dimension support

### DIFF
--- a/packages/core/addon/helpers/default-column-name.js
+++ b/packages/core/addon/helpers/default-column-name.js
@@ -30,6 +30,12 @@ export function getColumnDefaultName(
   let { name: id, field } = attributes,
     model = bardMetadata.getById(type, id, namespace);
 
+  //if metadata isn't found, check time-dimension bucket
+  //TODO: replace when we have full vizualization support for time-dimensions
+  if (model === undefined && type == 'dimension') {
+    model = bardMetadata.getById('time-dimension', id, namespace);
+  }
+
   if (type === 'metric') {
     return naviFormatter.formatMetric(model, attributes.parameters);
   }
@@ -41,7 +47,7 @@ export function getColumnDefaultName(
     });
   }
 
-  return model.name;
+  return model?.name;
 }
 
 export default class DefaultColumnNameHelper extends Helper {

--- a/packages/core/tests/integration/helpers/default-column-name-test.js
+++ b/packages/core/tests/integration/helpers/default-column-name-test.js
@@ -55,4 +55,13 @@ module('helper:default-column-name', function(hooks) {
         'The default column name for revenue metric with currency param of USD is Revenue (USD)'
       );
   });
+
+  test('time-dimension support test', async function(assert) {
+    const column = { type: 'dimension', attributes: { name: 'userSignupDate' } };
+    this.set('column', column);
+
+    await render(hbs`{{default-column-name column}}`);
+
+    assert.dom().hasText('User Signup Date', 'The default column name for time-dimension is correctly rendered');
+  });
 });


### PR DESCRIPTION
## Description

Tables request metadata with type 'dimension' still. This is a quick fix to make sure time-dimensions can still let the table render. #879 is for a better long term fix by supporting more than metric/dimensions as column types.

## Proposed Changes

- When dimension metadata can't be found, look in time-dimension bucket for default name helper.

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
