### PR TITLE
Update: Add field parameter to dimensions

### DIFF
--- a/packages/core/addon/utils/request.ts
+++ b/packages/core/addon/utils/request.ts
@@ -200,7 +200,9 @@ export function normalizeV1toV2(request: RequestV1<string>, namespace?: string):
     requestV2.columns.push({
       type: 'dimension',
       field: removeNamespace(dimension, namespace),
-      parameters: {}
+      parameters: {
+        field: 'id'
+      }
     })
   );
 
@@ -231,7 +233,7 @@ export function normalizeV1toV2(request: RequestV1<string>, namespace?: string):
     requestV2.filters.push({
       type: 'dimension',
       field: removeNamespace(dimension, namespace),
-      parameters: { projection: field },
+      parameters: { field },
       operator,
       values
     })

--- a/packages/core/tests/unit/models/bard-request-v2/fragments/column-test.js
+++ b/packages/core/tests/unit/models/bard-request-v2/fragments/column-test.js
@@ -5,7 +5,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 let mockModel;
 
-module('Unit | Model | Fragment | BardRequest V2 - Column', function(hooks) {
+module('Unit | Model | Fragment | BardRequest - Column', function(hooks) {
   setupTest(hooks);
   setupMirage(hooks);
 
@@ -88,7 +88,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Column', function(hooks) {
   });
 
   test('Serialization', async function(assert) {
-    assert.expect(3);
+    assert.expect(2);
 
     assert.deepEqual(
       mockModel.serialize().data.attributes.columns,
@@ -113,24 +113,11 @@ module('Unit | Model | Fragment | BardRequest V2 - Column', function(hooks) {
         {
           alias: 'time',
           field: 'dateTime',
+          parameters: {},
           type: 'timeDimension'
         }
       ],
       'The columns model attribute was serialized correctly when parameters is an empty object'
-    );
-
-    mockModel.columns.objectAt(0).set('parameters', null);
-
-    assert.deepEqual(
-      mockModel.serialize().data.attributes.columns,
-      [
-        {
-          alias: 'time',
-          field: 'dateTime',
-          type: 'timeDimension'
-        }
-      ],
-      'The columns model attribute was serialized correctly when parameters is null'
     );
   });
 });

--- a/packages/core/tests/unit/models/bard-request-v2/fragments/filter-test.js
+++ b/packages/core/tests/unit/models/bard-request-v2/fragments/filter-test.js
@@ -5,7 +5,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 let mockModel;
 
-module('Unit | Model | Fragment | BardRequest V2 - Filter', function(hooks) {
+module('Unit | Model | Fragment | BardRequest - Filter', function(hooks) {
   setupTest(hooks);
   setupMirage(hooks);
 
@@ -94,7 +94,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Filter', function(hooks) {
   });
 
   test('Serialization', async function(assert) {
-    assert.expect(3);
+    assert.expect(2);
 
     assert.deepEqual(
       mockModel.serialize().data.attributes.filters,
@@ -119,27 +119,13 @@ module('Unit | Model | Fragment | BardRequest V2 - Filter', function(hooks) {
       [
         {
           field: 'revenue',
+          parameters: {},
           operator: 'gt',
           type: 'metric',
           values: [3]
         }
       ],
       'The filters model attribute was serialized correctly when parameters is an empty object'
-    );
-
-    mockModel.filters.objectAt(0).set('parameters', null);
-
-    assert.deepEqual(
-      mockModel.serialize().data.attributes.filters,
-      [
-        {
-          field: 'revenue',
-          operator: 'gt',
-          type: 'metric',
-          values: [3]
-        }
-      ],
-      'The filters model attribute was serialized correctly when parameters is null'
     );
   });
 });

--- a/packages/core/tests/unit/models/bard-request-v2/fragments/sort-test.js
+++ b/packages/core/tests/unit/models/bard-request-v2/fragments/sort-test.js
@@ -5,7 +5,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 let mockModel;
 
-module('Unit | Model | Fragment | BardRequest V2 - Sort', function(hooks) {
+module('Unit | Model | Fragment | BardRequest - Sort', function(hooks) {
   setupTest(hooks);
   setupMirage(hooks);
 
@@ -13,7 +13,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Sort', function(hooks) {
     await this.owner.lookup('service:bard-metadata').loadMetadata();
     mockModel = run(() =>
       this.owner.lookup('service:store').createRecord('fragments-v2-mock', {
-        sort: [
+        sorts: [
           {
             field: 'revenue',
             type: 'metric',
@@ -30,7 +30,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Sort', function(hooks) {
 
     assert.ok(mockModel, 'mockModel is fetched from the store');
 
-    const sort = mockModel.sort.objectAt(0);
+    const sort = mockModel.sorts.objectAt(0);
 
     assert.equal(sort.field, 'revenue', 'the `field` property has the correct value');
 
@@ -53,7 +53,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Sort', function(hooks) {
   test('Validation', async function(assert) {
     assert.expect(8);
 
-    const sort = mockModel.sort.objectAt(0);
+    const sort = mockModel.sorts.objectAt(0);
 
     assert.ok(sort.validations.isValid, 'sort is valid');
     assert.equal(sort.validations.messages.length, 0, 'there are no validation errors for a valid sort');
@@ -85,10 +85,10 @@ module('Unit | Model | Fragment | BardRequest V2 - Sort', function(hooks) {
   });
 
   test('Serialization', async function(assert) {
-    assert.expect(3);
+    assert.expect(2);
 
     assert.deepEqual(
-      mockModel.serialize().data.attributes.sort,
+      mockModel.serialize().data.attributes.sorts,
       [
         {
           field: 'revenue',
@@ -102,32 +102,19 @@ module('Unit | Model | Fragment | BardRequest V2 - Sort', function(hooks) {
       'The sort model attribute was serialized correctly'
     );
 
-    mockModel.sort.objectAt(0).set('parameters', {});
+    mockModel.sorts.objectAt(0).set('parameters', {});
 
     assert.deepEqual(
-      mockModel.serialize().data.attributes.sort,
+      mockModel.serialize().data.attributes.sorts,
       [
         {
           field: 'revenue',
           type: 'metric',
+          parameters: {},
           direction: 'desc'
         }
       ],
       'The sort model attribute was serialized correctly when parameters is an empty object'
-    );
-
-    mockModel.sort.objectAt(0).set('parameters', null);
-
-    assert.deepEqual(
-      mockModel.serialize().data.attributes.sort,
-      [
-        {
-          field: 'revenue',
-          type: 'metric',
-          direction: 'desc'
-        }
-      ],
-      'The sort model attribute was serialized correctly when parameters is null'
     );
   });
 });

--- a/packages/core/tests/unit/models/bard-request-v2/request-test.js
+++ b/packages/core/tests/unit/models/bard-request-v2/request-test.js
@@ -5,7 +5,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 let mockModel;
 
-module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
+module('Unit | Model | Fragment | BardRequest  - Request', function(hooks) {
   setupTest(hooks);
   setupMirage(hooks);
 
@@ -43,7 +43,7 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
                   },
                   {
                     field: 'property',
-                    parameters: { projection: 'id' },
+                    parameters: { field: 'id' },
                     type: 'dimension'
                   },
                   {
@@ -339,12 +339,14 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
           {
             field: 'dateTime',
             type: 'timeDimension',
+            parameters: {},
             operator: 'bet',
             values: ['P1D', 'current']
           },
           {
             field: 'uniqueIdentifier',
             type: 'metric',
+            parameters: {},
             operator: 'gt',
             values: [3]
           }
@@ -358,29 +360,34 @@ module('Unit | Model | Fragment | BardRequest V2 - Request', function(hooks) {
           },
           {
             field: 'property',
-            parameters: { projection: 'id' },
-            type: 'dimension'
+            parameters: { field: 'id' },
+            type: 'dimension',
+            alias: null
           },
           {
             field: 'revenue',
             parameters: { currency: 'USD' },
-            type: 'metric'
+            type: 'metric',
+            alias: null
           },
           {
             field: 'navClicks',
             parameters: {},
-            type: 'metric'
+            type: 'metric',
+            alias: null
           }
         ],
         sorts: [
           {
             field: 'dateTime',
             type: 'timeDimension',
+            parameters: {},
             direction: 'asc'
           },
           {
             field: 'navClicks',
             type: 'metric',
+            parameters: {},
             direction: 'desc'
           }
         ],

--- a/packages/core/tests/unit/models/table-test.js
+++ b/packages/core/tests/unit/models/table-test.js
@@ -618,7 +618,7 @@ module('Unit | Model | Table Visualization Fragment', function(hooks) {
               type: 'dimension',
               field: dimension,
               parameters: {
-                projection: field
+                field
               }
             });
           });

--- a/packages/core/tests/unit/serializers/bard-request-v2/request-test.js
+++ b/packages/core/tests/unit/serializers/bard-request-v2/request-test.js
@@ -4,7 +4,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 let Store;
 
-module('Unit | Serializer | Request V2', function(hooks) {
+module('Unit | Serializer | Request', function(hooks) {
   setupTest(hooks);
   setupMirage(hooks);
 
@@ -116,7 +116,7 @@ module('Unit | Serializer | Request V2', function(hooks) {
     assert.deepEqual(columns.objectAt(0).parameters, { grain: 'day' }, 'dateTime column has correct parameters');
 
     assert.equal(columns.objectAt(1).columnMetadata.id, 'age', 'dimension columns are normalized correctly');
-    assert.deepEqual(columns.objectAt(1).parameters, {}, 'dimension columns have no parameters');
+    assert.deepEqual(columns.objectAt(1).parameters, { field: 'id' }, 'dimension columns have a field parameter');
 
     assert.equal(columns.objectAt(3).columnMetadata.id, 'revenue', 'metric columns are normalized correctly');
     assert.deepEqual(columns.objectAt(3).parameters, { currency: 'USD' }, 'metric columns have correct parameters');
@@ -129,18 +129,14 @@ module('Unit | Serializer | Request V2', function(hooks) {
     assert.deepEqual(filters.objectAt(0).values, ['P7D', 'current'], 'dateTime filter values are set correctly');
 
     assert.equal(filters.objectAt(1).columnMetadata.id, 'age', 'dimension filters are normalized correctly');
-    assert.deepEqual(
-      filters.objectAt(1).parameters,
-      { projection: 'id' },
-      'dimension filter has correct `id` projection param'
-    );
+    assert.deepEqual(filters.objectAt(1).parameters, { field: 'id' }, 'dimension filter has correct `id` field param');
     assert.equal(filters.objectAt(1).operator, 'in', 'dimension filter operator are normalized correctly');
     assert.deepEqual(filters.objectAt(1).values, ['2'], 'dimension filter values are normalized correctly');
 
     assert.deepEqual(
       filters.objectAt(2).parameters,
-      { projection: 'desc' },
-      'dimension filter has correct `desc` projection param'
+      { field: 'desc' },
+      'dimension filter has correct `desc` field param'
     );
 
     assert.equal(filters.objectAt(3).columnMetadata.id, 'revenue', 'metric filters are normalized correctly');

--- a/packages/core/tests/unit/utils/request-test.js
+++ b/packages/core/tests/unit/utils/request-test.js
@@ -409,12 +409,16 @@ module('Unit | Utils | Request', function(hooks) {
         {
           field: 'age',
           type: 'dimension',
-          parameters: {}
+          parameters: {
+            field: 'id'
+          }
         },
         {
           field: 'platform',
           type: 'dimension',
-          parameters: {}
+          parameters: {
+            field: 'id'
+          }
         },
         {
           field: 'revenue',
@@ -447,13 +451,15 @@ module('Unit | Utils | Request', function(hooks) {
           operator: 'bet',
           type: 'timeDimension',
           values: ['P7D', 'current'],
-          parameters: {}
+          parameters: {
+            grain: 'day'
+          }
         },
         {
           field: 'age',
           operator: 'in',
           parameters: {
-            projection: 'id'
+            field: 'id'
           },
           type: 'dimension',
           values: ['2']
@@ -462,7 +468,7 @@ module('Unit | Utils | Request', function(hooks) {
           field: 'platform',
           operator: 'contains',
           parameters: {
-            projection: 'desc'
+            field: 'desc'
           },
           type: 'dimension',
           values: ['win']
@@ -503,7 +509,9 @@ module('Unit | Utils | Request', function(hooks) {
           direction: 'desc',
           field: 'dateTime',
           type: 'timeDimension',
-          parameters: {}
+          parameters: {
+            grain: 'day'
+          }
         },
         {
           direction: 'asc',
@@ -542,12 +550,12 @@ module('Unit | Utils | Request', function(hooks) {
         {
           field: 'age',
           type: 'dimension',
-          parameters: {}
+          parameters: { field: 'id' }
         },
         {
           field: 'platform',
           type: 'dimension',
-          parameters: {}
+          parameters: { field: 'id' }
         },
         {
           field: 'revenue',
@@ -580,13 +588,15 @@ module('Unit | Utils | Request', function(hooks) {
           operator: 'bet',
           type: 'timeDimension',
           values: ['P7D', 'current'],
-          parameters: {}
+          parameters: {
+            grain: 'day'
+          }
         },
         {
           field: 'age',
           operator: 'in',
           parameters: {
-            projection: 'id'
+            field: 'id'
           },
           type: 'dimension',
           values: ['2']
@@ -595,7 +605,7 @@ module('Unit | Utils | Request', function(hooks) {
           field: 'platform',
           operator: 'contains',
           parameters: {
-            projection: 'desc'
+            field: 'desc'
           },
           type: 'dimension',
           values: ['win']
@@ -636,7 +646,9 @@ module('Unit | Utils | Request', function(hooks) {
           direction: 'desc',
           field: 'dateTime',
           type: 'timeDimension',
-          parameters: {}
+          parameters: {
+            grain: 'day'
+          }
         },
         {
           direction: 'asc',

--- a/packages/data/addon/adapters/bard-facts.ts
+++ b/packages/data/addon/adapters/bard-facts.ts
@@ -5,7 +5,7 @@
  * Description: The adapter for the bard-facts request v2 model.
  */
 
-import { assert } from '@ember/debug';
+import { assert, warn } from '@ember/debug';
 import { inject as service } from '@ember/service';
 import { A as array } from '@ember/array';
 import { assign } from '@ember/polyfills';
@@ -20,6 +20,7 @@ import NaviFactAdapter, {
   SORT_DIRECTIONS,
   AsyncQueryResponse
 } from './fact-interface';
+import { omit } from 'lodash-es';
 
 export type Query = RequestOptions & Dict<string | number | boolean>;
 export type AliasFn = (column: string) => string;
@@ -32,13 +33,17 @@ export type AliasFn = (column: string) => string;
  * @returns formatted dimension name
  */
 function formatDimensionFieldName(field: string, parameters: Parameters, includeFieldProj = true): string {
-  const [fieldName, displayField = 'id'] = field.split('.'); // default dimension field projection to "id"
-  let parameterString = serializeParameters(parameters);
+  assert(`the dimension ${field} specifies a field parameter`, parameters.field);
+  if (field.includes('.')) {
+    warn(`field '${field}' includes '.', which is likely an error, use the parameters instead`);
+  }
+  const restParams = omit(parameters, 'field');
+  let parameterString = serializeParameters(restParams);
 
   if (parameterString.length > 0) {
     parameterString = `(${parameterString})`;
   }
-  return `${fieldName}${parameterString}${includeFieldProj ? '|' + displayField : ''}`;
+  return `${field}${parameterString}${includeFieldProj ? `|${parameters.field}` : ''}`;
 }
 
 /**

--- a/packages/data/addon/adapters/fact-interface.ts
+++ b/packages/data/addon/adapters/fact-interface.ts
@@ -57,7 +57,7 @@ export type RequestV2 = {
   table: string;
   dataSource: string;
   sorts: Sort[];
-  limit?: TODO<string>;
+  limit: TODO<string> | null;
   requestVersion: '2.0';
 };
 

--- a/packages/data/tests/unit/adapters/bard-facts-test.js
+++ b/packages/data/tests/unit/adapters/bard-facts-test.js
@@ -21,21 +21,21 @@ const TestRequest = {
       },
       {
         field: 'd3',
-        parameters: {},
+        parameters: { field: 'id' },
         type: 'dimension',
         operator: 'in',
         values: ['v1', 'v2']
       },
       {
         field: 'd4',
-        parameters: {},
+        parameters: { field: 'id' },
         type: 'dimension',
         operator: 'in',
         values: ['v3', 'v4']
       },
       {
         field: 'd5',
-        parameters: {},
+        parameters: { field: 'id' },
         type: 'dimension',
         operator: 'notnull',
         values: ['']
@@ -73,12 +73,12 @@ const TestRequest = {
       },
       {
         field: 'd1',
-        parameters: {},
+        parameters: { field: 'id' },
         type: 'dimension'
       },
       {
         field: 'd2',
-        parameters: {},
+        parameters: { field: 'desc' },
         type: 'dimension'
       }
     ],
@@ -101,7 +101,7 @@ let Adapter,
   Server,
   aliasFunction = alias => (alias === 'a' ? 'r(p=123)' : alias);
 
-module('Unit | Bard Facts V2 Adapter', function(hooks) {
+module('Unit | Bard Facts Adapter', function(hooks) {
   setupTest(hooks);
 
   hooks.beforeEach(function() {
@@ -133,7 +133,7 @@ module('Unit | Bard Facts V2 Adapter', function(hooks) {
     assert.expect(4);
 
     let singleDim = {
-      columns: [{ field: 'd1', type: 'dimension', parameters: {} }]
+      columns: [{ field: 'd1', type: 'dimension', parameters: { field: 'id' } }]
     };
     assert.equal(
       Adapter._buildDimensionsPath(singleDim),
@@ -143,8 +143,8 @@ module('Unit | Bard Facts V2 Adapter', function(hooks) {
 
     let manyDims = {
       columns: [
-        { field: 'd1', type: 'dimension', parameters: {} },
-        { field: 'd2', type: 'dimension', parameters: {} }
+        { field: 'd1', type: 'dimension', parameters: { field: 'id' } },
+        { field: 'd2', type: 'dimension', parameters: { field: 'id' } }
       ]
     };
     assert.equal(
@@ -155,9 +155,9 @@ module('Unit | Bard Facts V2 Adapter', function(hooks) {
 
     let duplicateDims = {
       columns: [
-        { field: 'd1', type: 'dimension', parameters: {} },
-        { field: 'd2', type: 'dimension', parameters: {} },
-        { field: 'd1', type: 'dimension', parameters: {} }
+        { field: 'd1', type: 'dimension', parameters: { field: 'id' } },
+        { field: 'd2', type: 'dimension', parameters: { field: 'id' } },
+        { field: 'd1', type: 'dimension', parameters: { field: 'id' } }
       ]
     };
     assert.equal(
@@ -303,7 +303,7 @@ module('Unit | Bard Facts V2 Adapter', function(hooks) {
     assert.expect(7);
 
     let singleFilter = {
-      filters: [{ field: 'd1.desc', parameters: {}, type: 'dimension', operator: 'in', values: ['v1', 'v2'] }]
+      filters: [{ field: 'd1', parameters: { field: 'desc' }, type: 'dimension', operator: 'in', values: ['v1', 'v2'] }]
     };
     assert.equal(
       Adapter._buildFiltersParam(singleFilter),
@@ -313,8 +313,8 @@ module('Unit | Bard Facts V2 Adapter', function(hooks) {
 
     let manyFilters = {
       filters: [
-        { field: 'd1.desc', parameters: {}, type: 'dimension', operator: 'in', values: ['v1', 'v2'] },
-        { field: 'd2.id', parameters: {}, type: 'dimension', operator: 'notin', values: ['v3', 'v4'] }
+        { field: 'd1', parameters: { field: 'desc' }, type: 'dimension', operator: 'in', values: ['v1', 'v2'] },
+        { field: 'd2', parameters: { field: 'id' }, type: 'dimension', operator: 'notin', values: ['v3', 'v4'] }
       ]
     };
     assert.equal(
@@ -339,7 +339,13 @@ module('Unit | Bard Facts V2 Adapter', function(hooks) {
 
     let commaFilters = {
       filters: [
-        { field: 'd3.id', parameters: {}, type: 'dimension', operator: 'in', values: ['with, comma', 'no comma'] }
+        {
+          field: 'd3',
+          parameters: { field: 'id' },
+          type: 'dimension',
+          operator: 'in',
+          values: ['with, comma', 'no comma']
+        }
       ]
     };
     assert.equal(
@@ -349,7 +355,15 @@ module('Unit | Bard Facts V2 Adapter', function(hooks) {
     );
 
     let noIdFilters = {
-      filters: [{ field: 'd3', parameters: {}, type: 'dimension', operator: 'in', values: ['with, comma', 'no comma'] }]
+      filters: [
+        {
+          field: 'd3',
+          parameters: { field: 'id' },
+          type: 'dimension',
+          operator: 'in',
+          values: ['with, comma', 'no comma']
+        }
+      ]
     };
     assert.equal(
       Adapter._buildFiltersParam(noIdFilters),
@@ -359,7 +373,13 @@ module('Unit | Bard Facts V2 Adapter', function(hooks) {
 
     let quoteFilters = {
       filters: [
-        { field: 'd3.id', parameters: {}, type: 'dimension', operator: 'in', values: ['with "quote"', 'but why'] }
+        {
+          field: 'd3',
+          parameters: { field: 'id' },
+          type: 'dimension',
+          operator: 'in',
+          values: ['with "quote"', 'but why']
+        }
       ]
     };
     assert.equal(
@@ -522,7 +542,9 @@ module('Unit | Bard Facts V2 Adapter', function(hooks) {
       '_buildHavingParam returns undefined with empty having'
     );
 
-    let onlyDimFilters = { filters: [{ field: 'foo', type: 'dimension', operator: 'gt', values: [0] }] };
+    let onlyDimFilters = {
+      filters: [{ field: 'foo', type: 'dimension', parameters: { field: 'id' }, operator: 'gt', values: [0] }]
+    };
     assert.equal(
       Adapter._buildHavingParam(onlyDimFilters),
       undefined,

--- a/packages/data/tests/unit/services/navi-facts-test.js
+++ b/packages/data/tests/unit/services/navi-facts-test.js
@@ -12,8 +12,8 @@ const TestRequest = {
     { type: 'timeDimension', field: 'dateTime', parameters: { grain: 'grain1' } },
     { type: 'metric', field: 'm1', parameters: {} },
     { type: 'metric', field: 'm2', parameters: {} },
-    { type: 'dimension', field: 'd1', parameters: {} },
-    { type: 'dimension', field: 'd2', parameters: {} }
+    { type: 'dimension', field: 'd1', parameters: { field: 'id' } },
+    { type: 'dimension', field: 'd2', parameters: { field: 'id' } }
   ],
   filters: [
     {
@@ -28,14 +28,14 @@ const TestRequest = {
     {
       type: 'dimension',
       field: 'd3',
-      parameters: {},
+      parameters: { field: 'id' },
       operator: 'in',
       values: ['v1', 'v2']
     },
     {
       type: 'dimension',
       field: 'd4',
-      parameters: {},
+      parameters: { field: 'id' },
       operator: 'in',
       values: ['v3', 'v4']
     },

--- a/packages/reports/addon/components/filter-builders/dimension.js
+++ b/packages/reports/addon/components/filter-builders/dimension.js
@@ -92,7 +92,7 @@ class DimensionFilterBuilderComponent extends BaseFilterBuilderComponent {
       operator,
       values: dimensionFragment.values,
       validations: dimensionFragment.validations,
-      field: dimensionFragment.parameters.projection
+      field: dimensionFragment.parameters.field
     };
   }
 
@@ -116,13 +116,11 @@ class DimensionFilterBuilderComponent extends BaseFilterBuilderComponent {
    */
   @action
   setField(field) {
-    const changeSet = {
-      paramaters: {
-        ...this.requestFragment.paramaters,
-        projection: field
-      }
+    const parameters = {
+      ...this.requestFragment.parameters,
+      field
     };
-    this.onUpdateFilter(changeSet);
+    this.onUpdateFilter({ parameters });
   }
 }
 

--- a/packages/reports/addon/consumers/request/filter.js
+++ b/packages/reports/addon/consumers/request/filter.js
@@ -94,7 +94,7 @@ export default ActionConsumer.extend({
         type: 'dimension',
         dataSource: dimensionMetadataModel.source,
         field: dimensionMetadataModel.id,
-        parameters: { projection: dimensionMetadataModel.primaryKeyFieldName },
+        parameters: { field: dimensionMetadataModel.primaryKeyFieldName },
         operator: defaultOperator,
         values: []
       });

--- a/packages/reports/tests/unit/consumers/request/filter-test.js
+++ b/packages/reports/tests/unit/consumers/request/filter-test.js
@@ -78,7 +78,7 @@ module('Unit | Consumer | request filter', function(hooks) {
               dataSource: 'dummy',
               field: 'age',
               parameters: {
-                projection: 'id'
+                field: 'id'
               },
               operator: 'in',
               values: []


### PR DESCRIPTION
## Description
Navi makes a lot of assumptions regarding `id` and `desc` fields for dimensions

## Proposed Changes
- Every dimension now uses a `field` parameter defaulted to `'id'` we'll allow users to configure them later


## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
