### PR TITLE
Update: Travis config for integration branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,8 @@ env:
 branches:
   only:
     - master
-    - /^request-v2.*$/
+    - request-v2
+    - apex-charts
 install:
   - if [[ "${PACKAGE}" == "navi-webservice" ]]; then
     pushd packages/webservice && ./gradlew assemble && popd;

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ env:
 branches:
   only:
     - master
+    - /^request-v2.*$/
 install:
   - if [[ "${PACKAGE}" == "navi-webservice" ]]; then
     pushd packages/webservice && ./gradlew assemble && popd;


### PR DESCRIPTION
## Description
Travis is only configured to build master

> To only build pull requests targeting specific branches you can use the branches: only: key, which will also restrict the branches that trigger builds.
[Travis How Pull Requests are Built](https://docs.travis-ci.com/user/pull-requests#how-pull-requests-are-built)

## Proposed Changes
- add request-v2 branches and hopefully pull requests against them

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
