### PR TITLE
Update: Rename `columnMeta` to `columnMetadata`

### DIFF
--- a/packages/core/addon/components/navi-visualization-config/series-chart.js
+++ b/packages/core/addon/components/navi-visualization-config/series-chart.js
@@ -56,7 +56,7 @@ class NaviVisualizationConfigSeriesChartComponent extends Component {
   get dimensions() {
     return this.request.columns
       .filter(c => c.type === 'dimension' || (c.type === 'time-dimension' && c.field !== 'dateTime'))
-      .map(c => c.columnMeta);
+      .map(c => c.columnMetadata);
   }
 
   /**

--- a/packages/core/addon/models/bard-request-v2/fragments/base.js
+++ b/packages/core/addon/models/bard-request-v2/fragments/base.js
@@ -44,9 +44,9 @@ export default class Base extends Fragment.extend(Validations) {
    * @type {Meta}
    */
   @computed('field', 'type', 'source')
-  get columnMeta() {
-    assert('Source must be set in order to access columnMeta', isPresent(this.source));
-    assert('column type must be set in order to access columnMeta', isPresent(this.type));
+  get columnMetadata() {
+    assert('Source must be set in order to access columnMetadata', isPresent(this.source));
+    assert('column type must be set in order to access columnMetadata', isPresent(this.type));
     if (this.field === 'dateTime') {
       return {
         id: 'dateTime',

--- a/packages/core/addon/models/bard-request-v2/request.js
+++ b/packages/core/addon/models/bard-request-v2/request.js
@@ -234,7 +234,7 @@ export default class Request extends Fragment.extend(Validations) {
    * @param {object} parameters - the parameters to search for to be removed
    */
   removeColumnByMeta(columnMetadataModel, parameters) {
-    let columnsToRemove = this.columns.filter(column => column.columnMeta === columnMetadataModel);
+    let columnsToRemove = this.columns.filter(column => column.columnMetadata === columnMetadataModel);
 
     if (parameters) {
       columnsToRemove = columnsToRemove.filter(column => isEqual(column.parameters, parameters));
@@ -367,7 +367,7 @@ export default class Request extends Fragment.extend(Validations) {
    * @param {ColumnMetadata} metricMetadataModel - the metadata of the metric to remove sorts for
    */
   removeSortByMeta(metricMetadataModel) {
-    const sortsToRemove = this.sorts.filter(sort => sort.columnMeta === metricMetadataModel);
+    const sortsToRemove = this.sorts.filter(sort => sort.columnMetadata === metricMetadataModel);
     sortsToRemove.forEach(sort => this.removeSort(sort));
   }
 

--- a/packages/core/tests/unit/models/bard-request-v2/fragments/column-test.js
+++ b/packages/core/tests/unit/models/bard-request-v2/fragments/column-test.js
@@ -54,7 +54,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Column', function(hooks) {
 
     assert.equal(column.alias, 'revenueUSD', 'the `alias` property is set correctly');
 
-    assert.equal(column.columnMeta.id, 'revenue', 'metadata is populated with the right field');
+    assert.equal(column.columnMetadata.id, 'revenue', 'metadata is populated with the right field');
   });
 
   test('Validation', async function(assert) {

--- a/packages/core/tests/unit/models/bard-request-v2/fragments/filter-test.js
+++ b/packages/core/tests/unit/models/bard-request-v2/fragments/filter-test.js
@@ -55,7 +55,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Filter', function(hooks) {
 
     assert.deepEqual(filter.values, ['P1D', 'current'], 'the `values` property is set correctly');
 
-    assert.equal(filter.columnMeta.id, 'dateTime', 'metadata is loaded correctly');
+    assert.equal(filter.columnMetadata.id, 'dateTime', 'metadata is loaded correctly');
   });
 
   test('Validation', async function(assert) {

--- a/packages/core/tests/unit/models/bard-request-v2/fragments/sort-test.js
+++ b/packages/core/tests/unit/models/bard-request-v2/fragments/sort-test.js
@@ -47,7 +47,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Sort', function(hooks) {
     assert.deepEqual(sort.parameters, { grain: 'day' }, 'the `parameters` property is set correctly');
 
     assert.equal(sort.direction, 'asc', 'the `direction` property is set correctly');
-    assert.equal(sort.columnMeta.id, 'dateTime', 'correct meta data is populated');
+    assert.equal(sort.columnMetadata.id, 'dateTime', 'correct meta data is populated');
   });
 
   test('Validation', async function(assert) {

--- a/packages/core/tests/unit/models/bard-request-v2/request-test.js
+++ b/packages/core/tests/unit/models/bard-request-v2/request-test.js
@@ -96,15 +96,23 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
 
     assert.equal(request.dataSource, 'dummy', 'the `dataSource` property has the correct value');
 
-    assert.equal(request.columns.objectAt(1).columnMeta.category, 'Asset', 'meta data is populated on sub fragments');
-    assert.equal(request.columns.objectAt(2).columnMeta.category, 'Revenue', 'meta data is populated on sub fragments');
     assert.equal(
-      request.filters.objectAt(1).columnMeta.category,
+      request.columns.objectAt(1).columnMetadata.category,
+      'Asset',
+      'meta data is populated on sub fragments'
+    );
+    assert.equal(
+      request.columns.objectAt(2).columnMetadata.category,
+      'Revenue',
+      'meta data is populated on sub fragments'
+    );
+    assert.equal(
+      request.filters.objectAt(1).columnMetadata.category,
       'Identifiers',
       'Filters also have meta data populated'
     );
 
-    assert.equal(request.sorts.objectAt(1).columnMeta.category, 'Clicks', 'Sorts have meta data populated');
+    assert.equal(request.sorts.objectAt(1).columnMetadata.category, 'Clicks', 'Sorts have meta data populated');
   });
 
   test('Clone Request', async function(assert) {
@@ -144,7 +152,11 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
       'the `values` property of the second filter has the correct value'
     );
 
-    assert.equal(request.filters.objectAt(1).columnMeta.category, 'Identifiers', 'the meta data attached is correct');
+    assert.equal(
+      request.filters.objectAt(1).columnMetadata.category,
+      'Identifiers',
+      'the meta data attached is correct'
+    );
 
     // columns
 
@@ -172,7 +184,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
       'the `type` property of the second column has the correct value'
     );
 
-    assert.equal(request.columns.objectAt(1).columnMeta.category, 'Asset', 'the meta data attached is correct');
+    assert.equal(request.columns.objectAt(1).columnMetadata.category, 'Asset', 'the meta data attached is correct');
 
     // sort
 
@@ -188,7 +200,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
       'the `direction` property of the second sort has the correct value'
     );
 
-    assert.equal(request.sorts.objectAt(1).columnMeta.category, 'Clicks', 'the meta data attached is correct');
+    assert.equal(request.sorts.objectAt(1).columnMetadata.category, 'Clicks', 'the meta data attached is correct');
   });
 
   test('Validation', async function(assert) {

--- a/packages/core/tests/unit/serializers/bard-request-v2/request-test.js
+++ b/packages/core/tests/unit/serializers/bard-request-v2/request-test.js
@@ -111,24 +111,24 @@ module('Unit | Serializer | Request V2', function(hooks) {
 
     assert.equal(columns.length, 6, 'request has correct number of columns');
 
-    assert.equal(columns.objectAt(0).columnMeta.id, 'dateTime', 'dateTime column is normalized correctly');
+    assert.equal(columns.objectAt(0).columnMetadata.id, 'dateTime', 'dateTime column is normalized correctly');
     assert.equal(columns.objectAt(0).type, 'time-dimension', 'dateTime column type is set correctly');
     assert.deepEqual(columns.objectAt(0).parameters, { grain: 'day' }, 'dateTime column has correct parameters');
 
-    assert.equal(columns.objectAt(1).columnMeta.id, 'age', 'dimension columns are normalized correctly');
+    assert.equal(columns.objectAt(1).columnMetadata.id, 'age', 'dimension columns are normalized correctly');
     assert.deepEqual(columns.objectAt(1).parameters, {}, 'dimension columns have no parameters');
 
-    assert.equal(columns.objectAt(3).columnMeta.id, 'revenue', 'metric columns are normalized correctly');
+    assert.equal(columns.objectAt(3).columnMetadata.id, 'revenue', 'metric columns are normalized correctly');
     assert.deepEqual(columns.objectAt(3).parameters, { currency: 'USD' }, 'metric columns have correct parameters');
 
     assert.equal(filters.length, 5, 'request has correct number of filter fragments');
 
-    assert.equal(filters.objectAt(0).columnMeta.id, 'dateTime', 'dateTime filter is normalized correctly');
+    assert.equal(filters.objectAt(0).columnMetadata.id, 'dateTime', 'dateTime filter is normalized correctly');
     assert.equal(filters.objectAt(0).type, 'time-dimension', 'dateTime filter type is set correctly');
     assert.equal(filters.objectAt(0).operator, 'bet', 'dateTime filter operator is set correctly');
     assert.deepEqual(filters.objectAt(0).values, ['P7D', 'current'], 'dateTime filter values are set correctly');
 
-    assert.equal(filters.objectAt(1).columnMeta.id, 'age', 'dimension filters are normalized correctly');
+    assert.equal(filters.objectAt(1).columnMetadata.id, 'age', 'dimension filters are normalized correctly');
     assert.deepEqual(
       filters.objectAt(1).parameters,
       { projection: 'id' },
@@ -143,17 +143,17 @@ module('Unit | Serializer | Request V2', function(hooks) {
       'dimension filter has correct `desc` projection param'
     );
 
-    assert.equal(filters.objectAt(3).columnMeta.id, 'revenue', 'metric filters are normalized correctly');
+    assert.equal(filters.objectAt(3).columnMetadata.id, 'revenue', 'metric filters are normalized correctly');
     assert.deepEqual(filters.objectAt(3).parameters, { currency: 'USD' }, 'metric filters have correct parameters');
     assert.equal(filters.objectAt(3).operator, 'lt', 'metric filter operator are normalized correctly');
     assert.deepEqual(filters.objectAt(3).values, [24], 'metric filter values are normalized correctly');
 
     assert.equal(sorts.length, 2, 'request has correct number of sort fragments');
 
-    assert.equal(sorts.objectAt(0).columnMeta.id, 'dateTime', 'dateTime sort is normalized correctly');
+    assert.equal(sorts.objectAt(0).columnMetadata.id, 'dateTime', 'dateTime sort is normalized correctly');
     assert.equal(sorts.objectAt(0).direction, 'desc', 'dateTime sort direction is normalized correctly');
 
-    assert.equal(sorts.objectAt(1).columnMeta.id, 'revenue', 'metric sorts are normalized correctly');
+    assert.equal(sorts.objectAt(1).columnMetadata.id, 'revenue', 'metric sorts are normalized correctly');
     assert.deepEqual(sorts.objectAt(1).parameters, { currency: 'CAD' }, 'metric sorts have correct parameters');
   });
 });

--- a/packages/core/tests/unit/services/fragment-factory-test.js
+++ b/packages/core/tests/unit/services/fragment-factory-test.js
@@ -27,16 +27,24 @@ module('Unit | Service | fragmentFactory', function(hooks) {
     assert.equal(metricMetaFragment.parameters.avg, 'trailing31day', 'Metric fragment has right parameters');
     assert.equal(metricMetaFragment.alias, 'clicksTrailingMonthAvg', 'Metric Fragment has passed alias');
     assert.equal(metricMetaFragment.type, 'metric', 'Metric Fragment has metric type');
-    assert.equal(metricMetaFragment.columnMeta.category, 'Clicks', 'Metric fragment meta is populated correctly');
-    assert.equal(metricMetaFragment.columnMeta.source, 'dummy', 'Metric fragment meta data has right datasource');
+    assert.equal(metricMetaFragment.columnMetadata.category, 'Clicks', 'Metric fragment meta is populated correctly');
+    assert.equal(metricMetaFragment.columnMetadata.source, 'dummy', 'Metric fragment meta data has right datasource');
 
     const dimensionMetaFragment = service.createColumnFromMeta(dimMeta, {}, 'agent');
     assert.equal(dimensionMetaFragment.field, 'browser', 'Dimension has right field');
     assert.deepEqual(dimensionMetaFragment.parameters, {}, 'Dimension fragment has right parameters');
     assert.equal(dimensionMetaFragment.alias, 'agent', 'Dimension Fragment has passed alias');
     assert.equal(dimensionMetaFragment.type, 'dimension', 'Dimension Fragment has metric type');
-    assert.equal(dimensionMetaFragment.columnMeta.category, 'test', 'Dimension fragment meta is populated correctly');
-    assert.equal(dimensionMetaFragment.columnMeta.source, 'dummy', 'Dimension fragment meta data has right datasource');
+    assert.equal(
+      dimensionMetaFragment.columnMetadata.category,
+      'test',
+      'Dimension fragment meta is populated correctly'
+    );
+    assert.equal(
+      dimensionMetaFragment.columnMetadata.source,
+      'dummy',
+      'Dimension fragment meta data has right datasource'
+    );
   });
 
   test('Build Column Fragments Without Meta', function(assert) {
@@ -51,16 +59,24 @@ module('Unit | Service | fragmentFactory', function(hooks) {
     assert.equal(metricMetaFragment.parameters.currency, 'USD', 'Metric fragment has right parameters');
     assert.equal(metricMetaFragment.alias, 'revenueTrailingMonthAvg', 'Metric Fragment has passed alias');
     assert.equal(metricMetaFragment.type, 'metric', 'Metric Fragment has metric type');
-    assert.equal(metricMetaFragment.columnMeta.category, 'Revenue', 'Metric fragment meta is populated correctly');
-    assert.equal(metricMetaFragment.columnMeta.source, 'dummy', 'Metric fragment meta data has right datasource');
+    assert.equal(metricMetaFragment.columnMetadata.category, 'Revenue', 'Metric fragment meta is populated correctly');
+    assert.equal(metricMetaFragment.columnMetadata.source, 'dummy', 'Metric fragment meta data has right datasource');
 
     const dimensionMetaFragment = service.createColumn('dimension', 'dummy', 'browser', {}, 'agent');
     assert.equal(dimensionMetaFragment.field, 'browser', 'Dimension has right field');
     assert.deepEqual(dimensionMetaFragment.parameters, {}, 'Dimension fragment has right parameters');
     assert.equal(dimensionMetaFragment.alias, 'agent', 'Dimension Fragment has passed alias');
     assert.equal(dimensionMetaFragment.type, 'dimension', 'Dimension Fragment has metric type');
-    assert.equal(dimensionMetaFragment.columnMeta.category, 'test', 'Dimension fragment meta is populated correctly');
-    assert.equal(dimensionMetaFragment.columnMeta.source, 'dummy', 'Dimension fragment meta data has right datasource');
+    assert.equal(
+      dimensionMetaFragment.columnMetadata.category,
+      'test',
+      'Dimension fragment meta is populated correctly'
+    );
+    assert.equal(
+      dimensionMetaFragment.columnMetadata.source,
+      'dummy',
+      'Dimension fragment meta data has right datasource'
+    );
   });
 
   test('Build Filter Fragments From Meta', function(assert) {
@@ -72,16 +88,24 @@ module('Unit | Service | fragmentFactory', function(hooks) {
     assert.equal(metricMetaFragment.parameters.avg, 'trailing31day', 'Metric fragment has right parameters');
     assert.equal(metricMetaFragment.operator, 'in', 'Metric Fragment has passed operator');
     assert.deepEqual(metricMetaFragment.values, [1, 2, 3], 'Metric Fragment has right values');
-    assert.equal(metricMetaFragment.columnMeta.category, 'Clicks', 'Metric fragment meta is populated correctly');
-    assert.equal(metricMetaFragment.columnMeta.source, 'dummy', 'Metric fragment meta data has right datasource');
+    assert.equal(metricMetaFragment.columnMetadata.category, 'Clicks', 'Metric fragment meta is populated correctly');
+    assert.equal(metricMetaFragment.columnMetadata.source, 'dummy', 'Metric fragment meta data has right datasource');
 
     const dimensionMetaFragment = service.createFilterFromMeta(dimMeta, {}, 'contains', ['chrome', 'firefox']);
     assert.equal(dimensionMetaFragment.field, 'browser', 'Dimension has right field');
     assert.deepEqual(dimensionMetaFragment.parameters, {}, 'Dimension fragment has right parameters');
     assert.equal(dimensionMetaFragment.operator, 'contains', 'Dimension Fragment has passed opeator');
     assert.deepEqual(dimensionMetaFragment.values, ['chrome', 'firefox'], 'Dimension Fragment has metric values');
-    assert.equal(dimensionMetaFragment.columnMeta.category, 'test', 'Dimension fragment meta is populated correctly');
-    assert.equal(dimensionMetaFragment.columnMeta.source, 'dummy', 'Dimension fragment meta data has right datasource');
+    assert.equal(
+      dimensionMetaFragment.columnMetadata.category,
+      'test',
+      'Dimension fragment meta is populated correctly'
+    );
+    assert.equal(
+      dimensionMetaFragment.columnMetadata.source,
+      'dummy',
+      'Dimension fragment meta data has right datasource'
+    );
   });
 
   test('Build Filter Fragments Without Meta', function(assert) {
@@ -94,8 +118,8 @@ module('Unit | Service | fragmentFactory', function(hooks) {
     assert.equal(metricMetaFragment.parameters.avg, 'trailing31day', 'Metric fragment has right parameters');
     assert.equal(metricMetaFragment.operator, 'in', 'Metric Fragment has passed operator');
     assert.deepEqual(metricMetaFragment.values, [1, 2, 3], 'Metric Fragment has right values');
-    assert.equal(metricMetaFragment.columnMeta.category, 'Clicks', 'Metric fragment meta is populated correctly');
-    assert.equal(metricMetaFragment.columnMeta.source, 'dummy', 'Metric fragment meta data has right datasource');
+    assert.equal(metricMetaFragment.columnMetadata.category, 'Clicks', 'Metric fragment meta is populated correctly');
+    assert.equal(metricMetaFragment.columnMetadata.source, 'dummy', 'Metric fragment meta data has right datasource');
 
     const dimensionMetaFragment = service.createFilter('dimension', 'dummy', 'browser', {}, 'contains', [
       'chrome',
@@ -105,8 +129,16 @@ module('Unit | Service | fragmentFactory', function(hooks) {
     assert.deepEqual(dimensionMetaFragment.parameters, {}, 'Dimension fragment has right parameters');
     assert.equal(dimensionMetaFragment.operator, 'contains', 'Dimension Fragment has passed opeator');
     assert.deepEqual(dimensionMetaFragment.values, ['chrome', 'firefox'], 'Dimension Fragment has metric values');
-    assert.equal(dimensionMetaFragment.columnMeta.category, 'test', 'Dimension fragment meta is populated correctly');
-    assert.equal(dimensionMetaFragment.columnMeta.source, 'dummy', 'Dimension fragment meta data has right datasource');
+    assert.equal(
+      dimensionMetaFragment.columnMetadata.category,
+      'test',
+      'Dimension fragment meta is populated correctly'
+    );
+    assert.equal(
+      dimensionMetaFragment.columnMetadata.source,
+      'dummy',
+      'Dimension fragment meta data has right datasource'
+    );
   });
 
   test('Build Sort Fragments From Meta', function(assert) {
@@ -116,8 +148,8 @@ module('Unit | Service | fragmentFactory', function(hooks) {
     assert.equal(metricMetaFragment.field, 'navClicks', 'Sort Fragment has right field');
     assert.equal(metricMetaFragment.parameters.avg, 'trailing31day', 'Sort fragment has right parameters');
     assert.equal(metricMetaFragment.direction, 'asc', 'Sort Fragment has passed operator');
-    assert.equal(metricMetaFragment.columnMeta.category, 'Clicks', 'Sort fragment meta is populated correctly');
-    assert.equal(metricMetaFragment.columnMeta.source, 'dummy', 'Sort fragment meta data has right datasource');
+    assert.equal(metricMetaFragment.columnMetadata.category, 'Clicks', 'Sort fragment meta is populated correctly');
+    assert.equal(metricMetaFragment.columnMetadata.source, 'dummy', 'Sort fragment meta data has right datasource');
   });
 
   test('Build Sort Fragments Without Meta', function(assert) {
@@ -125,7 +157,7 @@ module('Unit | Service | fragmentFactory', function(hooks) {
     assert.equal(metricMetaFragment.field, 'revenue', 'Sort Fragment has right field');
     assert.equal(metricMetaFragment.parameters.currency, 'USD', 'Sort fragment has right parameters');
     assert.equal(metricMetaFragment.direction, 'desc', 'Sort Fragment has passed operator');
-    assert.equal(metricMetaFragment.columnMeta.category, 'Revenue', 'Sort fragment meta is populated correctly');
-    assert.equal(metricMetaFragment.columnMeta.source, 'dummy', 'Sort fragment meta data has right datasource');
+    assert.equal(metricMetaFragment.columnMetadata.category, 'Revenue', 'Sort fragment meta is populated correctly');
+    assert.equal(metricMetaFragment.columnMetadata.source, 'dummy', 'Sort fragment meta data has right datasource');
   });
 });

--- a/packages/reports/addon/components/dimension-selector.js
+++ b/packages/reports/addon/components/dimension-selector.js
@@ -130,7 +130,7 @@ export default class DimensionSelector extends Component {
   @computed('selectedColumns')
   get itemsChecked() {
     return this.selectedColumns.reduce((items, item) => {
-      items[item.columnMeta.id] = true;
+      items[item.columnMetadata.id] = true;
       return items;
     }, {});
   }
@@ -142,7 +142,7 @@ export default class DimensionSelector extends Component {
   @computed('request.dimensionFilters.[]')
   get dimensionsFiltered() {
     return this.request.dimensionFilters.reduce((list, dimension) => {
-      list[dimension.columnMeta.id] = true;
+      list[dimension.columnMetadata.id] = true;
       return list;
     }, {});
   }

--- a/packages/reports/addon/components/filter-builders/base.js
+++ b/packages/reports/addon/components/filter-builders/base.js
@@ -30,7 +30,7 @@ class BaseFilterBuilderComponent extends Component {
   /**
    * @property {String} displayName - display name for the filter
    */
-  @readOnly('filter.subject.columnMeta.name') displayName;
+  @readOnly('filter.subject.columnMetadata.name') displayName;
 
   /**
    * @property {Array} supportedOperators - list of valid values for filter.operator

--- a/packages/reports/addon/components/filter-builders/dimension.js
+++ b/packages/reports/addon/components/filter-builders/dimension.js
@@ -61,7 +61,7 @@ class DimensionFilterBuilderComponent extends BaseFilterBuilderComponent {
   /**
    * @property {String} primaryKeyField - Primary Key Field used so we know what to use as default field for operators
    */
-  @readOnly('requestFragment.columnMeta.primaryKeyFieldName') primaryKeyField;
+  @readOnly('requestFragment.columnMetadata.primaryKeyFieldName') primaryKeyField;
 
   /**
    * @property {?Boolean} showFields - Whether to show the field chooser in the filter builder
@@ -71,9 +71,9 @@ class DimensionFilterBuilderComponent extends BaseFilterBuilderComponent {
   /**
    * @property {Array} fields - List of fields that a user can choose from
    */
-  @computed('requestFragment.columnMeta')
+  @computed('requestFragment.columnMetadata')
   get fields() {
-    let fields = this.requestFragment.columnMeta.fields;
+    let fields = this.requestFragment.columnMetadata.fields;
     return fields ? fields.map(field => field.name) : ['id', 'desc'];
   }
 

--- a/packages/reports/addon/components/filter-builders/metric.js
+++ b/packages/reports/addon/components/filter-builders/metric.js
@@ -74,10 +74,10 @@ class MetricFilterBuilderComponent extends BaseFilterBuilderComponent {
    */
   @computed('requestFragment.{field,parameters}')
   get displayName() {
-    const { columnMeta, parameters } = this.requestFragment;
+    const { columnMetadata, parameters } = this.requestFragment;
     return getOwner(this)
       .lookup('service:navi-formatter')
-      .formatMetric(columnMeta, parameters);
+      .formatMetric(columnMetadata, parameters);
   }
 
   /**

--- a/packages/reports/addon/components/filter-collection.js
+++ b/packages/reports/addon/components/filter-collection.js
@@ -54,7 +54,7 @@ export default Component.extend({
     let dimFilters = filters
       .filter(f => f.type === 'dimension' || (f.type === 'time-dimension' && f.field !== 'dateTime'))
       .map(filter => {
-        let dimensionDataType = filter.columnMeta?.valueType?.toLowerCase?.(),
+        let dimensionDataType = filter.columnMetadata?.valueType?.toLowerCase?.(),
           type = this._dimensionFilterBuilder(dimensionDataType);
 
         return {

--- a/packages/reports/addon/components/filter-values/dimension-select.js
+++ b/packages/reports/addon/components/filter-values/dimension-select.js
@@ -45,7 +45,7 @@ export default class DimensionSelectComponent extends Component {
   /**
    * @property {String} primaryKey - primary key for this dimension
    */
-  @readOnly('filter.subject.columnMeta.primaryKeyFieldName') primaryKey;
+  @readOnly('filter.subject.columnMetadata.primaryKeyFieldName') primaryKey;
 
   /**
    * @property {BardDimensionArray} dimensionOptions - list of all dimension values
@@ -60,7 +60,7 @@ export default class DimensionSelectComponent extends Component {
       dimensionService = get(this, '_dimensionService'),
       source = get(this, 'filter.subject.source');
 
-    if (dimensionName && this.filter.subject.columnMeta.cardinality === CARDINALITY_SIZES[0]) {
+    if (dimensionName && this.filter.subject.columnMetadata.cardinality === CARDINALITY_SIZES[0]) {
       return dimensionService.all(dimensionName, { dataSourceName: source });
     }
 
@@ -98,9 +98,9 @@ export default class DimensionSelectComponent extends Component {
   /**
    * @property {String} filterValueFieldId - which id field to use as ID display.
    */
-  @computed('filter.{subject.columnMeta.idFieldName,field}')
+  @computed('filter.{subject.columnMetadata.idFieldName,field}')
   get filterValueFieldId() {
-    return this.filter.subject.columnMeta.idFieldName || this.filter.field;
+    return this.filter.subject.columnMetadata.idFieldName || this.filter.field;
   }
 
   /**

--- a/packages/reports/addon/components/metric-selector.js
+++ b/packages/reports/addon/components/metric-selector.js
@@ -55,7 +55,7 @@ class MetricSelectorComponent extends Component {
   @computed('selectedMetrics')
   get metricsChecked() {
     return this.selectedMetrics.reduce((list, metric) => {
-      list[metric.columnMeta.id] = true;
+      list[metric.columnMetadata.id] = true;
       return list;
     }, {});
   }
@@ -67,7 +67,7 @@ class MetricSelectorComponent extends Component {
   @computed('request.metricFilters.[]')
   get metricsFiltered() {
     return this.request.metricFilters.reduce((list, metric) => {
-      list[metric.columnMeta.id] = true;
+      list[metric.columnMetadata.id] = true;
       return list;
     }, {});
   }

--- a/packages/reports/addon/consumers/request/column.js
+++ b/packages/reports/addon/consumers/request/column.js
@@ -104,7 +104,7 @@ export default ActionConsumer.extend({
       if (
         featureFlag('enableRequestPreview') &&
         route.currentModel.request.columns.find(
-          column => column.type === 'metric' && column.columnMeta === metricMetadataModel
+          column => column.type === 'metric' && column.columnMetadata === metricMetadataModel
         )
       ) {
         // When adding a metric filter with the requestPreview, users can add multiple of the same metric
@@ -140,8 +140,8 @@ export default ActionConsumer.extend({
        * iterating over `request.columns` causes problems
        */
       request.columns.toArray().forEach(column => {
-        if (![...metrics, ...dimensions].includes(column.columnMeta)) {
-          this.requestActionDispatcher.dispatch(RequestActions.REMOVE_COLUMN, route, column.columnMeta);
+        if (![...metrics, ...dimensions].includes(column.columnMetadata)) {
+          this.requestActionDispatcher.dispatch(RequestActions.REMOVE_COLUMN, route, column.columnMetadata);
         }
       });
     }

--- a/packages/reports/addon/consumers/request/filter.js
+++ b/packages/reports/addon/consumers/request/filter.js
@@ -56,7 +56,7 @@ export default ActionConsumer.extend({
      */
     [RequestActions.TOGGLE_DIMENSION_FILTER]: function(route, dimensionMetadataModel) {
       const filter = route.currentModel.request.filters.find(
-        filter => filter.type === 'dimension' && filter.columnMeta === dimensionMetadataModel
+        filter => filter.type === 'dimension' && filter.columnMetadata === dimensionMetadataModel
       );
 
       //do not add filter if it already exists
@@ -180,7 +180,7 @@ export default ActionConsumer.extend({
         currentModel: { request }
       } = route;
 
-      const filters = request.filters.filter(filter => filter.columnMeta === columnMetadataModel);
+      const filters = request.filters.filter(filter => filter.columnMetadata === columnMetadataModel);
       filters.forEach(filter => this.requestActionDispatcher.dispatch(RequestActions.REMOVE_FILTER, route, filter));
     },
 

--- a/packages/reports/addon/consumers/request/sort.js
+++ b/packages/reports/addon/consumers/request/sort.js
@@ -98,7 +98,7 @@ export default ActionConsumer.extend({
       this.requestActionDispatcher.dispatch(
         RequestActions.REMOVE_SORT_WITH_PARAMS,
         route,
-        columnFragment.columnMeta,
+        columnFragment.columnMetadata,
         columnFragment.parameters
       );
     },
@@ -113,7 +113,7 @@ export default ActionConsumer.extend({
       this.requestActionDispatcher.dispatch(
         RequestActions.REMOVE_SORT_BY_COLUMN_META,
         route,
-        columnFragment.columnMeta
+        columnFragment.columnMetadata
       );
     }
   }

--- a/packages/reports/addon/utils/request-metric.js
+++ b/packages/reports/addon/utils/request-metric.js
@@ -11,7 +11,9 @@ import { A as arr } from '@ember/array';
  * @returns {Array} - array of selected metrics of given meta type
  */
 export function getSelectedMetricsOfBase(metricMetadataModel, request) {
-  return request.columns.filter(column => column.type === 'metric' && column.columnMeta?.id === metricMetadataModel.id);
+  return request.columns.filter(
+    column => column.type === 'metric' && column.columnMetadata?.id === metricMetadataModel.id
+  );
 }
 
 /**
@@ -21,7 +23,9 @@ export function getSelectedMetricsOfBase(metricMetadataModel, request) {
  * @returns {Array} - array of filtered metrics of given meta type
  */
 export function getFilteredMetricsOfBase(metricMetadataModel, request) {
-  return request.filters.filter(filter => filter.type === 'metric' && filter.columnMeta?.id === metricMetadataModel.id);
+  return request.filters.filter(
+    filter => filter.type === 'metric' && filter.columnMetadata?.id === metricMetadataModel.id
+  );
 }
 
 /**

--- a/packages/reports/tests/unit/consumers/request/column-test.js
+++ b/packages/reports/tests/unit/consumers/request/column-test.js
@@ -153,7 +153,7 @@ module('Unit | Consumer | request column', function(hooks) {
 
     const currentModel = {
       request: {
-        columns: [{ type: 'metric', columnMeta: 'pageViews' }]
+        columns: [{ type: 'metric', columnMetadata: 'pageViews' }]
       }
     };
 
@@ -200,10 +200,10 @@ module('Unit | Consumer | request column', function(hooks) {
     const currentModel = {
       request: {
         columns: arr([
-          { columnMeta: 'age' },
-          { columnMeta: 'browser' },
-          { columnMeta: 'adClicks' },
-          { columnMeta: 'pageViews' }
+          { columnMetadata: 'age' },
+          { columnMetadata: 'browser' },
+          { columnMetadata: 'adClicks' },
+          { columnMetadata: 'pageViews' }
         ])
       }
     };

--- a/packages/reports/tests/unit/consumers/request/filter-test.js
+++ b/packages/reports/tests/unit/consumers/request/filter-test.js
@@ -28,7 +28,7 @@ module('Unit | Consumer | request filter', function(hooks) {
   test('TOGGLE_DIMENSION_FILTER', function(assert) {
     assert.expect(4);
 
-    const filter = { type: 'dimension', columnMeta: 'age' };
+    const filter = { type: 'dimension', columnMetadata: 'age' };
     const currentModel = {
       request: {
         filters: [filter]


### PR DESCRIPTION

## Description

Rename `columnMeta` to `columnMetadata`

## Proposed Changes

We often use the word `metadata` instead of `meta`. For instance `metadataService`. This PR renames `columnMeta` to `columnMetadata`.

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
