### PR TITLE
Update: Remove unsupported metadata fields from graphql queries

### DIFF
--- a/packages/data/addon/gql/fragments/table.ts
+++ b/packages/data/addon/gql/fragments/table.ts
@@ -58,9 +58,7 @@ const fragment = gql`
               }
             }
           }
-          timeZone {
-            short
-          }
+          timeZone
         }
       }
     }

--- a/packages/data/addon/gql/queries/table.ts
+++ b/packages/data/addon/gql/queries/table.ts
@@ -3,19 +3,70 @@
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import gql from 'graphql-tag';
-import TableFragment from '../fragments/table';
 
 const query = gql`
   query($ids: [String!]) {
     table(ids: $ids) {
       edges {
         node {
-          ...TableFragment
+          id
+          name
+          description
+          category
+          cardinality
+          metrics {
+            edges {
+              node {
+                id
+                name
+                description
+                category
+                valueType
+                columnTags
+                columnType
+                expression
+              }
+            }
+          }
+          dimensions {
+            edges {
+              node {
+                id
+                name
+                description
+                category
+                valueType
+                columnTags
+                columnType
+                expression
+              }
+            }
+          }
+          timeDimensions {
+            edges {
+              node {
+                id
+                name
+                description
+                category
+                valueType
+                columnTags
+                columnType
+                expression
+                supportedGrains {
+                  edges {
+                    node {
+                      grain
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
   }
-  ${TableFragment}
 `;
 
 export default query;

--- a/packages/data/addon/gql/queries/tables.ts
+++ b/packages/data/addon/gql/queries/tables.ts
@@ -3,19 +3,70 @@
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import gql from 'graphql-tag';
-import TableFragment from '../fragments/table';
 
 const query = gql`
   query {
     table {
       edges {
         node {
-          ...TableFragment
+          id
+          name
+          description
+          category
+          cardinality
+          metrics {
+            edges {
+              node {
+                id
+                name
+                description
+                category
+                valueType
+                columnTags
+                columnType
+                expression
+              }
+            }
+          }
+          dimensions {
+            edges {
+              node {
+                id
+                name
+                description
+                category
+                valueType
+                columnTags
+                columnType
+                expression
+              }
+            }
+          }
+          timeDimensions {
+            edges {
+              node {
+                id
+                name
+                description
+                category
+                valueType
+                columnTags
+                columnType
+                expression
+                supportedGrains {
+                  edges {
+                    node {
+                      grain
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
   }
-  ${TableFragment}
 `;
 
 export default query;

--- a/packages/data/tests/unit/adapters/elide-metadata-test.js
+++ b/packages/data/tests/unit/adapters/elide-metadata-test.js
@@ -109,7 +109,6 @@ module('Unit | Elide Metadata Adapter', function(hooks) {
               category: 'categoryOne',
               valueType: 'NUMBER',
               columnTags: ['DISPLAY'],
-              defaultFormat: 'number',
               columnType: 'field',
               expression: null,
               __typename: 'Metric'
@@ -124,7 +123,6 @@ module('Unit | Elide Metadata Adapter', function(hooks) {
               category: 'categoryOne',
               valueType: 'NUMBER',
               columnTags: ['DISPLAY'],
-              defaultFormat: 'number',
               columnType: 'field',
               expression: null,
               __typename: 'Metric'
@@ -174,7 +172,6 @@ module('Unit | Elide Metadata Adapter', function(hooks) {
               category: 'categoryOne',
               valueType: 'NUMBER',
               columnTags: ['DISPLAY'],
-              defaultFormat: 'number',
               columnType: 'field',
               expression: null,
               __typename: 'Metric'
@@ -189,7 +186,6 @@ module('Unit | Elide Metadata Adapter', function(hooks) {
               category: 'categoryOne',
               valueType: 'NUMBER',
               columnTags: ['DISPLAY'],
-              defaultFormat: 'number',
               columnType: 'field',
               expression: null,
               __typename: 'Metric'
@@ -243,7 +239,6 @@ module('Unit | Elide Metadata Adapter', function(hooks) {
                         category: 'categoryOne',
                         valueType: 'NUMBER',
                         columnTags: ['DISPLAY'],
-                        defaultFormat: 'number',
                         columnType: 'field',
                         expression: null,
                         __typename: 'Metric'
@@ -258,7 +253,6 @@ module('Unit | Elide Metadata Adapter', function(hooks) {
                         category: 'categoryOne',
                         valueType: 'NUMBER',
                         columnTags: ['DISPLAY'],
-                        defaultFormat: 'number',
                         columnType: 'field',
                         expression: null,
                         __typename: 'Metric'


### PR DESCRIPTION
## Description
Elide doesn't support some of the fields we request in our metadata and has some issues with using fragments for now.

## Proposed Changes

- Temporarily remove some requested fields
- Temporarily stop using fragment

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
