### PR TITLE
GraphQL Mock Query Argument Handling

### DIFF
--- a/packages/data/addon/adapters/elide-facts.ts
+++ b/packages/data/addon/adapters/elide-facts.ts
@@ -28,7 +28,7 @@ interface RequestDimension {
 const OPERATOR_MAP: Dict<string> = {
   eq: '==',
   neq: '!=',
-  notin: 'out'
+  notin: '=out='
 };
 
 export default class ElideFacts extends EmberObject implements NaviFactAdapter {

--- a/packages/data/addon/gql/schema.js
+++ b/packages/data/addon/gql/schema.js
@@ -194,6 +194,7 @@ const schema = gql`
   }
 
   enum TimeGrain {
+    HOUR
     DAY
     WEEK
     MONTH

--- a/packages/data/addon/mirage/factories/time-dimension-grain.js
+++ b/packages/data/addon/mirage/factories/time-dimension-grain.js
@@ -8,7 +8,7 @@ export default Factory.extend({
   index: i => i,
 
   id() {
-    return `timeDimension${this.index}`;
+    return `timeDimensionGrain${this.index}`;
   },
 
   expression: null,

--- a/packages/data/addon/mirage/factories/time-dimension-grain.js
+++ b/packages/data/addon/mirage/factories/time-dimension-grain.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2020, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+import { Factory } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  index: i => i,
+
+  id() {
+    return `timeDimension${this.index}`;
+  },
+
+  expression: null,
+
+  grain: 'DAY'
+});

--- a/packages/data/addon/mirage/factories/time-dimension.js
+++ b/packages/data/addon/mirage/factories/time-dimension.js
@@ -29,8 +29,6 @@ export default Factory.extend({
 
   expression: null,
 
-  supportedGrains: () => [],
-
   timeZone() {
     return { short: 'UTC', long: 'Universal Time Coordinated' };
   }

--- a/packages/data/addon/mirage/handlers/graphql.js
+++ b/packages/data/addon/mirage/handlers/graphql.js
@@ -224,7 +224,6 @@ function _getDates(filters, requestedColumns) {
 }
 
 /**
- * @param {String} name
  * @param {Object} filter
  * @returns n random dimension values
  */

--- a/packages/data/addon/mirage/handlers/graphql.js
+++ b/packages/data/addon/mirage/handlers/graphql.js
@@ -7,9 +7,65 @@ import schema from 'navi-data/gql/schema';
 import gql from 'graphql-tag';
 import faker from 'faker';
 import moment from 'moment';
+import { capitalize } from '@ember/string';
+import { orderBy } from 'lodash-es';
 
-const API_DATE_FORMAT = 'YYYY-MM-DD';
 const ASYNC_RESPONSE_DELAY = 5000; // ms before async api response result is populated
+const DATE_FORMATS = {
+  hour: 'YYYY-MM-DD HH:MM:SS',
+  day: 'YYYY-MM-DD',
+  week: 'YYYY-MM-DD',
+  month: 'YYYY MMM',
+  quarter: 'YYYY [Q]Q',
+  year: 'YYYY'
+};
+const GRAINS = Object.keys(DATE_FORMATS);
+const TIME_DIMENSION_REGEX = new RegExp(
+  `(.+)(${Object.keys(DATE_FORMATS)
+    .map(grain => capitalize(grain))
+    .join('|')})`
+);
+const OPERATORS = {
+  eq: '==',
+  neq: '!=',
+  isIn: '=in=',
+  notIn: '=out=',
+  isNull: '=isnull=true',
+  notNull: '=isnull=false',
+  isEmpty: '=isempty=true',
+  lt: '=lt=',
+  gt: '=gt=',
+  le: '=le=',
+  ge: '=ge='
+};
+const FILTER_OPS = {
+  [OPERATORS.lt]: ([filterVal], vals) => vals.filter(val => val < filterVal),
+  [OPERATORS.gt]: ([filterVal], vals) => vals.filter(val => val > filterVal),
+  [OPERATORS.le]: ([filterVal], vals) => vals.filter(val => val <= filterVal),
+  [OPERATORS.ge]: ([filterVal], vals) => vals.filter(val => val >= filterVal),
+  [OPERATORS.isIn]: (filterVals, vals) => vals.filter(val => filterVals.includes(val)),
+  [OPERATORS.notIn]: (filterVals, vals) => vals.filter(val => !filterVals.includes(val)),
+  [OPERATORS.isNull]: (_, vals) => vals.filter(val => !val),
+  [OPERATORS.notNull]: (_, vals) => vals.filter(Boolean),
+  [OPERATORS.isEmpty]: () => [],
+  [OPERATORS.eq]: ([filterVal], vals) => vals.filter(val => val === filterVal),
+  [OPERATORS.neq]: ([filterVal], vals) => vals.filter(val => val !== filterVal)
+};
+const FILTER_REGEX = new RegExp(`(.*?)(?:\\((.+?)\\))?(${Object.values(OPERATORS).join('|')})\\((.+?)\\)`);
+
+//create an inclusive interval of dates based on filter values and operator
+const DATE_FILTER_OPS = {
+  [OPERATORS.lt]: ([val], grain) => [null, moment(val).subtract(1, grain)],
+  [OPERATORS.gt]: ([val], grain) => [moment(val).add(1, grain), null],
+  [OPERATORS.le]: ([val]) => [null, moment(val)],
+  [OPERATORS.ge]: ([val]) => [moment(val), null],
+  [OPERATORS.isIn]: () => [null, null], //TODO: Not sure if the following operators are really supported for dates
+  [OPERATORS.isNull]: () => [null, null],
+  [OPERATORS.notNull]: () => [null, null],
+  [OPERATORS.isEmpty]: () => [null, null],
+  [OPERATORS.eq]: () => [null, null],
+  [OPERATORS.neq]: () => [null, null]
+};
 
 function _getSeedForRequest(table, args, fields) {
   const tableLength = table.length;
@@ -18,33 +74,126 @@ function _getSeedForRequest(table, args, fields) {
   return tableLength + argsLength + fieldsLength;
 }
 
-/**
- * @param {string} filter
- * @returns 3 sequential days in format YYYY-MM-DD ending on today
- */
-function _getDates(/* filter */) {
-  // TODO: Generate dates based on filters on time dimensions and the chosen grain
-  let day = moment();
-  let days = [];
-  for (let i = 0; i < 3; i++) {
-    days.push(moment(day).format(API_DATE_FORMAT));
-    day = moment(day).subtract(1, 'days');
-  }
+function _createInterval(filters) {
+  const intervals = filters.map(f => DATE_FILTER_OPS[f.operator](f.values, f.grain));
+  const lowerBound = moment.max(intervals.map(interval => interval[0]).filter(Boolean));
+  const upperBound = moment.min(intervals.map(interval => interval[1]).filter(Boolean));
 
-  return days;
+  return [lowerBound, upperBound];
+}
+
+function _intervalsForFilters(filters) {
+  // Group filters by their field without grain and assign grain and filterWithoutGrain properties
+  const filtersWithGrain = filters.reduce((byField, filter) => {
+    const [, fieldWithoutGrain, grain] = TIME_DIMENSION_REGEX.exec(filter.field);
+    const filterObject = {
+      ...filter,
+      fieldWithoutGrain,
+      grain
+    };
+    byField[fieldWithoutGrain] = [...(byField[fieldWithoutGrain] || []), filterObject];
+    return byField;
+  }, {});
+
+  return Object.keys(filtersWithGrain).reduce((acc, curr) => {
+    acc[curr] = _createInterval(filtersWithGrain[curr]);
+    return acc;
+  }, {});
+}
+
+function _datesForInterval(interval, grain) {
+  const dates = [];
+  const start = moment(interval[0]).startOf(grain);
+  const end = moment(interval[1]).startOf(grain);
+  for (let i = start; i.isSameOrBefore(end); i.add(1, grain)) {
+    dates.push(moment(i));
+  }
+  return dates;
 }
 
 /**
- * @param {Number} n
+ * @param {Object[]} filters - filters from the request
+ * @param {Object[]} requestedColumns - time dimension columns from mirage db in the columns of the request
+ * @returns rows with values for each requested time dimension
+ */
+function _getDates(filters, requestedColumns) {
+  // Columns with buckets keyed by their field without grain where buckets are sorted by grain in ascending order
+  const columns = requestedColumns.reduce((acc, col) => {
+    const [, fieldWithoutGrain, grain] = TIME_DIMENSION_REGEX.exec(col.id);
+
+    const column = {
+      ...col,
+      fieldWithoutGrain,
+      grain
+    };
+
+    // Insert column into field bucket in order
+    if (!acc[fieldWithoutGrain]) {
+      acc[fieldWithoutGrain] = [column];
+    } else {
+      let index = acc[fieldWithoutGrain].length;
+      acc[fieldWithoutGrain].find((existing, i) => {
+        if (GRAINS.indexOf(existing.grain) > GRAINS.indexOf(column.grain)) {
+          index = i;
+          return true;
+        }
+        return false;
+      });
+      acc[fieldWithoutGrain].splice(index, 0, column);
+    }
+    return acc;
+  }, {});
+
+  // Time Dimensions will cover the same interval regardless of grain
+  // Calculate the interval for all grains of each time dimension
+  const intervals = _intervalsForFilters(filters);
+
+  let rows = [];
+  for (let field in columns) {
+    const columnsForField = columns[field];
+    // List of moment objects for an interval with the lowest requested grain passed in
+    const datesForField = _datesForInterval(intervals[field], columnsForField[0].grain);
+
+    // For each date for a field, add each date under the field's column names as keys with the date formatted depending on the grain
+    if (!rows.length) {
+      rows = datesForField.map(date =>
+        columnsForField.reduce((row, column) => {
+          row[column.id] = date.format(DATE_FORMATS[column.grain.toLowerCase()]);
+          return row;
+        }, {})
+      );
+    } else {
+      rows = rows.reduce((newRows, currentRow) => {
+        return [
+          ...newRows,
+          ...datesForField.map(date => ({
+            ...currentRow,
+            ...columnsForField.reduce((row, column) => {
+              row[column.id] = date.format(DATE_FORMATS[column.grain.toLowerCase()]);
+              return row;
+            }, {})
+          }))
+        ];
+      }, []);
+    }
+  }
+  return rows;
+}
+
+/**
+ * @param {String} name
+ * @param {Object} filter
  * @returns n random dimension values
  */
-function _dimensionValues(n) {
+function _dimensionValues(filter = {}) {
+  const { operator, values } = filter;
   const vals = [];
-  for (let i = 0; i < n; i++) {
+  const valCount = faker.random.number({ min: 3, max: 5 });
+  for (let i = 0; i < valCount; i++) {
     vals.push(faker.commerce.productName());
   }
 
-  return vals;
+  return operator && values ? FILTER_OPS[operator](values, vals) : vals;
 }
 
 /**
@@ -52,8 +201,9 @@ function _dimensionValues(n) {
  * @returns {Object}
  */
 function _parseGQLQuery(queryStr) {
+  const noEscapesQuery = queryStr.replace(/\\/g, '');
   const queryAST = gql`
-    ${queryStr}
+    ${noEscapesQuery}
   `;
 
   // Parse requested table, columns, and filters from graphql query
@@ -70,6 +220,47 @@ function _parseGQLQuery(queryStr) {
   };
 }
 
+function _parseArgs(args) {
+  const parsers = {
+    filter: filter =>
+      filter
+        .split(';')
+        .filter(Boolean)
+        .map(f => {
+          const [, field, parameters, operator, values] = f.match(FILTER_REGEX);
+          return {
+            field,
+            parameters: parameters && Object.fromEntries(parameters.split(',').map(p => p.split(': '))),
+            operator,
+            values: values.split(','),
+            canonicalName: `${field}${parameters ? `(${parameters})` : ''}`
+          };
+        }),
+    sort: sort =>
+      sort
+        .split(',')
+        .filter(Boolean)
+        .map(s => {
+          let field = s;
+          let direction = 'asc';
+          if (s.startsWith('-')) {
+            direction = 'desc';
+            field = field.substring(1);
+          }
+          return { field, direction };
+        }),
+    first: limit => limit
+  };
+
+  const parsed = {};
+
+  for (let param in args) {
+    parsed[param] = parsers[param](args[param]);
+  }
+
+  return parsed;
+}
+
 function _getResponseBody(db, parent) {
   // Create mocked response for an async query
   const { createdOn, query } = parent;
@@ -79,8 +270,8 @@ function _getResponseBody(db, parent) {
   if (responseTime - createdOn >= ASYNC_RESPONSE_DELAY) {
     parent.status = 'COMPLETE';
 
-    // TODO: get args from _parseGQLQuery result and handle filtering
     const { table, args, fields } = _parseGQLQuery(JSON.parse(query).query || '');
+    const { filter = [], sort = [], first } = _parseArgs(args);
     const seed = _getSeedForRequest(table, args, fields);
     faker.seed(seed);
 
@@ -97,17 +288,22 @@ function _getResponseBody(db, parent) {
         { metrics: [], dimensions: [], timeDimensions: [] }
       );
 
-      const dates = columns.timeDimensions.length > 0 ? _getDates(args.filter) : [];
-
       // Convert each date into a row of data
       // If no time dimension is sent, just return a single row
-      let rows = dates.length ? dates.map(dateTime => ({ dateTime })) : [{}];
+      let rows =
+        columns.timeDimensions.length > 0
+          ? _getDates(
+              filter.filter(fil => columns.timeDimensions.includes(fil.field)),
+              db.timeDimensions.find(columns.timeDimensions)
+            )
+          : [{}];
 
       // Add each dimension
       columns.dimensions.forEach(dimension => {
-        rows = rows.reduce((newRows, currentRow) => {
-          const dimensionValues = _dimensionValues(faker.random.number({ min: 3, max: 5 }));
+        const filterForDim = filter.find(f => f.field === dimension); // TODO: Handle parameterized dimensions
+        const dimensionValues = _dimensionValues(filterForDim);
 
+        rows = rows.reduce((newRows, currentRow) => {
           return [
             ...newRows,
             ...dimensionValues.map(value => ({
@@ -128,6 +324,20 @@ function _getResponseBody(db, parent) {
           currRow
         )
       );
+
+      // handle limit in request
+      if (first < rows.length) {
+        rows = rows.slice(0, first);
+      }
+
+      // sort rows
+      if (sort.length) {
+        rows = orderBy(
+          rows,
+          sort.map(r => r.field),
+          sort.map(r => r.direction)
+        );
+      }
 
       return JSON.stringify({
         data: {
@@ -169,7 +379,7 @@ const OPTIONS = {
         return Array.isArray(ids) ? records.filter(record => ids.includes(record.id)) : records;
       },
       op(records) {
-        return records;
+        return records; // op is not intended to be an actual filter in elide, but ember-cli-mirage-graphql treats it like one
       }
     }
   },

--- a/packages/data/addon/mirage/handlers/graphql.js
+++ b/packages/data/addon/mirage/handlers/graphql.js
@@ -10,11 +10,11 @@ import moment from 'moment';
 import { capitalize } from '@ember/string';
 import { orderBy } from 'lodash-es';
 
-const ASYNC_RESPONSE_DELAY = 5000; // ms before async api response result is populated
+const ASYNC_RESPONSE_DELAY = 2000; // ms before async api response result is populated
 const DATE_FORMATS = {
   hour: 'YYYY-MM-DD HH:MM:SS',
   day: 'YYYY-MM-DD',
-  week: 'YYYY-MM-DD',
+  isoweek: 'YYYY-MM-DD',
   month: 'YYYY MMM',
   quarter: 'YYYY [Q]Q',
   year: 'YYYY'
@@ -110,7 +110,7 @@ function _intervalsForFilters(filters) {
     const filterObject = {
       ...filter,
       fieldWithoutGrain,
-      grain
+      grain: grain === 'Week' ? 'Isoweek' : grain
     };
     byField[fieldWithoutGrain] = [...(byField[fieldWithoutGrain] || []), filterObject];
     return byField;
@@ -167,7 +167,7 @@ function _getDates(filters, requestedColumns) {
     const column = {
       ...col,
       fieldWithoutGrain,
-      grain
+      grain: grain === 'Week' ? 'Isoweek' : grain
     };
 
     // Insert column into field bucket in order
@@ -378,7 +378,7 @@ function _getResponseBody(db, parent) {
       );
 
       // handle limit in request
-      if (first < rows.length) {
+      if (first && first < rows.length) {
         rows = rows.slice(0, first);
       }
 

--- a/packages/data/addon/serializers/elide-facts.ts
+++ b/packages/data/addon/serializers/elide-facts.ts
@@ -7,11 +7,11 @@
 
 import EmberObject from '@ember/object';
 import NaviFactSerializer, { ResponseV1 } from './fact-interface';
-import { AsyncQueryResponse, RequestV1 } from 'navi-data/adapters/fact-interface';
+import { AsyncQueryResponse, RequestV1, RequestV2 } from 'navi-data/adapters/fact-interface';
 
 export default class ElideFactsSerializer extends EmberObject implements NaviFactSerializer {
-  normalize(payload: AsyncQueryResponse, request: RequestV1): ResponseV1 | undefined {
-    const requestTable: string = request.logicalTable.table;
+  normalize(payload: AsyncQueryResponse, request: RequestV1 | RequestV2): ResponseV1 | undefined {
+    const requestTable: string = request.logicalTable?.table || request.table; // Get table depending on request version
     const responseStr = payload?.asyncQuery.edges[0].node.result?.responseBody;
     if (responseStr) {
       const response = JSON.parse(responseStr);

--- a/packages/data/tests/dummy/mirage/factories/time-dimension-grain.js
+++ b/packages/data/tests/dummy/mirage/factories/time-dimension-grain.js
@@ -1,0 +1,1 @@
+export { default } from 'navi-data/mirage/factories/time-dimension-grain';

--- a/packages/data/tests/dummy/mirage/scenarios/graphql-blockhead.ts
+++ b/packages/data/tests/dummy/mirage/scenarios/graphql-blockhead.ts
@@ -1,4 +1,9 @@
 // TODO: Replace any with type supplied by new version of mirage
+import { grains } from './graphql';
+import { capitalize } from '@ember/string';
+
+const timeDimIds = ['eventTime'];
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default function(server: any) {
   const [table0, table1] = server.createList('table', 2);
@@ -6,6 +11,15 @@ export default function(server: any) {
   server.createList('metric', 1, { table: table1 });
   server.createList('dimension', 2, { table: table0 });
   server.createList('dimension', 3, { table: table1 });
-  server.createList('time-dimension', 1, { table: table0 });
-  server.createList('time-dimension', 1, { table: table1 });
+  grains.forEach(grain => {
+    timeDimIds.forEach(timeDimId => {
+      const idWithGrain = `${timeDimId}${capitalize(grain)}`;
+      let newGrain = server.create('time-dimension-grain', {
+        id: `${idWithGrain}.${grain}`,
+        expression: null,
+        grain: grain.toUpperCase()
+      });
+      server.create('time-dimension', { id: idWithGrain, table: table1, supportedGrains: [newGrain] });
+    });
+  });
 }

--- a/packages/data/tests/dummy/mirage/scenarios/graphql.ts
+++ b/packages/data/tests/dummy/mirage/scenarios/graphql.ts
@@ -1,7 +1,7 @@
 // TODO: Replace any with type supplied by new version of mirage
 import { capitalize } from '@ember/string';
 
-const grains = ['hour', 'day', 'week', 'month', 'quarter', 'year'];
+export const grains = ['hour', 'day', 'week', 'month', 'quarter', 'year'];
 const timeDimIds = ['eventTime', 'orderTime'];
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default function(server: any) {

--- a/packages/data/tests/dummy/mirage/scenarios/graphql.ts
+++ b/packages/data/tests/dummy/mirage/scenarios/graphql.ts
@@ -1,9 +1,23 @@
 // TODO: Replace any with type supplied by new version of mirage
+import { capitalize } from '@ember/string';
+
+const grains = ['hour', 'day', 'week', 'month', 'quarter', 'year'];
+const timeDimIds = ['eventTime', 'orderTime'];
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default function(server: any) {
   const [table0, table1] = server.createList('table', 2);
   server.createList('metric', 3, { table: table0 });
   server.createList('metric', 2, { table: table1 });
   server.createList('dimension', 3, { table: table0 });
-  server.create('time-dimension', { table: table1 });
+  grains.forEach(grain => {
+    timeDimIds.forEach(timeDimId => {
+      const idWithGrain = `${timeDimId}${capitalize(grain)}`;
+      let newGrain = server.create('time-dimension-grain', {
+        id: `${idWithGrain}.${grain}`,
+        expression: null,
+        grain: grain.toUpperCase()
+      });
+      server.create('time-dimension', { id: idWithGrain, table: table1, supportedGrains: [newGrain] });
+    });
+  });
 }

--- a/packages/data/tests/unit/services/elide-metadata-test.ts
+++ b/packages/data/tests/unit/services/elide-metadata-test.ts
@@ -56,7 +56,20 @@ module('Unit | Service | elide-metadata', function(hooks) {
 
     assert.deepEqual(
       keg.all('metadata/time-dimension').mapBy('id'),
-      ['timeDimension0'],
+      [
+        'eventTimeHour',
+        'orderTimeHour',
+        'eventTimeDay',
+        'orderTimeDay',
+        'eventTimeWeek',
+        'orderTimeWeek',
+        'eventTimeMonth',
+        'orderTimeMonth',
+        'eventTimeQuarter',
+        'orderTimeQuarter',
+        'eventTimeYear',
+        'orderTimeYear'
+      ],
       'All time-dimensions are loaded in the keg'
     );
 
@@ -123,9 +136,24 @@ module('Unit | Service | elide-metadata', function(hooks) {
     assert.deepEqual(
       keg.all('metadata/time-dimension').map((t: TimeDimensionMetadata) => ({ id: t.id, source: t.source })),
       [
-        { id: 'timeDimension0', source: 'dummy' },
-        { id: 'timeDimension1', source: 'blockhead' },
-        { id: 'timeDimension2', source: 'blockhead' }
+        { id: 'eventTimeHour', source: 'dummy' },
+        { id: 'orderTimeHour', source: 'dummy' },
+        { id: 'eventTimeDay', source: 'dummy' },
+        { id: 'orderTimeDay', source: 'dummy' },
+        { id: 'eventTimeWeek', source: 'dummy' },
+        { id: 'orderTimeWeek', source: 'dummy' },
+        { id: 'eventTimeMonth', source: 'dummy' },
+        { id: 'orderTimeMonth', source: 'dummy' },
+        { id: 'eventTimeQuarter', source: 'dummy' },
+        { id: 'orderTimeQuarter', source: 'dummy' },
+        { id: 'eventTimeYear', source: 'dummy' },
+        { id: 'orderTimeYear', source: 'dummy' },
+        { id: 'eventTimeHour', source: 'blockhead' },
+        { id: 'eventTimeDay', source: 'blockhead' },
+        { id: 'eventTimeWeek', source: 'blockhead' },
+        { id: 'eventTimeMonth', source: 'blockhead' },
+        { id: 'eventTimeQuarter', source: 'blockhead' },
+        { id: 'eventTimeYear', source: 'blockhead' }
       ],
       'All time-dimensions are loaded in the keg'
     );
@@ -230,7 +258,26 @@ module('Unit | Service | elide-metadata', function(hooks) {
     );
     assert.deepEqual(
       allTimeDimensions.mapBy('id'),
-      ['timeDimension0', 'timeDimension1', 'timeDimension2'],
+      [
+        'eventTimeHour',
+        'orderTimeHour',
+        'eventTimeDay',
+        'orderTimeDay',
+        'eventTimeWeek',
+        'orderTimeWeek',
+        'eventTimeMonth',
+        'orderTimeMonth',
+        'eventTimeQuarter',
+        'orderTimeQuarter',
+        'eventTimeYear',
+        'orderTimeYear',
+        'eventTimeHour',
+        'eventTimeDay',
+        'eventTimeWeek',
+        'eventTimeMonth',
+        'eventTimeQuarter',
+        'eventTimeYear'
+      ],
       'all method returns all loaded time-dimensions for every source'
     );
 

--- a/packages/data/tests/unit/services/navi-facts-elide-test.js
+++ b/packages/data/tests/unit/services/navi-facts-elide-test.js
@@ -413,6 +413,7 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
         ],
         filters,
         sorts: [],
+        limit: null,
         requestVersion: '2.0',
         dataSource: 'dummy-gql'
       },
@@ -434,6 +435,7 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
         columns: [{ field: 'metric1', parameters: {}, type: 'metric' }],
         filters,
         sorts: [],
+        limit: null,
         requestVersion: '2.0',
         dataSource: 'dummy-gql'
       },
@@ -469,6 +471,7 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
           }
         ],
         sorts: [],
+        limit: null,
         requestVersion: '2.0',
         dataSource: 'dummy-gql'
       },
@@ -504,6 +507,7 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
           }
         ],
         sorts: [],
+        limit: null,
         requestVersion: '2.0',
         dataSource: 'dummy-gql'
       },
@@ -540,6 +544,7 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
           }
         ],
         sorts: [],
+        limit: null,
         requestVersion: '2.0',
         dataSource: 'dummy-gql'
       },
@@ -567,6 +572,194 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
         meta: {}
       },
       'A date filter with no end date ends at current if start is not more than a month before current'
+    );
+  });
+
+  test('fetch RequestV2 - sorts', async function(assert) {
+    assert.expect(2);
+
+    const response = await this.service.fetch(
+      {
+        table: 'table1',
+        columns: [
+          { field: 'metric1', parameters: {}, type: 'metric' },
+          { field: 'eventTimeDay', parameters: {}, type: 'timeDimension' }
+        ],
+        filters: [
+          {
+            field: 'eventTimeDay',
+            operator: 'ge',
+            values: ['2015-01-01'],
+            parameters: {},
+            type: 'timeDimension'
+          },
+          {
+            field: 'eventTimeDay',
+            operator: 'lt',
+            values: ['2015-01-04'],
+            parameters: {},
+            type: 'timeDimension'
+          }
+        ],
+        sorts: [{ field: 'metric1', parameters: {}, type: 'metric', direction: 'asc' }],
+        limit: null,
+        requestVersion: '2.0',
+        dataSource: 'dummy-gql'
+      },
+      { dataSourceName: 'dummy-gql' }
+    );
+
+    assert.deepEqual(
+      response.response,
+      {
+        rows: [
+          { eventTimeDay: '2015-01-02', metric1: '139.22' },
+          { eventTimeDay: '2015-01-03', metric1: '464.10' },
+          { eventTimeDay: '2015-01-01', metric1: '944.50' }
+        ],
+        meta: {}
+      },
+      'Response is sorted as specified by the request'
+    );
+
+    const multiSortResponse = await this.service.fetch(
+      {
+        table: 'table1',
+        columns: [
+          { field: 'dimension1', parameters: {}, type: 'dimension' },
+          { field: 'dimension2', parameters: {}, type: 'dimension' },
+          { field: 'metric1', parameters: {}, type: 'metric' }
+        ],
+        filters: [],
+        sorts: [
+          { field: 'dimension1', parameters: {}, type: 'metric', direction: 'asc' },
+          { field: 'dimension2', parameters: {}, type: 'metric', direction: 'asc' }
+        ],
+        limit: null,
+        requestVersion: '2.0',
+        dataSource: 'dummy-gql'
+      },
+      { dataSourceName: 'dummy-gql' }
+    );
+
+    assert.deepEqual(
+      multiSortResponse.response,
+      {
+        rows: [
+          { dimension1: 'Licensed Cotton Computer', dimension2: 'Gorgeous Frozen Sausages', metric1: '990.67' },
+          { dimension1: 'Licensed Cotton Computer', dimension2: 'Licensed Granite Sausages', metric1: '825.82' },
+          { dimension1: 'Licensed Cotton Computer', dimension2: 'Sleek Metal Tuna', metric1: '414.83' },
+          { dimension1: 'Refined Rubber Soap', dimension2: 'Gorgeous Frozen Sausages', metric1: '946.26' },
+          { dimension1: 'Refined Rubber Soap', dimension2: 'Licensed Granite Sausages', metric1: '247.63' },
+          { dimension1: 'Refined Rubber Soap', dimension2: 'Sleek Metal Tuna', metric1: '335.55' },
+          { dimension1: 'Sleek Cotton Shoes', dimension2: 'Gorgeous Frozen Sausages', metric1: '344.62' },
+          { dimension1: 'Sleek Cotton Shoes', dimension2: 'Licensed Granite Sausages', metric1: '252.27' },
+          { dimension1: 'Sleek Cotton Shoes', dimension2: 'Sleek Metal Tuna', metric1: '628.05' },
+          { dimension1: 'Small Soft Bacon', dimension2: 'Gorgeous Frozen Sausages', metric1: '919.59' },
+          { dimension1: 'Small Soft Bacon', dimension2: 'Licensed Granite Sausages', metric1: '469.79' },
+          { dimension1: 'Small Soft Bacon', dimension2: 'Sleek Metal Tuna', metric1: '233.23' }
+        ],
+        meta: {}
+      },
+      'Multiple sorts are handled properly in order'
+    );
+  });
+
+  test('fetch RequestV2 - limit', async function(assert) {
+    assert.expect(2);
+
+    const response = await this.service.fetch(
+      {
+        table: 'table1',
+        columns: [
+          { field: 'metric1', parameters: {}, type: 'metric' },
+          { field: 'eventTimeDay', parameters: {}, type: 'timeDimension' }
+        ],
+        filters: [
+          {
+            field: 'eventTimeDay',
+            operator: 'ge',
+            values: ['2015-01-01'],
+            parameters: {},
+            type: 'timeDimension'
+          },
+          {
+            field: 'eventTimeDay',
+            operator: 'lt',
+            values: ['2015-01-10'],
+            parameters: {},
+            type: 'timeDimension'
+          }
+        ],
+        sorts: [],
+        limit: 3,
+        requestVersion: '2.0',
+        dataSource: 'dummy-gql'
+      },
+      { dataSourceName: 'dummy-gql' }
+    );
+
+    assert.deepEqual(
+      response.response,
+      {
+        rows: [
+          { eventTimeDay: '2015-01-01', metric1: '384.77' },
+          { eventTimeDay: '2015-01-02', metric1: '897.01' },
+          { eventTimeDay: '2015-01-03', metric1: '859.71' }
+        ],
+        meta: {}
+      },
+      'Limit in the request determines the max number of rows returned'
+    );
+
+    const limitless = await this.service.fetch(
+      {
+        table: 'table1',
+        columns: [
+          { field: 'metric1', parameters: {}, type: 'metric' },
+          { field: 'eventTimeDay', parameters: {}, type: 'timeDimension' }
+        ],
+        filters: [
+          {
+            field: 'eventTimeDay',
+            operator: 'ge',
+            values: ['2015-01-01'],
+            parameters: {},
+            type: 'timeDimension'
+          },
+          {
+            field: 'eventTimeDay',
+            operator: 'lt',
+            values: ['2015-01-10'],
+            parameters: {},
+            type: 'timeDimension'
+          }
+        ],
+        sorts: [],
+        limit: null,
+        requestVersion: '2.0',
+        dataSource: 'dummy-gql'
+      },
+      { dataSourceName: 'dummy-gql' }
+    );
+
+    assert.deepEqual(
+      limitless.response,
+      {
+        rows: [
+          { eventTimeDay: '2015-01-01', metric1: '858.89' },
+          { eventTimeDay: '2015-01-02', metric1: '59.65' },
+          { eventTimeDay: '2015-01-03', metric1: '372.71' },
+          { eventTimeDay: '2015-01-04', metric1: '421.04' },
+          { eventTimeDay: '2015-01-05', metric1: '555.13' },
+          { eventTimeDay: '2015-01-06', metric1: '330.39' },
+          { eventTimeDay: '2015-01-07', metric1: '955.66' },
+          { eventTimeDay: '2015-01-08', metric1: '754.00' },
+          { eventTimeDay: '2015-01-09', metric1: '736.67' }
+        ],
+        meta: {}
+      },
+      'A null limit in the request results in no row limit'
     );
   });
 

--- a/packages/data/tests/unit/services/navi-facts-elide-test.js
+++ b/packages/data/tests/unit/services/navi-facts-elide-test.js
@@ -33,6 +33,67 @@ const TestRequest = {
   ]
 };
 
+const TestRequestV2 = {
+  table: 'table1',
+  columns: [
+    { field: 'eventTimeDay', parameters: {}, type: 'timeDimension' },
+    { field: 'eventTimeMonth', parameters: {}, type: 'timeDimension' },
+    { field: 'orderTimeDay', parameters: {}, type: 'timeDimension' },
+    { field: 'metric1', parameters: {}, type: 'metric' },
+    { field: 'metric2', parameters: {}, type: 'metric' },
+    { field: 'dimension1', parameters: {}, type: 'dimension' },
+    { field: 'dimension2', parameters: {}, type: 'dimension' }
+  ],
+  filters: [
+    { field: 'dimension1', operator: 'eq', values: ['Small Metal Hat'], parameters: {}, type: 'dimension' },
+    {
+      field: 'dimension2',
+      operator: 'notin',
+      values: ['Gorgeous Frozen Table', 'Refined Soft Sausages'],
+      parameters: {},
+      type: 'dimension'
+    },
+    { field: 'dimension3', operator: 'in', values: ['v1', 'v2'], parameters: {}, type: 'dimension' },
+    { field: 'dimension4', operator: 'in', values: ['v3', 'v4'], parameters: {}, type: 'dimension' },
+    { field: 'metric1', operator: 'gt', values: ['0'], parameters: {}, type: 'metric' },
+    {
+      field: 'eventTimeDay',
+      operator: 'ge',
+      values: ['2015-01-29'],
+      parameters: {},
+      type: 'timeDimension'
+    },
+    {
+      field: 'eventTimeDay',
+      operator: 'lt',
+      values: ['2015-02-04'],
+      parameters: {},
+      type: 'timeDimension'
+    },
+    {
+      field: 'orderTimeDay',
+      operator: 'ge',
+      values: ['2014-01-05'],
+      parameters: {},
+      type: 'timeDimension'
+    },
+    {
+      field: 'orderTimeDay',
+      operator: 'lt',
+      values: ['2014-01-07'],
+      parameters: {},
+      type: 'timeDimension'
+    }
+  ],
+  sorts: [
+    { field: 'eventTimeDay', parameters: {}, type: 'timeDimension', direction: 'asc' },
+    { field: 'dimension2', parameters: {}, type: 'dimension', direction: 'desc' }
+  ],
+  limit: 15,
+  requestVersion: '2.0',
+  dataSource: 'dummy-gql'
+};
+
 module('Unit | Service | Navi Facts - Elide', function(hooks) {
   setupTest(hooks);
   setupMirage(hooks);
@@ -49,67 +110,262 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
     assert.deepEqual(
       response.response,
       {
-        meta: {},
         rows: [
           {
             dimension1: 'Sleek Rubber Computer',
+            dimension2: 'Ergonomic Metal Car',
+            metric1: '56.88',
+            metric2: '954.75'
+          },
+          {
+            dimension1: 'Sleek Rubber Computer',
+            dimension2: 'Awesome Rubber Chair',
+            metric1: '866.65',
+            metric2: '555.78'
+          },
+          {
+            dimension1: 'Sleek Rubber Computer',
+            dimension2: 'Generic Soft Ball',
+            metric1: '221.03',
+            metric2: '649.72'
+          },
+          {
+            dimension1: 'Sleek Rubber Computer',
+            dimension2: 'Fantastic Wooden Bacon',
+            metric1: '404.99',
+            metric2: '580.88'
+          },
+          {
+            dimension1: 'Sleek Rubber Computer',
+            dimension2: 'Small Concrete Shoes',
+            metric1: '316.09',
+            metric2: '168.88'
+          },
+          { dimension1: 'Rustic Wooden Bike', dimension2: 'Ergonomic Metal Car', metric1: '76.66', metric2: '415.87' },
+          {
+            dimension1: 'Rustic Wooden Bike',
+            dimension2: 'Awesome Rubber Chair',
+            metric1: '843.23',
+            metric2: '653.01'
+          },
+          { dimension1: 'Rustic Wooden Bike', dimension2: 'Generic Soft Ball', metric1: '848.94', metric2: '620.57' },
+          {
+            dimension1: 'Rustic Wooden Bike',
+            dimension2: 'Fantastic Wooden Bacon',
+            metric1: '971.47',
+            metric2: '403.77'
+          },
+          {
+            dimension1: 'Rustic Wooden Bike',
+            dimension2: 'Small Concrete Shoes',
+            metric1: '385.38',
+            metric2: '873.77'
+          },
+          {
+            dimension1: 'Rustic Plastic Bacon',
             dimension2: 'Ergonomic Metal Car',
             metric1: '954.49',
             metric2: '555.07'
           },
           {
-            dimension1: 'Sleek Rubber Computer',
+            dimension1: 'Rustic Plastic Bacon',
             dimension2: 'Awesome Rubber Chair',
             metric1: '445.76',
             metric2: '428.91'
           },
+          { dimension1: 'Rustic Plastic Bacon', dimension2: 'Generic Soft Ball', metric1: '669.73', metric2: '139.69' },
           {
-            dimension1: 'Sleek Rubber Computer',
-            dimension2: 'Generic Soft Ball',
-            metric1: '669.73',
-            metric2: '139.69'
-          },
-          {
-            dimension1: 'Sleek Rubber Computer',
+            dimension1: 'Rustic Plastic Bacon',
             dimension2: 'Fantastic Wooden Bacon',
             metric1: '82.50',
             metric2: '230.24'
           },
           {
-            dimension1: 'Sleek Rubber Computer',
+            dimension1: 'Rustic Plastic Bacon',
             dimension2: 'Small Concrete Shoes',
             metric1: '897.10',
             metric2: '197.14'
-          },
-          { dimension1: 'Rustic Wooden Bike', dimension2: 'Tasty Fresh Towels', metric1: '298.00', metric2: '798.50' },
-          {
-            dimension1: 'Rustic Wooden Bike',
-            dimension2: 'Intelligent Metal Shirt',
-            metric1: '262.30',
-            metric2: '332.33'
-          },
-          { dimension1: 'Rustic Wooden Bike', dimension2: 'Awesome Plastic Mouse', metric1: '5.12', metric2: '421.10' },
-          {
-            dimension1: 'Rustic Plastic Bacon',
-            dimension2: 'Practical Fresh Tuna',
-            metric1: '543.20',
-            metric2: '444.82'
-          },
-          {
-            dimension1: 'Rustic Plastic Bacon',
-            dimension2: 'Refined Rubber Chips',
-            metric1: '475.60',
-            metric2: '824.77'
-          },
-          {
-            dimension1: 'Rustic Plastic Bacon',
-            dimension2: 'Fantastic Cotton Pizza',
-            metric1: '636.38',
-            metric2: '162.65'
           }
-        ]
+        ],
+        meta: {}
       },
       'Response rows are correctly formatted for request'
+    );
+  });
+
+  test('fetch RequestV2', async function(assert) {
+    assert.expect(1);
+
+    const response = await this.service.fetch(TestRequestV2, { dataSourceName: TestRequestV2.dataSource });
+    assert.deepEqual(
+      response.response,
+      {
+        rows: [
+          {
+            eventTimeDay: '2015-01-29',
+            eventTimeMonth: '2015 Jan',
+            orderTimeDay: '2014-01-05',
+            dimension1: 'Small Metal Hat',
+            dimension2: 'Unbranded Concrete Fish',
+            metric1: '785.60',
+            metric2: '590.23'
+          },
+          {
+            eventTimeDay: '2015-01-29',
+            eventTimeMonth: '2015 Jan',
+            orderTimeDay: '2014-01-06',
+            dimension1: 'Small Metal Hat',
+            dimension2: 'Unbranded Concrete Fish',
+            metric1: '603.55',
+            metric2: '977.92'
+          },
+          {
+            eventTimeDay: '2015-01-29',
+            eventTimeMonth: '2015 Jan',
+            orderTimeDay: '2014-01-05',
+            dimension1: 'Small Metal Hat',
+            dimension2: 'Refined Concrete Chair',
+            metric1: '83.56',
+            metric2: '774.72'
+          },
+          {
+            eventTimeDay: '2015-01-29',
+            eventTimeMonth: '2015 Jan',
+            orderTimeDay: '2014-01-06',
+            dimension1: 'Small Metal Hat',
+            dimension2: 'Refined Concrete Chair',
+            metric1: '685.31',
+            metric2: '432.90'
+          },
+          {
+            eventTimeDay: '2015-01-29',
+            eventTimeMonth: '2015 Jan',
+            orderTimeDay: '2014-01-05',
+            dimension1: 'Small Metal Hat',
+            dimension2: 'Licensed Concrete Salad',
+            metric1: '965.49',
+            metric2: '534.25'
+          },
+          {
+            eventTimeDay: '2015-01-29',
+            eventTimeMonth: '2015 Jan',
+            orderTimeDay: '2014-01-06',
+            dimension1: 'Small Metal Hat',
+            dimension2: 'Licensed Concrete Salad',
+            metric1: '729.00',
+            metric2: '611.60'
+          },
+          {
+            eventTimeDay: '2015-01-29',
+            eventTimeMonth: '2015 Jan',
+            orderTimeDay: '2014-01-05',
+            dimension1: 'Small Metal Hat',
+            dimension2: 'Awesome Steel Pants',
+            metric1: '232.35',
+            metric2: '581.26'
+          },
+          {
+            eventTimeDay: '2015-01-29',
+            eventTimeMonth: '2015 Jan',
+            orderTimeDay: '2014-01-06',
+            dimension1: 'Small Metal Hat',
+            dimension2: 'Awesome Steel Pants',
+            metric1: '276.24',
+            metric2: '946.29'
+          },
+          {
+            eventTimeDay: '2015-01-30',
+            eventTimeMonth: '2015 Jan',
+            orderTimeDay: '2014-01-05',
+            dimension1: 'Small Metal Hat',
+            dimension2: 'Unbranded Concrete Fish',
+            metric1: '517.87',
+            metric2: '791.83'
+          },
+          {
+            eventTimeDay: '2015-01-30',
+            eventTimeMonth: '2015 Jan',
+            orderTimeDay: '2014-01-06',
+            dimension1: 'Small Metal Hat',
+            dimension2: 'Unbranded Concrete Fish',
+            metric1: '994.32',
+            metric2: '602.63'
+          },
+          {
+            eventTimeDay: '2015-01-30',
+            eventTimeMonth: '2015 Jan',
+            orderTimeDay: '2014-01-05',
+            dimension1: 'Small Metal Hat',
+            dimension2: 'Refined Concrete Chair',
+            metric1: '186.96',
+            metric2: '146.24'
+          },
+          {
+            eventTimeDay: '2015-01-30',
+            eventTimeMonth: '2015 Jan',
+            orderTimeDay: '2014-01-05',
+            dimension1: 'Small Metal Hat',
+            dimension2: 'Licensed Concrete Salad',
+            metric1: '48.48',
+            metric2: '456.50'
+          },
+          {
+            eventTimeDay: '2015-01-30',
+            eventTimeMonth: '2015 Jan',
+            orderTimeDay: '2014-01-06',
+            dimension1: 'Small Metal Hat',
+            dimension2: 'Licensed Concrete Salad',
+            metric1: '520.67',
+            metric2: '591.28'
+          },
+          {
+            eventTimeDay: '2015-01-30',
+            eventTimeMonth: '2015 Jan',
+            orderTimeDay: '2014-01-05',
+            dimension1: 'Small Metal Hat',
+            dimension2: 'Awesome Steel Pants',
+            metric1: '137.87',
+            metric2: '826.68'
+          },
+          {
+            eventTimeDay: '2015-01-30',
+            eventTimeMonth: '2015 Jan',
+            orderTimeDay: '2014-01-06',
+            dimension1: 'Small Metal Hat',
+            dimension2: 'Awesome Steel Pants',
+            metric1: '578.79',
+            metric2: '441.69'
+          }
+        ],
+        meta: {}
+      },
+      'Request V2 query is properly sent with all necessary arguments supplied'
+    );
+  });
+
+  test('fetch RequestV2 - only metrics', async function(assert) {
+    assert.expect(1);
+
+    const response = await this.service.fetch(
+      {
+        table: 'table1',
+        columns: [
+          { field: 'metric1', parameters: {}, type: 'metric' },
+          { field: 'metric2', parameters: {}, type: 'metric' }
+        ],
+        filters: [{ field: 'metric1', operator: 'gt', values: ['100'], parameters: {}, type: 'metric' }],
+        sorts: [{ field: 'metric2', parameters: {}, type: 'metric', direction: 'asc' }],
+        limit: 15,
+        requestVersion: '2.0',
+        dataSource: 'dummy-gql'
+      },
+      { dataSourceName: TestRequestV2.dataSource }
+    );
+
+    assert.deepEqual(
+      response.response,
+      { rows: [{ metric1: '384.77', metric2: '897.01' }], meta: {} },
+      'Request with only metrics is formatted correctly'
     );
   });
 


### PR DESCRIPTION
## Description
The elide fact mock is pretty bare bones and can't alter the results based on filters, sorts, or limits in the request.

## Proposed Changes

- Parse the GraphQL query for filters, sorts, and limits
- Generate values of the response based on all parts of the request

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
