### PR TITLE
Update: Use `Uncategorized` for grouped-list falsy group values

### DIFF
--- a/packages/reports/addon/components/grouped-list.js
+++ b/packages/reports/addon/components/grouped-list.js
@@ -19,7 +19,6 @@ import { isBlank } from '@ember/utils';
 import layout from '../templates/components/grouped-list';
 import { groupBy, sortBy } from 'lodash-es';
 import { layout as templateLayout, tagName } from '@ember-decorators/component';
-import { capitalize } from '@ember/string';
 
 @templateLayout(layout)
 @tagName('')

--- a/packages/reports/addon/components/grouped-list.js
+++ b/packages/reports/addon/components/grouped-list.js
@@ -61,7 +61,7 @@ class GroupedListComponent extends Component {
   get groupedItems() {
     const { items, groupByField, sortByField } = this;
 
-    const grouped = groupBy(items, row => row[groupByField]?.split(',')[0] || `No ${capitalize(groupByField)}`);
+    const grouped = groupBy(items, row => row[groupByField]?.split(',')[0] || `Uncategorized`);
 
     if (!isBlank(sortByField)) {
       Object.entries(grouped).forEach(([key, value]) => {

--- a/packages/reports/addon/components/grouped-list.js
+++ b/packages/reports/addon/components/grouped-list.js
@@ -19,6 +19,7 @@ import { isBlank } from '@ember/utils';
 import layout from '../templates/components/grouped-list';
 import { groupBy, sortBy } from 'lodash-es';
 import { layout as templateLayout, tagName } from '@ember-decorators/component';
+import { capitalize } from '@ember/string';
 
 @templateLayout(layout)
 @tagName('')
@@ -60,7 +61,7 @@ class GroupedListComponent extends Component {
   get groupedItems() {
     const { items, groupByField, sortByField } = this;
 
-    const grouped = groupBy(items, row => row[groupByField] && row[groupByField].split(',')[0]);
+    const grouped = groupBy(items, row => row[groupByField]?.split(',')[0] || `No ${capitalize(groupByField)}`);
 
     if (!isBlank(sortByField)) {
       Object.entries(grouped).forEach(([key, value]) => {

--- a/packages/reports/tests/integration/components/grouped-list-test.js
+++ b/packages/reports/tests/integration/components/grouped-list-test.js
@@ -52,7 +52,7 @@ module('Integration | Component | grouped list', function(hooks) {
     const groups = findAll('.grouped-list__group-header-content');
     assert.deepEqual(
       groups.map(el => el.textContent.trim()),
-      ['foo (3)', 'bar (1)', 'undefined (1)', 'null (1)'],
+      ['foo (3)', 'bar (1)', 'No Field (2)'],
       'the groups in the grouped-list are rendered, only the first item in the groupByField is considered for grouping'
     );
 
@@ -71,7 +71,7 @@ module('Integration | Component | grouped list', function(hooks) {
 
     assert.deepEqual(
       findAll('.grouped-list li').map(el => el.textContent.trim()),
-      ['foo (3)', '1', '2', '3', 'bar (1)', '6', 'undefined (1)', '4', 'null (1)', '5'],
+      ['foo (3)', '1', '2', '3', 'bar (1)', '6', 'No Field (2)', '4', '5'],
       'All groups are open when `shouldOpenAllGroups` attribute is true'
     );
   });

--- a/packages/reports/tests/integration/components/grouped-list-test.js
+++ b/packages/reports/tests/integration/components/grouped-list-test.js
@@ -52,7 +52,7 @@ module('Integration | Component | grouped list', function(hooks) {
     const groups = findAll('.grouped-list__group-header-content');
     assert.deepEqual(
       groups.map(el => el.textContent.trim()),
-      ['foo (3)', 'bar (1)', 'No Field (2)'],
+      ['foo (3)', 'bar (1)', 'Uncategorized (2)'],
       'the groups in the grouped-list are rendered, only the first item in the groupByField is considered for grouping'
     );
 
@@ -71,7 +71,7 @@ module('Integration | Component | grouped list', function(hooks) {
 
     assert.deepEqual(
       findAll('.grouped-list li').map(el => el.textContent.trim()),
-      ['foo (3)', '1', '2', '3', 'bar (1)', '6', 'No Field (2)', '4', '5'],
+      ['foo (3)', '1', '2', '3', 'bar (1)', '6', 'Uncategorized (2)', '4', '5'],
       'All groups are open when `shouldOpenAllGroups` attribute is true'
     );
   });


### PR DESCRIPTION
## Description
We shouldn't use `undefined` or `null` as grouping values in the grouped-list

## Proposed Changes

- Use `Uncategorized` as the grouping value for falsy values

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
