### PR TITLE
Allow grouped list to group on fields with possibly falsey values

### DIFF
--- a/packages/reports/addon/components/grouped-list.js
+++ b/packages/reports/addon/components/grouped-list.js
@@ -60,7 +60,7 @@ class GroupedListComponent extends Component {
   get groupedItems() {
     const { items, groupByField, sortByField } = this;
 
-    let grouped = groupBy(items, row => row[groupByField].split(',')[0]);
+    const grouped = groupBy(items, row => row[groupByField] && row[groupByField].split(',')[0]);
 
     if (!isBlank(sortByField)) {
       Object.entries(grouped).forEach(([key, value]) => {

--- a/packages/reports/tests/integration/components/grouped-list-test.js
+++ b/packages/reports/tests/integration/components/grouped-list-test.js
@@ -12,7 +12,8 @@ module('Integration | Component | grouped list', function(hooks) {
       { val: 6, field: 'bar' },
       { val: 2, field: 'foo' },
       { val: 3, field: 'foo,bar' },
-      { val: 4 }
+      { val: 4 },
+      { val: 5, field: null }
     ]);
 
     this.set('sortme', [
@@ -51,7 +52,7 @@ module('Integration | Component | grouped list', function(hooks) {
     const groups = findAll('.grouped-list__group-header-content');
     assert.deepEqual(
       groups.map(el => el.textContent.trim()),
-      ['foo (3)', 'bar (1)', 'undefined (1)'],
+      ['foo (3)', 'bar (1)', 'undefined (1)', 'null (1)'],
       'the groups in the grouped-list are rendered, only the first item in the groupByField is considered for grouping'
     );
 
@@ -70,7 +71,7 @@ module('Integration | Component | grouped list', function(hooks) {
 
     assert.deepEqual(
       findAll('.grouped-list li').map(el => el.textContent.trim()),
-      ['foo (3)', '1', '2', '3', 'bar (1)', '6', 'undefined (1)', '4'],
+      ['foo (3)', '1', '2', '3', 'bar (1)', '6', 'undefined (1)', '4', 'null (1)', '5'],
       'All groups are open when `shouldOpenAllGroups` attribute is true'
     );
   });

--- a/packages/reports/tests/integration/components/grouped-list-test.js
+++ b/packages/reports/tests/integration/components/grouped-list-test.js
@@ -11,7 +11,8 @@ module('Integration | Component | grouped list', function(hooks) {
       { val: 1, field: 'foo,bar' },
       { val: 6, field: 'bar' },
       { val: 2, field: 'foo' },
-      { val: 3, field: 'foo,bar' }
+      { val: 3, field: 'foo,bar' },
+      { val: 4 }
     ]);
 
     this.set('sortme', [
@@ -50,7 +51,7 @@ module('Integration | Component | grouped list', function(hooks) {
     const groups = findAll('.grouped-list__group-header-content');
     assert.deepEqual(
       groups.map(el => el.textContent.trim()),
-      ['foo (3)', 'bar (1)'],
+      ['foo (3)', 'bar (1)', 'undefined (1)'],
       'the groups in the grouped-list are rendered, only the first item in the groupByField is considered for grouping'
     );
 
@@ -69,7 +70,7 @@ module('Integration | Component | grouped list', function(hooks) {
 
     assert.deepEqual(
       findAll('.grouped-list li').map(el => el.textContent.trim()),
-      ['foo (3)', '1', '2', '3', 'bar (1)', '6'],
+      ['foo (3)', '1', '2', '3', 'bar (1)', '6', 'undefined (1)', '4'],
       'All groups are open when `shouldOpenAllGroups` attribute is true'
     );
   });


### PR DESCRIPTION
## Description
Grouped-list component would blow up if one of the items had a falsey value in the `groupByField`

## Proposed Changes

- Use falsey values as a value for grouping too

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
