### PR TITLE
Carbon Query Logger

### DIFF
--- a/packages/webservice/app/build.gradle.kts
+++ b/packages/webservice/app/build.gradle.kts
@@ -11,15 +11,17 @@ plugins {
 
 repositories {
     mavenCentral()
+    mavenLocal()
 }
 
 dependencies {
     implementation(project(":models"))
     implementation("org.springframework.boot:spring-boot-starter-security")
-    implementation("com.yahoo.elide", "elide-spring-boot-starter", "5.0.0-pr12")
+    implementation("com.yahoo.elide", "elide-spring-boot-starter", "5.0.0-pr14-SNAPSHOT")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("com.h2database", "h2", "1.3.176")
     implementation("io.micrometer","micrometer-core", "1.5.1")
+    //implementation("org.json:json:20200518")
     testImplementation("org.springframework.boot:spring-boot-starter-test") {
         exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
     }

--- a/packages/webservice/app/build.gradle.kts
+++ b/packages/webservice/app/build.gradle.kts
@@ -21,7 +21,6 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("com.h2database", "h2", "1.3.176")
     implementation("io.micrometer","micrometer-core", "1.5.1")
-    //implementation("org.json:json:20200518")
     testImplementation("org.springframework.boot:spring-boot-starter-test") {
         exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
     }

--- a/packages/webservice/app/src/main/kotlin/com/yahoo/navi/ws/config/ElideConfig.kt
+++ b/packages/webservice/app/src/main/kotlin/com/yahoo/navi/ws/config/ElideConfig.kt
@@ -10,13 +10,20 @@ import com.yahoo.elide.ElideSettingsBuilder
 import com.yahoo.elide.core.DataStore
 import com.yahoo.elide.core.EntityDictionary
 import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect
+import com.yahoo.elide.datastores.aggregation.core.QueryLogger
 import com.yahoo.elide.spring.config.ElideConfigProperties
+import com.yahoo.navi.ws.utilities.CarbonQueryLogger
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import java.util.TimeZone
 
 @Configuration
 class ElideConfig {
+    @Bean
+    fun buildQueryLogger(): QueryLogger {
+        return CarbonQueryLogger(5, 10000)
+    }
+
     @Bean
     fun initializeElide(dictionary: EntityDictionary, dataStore: DataStore, settings: ElideConfigProperties): Elide {
         val builder = ElideSettingsBuilder(dataStore)

--- a/packages/webservice/app/src/main/kotlin/com/yahoo/navi/ws/utilities/CarbonQueryLogger.kt
+++ b/packages/webservice/app/src/main/kotlin/com/yahoo/navi/ws/utilities/CarbonQueryLogger.kt
@@ -70,9 +70,10 @@ open class CarbonQueryLogger constructor(
     ) {
         var start: Long = System.currentTimeMillis()
         var apiQuery: String? = constructAPIQuery(queryParams, path)
+        var userName: String? = user?.name
         synchronized(queryWatcher) {
             var qStat = QueryStats(queryId)
-            qStat.user = user
+            qStat.user = userName
             qStat.apiVersion = apiVer
             qStat.apiQuery = apiQuery
             qStat.startTime = start

--- a/packages/webservice/app/src/main/kotlin/com/yahoo/navi/ws/utilities/CarbonQueryLogger.kt
+++ b/packages/webservice/app/src/main/kotlin/com/yahoo/navi/ws/utilities/CarbonQueryLogger.kt
@@ -1,0 +1,155 @@
+/**
+* Copyright 2020, Yahoo Holdings Inc.
+* Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+*/
+package com.yahoo.navi.ws.utilities
+
+import com.google.common.collect.Iterables
+import com.yahoo.elide.datastores.aggregation.core.QueryLogger
+import com.yahoo.elide.datastores.aggregation.core.QueryResponse
+import com.yahoo.elide.datastores.aggregation.query.Query
+import com.yahoo.elide.security.User
+import com.yahoo.navi.ws.models.beans.utilities.QueryStats
+import com.yahoo.navi.ws.models.beans.utilities.QueryStatus
+import java.net.InetAddress.getLocalHost
+import java.util.Optional
+import java.util.Timer
+import java.util.TimerTask
+import java.util.UUID
+import javax.persistence.EntityManager
+import javax.persistence.PersistenceContext
+import javax.transaction.Transactional
+import javax.ws.rs.core.MultivaluedMap
+
+object Constants {
+    const val MAX_QUERIES = 5
+    const val TIMEOUT = 10000
+}
+
+@Transactional
+open class CarbonQueryLogger constructor(
+    maxQueries: Int = Constants.MAX_QUERIES,
+    timeOut: Long = Constants.TIMEOUT.toLong()
+) : QueryLogger, TimerTask() {
+
+    private var queriesToBeLogged: MutableList<QueryStats> = ArrayList()
+    private var queryWatcher: MutableMap<UUID, QueryStats> = HashMap()
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    private var t: Timer = Timer()
+    private val maxQueries: Int = maxQueries
+    private val timeOut: Long = timeOut
+
+    init {
+        t.schedule(this, 0, this.timeOut)
+    }
+
+    override fun cancelQuery(queryId: UUID) {
+        var endTime: Long = System.currentTimeMillis()
+        var qstat: QueryStats = queryWatcher[queryId]!!
+        synchronized(this) {
+            qstat.status = QueryStatus.CANCELLED
+            qstat.durationInMillis = endTime - qstat.startTime!!
+            qstat.bytesReturned = 0
+            qstat.rowsReturned = 0
+            queriesToBeLogged.add(qstat)
+            queryWatcher.remove(queryId)
+        }
+        if (queriesToBeLogged.size > maxQueries) { run() }
+    }
+
+    override fun acceptQuery(
+        queryId: UUID,
+        user: User?,
+        headers: MutableMap<String, String>?,
+        apiVer: String?,
+        queryParams: Optional<MultivaluedMap<String, String>>?,
+        path: String?
+    ) {
+        var start: Long = System.currentTimeMillis()
+        var apiQuery: String? = constructAPIQuery(queryParams, path)
+        synchronized(queryWatcher) {
+            var qStat = QueryStats(queryId)
+            qStat.user = user
+            qStat.apiVersion = apiVer
+            qStat.apiQuery = apiQuery
+            qStat.startTime = start
+            qStat.status = QueryStatus.ACCEPTED
+            qStat.hostName = getLocalHost().hostName
+            queryWatcher.put(queryId, qStat)
+        }
+    }
+
+    override fun completeQuery(queryId: UUID, response: QueryResponse) {
+        var endTime: Long = System.currentTimeMillis()
+        var qstat: QueryStats = queryWatcher[queryId]!!
+        var status: QueryStatus = if (response.data == null) QueryStatus.FAILED else QueryStatus.COMPLETED
+        synchronized(this) {
+            qstat.status = status
+            qstat.durationInMillis = endTime - qstat.startTime!!
+            qstat.bytesReturned = getTotalBytesReturned(response)
+            qstat.rowsReturned = getTotalRowsReturned(response)
+            queriesToBeLogged.add(qstat)
+            queryWatcher.remove(queryId)
+        }
+        if (queriesToBeLogged.size > maxQueries) { run() }
+    }
+
+    override fun processQuery(queryId: UUID, query: Query, apiQuery: String?, isCached: Boolean) {
+        var qstat: QueryStats = queryWatcher[queryId]!!
+        synchronized(queryWatcher) {
+            qstat.modelName = query.table.name
+            qstat.storeQuery = apiQuery
+            qstat.status = QueryStatus.INPROGRESS
+            qstat.isCached = isCached
+            queryWatcher[queryId] = qstat
+        }
+    }
+
+    override fun run() {
+        synchronized(queriesToBeLogged) {
+            for (qs in queriesToBeLogged) {
+                entityManager.persist(qs)
+            }
+            queriesToBeLogged.clear()
+        }
+    }
+
+    private fun constructAPIQuery(queryParams: Optional<MultivaluedMap<String, String>>?, path: String?): String? {
+        var apiQuery: String? = null
+        if (queryParams == null) {
+            return null
+        } else if (!queryParams.isPresent) {
+            apiQuery = path
+        } else {
+            apiQuery = "$path?"
+            val qParams: MultivaluedMap<String, String> = queryParams.get()
+            qParams.forEach { (key, value) ->
+                run {
+                    for (v in value) {
+                        apiQuery += "$key=$v"
+                    }
+                }
+            }
+        }
+        return apiQuery
+    }
+
+    private fun getTotalRowsReturned(response: QueryResponse): Int {
+        if (response.data == null) { return 0 }
+        val data: Iterable<Object> = response.data as Iterable<Object>
+        return Iterables.size(data)
+    }
+
+    private fun getTotalBytesReturned(response: QueryResponse): Int {
+        if (response.data == null) { return 0 }
+        var totalBytes: Int = 0
+        val data: Iterable<Object> = response.data as Iterable<Object>
+        for (d in data) {
+            totalBytes += d.toString().length
+        }
+        return totalBytes
+    }
+}

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/utilities/QueryStats.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/utilities/QueryStats.kt
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2020, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+package com.yahoo.navi.ws.models.beans.utilities
+
+import com.sun.istack.NotNull
+import com.yahoo.elide.annotation.CreatePermission
+import com.yahoo.elide.annotation.DeletePermission
+import com.yahoo.elide.annotation.Include
+import com.yahoo.elide.annotation.UpdatePermission
+import com.yahoo.elide.security.User
+import com.yahoo.navi.ws.models.checks.DefaultNobodyCheck
+import org.hibernate.annotations.CreationTimestamp
+import java.util.Date
+import java.util.UUID
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.Table
+import javax.persistence.Temporal
+import javax.persistence.TemporalType
+
+@Entity
+@Include(rootLevel = true)
+@Table(name = "querystats")
+@CreatePermission(expression = DefaultNobodyCheck.NOBODY)
+@UpdatePermission(expression = DefaultNobodyCheck.NOBODY)
+@DeletePermission(expression = DefaultNobodyCheck.NOBODY)
+class QueryStats(id: UUID){
+
+    @Id
+    @NotNull
+    var id: UUID = id
+
+    var name: String? = null
+    var label: String? = null
+    var sessionId: String? = null
+    var fromUI: Boolean? = null
+
+    @Column(columnDefinition = "user API version")
+    var apiVersion: String? = null
+
+    @Column(columnDefinition = "API query query string")
+    var apiQuery: String? = null
+
+    @Column(columnDefinition = "underlying SQL query")
+    var storeQuery: String? = null
+
+    @Column(columnDefinition = "underlying base table name")
+    var modelName: String? = null
+
+    @Column(columnDefinition = "user information")
+    var user: User? = null
+
+    @Column(columnDefinition = "current query state")
+    var status: QueryStatus? = null
+
+    @Column(columnDefinition = "query execution time")
+    var durationInMillis: Long? = null
+
+    @Column(columnDefinition = "output rows returned")
+    var rowsReturned: Int? = null
+
+    @Column(columnDefinition = "output bytes returned")
+    var bytesReturned: Int? = null
+
+    @Column(columnDefinition = "query comes form cache or not")
+    var isCached: Boolean = false
+
+    @CreationTimestamp
+    @Column(columnDefinition = "timestamp default current_timestamp", name = "CreatedDate", updatable = false)
+    @Temporal(TemporalType.TIMESTAMP)
+    var createdOn: Date? = null
+
+    @Column(columnDefinition = "user system hostname")
+    var hostName: String? = null
+
+    @Transient
+    var startTime: Long? = null
+}

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/utilities/QueryStats.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/utilities/QueryStats.kt
@@ -9,7 +9,6 @@ import com.yahoo.elide.annotation.CreatePermission
 import com.yahoo.elide.annotation.DeletePermission
 import com.yahoo.elide.annotation.Include
 import com.yahoo.elide.annotation.UpdatePermission
-import com.yahoo.elide.security.User
 import com.yahoo.navi.ws.models.checks.DefaultNobodyCheck
 import org.hibernate.annotations.CreationTimestamp
 import java.util.Date
@@ -51,7 +50,7 @@ class QueryStats(id: UUID){
     var modelName: String? = null
 
     @Column(columnDefinition = "user information")
-    var user: User? = null
+    var user: String? = null
 
     @Column(columnDefinition = "current query state")
     var status: QueryStatus? = null

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/utilities/QueryStatus.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/utilities/QueryStatus.kt
@@ -1,0 +1,13 @@
+/**
+* Copyright 2020, Yahoo Holdings Inc.
+* Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+*/
+package com.yahoo.navi.ws.models.beans.utilities
+
+enum class QueryStatus {
+    ACCEPTED,
+    COMPLETED,
+    CANCELLED,
+    FAILED,
+    INPROGRESS
+}


### PR DESCRIPTION
## Description
Added QueryLogging Implementation for Carbon in Navi. 

## Proposed Changes
In package/webservice, the following files were added to reflect this change:
1. CarbonQueryLogger.kt: Has the implementation for Query Logging and overrides the QueryLogger interface from Elide.
2. QueryStatus.kt: Enum class with all the possible query statuses that a query could have when an response is received from Elide
3. QueryStats.kt: Our querylogging entity class.

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
