### PR TITLE
Navi Search Load Search Results Individually

### DIFF
--- a/packages/core/addon/templates/components/navi-loader.hbs
+++ b/packages/core/addon/templates/components/navi-loader.hbs
@@ -1,5 +1,5 @@
 {{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
-<div class="navi-loader__container {{this.containerClass}}">
+<div class="navi-loader__container {{this.containerClass}}" ...attributes>
   <div class="navi-loader__spinner spinner">
     <div class="navi-loader__bounce bounce1"></div>
     <div class="navi-loader__bounce bounce2"></div>

--- a/packages/search/addon/components/navi-search-bar.js
+++ b/packages/search/addon/components/navi-search-bar.js
@@ -70,7 +70,7 @@ export default class NaviSearchBarComponent extends Component {
    */
   @(task(function*(query) {
     yield timeout(DEBOUNCE_MS);
-    return this.searchProviderService.search.perform(query);
+    return this.searchProviderService.search(query);
   }).restartable())
   launchQuery;
 }

--- a/packages/search/addon/components/navi-search-bar.js
+++ b/packages/search/addon/components/navi-search-bar.js
@@ -12,14 +12,6 @@ import { action } from '@ember/object';
 import { task, timeout } from 'ember-concurrency';
 
 /**
- * @constant EMPTY_RESULT – Empty result object
- */
-const EMPTY_RESULT = {
-  title: '',
-  component: 'navi-search-result/no-result'
-};
-
-/**
  * @constant ENTER_KEY
  */
 const ENTER_KEY = 13;
@@ -78,11 +70,7 @@ export default class NaviSearchBarComponent extends Component {
    */
   @(task(function*(query) {
     yield timeout(DEBOUNCE_MS);
-    const results = yield this.searchProviderService.search.perform(query);
-    if (results.length === 0 && query !== '') {
-      return [EMPTY_RESULT];
-    }
-    return results;
+    return this.searchProviderService.search.perform(query);
   }).restartable())
   launchQuery;
 }

--- a/packages/search/addon/components/navi-search-result/wrapper.hbs
+++ b/packages/search/addon/components/navi-search-result/wrapper.hbs
@@ -1,9 +1,25 @@
 {{! Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. }}
-{{#each @searchResults as |result|}}
-  <li class="navi-search-result-wrapper__item" ...attributes>
-    {{#if result.title}}
-      <h3 class="navi-search-result-wrapper__item-title">{{result.title}}</h3>
-    {{/if}}
-    {{component result.component data=result.data closeResults=@closeResults}}
-  </li>
+{{#each @searchResults as |searchResult|}}
+  {{#if searchResult.isSuccessful}}
+    {{#let searchResult.value as |result|}}
+      {{#if (gt result.data.length 0)}}
+        <li class="navi-search-result-wrapper__item" ...attributes>
+          {{#if result.title}}
+            <h3 class="navi-search-result-wrapper__item-title">{{result.title}}</h3>
+          {{/if}}
+          {{component result.component data=result.data closeResults=@closeResults}}
+        </li>
+      {{/if}}
+    {{/let}}
+  {{/if}}
 {{/each}}
+{{#if this.areTasksRunning}}
+  <li class="navi-search-result-wrapper__item" ...attributes>
+    <NaviLoader />
+  </li>
+{{/if}}
+{{#if this.areResultsEmpty}}
+  <li class="navi-search-result-wrapper__item" ...attributes>
+    <NaviSearchResult::NoResult closeResults={{@closeResults}} />
+  </li>
+{{/if}}

--- a/packages/search/addon/components/navi-search-result/wrapper.hbs
+++ b/packages/search/addon/components/navi-search-result/wrapper.hbs
@@ -13,13 +13,11 @@
     {{/let}}
   {{/if}}
 {{/each}}
-{{#if this.areTasksRunning}}
-  <li class="navi-search-result-wrapper__item" ...attributes>
-    <NaviLoader />
-  </li>
-{{/if}}
 {{#if this.areResultsEmpty}}
   <li class="navi-search-result-wrapper__item" ...attributes>
     <NaviSearchResult::NoResult closeResults={{@closeResults}} />
   </li>
+{{/if}}
+{{#if this.areTasksRunning}}
+  <NaviLoader class="navi-search-result-wrapper__loader"/>
 {{/if}}

--- a/packages/search/addon/components/navi-search-result/wrapper.hbs
+++ b/packages/search/addon/components/navi-search-result/wrapper.hbs
@@ -7,7 +7,9 @@
           {{#if result.title}}
             <h3 class="navi-search-result-wrapper__item-title">{{result.title}}</h3>
           {{/if}}
-          {{component result.component data=result.data closeResults=@closeResults}}
+          {{#let (component result.component) as |SearchResult|}}
+            <SearchResult @data={{result.data}} @closeResults={{@closeResults}} />
+          {{/let}}
         </li>
       {{/if}}
     {{/let}}
@@ -15,7 +17,7 @@
 {{/each}}
 {{#if this.areResultsEmpty}}
   <li class="navi-search-result-wrapper__item" ...attributes>
-    <NaviSearchResult::NoResult closeResults={{@closeResults}} />
+    <NaviSearchResult::NoResult @closeResults={{@closeResults}} />
   </li>
 {{/if}}
 {{#if this.areTasksRunning}}

--- a/packages/search/addon/components/navi-search-result/wrapper.ts
+++ b/packages/search/addon/components/navi-search-result/wrapper.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2020, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ *
+ * Search result wrapper component
+ */
+
+import Component from '@glimmer/component';
+
+/**
+ * @interface Args
+ */
+interface Args {
+  searchResults: Array<TODO>;
+}
+
+export default class NaviWrapperSearchResultComponent extends Component<Args> {
+  /**
+   * @property {boolean} areTasksRunning
+   */
+  get areTasksRunning() {
+    return this.args?.searchResults.some(searchResult => searchResult.isRunning);
+  }
+
+  /**
+   * @property {boolean} areTasksRunning
+   */
+  get areResultsEmpty() {
+    return this.args?.searchResults.every(searchResult => {
+      return !searchResult.isSuccessful || !(searchResult.value.data.length > 0);
+    });
+  }
+}

--- a/packages/search/addon/components/navi-search-result/wrapper.ts
+++ b/packages/search/addon/components/navi-search-result/wrapper.ts
@@ -27,7 +27,10 @@ export default class NaviWrapperSearchResultComponent extends Component<Args> {
    */
   get areResultsEmpty() {
     return this.args?.searchResults.every(searchResult => {
-      return !searchResult.isSuccessful || !(searchResult.value.data.length > 0);
+      return (
+        (!searchResult.isRunning && !searchResult.isSuccessful) ||
+        (!searchResult.isRunning && !(searchResult.value.data.length > 0))
+      );
     });
   }
 }

--- a/packages/search/addon/components/navi-search-result/wrapper.ts
+++ b/packages/search/addon/components/navi-search-result/wrapper.ts
@@ -27,10 +27,7 @@ export default class NaviWrapperSearchResultComponent extends Component<Args> {
    */
   get areResultsEmpty() {
     return this.args.searchResults.every(searchResult => {
-      return (
-        (!searchResult.isRunning && !searchResult.isSuccessful) ||
-        (!searchResult.isRunning && !(searchResult.value.data.length > 0))
-      );
+      return !searchResult.isRunning && (!searchResult.isSuccessful || !searchResult.value.data.length);
     });
   }
 }

--- a/packages/search/addon/components/navi-search-result/wrapper.ts
+++ b/packages/search/addon/components/navi-search-result/wrapper.ts
@@ -19,14 +19,14 @@ export default class NaviWrapperSearchResultComponent extends Component<Args> {
    * @property {boolean} areTasksRunning
    */
   get areTasksRunning() {
-    return this.args?.searchResults.some(searchResult => searchResult.isRunning);
+    return this.args.searchResults.some(searchResult => searchResult.isRunning);
   }
 
   /**
-   * @property {boolean} areTasksRunning
+   * @property {boolean} areResultsEmpty
    */
   get areResultsEmpty() {
-    return this.args?.searchResults.every(searchResult => {
+    return this.args.searchResults.every(searchResult => {
       return (
         (!searchResult.isRunning && !searchResult.isSuccessful) ||
         (!searchResult.isRunning && !(searchResult.value.data.length > 0))

--- a/packages/search/addon/services/navi-search-provider.js
+++ b/packages/search/addon/services/navi-search-provider.js
@@ -38,8 +38,7 @@ export default class NaviSearchProviderService extends Service {
   /**
    * @method search – Uses all the discovered search providers to fetch search results
    * @param {String} query
-   * @returns {Array} array of objects that contain the search results,
-   * the name of the result component as well as result ordering information
+   * @returns {Array} array of task instances that fetch the search results
    */
   search(query) {
     const searchProviders = this._all();

--- a/packages/search/addon/services/navi-search-provider.js
+++ b/packages/search/addon/services/navi-search-provider.js
@@ -42,11 +42,6 @@ export default class NaviSearchProviderService extends Service {
    */
   search(query) {
     const searchProviders = this._all();
-    let results = [];
-    for (const provider of searchProviders) {
-      const result = provider.search.perform(query);
-      results.push(result);
-    }
-    return results;
+    return searchProviders.map(provider => provider.search.perform(query));
   }
 }

--- a/packages/search/addon/services/navi-search-provider.js
+++ b/packages/search/addon/services/navi-search-provider.js
@@ -8,7 +8,6 @@
 import Service from '@ember/service';
 import { getOwner } from '@ember/application';
 import config from 'ember-get-config';
-import { task } from 'ember-concurrency';
 
 /* global requirejs */
 

--- a/packages/search/addon/services/navi-search-provider.js
+++ b/packages/search/addon/services/navi-search-provider.js
@@ -42,16 +42,13 @@ export default class NaviSearchProviderService extends Service {
    * @returns {Array} array of objects that contain the search results,
    * the name of the result component as well as result ordering information
    */
-  @(task(function*(query) {
+  search(query) {
     const searchProviders = this._all();
     let results = [];
     for (const provider of searchProviders) {
-      const result = yield provider.search.perform(query);
-      if (result.data.length) {
-        results.push(result);
-      }
+      const result = provider.search.perform(query);
+      results.push(result);
     }
     return results;
-  }).restartable())
-  search;
+  }
 }

--- a/packages/search/app/components/navi-search-result/wrapper.js
+++ b/packages/search/app/components/navi-search-result/wrapper.js
@@ -1,1 +1,1 @@
-export { default } from 'navi-search/components/navi-search-result/wrapper';
+export { default } from 'navi-search/components/navi-search-result/wrapper.ts';

--- a/packages/search/app/components/navi-search-result/wrapper.js
+++ b/packages/search/app/components/navi-search-result/wrapper.js
@@ -1,1 +1,1 @@
-export { default } from 'navi-search/components/navi-search-result/wrapper.ts';
+export { default } from 'navi-search/components/navi-search-result/wrapper';

--- a/packages/search/app/styles/navi-search/components/navi-wrapper-search-result.less
+++ b/packages/search/app/styles/navi-search/components/navi-wrapper-search-result.less
@@ -22,9 +22,9 @@
 
   &__loader {
     height: 10px;
+    
+    & > .navi-loader__spinner {
+      background-color: @denali-grey-100;
+    }
   }
-}
-
-.navi-search-result-wrapper__loader > .navi-loader__spinner {
-  background-color: @denali-grey-100;
 }

--- a/packages/search/app/styles/navi-search/components/navi-wrapper-search-result.less
+++ b/packages/search/app/styles/navi-search/components/navi-wrapper-search-result.less
@@ -19,4 +19,12 @@
     line-height: 1.5;
     margin-block-start: 0;
   }
+
+  &__loader {
+    height: 10px;
+  }
+}
+
+.navi-search-result-wrapper__loader > .navi-loader__spinner {
+  background-color: @denali-grey-100;
 }

--- a/packages/search/tests/integration/components/navi-search-result/wrapper-test.js
+++ b/packages/search/tests/integration/components/navi-search-result/wrapper-test.js
@@ -1,0 +1,138 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { set } from '@ember/object';
+
+module('Integration | Component | navi-search-result-wrapper', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('no results tasks are not succeeded', async function(assert) {
+    assert.expect(1);
+
+    set(this, 'searchResults', [
+      {
+        isRunning: false,
+        isSuccessful: false,
+        value: {
+          component: 'navi-search-result/sample',
+          title: 'Sample',
+          data: []
+        }
+      }
+    ]);
+    set(this, 'closeResults', {});
+
+    await render(
+      hbs`<NaviSearchResult::Wrapper @searchResults={{this.searchResults}} @closeResults={{this.closeResults}} />`
+    );
+
+    assert.dom('.navi-search-no-result').exists('No Results component shown');
+  });
+
+  test('no results tasks return no data', async function(assert) {
+    assert.expect(1);
+
+    set(this, 'searchResults', [
+      {
+        isRunning: false,
+        isSuccessful: true,
+        value: {
+          component: 'navi-search-result/sample',
+          title: 'Sample',
+          data: []
+        }
+      }
+    ]);
+    set(this, 'closeResults', {});
+
+    await render(
+      hbs`<NaviSearchResult::Wrapper @searchResults={{this.searchResults}} @closeResults={{this.closeResults}} />`
+    );
+
+    assert.dom('.navi-search-no-result').exists('No Results component shown');
+  });
+
+  test('results are loading', async function(assert) {
+    assert.expect(1);
+
+    set(this, 'searchResults', [
+      {
+        isRunning: true,
+        isSuccessful: false,
+        value: {
+          component: 'navi-search-result/sample',
+          title: 'Sample',
+          data: []
+        }
+      }
+    ]);
+    set(this, 'closeResults', {});
+
+    await render(
+      hbs`<NaviSearchResult::Wrapper @searchResults={{this.searchResults}} @closeResults={{this.closeResults}} />`
+    );
+
+    assert.dom('.navi-search-result-wrapper__loader').exists('Loader is shown.');
+  });
+
+  test('some results are shown and some results are loading', async function(assert) {
+    assert.expect(2);
+
+    set(this, 'searchResults', [
+      {
+        isRunning: false,
+        isSuccessful: true,
+        value: {
+          component: 'navi-search-result/sample',
+          title: 'Sample Loaded',
+          data: ['some data', 'some other data']
+        }
+      },
+      {
+        isRunning: true,
+        isSuccessful: false,
+        value: {
+          component: 'navi-search-result/sample',
+          title: 'Sample Loading',
+          data: []
+        }
+      }
+    ]);
+    set(this, 'closeResults', {});
+
+    await render(
+      hbs`<NaviSearchResult::Wrapper @searchResults={{this.searchResults}} @closeResults={{this.closeResults}} />`
+    );
+
+    assert
+      .dom('.navi-search-result-wrapper__item-title')
+      .hasText('Sample Loaded', 'Loaded search results are displayed');
+    assert.dom('.navi-search-result-wrapper__loader').exists('Loader is shown for pending search results.');
+  });
+
+  test('results rendered', async function(assert) {
+    assert.expect(1);
+
+    set(this, 'searchResults', [
+      {
+        isRunning: false,
+        isSuccessful: true,
+        value: {
+          component: 'navi-search-result/sample',
+          title: 'Sample Loaded',
+          data: ['some data', 'some other data']
+        }
+      }
+    ]);
+    set(this, 'closeResults', {});
+
+    await render(
+      hbs`<NaviSearchResult::Wrapper @searchResults={{this.searchResults}} @closeResults={{this.closeResults}} />`
+    );
+
+    assert
+      .dom('.navi-search-result-wrapper__item-title')
+      .hasText('Sample Loaded', 'Loaded search results are displayed');
+  });
+});

--- a/packages/search/tests/integration/components/navi-search-result/wrapper-test.js
+++ b/packages/search/tests/integration/components/navi-search-result/wrapper-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, findAll } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { set } from '@ember/object';
 
@@ -8,7 +8,7 @@ module('Integration | Component | navi-search-result-wrapper', function(hooks) {
   setupRenderingTest(hooks);
 
   test('no results tasks are not succeeded', async function(assert) {
-    assert.expect(1);
+    assert.expect(2);
 
     set(this, 'searchResults', [
       {
@@ -28,10 +28,11 @@ module('Integration | Component | navi-search-result-wrapper', function(hooks) {
     );
 
     assert.dom('.navi-search-no-result').exists('No Results component shown');
+    assert.dom('.navi-search-result-wrapper__loader').doesNotExist('Loader is not shown');
   });
 
   test('no results tasks return no data', async function(assert) {
-    assert.expect(1);
+    assert.expect(2);
 
     set(this, 'searchResults', [
       {
@@ -51,10 +52,11 @@ module('Integration | Component | navi-search-result-wrapper', function(hooks) {
     );
 
     assert.dom('.navi-search-no-result').exists('No Results component shown');
+    assert.dom('.navi-search-result-wrapper__loader').doesNotExist('Loader is not shown');
   });
 
   test('results are loading', async function(assert) {
-    assert.expect(1);
+    assert.expect(2);
 
     set(this, 'searchResults', [
       {
@@ -73,11 +75,12 @@ module('Integration | Component | navi-search-result-wrapper', function(hooks) {
       hbs`<NaviSearchResult::Wrapper @searchResults={{this.searchResults}} @closeResults={{this.closeResults}} />`
     );
 
+    assert.dom('.navi-search-no-result').doesNotExist('No Results component is not shown');
     assert.dom('.navi-search-result-wrapper__loader').exists('Loader is shown.');
   });
 
   test('some results are shown and some results are loading', async function(assert) {
-    assert.expect(2);
+    assert.expect(3);
 
     set(this, 'searchResults', [
       {
@@ -105,6 +108,7 @@ module('Integration | Component | navi-search-result-wrapper', function(hooks) {
       hbs`<NaviSearchResult::Wrapper @searchResults={{this.searchResults}} @closeResults={{this.closeResults}} />`
     );
 
+    assert.dom('.navi-search-no-result').doesNotExist('No Results component is not shown');
     assert
       .dom('.navi-search-result-wrapper__item-title')
       .hasText('Sample Loaded', 'Loaded search results are displayed');
@@ -112,7 +116,7 @@ module('Integration | Component | navi-search-result-wrapper', function(hooks) {
   });
 
   test('results rendered', async function(assert) {
-    assert.expect(1);
+    assert.expect(2);
 
     set(this, 'searchResults', [
       {
@@ -134,5 +138,43 @@ module('Integration | Component | navi-search-result-wrapper', function(hooks) {
     assert
       .dom('.navi-search-result-wrapper__item-title')
       .hasText('Sample Loaded', 'Loaded search results are displayed');
+    assert.dom('.navi-search-result-wrapper__loader').doesNotExist('Loader is not shown');
+  });
+
+  test('multiple results rendered', async function(assert) {
+    assert.expect(2);
+
+    set(this, 'searchResults', [
+      {
+        isRunning: false,
+        isSuccessful: true,
+        value: {
+          component: 'navi-search-result/sample',
+          title: 'Sample Loaded',
+          data: ['some data', 'some other data']
+        }
+      },
+      {
+        isRunning: false,
+        isSuccessful: true,
+        value: {
+          component: 'navi-search-result/sample',
+          title: 'Another Sample Loaded',
+          data: ['some data', 'some other data']
+        }
+      }
+    ]);
+    set(this, 'closeResults', {});
+
+    await render(
+      hbs`<NaviSearchResult::Wrapper @searchResults={{this.searchResults}} @closeResults={{this.closeResults}} />`
+    );
+
+    assert.deepEqual(
+      findAll('.navi-search-result-wrapper__item-title').map(el => el.textContent.trim()),
+      ['Sample Loaded', 'Another Sample Loaded'],
+      'Loaded search results are displayed'
+    );
+    assert.dom('.navi-search-result-wrapper__loader').doesNotExist('Loader is not shown');
   });
 });

--- a/packages/search/tests/integration/components/navi-search-result/wrapper-test.js
+++ b/packages/search/tests/integration/components/navi-search-result/wrapper-test.js
@@ -7,7 +7,7 @@ import { set } from '@ember/object';
 module('Integration | Component | navi-search-result-wrapper', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('no results tasks are not succeeded', async function(assert) {
+  test('no successful results tasks', async function(assert) {
     assert.expect(2);
 
     set(this, 'searchResults', [
@@ -31,7 +31,7 @@ module('Integration | Component | navi-search-result-wrapper', function(hooks) {
     assert.dom('.navi-search-result-wrapper__loader').doesNotExist('Loader is not shown');
   });
 
-  test('no results tasks return no data', async function(assert) {
+  test('no results tasks return data', async function(assert) {
     assert.expect(2);
 
     set(this, 'searchResults', [

--- a/packages/search/tests/unit/services/navi-search-provider-test.js
+++ b/packages/search/tests/unit/services/navi-search-provider-test.js
@@ -42,12 +42,11 @@ module('Unit | Service | navi-search-provider', function(hooks) {
   test('search all providers', async function(assert) {
     assert.expect(1);
 
-    let availableSearchProviders = service._all();
     let results = service.search('sample');
 
     assert.deepEqual(
       results.map(result => result.context.constructor.name),
-      availableSearchProviders.map(result => result.constructor.name),
+      ['NaviAssetSearchProviderService', 'NaviDefinitionSearchProviderService', 'NaviSampleSearchProviderService'],
       'Search returns a task instance of every available search provider'
     );
   });

--- a/packages/search/tests/unit/services/navi-search-provider-test.js
+++ b/packages/search/tests/unit/services/navi-search-provider-test.js
@@ -42,19 +42,13 @@ module('Unit | Service | navi-search-provider', function(hooks) {
   test('search all providers', async function(assert) {
     assert.expect(1);
 
-    let results = await service.search.perform('sample');
-    let expectedResults = ['Revenue result', 'Revenue success'];
+    let availableSearchProviders = service._all();
+    let results = service.search('sample');
+
     assert.deepEqual(
-      results.find(result => result.component === 'navi-search-result/sample').data,
-      expectedResults,
-      'Search returns the expected results'
+      results.map(result => result.context.constructor.name),
+      availableSearchProviders.map(result => result.constructor.name),
+      'Search returns a task instance of every available search provider'
     );
-  });
-
-  test('search with no results', async function(assert) {
-    assert.expect(1);
-
-    let results = await service.search.perform('something');
-    assert.equal(results.length, 0, 'Returns no results');
   });
 });


### PR DESCRIPTION
Resolves #

<!-- The above line will close the issue upon merge -->

## Description
It used to be that for the navi-search-provider federated service to return results it had to successfully resolve the responses of all the search providers. 

Now changed so that the federated service returns tasks instances of the search providers and the result wrapper is the one that takes care of displaying only the results that successfully resolved from the task instances.

## Proposed Changes

-

## Screenshots
![Screen Recording 2020-07-22 at 3 49 18 PM](https://user-images.githubusercontent.com/1649445/88227433-38689d80-cc33-11ea-9dd6-487da096faa9.gif)

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
