### PR TITLE
Update: Elide-facts adapter can send queries with RequestV2

### DIFF
--- a/packages/data/addon/adapters/elide-facts.ts
+++ b/packages/data/addon/adapters/elide-facts.ts
@@ -4,11 +4,18 @@
  */
 import EmberObject from '@ember/object';
 import { queryManager } from 'ember-apollo-client';
-import NaviFactAdapter, { RequestV1, RequestOptions, AsyncQueryResponse, QueryStatus } from './fact-interface';
+import NaviFactAdapter, {
+  RequestV1,
+  RequestOptions,
+  AsyncQueryResponse,
+  QueryStatus,
+  RequestV2
+} from './fact-interface';
 import { DocumentNode } from 'graphql';
 import GQLQueries from 'navi-data/gql/fact-queries';
 import { task, timeout } from 'ember-concurrency';
 import { v1 } from 'ember-uuid';
+import { queryStrForField } from 'navi-data/utils/adapter';
 
 interface RequestMetric {
   metric: string;
@@ -17,6 +24,11 @@ interface RequestMetric {
 interface RequestDimension {
   dimension: string;
 }
+
+const OPERATOR_MAP: Dict<string> = {
+  eq: '==',
+  neq: '!='
+};
 
 export default class ElideFacts extends EmberObject implements NaviFactAdapter {
   /**
@@ -52,12 +64,49 @@ export default class ElideFacts extends EmberObject implements NaviFactAdapter {
 
   /**
    * @param request
+   * @returns graphql query string for a v2 request
+   */
+  private dataQueryFromRequestV2(request: RequestV2): string {
+    const argStrings = [];
+    const { table, columns, sorts, limit, filters } = request;
+    const columnsStr = columns.map(col => queryStrForField(col.field, col.parameters)).join(' ');
+
+    const filterStrings = filters.map(fil => {
+      const { field, parameters, operator, values } = fil;
+      const fieldStr = queryStrForField(field, parameters);
+      const operatorStr = OPERATOR_MAP[operator] || `=${operator}=`;
+      const valuesStr = values.length > 1 ? `(${values.join(',')})` : `${values[0]}`;
+      return `${fieldStr}${operatorStr}${valuesStr}`;
+    });
+    filterStrings.length && argStrings.push(`filter: \\"${filterStrings.join(';')}\\"`);
+
+    const sortStrings = sorts.map(sort => {
+      const { field, parameters, direction } = sort;
+      const cName = queryStrForField(field, parameters);
+      return `${direction === 'desc' ? '-' : ''}${cName}`;
+    });
+    sortStrings.length && argStrings.push(`sort: \\"${sortStrings.join(',')}\\"`);
+
+    const limitStr = limit ? `first: \\"${limit}\\"` : null;
+    limitStr && argStrings.push(limitStr);
+
+    const argsString = argStrings.length ? `(${argStrings.join(',')})` : '';
+
+    return JSON.stringify({
+      query: `{ ${table}${argsString} { edges { node { ${columnsStr} } } } }`
+    });
+  }
+
+  /**
+   * @param request
    * @param options
    * @returns Promise that resolves to the result of the AsyncQuery creation mutation
    */
-  createAsyncQuery(request: RequestV1, options: RequestOptions = {}): Promise<AsyncQueryResponse> {
+  createAsyncQuery(request: RequestV1 | RequestV2, options: RequestOptions = {}): Promise<AsyncQueryResponse> {
     const mutation: DocumentNode = GQLQueries['asyncFactsMutation'];
-    const query = this.dataQueryFromRequest(request);
+    const query = request.requestVersion?.startsWith('2.')
+      ? this.dataQueryFromRequestV2(request)
+      : this.dataQueryFromRequest(request);
     const id: string = options.requestId || v1();
 
     // TODO: Add other options based on RequestOptions

--- a/packages/data/tests/unit/adapters/elide-facts-test.ts
+++ b/packages/data/tests/unit/adapters/elide-facts-test.ts
@@ -46,6 +46,11 @@ const TestRequestV2: RequestV2 = {
   dataSource: 'dummy-graphql'
 };
 
+// Double the escaped characters as well as escape the double quote character
+function escapeQuotes(str: string) {
+  return str.replace(/\\"/g, '\\\\\\"');
+}
+
 let Server: Pretender;
 
 module('Unit | Adapter | elide facts', function(hooks) {
@@ -95,8 +100,9 @@ module('Unit | Adapter | elide facts', function(hooks) {
     const queryStr = adapter.dataQueryFromRequestV2(TestRequestV2);
     assert.equal(
       queryStr,
-      // We have to escape each escape character so we end up with double the escape characters in this comparison
-      '{"query":"{ table1(filter: \\\\\\"d3=in=(v1,v2);d4=in=(v3,v4);d5=isnull=(false);time=ge=(2015-01-03);time=lt=(2015-01-04);m1=gt=(0)\\\\\\",sort: \\\\\\"d1\\\\\\",first: \\\\\\"10000\\\\\\") { edges { node { m1 m2 r(p: 123,as: a) d1 d2 } } } }"}',
+      escapeQuotes(
+        '{"query":"{ table1(filter: \\"d3=in=(v1,v2);d4=in=(v3,v4);d5=isnull=(false);time=ge=(2015-01-03);time=lt=(2015-01-04);m1=gt=(0)\\",sort: \\"d1\\",first: \\"10000\\") { edges { node { m1 m2 r(p: 123,as: a) d1 d2 } } } }"}'
+      ),
       'dataQueryFromRequestV2 returns the correct query string for the given request V2'
     );
 
@@ -131,7 +137,7 @@ module('Unit | Adapter | elide facts', function(hooks) {
         requestVersion: '2.0',
         dataSource: 'dummy-graphql'
       }),
-      `{"query":"{ myTable(sort: \\\\\\"-m1(p: q),d1\\\\\\") { edges { node { m1(p: q) d1 } } } }"}`,
+      escapeQuotes(`{"query":"{ myTable(sort: \\"-m1(p: q),d1\\") { edges { node { m1(p: q) d1 } } } }"}`),
       'Request with sorts and parameters is queried correctly'
     );
 
@@ -151,7 +157,9 @@ module('Unit | Adapter | elide facts', function(hooks) {
         requestVersion: '2.0',
         dataSource: 'dummy-graphql'
       }),
-      `{"query":"{ myTable(filter: \\\\\\"m1(p: q)=in=(v1,v2);d1!=(a);d2==(b)\\\\\\") { edges { node { m1(p: q) d1 } } } }"}`,
+      escapeQuotes(
+        `{"query":"{ myTable(filter: \\"m1(p: q)=in=(v1,v2);d1!=(a);d2==(b)\\") { edges { node { m1(p: q) d1 } } } }"}`
+      ),
       'Request with filters and parameters is queried correctly'
     );
 
@@ -168,7 +176,7 @@ module('Unit | Adapter | elide facts', function(hooks) {
         requestVersion: '2.0',
         dataSource: 'dummy-graphql'
       }),
-      `{"query":"{ myTable(first: \\\\\\"5\\\\\\") { edges { node { m1(p: q) d1 } } } }"}`,
+      escapeQuotes(`{"query":"{ myTable(first: \\"5\\") { edges { node { m1(p: q) d1 } } } }"}`),
       'Request with limit is queried correctly'
     );
   });

--- a/packages/data/tests/unit/adapters/elide-facts-test.ts
+++ b/packages/data/tests/unit/adapters/elide-facts-test.ts
@@ -3,6 +3,8 @@ import { setupTest } from 'ember-qunit';
 import { asyncFactsMutationStr } from 'navi-data/gql/mutations/async-facts';
 import { asyncFactsCancelMutationStr } from 'navi-data/gql/mutations/async-facts-cancel';
 import { asyncFactsQueryStr } from 'navi-data/gql/queries/async-facts';
+import { RequestV2 } from 'navi-data/adapters/fact-interface';
+import { queryStrForField } from 'navi-data/utils/adapter';
 import Pretender from 'pretender';
 import config from 'ember-get-config';
 
@@ -20,6 +22,29 @@ const TestRequest = {
   ],
   intervals: [{ start: '2015-01-03', end: '2015-01-04' }],
   having: [{ metric: 'm1', operator: 'gt', values: [0] }]
+};
+
+const TestRequestV2: RequestV2 = {
+  table: 'table1',
+  columns: [
+    { field: 'm1', type: 'metric', parameters: {} },
+    { field: 'm2', type: 'metric', parameters: {} },
+    { field: 'r', type: 'metric', parameters: { p: '123', as: 'a' } },
+    { field: 'd1', type: 'dimension', parameters: {} },
+    { field: 'd2', type: 'dimension', parameters: {} }
+  ],
+  filters: [
+    { field: 'd3', operator: 'in', values: ['v1', 'v2'], type: 'dimension', parameters: {} },
+    { field: 'd4', operator: 'in', values: ['v3', 'v4'], type: 'dimension', parameters: {} },
+    { field: 'd5', operator: 'neq', values: ['null'], type: 'dimension', parameters: {} },
+    { field: 'time', operator: 'ge', values: ['2015-01-03'], type: 'timeDimension', parameters: {} },
+    { field: 'time', operator: 'lt', values: ['2015-01-04'], type: 'timeDimension', parameters: {} },
+    { field: 'm1', operator: 'gt', values: ['0'], type: 'metric', parameters: {} }
+  ],
+  sorts: [{ field: 'd1', parameters: {}, type: 'dimension', direction: 'asc' }],
+  limit: '10000',
+  requestVersion: '2.0',
+  dataSource: 'dummy-graphql'
 };
 
 let Server: Pretender;
@@ -43,10 +68,21 @@ module('Unit | Adapter | elide facts', function(hooks) {
   test('dataQueryFromRequest', function(assert) {
     const adapter = this.owner.lookup('adapter:elide-facts');
     const queryStr = adapter.dataQueryFromRequest(TestRequest);
-    assert.deepEqual(
+    assert.equal(
       queryStr,
       '{"query":"{ table1 { edges { node { m1 m2 r d1 d2 } } } }"}',
       'dataQueryFromRequest returns the correct query string for the given request'
+    );
+  });
+
+  test('dataQueryFromRequestV2', function(assert) {
+    const adapter = this.owner.lookup('adapter:elide-facts');
+    const queryStr = adapter.dataQueryFromRequestV2(TestRequestV2);
+    assert.equal(
+      queryStr,
+      // QUnit forces us to escape all our escapes which are escapes of escapes for the request. It's messy
+      '{"query":"{ table1(filter: \\\\\\"d3=in=(v1,v2);d4=in=(v3,v4);d5!=null;time=ge=2015-01-03;time=lt=2015-01-04;m1=gt=0\\\\\\",sort: \\\\\\"d1\\\\\\",first: \\\\\\"10000\\\\\\") { edges { node { m1 m2 r(p: 123,as: a) d1 d2 } } } }"}',
+      'dataQueryFromRequestV2 returns the correct query string for the given request V2'
     );
   });
 
@@ -106,6 +142,65 @@ module('Unit | Adapter | elide facts', function(hooks) {
     });
 
     const asyncQuery = await adapter.createAsyncQuery(TestRequest);
+
+    assert.deepEqual(asyncQuery, response, 'createAsyncQuery returns the correct response payload');
+  });
+
+  test('createAsyncQuery (RequestV2) - success', async function(assert) {
+    assert.expect(5);
+    const adapter = this.owner.lookup('adapter:elide-facts');
+
+    let response;
+    Server.post(`${HOST}/graphql`, function({ requestBody }) {
+      const requestObj = JSON.parse(requestBody);
+
+      assert.deepEqual(
+        Object.keys(requestObj.variables),
+        ['id', 'query'],
+        'createAsyncQuery sends id and query request variables'
+      );
+
+      assert.ok(uuidRegex.exec(requestObj.variables.id), 'A uuid is generated for the request id');
+
+      const expectedTable = TestRequestV2.table;
+      const expectedColumns = TestRequestV2.columns.map(c => queryStrForField(c.field, c.parameters)).join(' ');
+      const expectedArgs =
+        '(filter: \\"d3=in=(v1,v2);d4=in=(v3,v4);d5!=null;time=ge=2015-01-03;time=lt=2015-01-04;m1=gt=0\\",sort: \\"d1\\",first: \\"10000\\")';
+
+      assert.equal(
+        requestObj.variables.query.replace(/[ \t\r\n]+/g, ' '),
+        JSON.stringify({
+          query: `{ ${expectedTable}${expectedArgs} { edges { node { ${expectedColumns} } } } }`
+        }).replace(/[ \t\r\n]+/g, ' '),
+        'createAsyncQuery sends the correct query variable string'
+      );
+
+      assert.equal(
+        requestObj.query.replace(/__typename/g, '').replace(/[ \t\r\n]+/g, ''),
+        asyncFactsMutationStr.replace(/[ \t\r\n]+/g, ''),
+        'createAsyncQuery sends the correct mutation to create a new asyncQuery'
+      );
+
+      response = {
+        asyncQuery: {
+          edges: [
+            {
+              node: {
+                id: requestObj.variables.id,
+                query: requestObj.variables.query,
+                queryType: 'GRAPHQL_V1_0',
+                status: 'QUEUED',
+                result: null
+              }
+            }
+          ]
+        }
+      };
+
+      return [200, { 'Content-Type': 'application/json' }, JSON.stringify({ data: response })];
+    });
+
+    const asyncQuery = await adapter.createAsyncQuery(TestRequestV2);
 
     assert.deepEqual(asyncQuery, response, 'createAsyncQuery returns the correct response payload');
   });

--- a/packages/data/tests/unit/utils/adapter-test.js
+++ b/packages/data/tests/unit/utils/adapter-test.js
@@ -91,4 +91,18 @@ module('Unit - Utils - Adapter Utils', function() {
 
     set(config, 'navi.defaultDataSource', oldDefault);
   });
+
+  test('queryStrForField', function(assert) {
+    assert.equal(
+      queryStrForField('foo', { bar: 'baz' }),
+      'foo(bar: baz)',
+      'Field with parameter is formatted correctly'
+    );
+    assert.equal(
+      queryStrForField('foo', { bar: 'baz', bang: 'boom' }),
+      'foo(bar: baz,bang: boom)',
+      'Field with multiple parameters is formatted correctly'
+    );
+    assert.equal(queryStrForField('foo'), 'foo', 'Name is returned for field with no parameters');
+  });
 });

--- a/packages/data/tests/unit/utils/adapter-test.js
+++ b/packages/data/tests/unit/utils/adapter-test.js
@@ -91,18 +91,4 @@ module('Unit - Utils - Adapter Utils', function() {
 
     set(config, 'navi.defaultDataSource', oldDefault);
   });
-
-  test('queryStrForField', function(assert) {
-    assert.equal(
-      queryStrForField('foo', { bar: 'baz' }),
-      'foo(bar: baz)',
-      'Field with parameter is formatted correctly'
-    );
-    assert.equal(
-      queryStrForField('foo', { bar: 'baz', bang: 'boom' }),
-      'foo(bar: baz,bang: boom)',
-      'Field with multiple parameters is formatted correctly'
-    );
-    assert.equal(queryStrForField('foo'), 'foo', 'Name is returned for field with no parameters');
-  });
 });


### PR DESCRIPTION
##  Description
We need to be able to send Elide queries using the new request V2 format.

## Proposed Changes

- Add function to compose query string from a request v2 object
- Add util function for formatting a parameterized field for query

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
