### PR TITLE
Update: Rename time-dimension -> timeDimension

### DIFF
--- a/packages/core/addon/chart-builders/metric.js
+++ b/packages/core/addon/chart-builders/metric.js
@@ -52,8 +52,8 @@ export default EmberObject.extend({
     const buildDateKey = dateTime => moment(dateTime).format(DateUtils.API_DATE_FORMAT_STRING);
 
     const metrics = config.metrics;
-    const grain = request.columns.find(f => f.type === 'time-dimension' && f.field === 'dateTime').parameters.grain;
-    const interval = request.filters.find(f => f.type === 'time-dimension' && f.field === 'dateTime');
+    const grain = request.columns.find(f => f.type === 'timeDimension' && f.field === 'dateTime').parameters.grain;
+    const interval = request.filters.find(f => f.type === 'timeDimension' && f.field === 'dateTime');
     const requestInterval = Interval.parseFromStrings(interval.values[0], interval.values[1]);
 
     /*

--- a/packages/core/addon/components/navi-visualization-config/series-chart.js
+++ b/packages/core/addon/components/navi-visualization-config/series-chart.js
@@ -55,7 +55,7 @@ class NaviVisualizationConfigSeriesChartComponent extends Component {
   @computed('request')
   get dimensions() {
     return this.request.columns
-      .filter(c => c.type === 'dimension' || (c.type === 'time-dimension' && c.field !== 'dateTime'))
+      .filter(c => c.type === 'dimension' || (c.type === 'timeDimension' && c.field !== 'dateTime'))
       .map(c => c.columnMetadata);
   }
 

--- a/packages/core/addon/models/bard-request-v2/fragments/base.js
+++ b/packages/core/addon/models/bard-request-v2/fragments/base.js
@@ -17,11 +17,11 @@ const Validations = buildValidations({
     message: 'The `field` field cannot be empty'
   }),
   type: validator('inclusion', {
-    in: ['dimension', 'metric', 'time-dimension'],
+    in: ['dimension', 'metric', 'timeDimension'],
     allowBlank: true,
     message() {
       const { field } = this.model;
-      return 'The `type` field of `' + field + '` column must equal to `dimension`, `metric`, or `time-dimension`';
+      return 'The `type` field of `' + field + '` column must equal to `dimension`, `metric`, or `timeDimension`';
     }
   })
 });

--- a/packages/core/addon/models/bard-request-v2/request.js
+++ b/packages/core/addon/models/bard-request-v2/request.js
@@ -135,11 +135,11 @@ export default class Request extends Fragment.extend(Validations) {
   }
 
   /**
-   * @property {ColumnFragment[]} dimensionColumns - The dimension and time-dimension columns
+   * @property {ColumnFragment[]} dimensionColumns - The dimension and timeDimension columns
    */
   @computed('columns.[]')
   get dimensionColumns() {
-    return this.columns.filter(column => column.type === 'time-dimension' || column.type === 'dimension');
+    return this.columns.filter(column => column.type === 'timeDimension' || column.type === 'dimension');
   }
 
   /**
@@ -151,23 +151,23 @@ export default class Request extends Fragment.extend(Validations) {
   }
 
   /**
-   * @property {ColumnFragment[]} dimensionFilters - The dimension and time-dimension filters
+   * @property {ColumnFragment[]} dimensionFilters - The dimension and timeDimension filters
    */
   @computed('filters.[]')
   get dimensionFilters() {
-    return this.filters.filter(filter => filter.type === 'time-dimension' || filter.type === 'dimension');
+    return this.filters.filter(filter => filter.type === 'timeDimension' || filter.type === 'dimension');
   }
 
   /**
-   * @property {ColumnFragment} timeGrainColumn - The column containing the dateTime time-dimension
+   * @property {ColumnFragment} timeGrainColumn - The column containing the dateTime timeDimension
    */
   @computed('columns.[]')
   get timeGrainColumn() {
-    return this.columns.find(column => column.type === 'time-dimension' && column.field === 'dateTime');
+    return this.columns.find(column => column.type === 'timeDimension' && column.field === 'dateTime');
   }
 
   /**
-   * @property {string} timeGrain - The grain parameter of the column containing the dateTime time-dimension
+   * @property {string} timeGrain - The grain parameter of the column containing the dateTime timeDimension
    */
   @computed('timeGrainColumn')
   get timeGrain() {
@@ -179,7 +179,7 @@ export default class Request extends Fragment.extend(Validations) {
    */
   @computed('filters.[]')
   get dateTimeFilter() {
-    return this.filters.find(filter => filter.type === 'time-dimension' && filter.field === 'dateTime');
+    return this.filters.find(filter => filter.type === 'timeDimension' && filter.field === 'dateTime');
   }
 
   /**
@@ -262,7 +262,7 @@ export default class Request extends Fragment.extend(Validations) {
   }
 
   /**
-   * Makes the request have a dateTime time-dimension column with the given grain
+   * Makes the request have a dateTime timeDimension column with the given grain
    * @param {string} newTimeGrain - the new timegrain to use for the request
    */
   updateTimeGrain(newTimeGrain) {
@@ -270,7 +270,7 @@ export default class Request extends Fragment.extend(Validations) {
 
     if (!timeGrainColumn) {
       this.addColumn({
-        type: 'time-dimension',
+        type: 'timeDimension',
         dataSource: this.dataSource,
         field: 'dateTime',
         parameters: { grain: newTimeGrain }
@@ -331,7 +331,7 @@ export default class Request extends Fragment.extend(Validations) {
    */
   addDateTimeSort(direction) {
     this.sorts.unshiftObject(
-      this.fragmentFactory.createSort('time-dimension', this.dataSource, 'dateTime', {}, direction)
+      this.fragmentFactory.createSort('timeDimension', this.dataSource, 'dateTime', {}, direction)
     );
   }
 

--- a/packages/core/addon/models/table.js
+++ b/packages/core/addon/models/table.js
@@ -126,7 +126,7 @@ function hasAllColumns(request, columns) {
     .rejectBy('type', 'dateTime')
     .map(column => {
       const { attributes, type } = column;
-      if (type === 'dimension' || type === 'time-dimension') {
+      if (type === 'dimension' || type === 'timeDimension') {
         const attrs = Object.assign({}, attributes, { id: attributes.name });
         delete attrs.name;
         return canonicalizeDimension(attrs);

--- a/packages/core/addon/services/fragment-factory.ts
+++ b/packages/core/addon/services/fragment-factory.ts
@@ -10,7 +10,7 @@ import FilterFragment from '../models/bard-request-v2/fragments/filter';
 import SortFragment from '../models/bard-request-v2/fragments/sort';
 import { dasherize } from '@ember/string';
 
-type FieldType = 'metric' | 'dimension' | 'time-dimension';
+type FieldType = 'metric' | 'dimension' | 'timeDimension';
 
 export default class FragmentFactory extends Service {
   @service store!: Store;
@@ -29,7 +29,7 @@ export default class FragmentFactory extends Service {
 
   /**
    * Builds a request v2 column fragment and applies the appropriate meta data
-   * @param type - metric, dimension or time-dimension
+   * @param type - metric, dimension or timeDimension
    * @param dataSource - datasource or namespace for metadata lookups
    * @param field - field name, if dimension includes field `dimension.id`
    * @param parameters - parameters to attach to column, if none pass empty object `{}`
@@ -71,7 +71,7 @@ export default class FragmentFactory extends Service {
 
   /**
    * Builds a request v2 filter fragment and applies the appropriate meta data
-   * @param type - metric, dimension or time-dimension
+   * @param type - metric, dimension or timeDimension
    * @param dataSource - datasource or namespace for metadata lookups
    * @param field - field name, if dimension includes field `dimension.id`
    * @param parameters - parameters to attach to column, if none pass empty object `{}`
@@ -114,7 +114,7 @@ export default class FragmentFactory extends Service {
 
   /**
    * Builds a request v2 sort fragment and applies the appropriate meta data
-   * @param type - metric, dimension or time-dimension
+   * @param type - metric, dimension or timeDimension
    * @param dataSource - datasource or namespace for metadata lookups
    * @param field - field name, if dimension includes field `dimension.id`
    * @param parameters - parameters to attach to column, if none pass empty object `{}`

--- a/packages/core/addon/utils/chart-data.js
+++ b/packages/core/addon/utils/chart-data.js
@@ -102,7 +102,7 @@ export function getRequestMetrics(request) {
  */
 export function getRequestDimensions(request) {
   return request.columns
-    .filter(c => c.type === 'dimension' || (c.type === 'time-dimension' && c.field !== 'dateTime'))
+    .filter(c => c.type === 'dimension' || (c.type === 'timeDimension' && c.field !== 'dateTime'))
     .map(c => c.field);
 }
 

--- a/packages/core/addon/utils/request.ts
+++ b/packages/core/addon/utils/request.ts
@@ -192,7 +192,7 @@ export function normalizeV1toV2(request: RequestV1<string>, namespace?: string):
   requestV2.columns.push({
     field: 'dateTime',
     parameters: { grain },
-    type: 'time-dimension'
+    type: 'timeDimension'
   });
 
   //normalize dimensions
@@ -216,7 +216,7 @@ export function normalizeV1toV2(request: RequestV1<string>, namespace?: string):
   //normalize intervals
   normalized.intervals.forEach(({ start, end }) =>
     requestV2.filters.push({
-      type: 'time-dimension',
+      type: 'timeDimension',
       field: 'dateTime',
       operator: 'bet',
       values: [start, end],
@@ -252,7 +252,7 @@ export function normalizeV1toV2(request: RequestV1<string>, namespace?: string):
   normalized.sort.forEach(({ metric: { metric, parameters = {} }, direction }) => {
     const isDateTime = metric === 'dateTime' || metric.endsWith('.dateTime');
     requestV2.sorts.push({
-      type: isDateTime ? 'time-dimension' : 'metric',
+      type: isDateTime ? 'timeDimension' : 'metric',
       field: isDateTime ? 'dateTime' : removeNamespace(metric, namespace),
       parameters: isDateTime ? { grain } : parameters,
       direction

--- a/packages/core/tests/integration/components/navi-cell-renderers/time-dimension-test.ts
+++ b/packages/core/tests/integration/components/navi-cell-renderers/time-dimension-test.ts
@@ -38,7 +38,7 @@ module('Integration | Component | cell renderers/time-dimension', function(hooks
     this.set(
       'request',
       store.createFragment('bard-request-v2/request', {
-        columns: [factory.createColumn('time-dimension', 'dummy', 'dateTime', { grain: 'day' })],
+        columns: [factory.createColumn('timeDimension', 'dummy', 'dateTime', { grain: 'day' })],
         filters: [],
         sorts: [],
         requestVersion: '2.0',
@@ -48,7 +48,7 @@ module('Integration | Component | cell renderers/time-dimension', function(hooks
     );
 
     this.set('column', {
-      type: 'time-dimension',
+      type: 'time-dimension', // TODO: what type here
       displayName: 'Date',
       attributes: {
         name: 'dateTime',

--- a/packages/core/tests/unit/models/bard-request-v2/fragments/column-test.js
+++ b/packages/core/tests/unit/models/bard-request-v2/fragments/column-test.js
@@ -17,7 +17,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Column', function(hooks) {
           {
             field: 'dateTime',
             parameters: { grain: 'day' },
-            type: 'time-dimension',
+            type: 'timeDimension',
             alias: 'time',
             source: 'dummy'
           }
@@ -37,7 +37,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Column', function(hooks) {
 
     assert.deepEqual(column.parameters, { grain: 'day' }, 'the `parameters` property has the correct object');
 
-    assert.equal(column.type, 'time-dimension', 'the `type` property has the correct value');
+    assert.equal(column.type, 'timeDimension', 'the `type` property has the correct value');
 
     assert.equal(column.alias, 'time', 'the `alias` property has the correct value');
 
@@ -73,7 +73,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Column', function(hooks) {
     assert.notOk(column.validations.isValid, 'a column with an invalid `type` is invalid');
     assert.deepEqual(
       column.validations.messages,
-      ['The `type` field of `dateTime` column must equal to `dimension`, `metric`, or `time-dimension`'],
+      ['The `type` field of `dateTime` column must equal to `dimension`, `metric`, or `timeDimension`'],
       'error messages collection is correct for a column with an invalid `type`'
     );
 
@@ -99,7 +99,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Column', function(hooks) {
           parameters: {
             grain: 'day'
           },
-          type: 'time-dimension'
+          type: 'timeDimension'
         }
       ],
       'The columns model attribute was serialized correctly'
@@ -113,7 +113,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Column', function(hooks) {
         {
           alias: 'time',
           field: 'dateTime',
-          type: 'time-dimension'
+          type: 'timeDimension'
         }
       ],
       'The columns model attribute was serialized correctly when parameters is an empty object'
@@ -127,7 +127,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Column', function(hooks) {
         {
           alias: 'time',
           field: 'dateTime',
-          type: 'time-dimension'
+          type: 'timeDimension'
         }
       ],
       'The columns model attribute was serialized correctly when parameters is null'

--- a/packages/core/tests/unit/models/bard-request-v2/request-test.js
+++ b/packages/core/tests/unit/models/bard-request-v2/request-test.js
@@ -24,7 +24,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
                   {
                     field: 'dateTime',
                     operator: 'bet',
-                    type: 'time-dimension',
+                    type: 'timeDimension',
                     values: ['P1D', 'current']
                   },
                   {
@@ -38,7 +38,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
                   {
                     field: 'dateTime',
                     parameters: { grain: 'day' },
-                    type: 'time-dimension',
+                    type: 'timeDimension',
                     alias: 'time'
                   },
                   {
@@ -59,7 +59,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
                 sorts: [
                   {
                     field: 'dateTime',
-                    type: 'time-dimension',
+                    type: 'timeDimension',
                     direction: 'asc'
                   },
                   {
@@ -263,7 +263,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
       {
         field: 'dateTime',
         operator: 'bet',
-        type: 'time-dimension',
+        type: 'timeDimension',
         values: ['P1D', 'current']
       },
       {
@@ -290,7 +290,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
       {
         field: 'dateTime',
         parameters: { grain: 'day' },
-        type: 'time-dimension',
+        type: 'timeDimension',
         alias: 'time'
       },
       {
@@ -313,7 +313,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
     request.set('sorts', [
       {
         field: 'dateTime',
-        type: 'time-dimension',
+        type: 'timeDimension',
         direction: 'asc'
       },
       {
@@ -338,7 +338,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
         filters: [
           {
             field: 'dateTime',
-            type: 'time-dimension',
+            type: 'timeDimension',
             operator: 'bet',
             values: ['P1D', 'current']
           },
@@ -353,7 +353,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
           {
             field: 'dateTime',
             parameters: { grain: 'day' },
-            type: 'time-dimension',
+            type: 'timeDimension',
             alias: 'time'
           },
           {
@@ -375,7 +375,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
         sorts: [
           {
             field: 'dateTime',
-            type: 'time-dimension',
+            type: 'timeDimension',
             direction: 'asc'
           },
           {

--- a/packages/core/tests/unit/models/report-test.js
+++ b/packages/core/tests/unit/models/report-test.js
@@ -13,14 +13,14 @@ let Store, MetadataService;
 const ExpectedRequest = {
     table: 'network',
     columns: [
-      { type: 'time-dimension', field: 'dateTime', parameters: { grain: 'day' } },
+      { type: 'timeDimension', field: 'dateTime', parameters: { grain: 'day' } },
       { type: 'dimension', field: 'property', parameters: {} },
       { type: 'metric', field: 'adClicks', parameters: {} },
       { type: 'metric', field: 'navClicks', parameters: {} }
     ],
     filters: [
       {
-        type: 'time-dimension',
+        type: 'timeDimension',
         field: 'dateTime',
         parameters: { grain: 'day' },
         operator: 'bet',

--- a/packages/core/tests/unit/models/table-test.js
+++ b/packages/core/tests/unit/models/table-test.js
@@ -598,7 +598,7 @@ module('Unit | Model | Table Visualization Fragment', function(hooks) {
     return store.createFragment('bard-request-v2/request', {
       columns: [
         store.createFragment('bard-request-v2/fragments/column', {
-          type: 'time-dimension',
+          type: 'timeDimension',
           field: 'dateTime',
           parameters: {
             grain: timeGrain

--- a/packages/core/tests/unit/serializers/bard-request-v2/request-test.js
+++ b/packages/core/tests/unit/serializers/bard-request-v2/request-test.js
@@ -112,7 +112,7 @@ module('Unit | Serializer | Request V2', function(hooks) {
     assert.equal(columns.length, 6, 'request has correct number of columns');
 
     assert.equal(columns.objectAt(0).columnMetadata.id, 'dateTime', 'dateTime column is normalized correctly');
-    assert.equal(columns.objectAt(0).type, 'time-dimension', 'dateTime column type is set correctly');
+    assert.equal(columns.objectAt(0).type, 'timeDimension', 'dateTime column type is set correctly');
     assert.deepEqual(columns.objectAt(0).parameters, { grain: 'day' }, 'dateTime column has correct parameters');
 
     assert.equal(columns.objectAt(1).columnMetadata.id, 'age', 'dimension columns are normalized correctly');
@@ -124,7 +124,7 @@ module('Unit | Serializer | Request V2', function(hooks) {
     assert.equal(filters.length, 5, 'request has correct number of filter fragments');
 
     assert.equal(filters.objectAt(0).columnMetadata.id, 'dateTime', 'dateTime filter is normalized correctly');
-    assert.equal(filters.objectAt(0).type, 'time-dimension', 'dateTime filter type is set correctly');
+    assert.equal(filters.objectAt(0).type, 'timeDimension', 'dateTime filter type is set correctly');
     assert.equal(filters.objectAt(0).operator, 'bet', 'dateTime filter operator is set correctly');
     assert.deepEqual(filters.objectAt(0).values, ['P7D', 'current'], 'dateTime filter values are set correctly');
 

--- a/packages/core/tests/unit/utils/request-test.js
+++ b/packages/core/tests/unit/utils/request-test.js
@@ -404,7 +404,7 @@ module('Unit | Utils | Request', function(hooks) {
           parameters: {
             grain: 'day'
           },
-          type: 'time-dimension'
+          type: 'timeDimension'
         },
         {
           field: 'age',
@@ -445,7 +445,7 @@ module('Unit | Utils | Request', function(hooks) {
         {
           field: 'dateTime',
           operator: 'bet',
-          type: 'time-dimension',
+          type: 'timeDimension',
           values: ['P7D', 'current'],
           parameters: {}
         },
@@ -502,7 +502,7 @@ module('Unit | Utils | Request', function(hooks) {
         {
           direction: 'desc',
           field: 'dateTime',
-          type: 'time-dimension',
+          type: 'timeDimension',
           parameters: {}
         },
         {
@@ -537,7 +537,7 @@ module('Unit | Utils | Request', function(hooks) {
           parameters: {
             grain: 'day'
           },
-          type: 'time-dimension'
+          type: 'timeDimension'
         },
         {
           field: 'age',
@@ -578,7 +578,7 @@ module('Unit | Utils | Request', function(hooks) {
         {
           field: 'dateTime',
           operator: 'bet',
-          type: 'time-dimension',
+          type: 'timeDimension',
           values: ['P7D', 'current'],
           parameters: {}
         },
@@ -635,7 +635,7 @@ module('Unit | Utils | Request', function(hooks) {
         {
           direction: 'desc',
           field: 'dateTime',
-          type: 'time-dimension',
+          type: 'timeDimension',
           parameters: {}
         },
         {

--- a/packages/data/tests/unit/services/navi-facts-test.js
+++ b/packages/data/tests/unit/services/navi-facts-test.js
@@ -9,7 +9,7 @@ const TestRequest = {
   table: 'table1',
   requestVersion: '2.0',
   columns: [
-    { type: 'time-dimension', field: 'dateTime', parameters: { grain: 'grain1' } },
+    { type: 'timeDimension', field: 'dateTime', parameters: { grain: 'grain1' } },
     { type: 'metric', field: 'm1', parameters: {} },
     { type: 'metric', field: 'm2', parameters: {} },
     { type: 'dimension', field: 'd1', parameters: {} },
@@ -17,7 +17,7 @@ const TestRequest = {
   ],
   filters: [
     {
-      type: 'time-dimension',
+      type: 'timeDimension',
       field: 'dateTime',
       parameters: {
         grain: 'grain1'

--- a/packages/reports/addon/components/filter-collection.js
+++ b/packages/reports/addon/components/filter-collection.js
@@ -44,7 +44,7 @@ export default Component.extend({
   orderedFilters: computed('request.filters.[]', function() {
     const { filters } = this.request;
     const dateFilters = filters
-      .filter(f => f.type === 'time-dimension' && f.field === 'dateTime')
+      .filter(f => f.type === 'timeDimension' && f.field === 'dateTime')
       .map(filter => ({
         type: 'date-time', // Dasherized to match filter-builder component name
         requestFragment: filter,
@@ -52,7 +52,7 @@ export default Component.extend({
       }));
 
     let dimFilters = filters
-      .filter(f => f.type === 'dimension' || (f.type === 'time-dimension' && f.field !== 'dateTime'))
+      .filter(f => f.type === 'dimension' || (f.type === 'timeDimension' && f.field !== 'dateTime'))
       .map(filter => {
         let dimensionDataType = filter.columnMetadata?.valueType?.toLowerCase?.(),
           type = this._dimensionFilterBuilder(dimensionDataType);


### PR DESCRIPTION
## Description
Fix usage of `time-dimension` under request v2. Right now we only expect it to be used when looking up/fetching metadata

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
