### PR TITLE
Fix: Request clones time-dimensions correctly

### DIFF
--- a/packages/core/addon/models/bard-request/request.js
+++ b/packages/core/addon/models/bard-request/request.js
@@ -549,11 +549,15 @@ export default Fragment.extend(Validations, {
    * @returns {MF.Fragment} copy of this fragment
    */
   clone() {
-    let clonedRequest = this.toJSON(),
-      store = this.store,
-      metadataService = this.metadataService,
-      dimensionTypeMap = Object.fromEntries(this.dimensions.map(dim => [dim.dimension.id, dim.dimension.valueType])),
-      filterTypeMap = Object.fromEntries(this.filters.map(filter => [filter.dimension.id, filter.dimension.valueType]));
+    const clonedRequest = this.toJSON();
+    const store = this.store;
+    const metadataService = this.metadataService;
+    const dimensionTypeMap = Object.fromEntries(
+      this.dimensions.map(dim => [dim.dimension.id, dim.dimension.valueType])
+    );
+    const filterTypeMap = Object.fromEntries(
+      this.filters.map(filter => [filter.dimension.id, filter.dimension.valueType])
+    );
 
     return store.createFragment('bard-request/request', {
       logicalTable: store.createFragment('bard-request/fragments/logicalTable', {
@@ -581,7 +585,7 @@ export default Fragment.extend(Validations, {
       filters: clonedRequest.filters.map(filter =>
         store.createFragment('bard-request/fragments/filter', {
           dimension: metadataService.getById(
-            dimensionTypeMap[filter.dimension] === 'date' ? 'time-dimension' : 'dimension',
+            filterTypeMap[filter.dimension] === 'date' ? 'time-dimension' : 'dimension',
             filter.dimension,
             clonedRequest.dataSource
           ),

--- a/packages/core/addon/models/bard-request/request.js
+++ b/packages/core/addon/models/bard-request/request.js
@@ -551,7 +551,9 @@ export default Fragment.extend(Validations, {
   clone() {
     let clonedRequest = this.toJSON(),
       store = this.store,
-      metadataService = this.metadataService;
+      metadataService = this.metadataService,
+      dimensionTypeMap = Object.fromEntries(this.dimensions.map(dim => [dim.dimension.id, dim.dimension.valueType])),
+      filterTypeMap = Object.fromEntries(this.filters.map(filter => [filter.dimension.id, filter.dimension.valueType]));
 
     return store.createFragment('bard-request/request', {
       logicalTable: store.createFragment('bard-request/fragments/logicalTable', {
@@ -561,7 +563,11 @@ export default Fragment.extend(Validations, {
 
       dimensions: clonedRequest.dimensions.map(dimension =>
         store.createFragment('bard-request/fragments/dimension', {
-          dimension: metadataService.getById('dimension', dimension.dimension, clonedRequest.dataSource)
+          dimension: metadataService.getById(
+            dimensionTypeMap[dimension.dimension] === 'date' ? 'time-dimension' : 'dimension',
+            dimension.dimension,
+            clonedRequest.dataSource
+          )
         })
       ),
 
@@ -574,7 +580,11 @@ export default Fragment.extend(Validations, {
 
       filters: clonedRequest.filters.map(filter =>
         store.createFragment('bard-request/fragments/filter', {
-          dimension: metadataService.getById('dimension', filter.dimension, clonedRequest.dataSource),
+          dimension: metadataService.getById(
+            dimensionTypeMap[filter.dimension] === 'date' ? 'time-dimension' : 'dimension',
+            filter.dimension,
+            clonedRequest.dataSource
+          ),
           field: filter.field,
           operator: filter.operator,
           rawValues: filter.values

--- a/packages/core/tests/unit/models/bard-request/request-test.js
+++ b/packages/core/tests/unit/models/bard-request/request-test.js
@@ -374,7 +374,7 @@ module('Unit | Model Fragment | BardRequest - Request', function(hooks) {
     mockRequest.clearDimensions();
     const request = mockRequest.clone();
 
-    assert.ok(request.dimensions.length === 0, 'Dimensions for request are empty');
+    assert.equal(request.dimensions.length, 0, 'Dimensions for request are empty');
 
     assert.equal(
       request.filters.objectAt(2).dimension,

--- a/packages/core/tests/unit/models/bard-request/request-test.js
+++ b/packages/core/tests/unit/models/bard-request/request-test.js
@@ -367,6 +367,22 @@ module('Unit | Model Fragment | BardRequest - Request', function(hooks) {
     assert.equal(request.dataSource, 'dummy', 'datasource was cloned correctly');
   });
 
+  test('Clone request with time-dimension filter and no matching dimension', async function(assert) {
+    assert.expect(2);
+    await settled();
+    const mockRequest = Store.peekRecord('fragments-mock', MODEL_TO_CLONE).request;
+    mockRequest.clearDimensions();
+    const request = mockRequest.clone();
+
+    assert.ok(request.dimensions.length === 0, 'Dimensions for request are empty');
+
+    assert.equal(
+      request.filters.objectAt(2).dimension,
+      MetadataService.getById('time-dimension', 'userSignupDate'),
+      'clone time dimension filter correctly when no request dimension is present'
+    );
+  });
+
   // Test that navi supports legacy saved reports without a sort field
   test('Clone Request without sort', async function(assert) {
     assert.expect(1);

--- a/packages/core/tests/unit/models/bard-request/request-test.js
+++ b/packages/core/tests/unit/models/bard-request/request-test.js
@@ -110,6 +110,9 @@ module('Unit | Model Fragment | BardRequest - Request', function(hooks) {
                   dimensions: [
                     {
                       dimension: 'property'
+                    },
+                    {
+                      dimension: 'userSignupDate'
                     }
                   ],
                   filters: [
@@ -123,6 +126,11 @@ module('Unit | Model Fragment | BardRequest - Request', function(hooks) {
                       operator: 'in',
                       field: 'key',
                       values: ['12345']
+                    },
+                    {
+                      dimension: 'userSignupDate',
+                      operator: 'in',
+                      values: ['1']
                     }
                   ],
                   having: [
@@ -243,7 +251,7 @@ module('Unit | Model Fragment | BardRequest - Request', function(hooks) {
   });
 
   test('Clone Request', async function(assert) {
-    assert.expect(14);
+    assert.expect(16);
 
     await settled();
     const mockModel = Store.peekRecord('fragments-mock', MODEL_TO_CLONE);
@@ -302,6 +310,12 @@ module('Unit | Model Fragment | BardRequest - Request', function(hooks) {
       'The property dimensions is set with correct metadata'
     );
 
+    assert.equal(
+      request.dimensions.objectAt(1).dimension,
+      MetadataService.getById('time-dimension', 'userSignupDate'),
+      'The date dimension is set with correct metadata'
+    );
+
     /**
      * TODO uncomment when cloning filters is fixed
      * assert.equal(request.get('filters.firstObject.values.length'),
@@ -316,6 +330,12 @@ module('Unit | Model Fragment | BardRequest - Request', function(hooks) {
         .get('field'),
       'key',
       'clone field when it is present'
+    );
+
+    assert.equal(
+      request.filters.objectAt(2).dimension,
+      MetadataService.getById('time-dimension', 'userSignupDate'),
+      'clone time dimension filter correctly'
     );
 
     assert.deepEqual(

--- a/packages/core/tests/unit/models/bard-request/request-test.js
+++ b/packages/core/tests/unit/models/bard-request/request-test.js
@@ -368,7 +368,7 @@ module('Unit | Model Fragment | BardRequest - Request', function(hooks) {
   });
 
   test('Clone request with time-dimension filter and no matching dimension', async function(assert) {
-    assert.expect(2);
+    assert.expect(3);
     await settled();
     const mockRequest = Store.peekRecord('fragments-mock', MODEL_TO_CLONE).request;
     mockRequest.clearDimensions();
@@ -380,6 +380,12 @@ module('Unit | Model Fragment | BardRequest - Request', function(hooks) {
       request.filters.objectAt(2).dimension,
       MetadataService.getById('time-dimension', 'userSignupDate'),
       'clone time dimension filter correctly when no request dimension is present'
+    );
+
+    assert.equal(
+      request.filters.objectAt(1).dimension,
+      MetadataService.getById('dimension', 'multiSystemId'),
+      'The dimension is set with correct metadata'
     );
   });
 

--- a/packages/webservice/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/webservice/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Description

 When cloning a report, time-dimensions get cloned as undefined

## Proposed Changes

- Make sure dimension/time-dimension metadata gets queried as the right type during clone
- Also gradle update for java > 8

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
