### PR TITLE
Fix: Normalize dims with id only fields

### DIFF
--- a/packages/data/addon/services/metric-parameter.js
+++ b/packages/data/addon/services/metric-parameter.js
@@ -74,6 +74,12 @@ export default class MetricParameterService extends Service {
       Object.entries(res).forEach(([key, values]) => {
         const valArray = Array.isArray(values) ? values : values.toArray();
         valArray.forEach(val => {
+          const valKeys = Object.keys(val);
+
+          //normalize values to use name if it's id only
+          if (valKeys.length === 1 && valKeys[0] === 'id') {
+            val.name = val.id;
+          }
           // copy value and specify param
           const paramVal = Object.assign({}, val, { param: key });
 

--- a/packages/data/test-support/helpers/metadata-routes.js
+++ b/packages/data/test-support/helpers/metadata-routes.js
@@ -58,6 +58,21 @@ export const MetricSix = {
   }
 };
 
+export const IDOnlyDim = {
+  category: 'categoryTwo',
+  name: 'idOnlyDim',
+  longName: 'ID only dim',
+  description: 'This is Dimension that only has id field',
+  cardinality: 100,
+  fields: [
+    {
+      name: 'id',
+      description: 'description',
+      tags: ['primaryKey', 'display']
+    }
+  ]
+};
+
 export const DimensionOne = {
   category: 'categoryOne',
   name: 'dimensionOne',
@@ -210,7 +225,7 @@ export const Tables = [
         metrics: [MetricTwo],
         retention: 'P24M',
         longName: 'Day',
-        dimensions: [DimensionTwo]
+        dimensions: [DimensionTwo, IDOnlyDim]
       }
     ]
   },

--- a/packages/data/tests/unit/services/bard-metadata-test.js
+++ b/packages/data/tests/unit/services/bard-metadata-test.js
@@ -7,6 +7,7 @@ import metadataRoutes, {
   TableOne,
   TableTwo,
   Tables,
+  IDOnlyDim,
   DimensionOne,
   DimensionTwo,
   DimensionThree,
@@ -64,7 +65,7 @@ module('Unit - Service - Bard Metadata', function(hooks) {
 
     assert.deepEqual(
       keg.all('metadata/dimension').mapBy('id'),
-      [DimensionOne.name, DimensionThree.name, DimensionTwo.name],
+      [DimensionOne.name, DimensionThree.name, DimensionTwo.name, IDOnlyDim.name],
       'All dimensions are loaded in the keg'
     );
 
@@ -216,7 +217,7 @@ module('Unit - Service - Bard Metadata', function(hooks) {
 
     assert.deepEqual(
       Service.all('dimension').mapBy('id'),
-      ['dimensionOne', 'dimensionThree', 'dimensionTwo'],
+      ['dimensionOne', 'dimensionThree', 'dimensionTwo', 'idOnlyDim'],
       'all method returns all loaded dimensions'
     );
 


### PR DESCRIPTION
## Description

Dimensions that only have id fields don't work correctly as metric function parameter values

## Proposed Changes

- Normalize metric function parameter values.

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
