### PR TITLE
Navi metadata service

### DIFF
--- a/packages/core/addon/mirage/fixtures/dashboard-widget.js
+++ b/packages/core/addon/mirage/fixtures/dashboard-widget.js
@@ -288,7 +288,7 @@ export default [
             series: {
               type: 'metric',
               config: {
-                metrics: ['personalSold', 'globalySold']
+                metrics: ['personalSold', 'globallySold']
               }
             }
           }
@@ -301,7 +301,7 @@ export default [
           table: 'inventory',
           timeGrain: 'day'
         },
-        metrics: [{ metric: 'personalSold' }, { metric: 'globalySold' }],
+        metrics: [{ metric: 'personalSold' }, { metric: 'globallySold' }],
         dimensions: [],
         filters: [],
         intervals: [

--- a/packages/core/tests/integration/components/navi-visualizations/pie-chart-test.js
+++ b/packages/core/tests/integration/components/navi-visualizations/pie-chart-test.js
@@ -386,9 +386,9 @@ module('Integration | Component | pie chart', function(hooks) {
         type: 'dimension',
         config: {
           metric: {
-            metric: 'globalySold',
+            metric: 'globallySold',
             parameters: {},
-            canonicalName: 'globalySold'
+            canonicalName: 'globallySold'
           },
           dimensionOrder: ['container'],
           dimensions: [

--- a/packages/data/addon/adapters/metadata/elide.ts
+++ b/packages/data/addon/adapters/metadata/elide.ts
@@ -31,7 +31,7 @@ export default class ElideMetadataAdapter extends EmberObject implements NaviMet
     const query: DocumentNode | undefined = GQLQueries[type]?.[id ? 'single' : 'all'];
 
     assert(
-      'Type requested in navi-data/elide-metadata adapter must be defined as a query in the gql/metadata-queries.js file',
+      'Type requested in ElideMetadataAdapter must be defined as a query in the gql/metadata-queries.js file',
       query
     );
 

--- a/packages/data/addon/mirage/fixtures/bard-meta-dimensions.js
+++ b/packages/data/addon/mirage/fixtures/bard-meta-dimensions.js
@@ -258,7 +258,7 @@ export default {
     }
   ],
 
-  blockheadDims: [
+  bardTwoDims: [
     {
       name: 'item',
       longName: 'Item',

--- a/packages/data/addon/mirage/fixtures/bard-meta-metrics.js
+++ b/packages/data/addon/mirage/fixtures/bard-meta-metrics.js
@@ -343,7 +343,7 @@ export default {
     },
     {
       category: 'World',
-      name: 'globalySold',
+      name: 'globallySold',
       longName: 'How many have sold worldwide',
       type: 'number'
     },

--- a/packages/data/addon/mirage/routes/bard-meta.js
+++ b/packages/data/addon/mirage/routes/bard-meta.js
@@ -33,7 +33,7 @@ export default function() {
     if (req.queryParams.format === 'fullview') {
       tables = tables.map(table => {
         let timeGrains = timeGrainModels.map(timeGrain => {
-          let tableDimModels = isBardTwo ? dimModels.blockheadDims : dimModels.defaultDims;
+          let tableDimModels = isBardTwo ? dimModels.bardTwoDims : dimModels.defaultDims;
           let defaultMetricModels = isBardTwo ? metricModels.blockheadMetrics : metricModels.defaultMetrics;
 
           if (table.name === 'tableC') {

--- a/packages/data/addon/models/metadata/column-function.ts
+++ b/packages/data/addon/models/metadata/column-function.ts
@@ -71,3 +71,8 @@ export default class ColumnFunctionMetadataModel extends EmberObject
    */
   parameters!: FunctionParameter[];
 }
+declare module './registry' {
+  export default interface MetadataModelRegistry {
+    columnFunction: ColumnFunctionMetadataModel;
+  }
+}

--- a/packages/data/addon/models/metadata/dimension.ts
+++ b/packages/data/addon/models/metadata/dimension.ts
@@ -151,3 +151,9 @@ export default class DimensionMetadataModel extends ColumnMetadataModel
     return metadata.findById('dimension', id, source);
   }
 }
+
+declare module './registry' {
+  export default interface MetadataModelRegistry {
+    dimension: DimensionMetadataModel;
+  }
+}

--- a/packages/data/addon/models/metadata/metric.ts
+++ b/packages/data/addon/models/metadata/metric.ts
@@ -42,3 +42,9 @@ export default class MetricMetadataModel extends ColumnMetadataModel implements 
     return metadataService.findById('metric', id, source);
   }
 }
+
+declare module './registry' {
+  export default interface MetadataModelRegistry {
+    metric: MetricMetadataModel;
+  }
+}

--- a/packages/data/addon/models/metadata/registry.ts
+++ b/packages/data/addon/models/metadata/registry.ts
@@ -1,0 +1,7 @@
+/**
+ * Copyright 2020, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export default interface MetadataModelRegistry {}

--- a/packages/data/addon/models/metadata/table.ts
+++ b/packages/data/addon/models/metadata/table.ts
@@ -157,3 +157,9 @@ export default class TableMetadataModel extends EmberObject implements TableMeta
     });
   }
 }
+
+declare module './registry' {
+  export default interface MetadataModelRegistry {
+    table: TableMetadataModel;
+  }
+}

--- a/packages/data/addon/models/metadata/time-dimension.ts
+++ b/packages/data/addon/models/metadata/time-dimension.ts
@@ -32,3 +32,8 @@ export default class TimeDimensionMetadataModel extends DimensionMetadataModel
    */
   timeZone!: string;
 }
+declare module './registry' {
+  export default interface MetadataModelRegistry {
+    timeDimension: TimeDimensionMetadataModel;
+  }
+}

--- a/packages/data/addon/serializers/metadata/bard.ts
+++ b/packages/data/addon/serializers/metadata/bard.ts
@@ -177,11 +177,11 @@ export default class BardMetadataSerializer extends EmberObject implements NaviM
 
   /**
    * @param metric - raw metrics
-   * @param source - data source name
+   * @param dataSourceName - data source name
    */
   private getColumnFunctionFromParameters(
     metric: RawMetricPayload,
-    source: string
+    dataSourceName: string
   ): ColumnFunctionMetadataPayload | null {
     const { parameters, metricFunctionId } = metric;
 
@@ -193,8 +193,8 @@ export default class BardMetadataSerializer extends EmberObject implements NaviM
           .join('|'),
         name: '',
         description: '',
-        _parametersPayload: this.constructFunctionParameters(parameters, source),
-        source
+        _parametersPayload: this.constructFunctionParameters(parameters, dataSourceName),
+        source: dataSourceName
       };
       return newColumnFunction;
     }
@@ -203,11 +203,11 @@ export default class BardMetadataSerializer extends EmberObject implements NaviM
 
   /**
    * @param parameters - raw function parameters
-   * @param source - data source name
+   * @param dataSourceName - data source name
    */
   private constructFunctionParameters(
     parameters: RawColumnFunctionArguments,
-    source: string
+    dataSourceName: string
   ): FunctionParameterMetadataPayload[] {
     return Object.keys(parameters).map(param => {
       const { type, defaultValue, values, dimensionName, description } = parameters[param];
@@ -220,7 +220,7 @@ export default class BardMetadataSerializer extends EmberObject implements NaviM
         type: 'ref', // It will always be ref for our case because all our parameters have their valid values defined in a dimension or enum
         expression: type === 'dimension' ? `dimension:${dimensionName}` : INTRINSIC_VALUE_EXPRESSION,
         _localValues: values,
-        source,
+        source: dataSourceName,
         defaultValue
       };
       return normalized;
@@ -229,9 +229,9 @@ export default class BardMetadataSerializer extends EmberObject implements NaviM
 
   /**
    * @param dimensions - raw dimensions
-   * @param source - data source name
+   * @param dataSourceName - data source name
    */
-  private normalizeDimensions(dimensions: RawDimensionPayload[], source: string): DimensionMetadataPayload[] {
+  private normalizeDimensions(dimensions: RawDimensionPayload[], dataSourceName: string): DimensionMetadataPayload[] {
     return dimensions.map(dimension => {
       const {
         name,
@@ -260,7 +260,7 @@ export default class BardMetadataSerializer extends EmberObject implements NaviM
         fields,
         cardinality: dimCardinality,
         storageStrategy: storageStrategy || null,
-        source,
+        source: dataSourceName,
         partialData: isNone(description)
       };
     });
@@ -268,9 +268,9 @@ export default class BardMetadataSerializer extends EmberObject implements NaviM
 
   /**
    * @param metrics - raw metrics
-   * @param source - data source name
+   * @param dataSourceName - data source name
    */
-  private normalizeMetrics(metrics: RawMetricPayload[], source: string): MetricMetadataPayload[] {
+  private normalizeMetrics(metrics: RawMetricPayload[], dataSourceName: string): MetricMetadataPayload[] {
     return metrics.map(metric => {
       const { type: valueType, longName, name, description, category, metricFunctionId } = metric;
       return {
@@ -279,7 +279,7 @@ export default class BardMetadataSerializer extends EmberObject implements NaviM
         description,
         type: 'field',
         valueType,
-        source,
+        source: dataSourceName,
         category,
         partialData: isNone(description),
         columnFunctionId: metricFunctionId
@@ -289,11 +289,11 @@ export default class BardMetadataSerializer extends EmberObject implements NaviM
 
   /**
    * @param metricFunctions - raw metric functions
-   * @param source - data source name
+   * @param dataSourceName - data source name
    */
   private normalizeColumnFunctions(
     columnFunctions: RawColumnFunction[],
-    source: string
+    dataSourceName: string
   ): ColumnFunctionMetadataPayload[] {
     return columnFunctions.map(func => {
       const { id, name, description, arguments: args } = func;
@@ -301,10 +301,10 @@ export default class BardMetadataSerializer extends EmberObject implements NaviM
         id,
         name,
         description,
-        source
+        source: dataSourceName
       };
       if (args) {
-        normalizedFunc._parametersPayload = this.constructFunctionParameters(args, source);
+        normalizedFunc._parametersPayload = this.constructFunctionParameters(args, dataSourceName);
       }
       return normalizedFunc;
     });

--- a/packages/data/addon/serializers/metadata/elide.ts
+++ b/packages/data/addon/serializers/metadata/elide.ts
@@ -54,7 +54,6 @@ type TableNode = {
 
 export interface TablePayload {
   table: Connection<TableNode>;
-  source: string;
 }
 
 export default class ElideMetadataSerializer extends EmberObject implements NaviMetadataSerializer {
@@ -199,12 +198,21 @@ export default class ElideMetadataSerializer extends EmberObject implements Navi
     });
   }
 
-  normalize<K extends keyof MetadataPayloadMap>(type: K, rawPayload: TablePayload): MetadataPayloadMap[K] {
-    assert('ElideMetadataSerializer only supports normalizing type `everything`', type === 'everything');
+  private supportedTypes = new Set<keyof MetadataPayloadMap>(['everything']);
+
+  normalize<K extends keyof MetadataPayloadMap>(
+    type: K,
+    rawPayload: TablePayload,
+    dataSourceName: string
+  ): MetadataPayloadMap[K] {
+    assert(
+      `ElideMetadataSerializer only supports normalizing type: ${[...this.supportedTypes]}`,
+      this.supportedTypes.has(type)
+    );
 
     const normalized: MetadataPayloadMap['everything'] = this._normalizeTableConnection(
       rawPayload.table,
-      rawPayload.source
+      dataSourceName
     );
     return normalized as MetadataPayloadMap[K];
   }

--- a/packages/data/addon/serializers/metadata/interface.ts
+++ b/packages/data/addon/serializers/metadata/interface.ts
@@ -22,11 +22,15 @@ export interface MetadataPayloadMap {
   metric: MetricMetadataPayload[];
   dimension: DimensionMetadataPayload[];
   timeDimension: TimeDimensionMetadataPayload[];
-  columnFunctions: MetricMetadataPayload[];
+  columnFunction: ColumnFunctionMetadataPayload[];
 }
 
 export type RawMetadataPayload = unknown;
 
 export default interface NaviMetadataSerializer {
-  normalize<K extends keyof MetadataPayloadMap>(type: K, rawPayload: RawMetadataPayload): MetadataPayloadMap[K];
+  normalize<K extends keyof MetadataPayloadMap>(
+    type: K,
+    rawPayload: RawMetadataPayload,
+    dataSourceName: string
+  ): MetadataPayloadMap[K] | undefined;
 }

--- a/packages/data/addon/services/bard-metadata.js
+++ b/packages/data/addon/services/bard-metadata.js
@@ -67,8 +67,7 @@ export default class BardMetadataService extends Service {
     if (!this.loadedDataSources.includes(dataSource)) {
       const payload = await this._adapter.fetchEverything(options);
       //normalize payload
-      payload.source = dataSource;
-      const metadata = this._serializer.normalize('everything', payload);
+      const metadata = this._serializer.normalize('everything', payload, dataSource);
       this._loadMetadataIntoKeg(metadata, dataSource);
     }
   }
@@ -166,7 +165,7 @@ export default class BardMetadataService extends Service {
       //If there is a serializer defined for the type, normalize before loading into keg
       meta = getOwner(this)
         .lookup(`serializer:metadata/${type}`)
-        ?.normalize({ [pluralize(type)]: [meta] }, namespace) || [meta];
+        ?.normalize({ [pluralize(type)]: meta }, dataSourceName) || [meta];
 
       //load into keg if not already present
       return this._loadMetadataForType(type, meta, dataSourceName)?.[0];

--- a/packages/data/addon/services/elide-metadata.ts
+++ b/packages/data/addon/services/elide-metadata.ts
@@ -81,8 +81,7 @@ export default class ElideMetadata extends Service {
       const payload = await this._adapter.fetchEverything(options);
 
       //normalize payload
-      payload.source = dataSource;
-      const metadata = this._serializer.normalize('everything', payload);
+      const metadata = this._serializer.normalize('everything', payload, dataSource);
       this._loadMetadataIntoKeg(metadata, dataSource);
     }
   }

--- a/packages/data/addon/services/keg.ts
+++ b/packages/data/addon/services/keg.ts
@@ -12,12 +12,12 @@ import { getOwner } from '@ember/application';
 import { setProperties } from '@ember/object';
 
 type Identifier = string | number;
-type Record = unknown & {
-  partialData?: boolean;
-  [key: string]: unknown;
-};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type KegRecord = Record<string, any>;
+
 interface Factory {
-  create(obj: object): Record;
+  create(obj: object): KegRecord;
   identifierField: string;
 }
 type Options = {
@@ -25,7 +25,7 @@ type Options = {
   namespace: string; // namespace to store data under, defaults to 'navi'
 };
 
-type FilterFn = (value: Record, index: number, array: Record[]) => boolean;
+type FilterFn = (value: KegRecord, index: number, array: KegRecord[]) => boolean;
 
 export default class KegService extends Service {
   /**
@@ -36,12 +36,12 @@ export default class KegService extends Service {
   /**
    * @property {Object} recordKeg - Object of record arrays
    */
-  recordKegs: Dict<MutableArray<Record>> = {};
+  recordKegs: Dict<MutableArray<KegRecord>> = {};
 
   /**
-   * @property {Object} idIndexes - Object of record idexes
+   * @property {Object} idIndexes - Object of record indexes
    */
-  idIndexes: Dict<Dict<Record>> = {};
+  idIndexes: Dict<Dict<KegRecord>> = {};
 
   /**
    * @property {String} defaultNamespace
@@ -81,8 +81,8 @@ export default class KegService extends Service {
    * @param {String} [options.modelFactory] - name of explicit modelFactory to store
    * @returns {Object} record that was pushed to the keg
    */
-  push(type: string, rawRecord: Record, options: Partial<Options>) {
-    return this.pushMany(type, [rawRecord], options).get('firstObject');
+  push(type: string, rawRecord: KegRecord, options: Partial<Options>) {
+    return this.pushMany(type, [rawRecord], options).firstObject;
   }
 
   /**
@@ -94,7 +94,7 @@ export default class KegService extends Service {
    * @param {Options} [options] - config object
    * @returns {Array} records that were pushed to the keg
    */
-  pushMany(type: string, rawRecords: Array<Record>, options: Partial<Options> = {}) {
+  pushMany(type: string, rawRecords: Array<KegRecord>, options: Partial<Options> = {}): EmberArray<KegRecord> {
     const factory = this._getFactoryForType(options.modelFactory || type);
     const recordKeg = this._getRecordKegForType(type);
     const idIndex = this._getIdIndexForType(type);
@@ -102,7 +102,7 @@ export default class KegService extends Service {
     const identifierField = factory?.identifierField || KegService.identifierField;
     const owner = getOwner(this);
 
-    const returnedRecords = A();
+    const returnedRecords: MutableArray<KegRecord> = A();
     for (let i = 0; i < rawRecords.length; i++) {
       const id = rawRecords[i][identifierField] as Identifier;
       const existingRecord = this.getById(type, id, namespace);
@@ -133,7 +133,7 @@ export default class KegService extends Service {
    * @param {string} namespace - (optional) namespace for the id
    * @returns {Object|undefined} the found record
    */
-  getById(type: string, id: Identifier, namespace?: string): Record | undefined {
+  getById(type: string, id: Identifier, namespace?: string): KegRecord | undefined {
     let idIndex = this._getIdIndexForType(type) || {};
     let source = namespace || this.defaultNamespace;
     return idIndex[`${source}.${id}`];
@@ -145,11 +145,11 @@ export default class KegService extends Service {
    * @method getBy
    * @param {String} type - type name of the model type
    * @param {Dict<unknown|Array<unknown>>|FilterFn} clause
-   * @returns {EmberArray<Record>} array of found records
+   * @returns {EmberArray<KegRecord>} array of found records
    */
-  getBy(type: string, clause: Dict<unknown | Array<unknown>> | FilterFn): EmberArray<Record> {
+  getBy(type: string, clause: Dict<unknown | Array<unknown>> | FilterFn): EmberArray<KegRecord> {
     const recordKeg = this._getRecordKegForType(type);
-    let foundRecords: EmberArray<Record> = A();
+    let foundRecords: EmberArray<KegRecord> = A();
 
     if (typeof clause === 'object') {
       foundRecords = recordKeg;
@@ -180,7 +180,7 @@ export default class KegService extends Service {
    * @param {string} namespace - (optional) namespace for the id
    * @returns {Array} array of records of the provided type
    */
-  all(type: string, namespace: string): EmberArray<Record> {
+  all(type: string, namespace?: string): EmberArray<KegRecord> {
     const all = this._getRecordKegForType(type);
     if (namespace && all.any(item => !!item.source)) {
       return A(all.filter(item => item.source === namespace));
@@ -210,9 +210,9 @@ export default class KegService extends Service {
    * @private
    * @method _getRecordKegForType
    * @param {string} type - type name of the model type
-   * @returns {EmberArray<Record>} - record keg
+   * @returns {EmberArray<KegRecord>} - record keg
    */
-  _getRecordKegForType(type: string): MutableArray<Record> {
+  _getRecordKegForType(type: string): MutableArray<KegRecord> {
     const { recordKegs } = this;
 
     recordKegs[type] = recordKegs[type] || A();
@@ -225,9 +225,9 @@ export default class KegService extends Service {
    * @private
    * @method _getIdIndexForType
    * @param {string} type - type name of the model type
-   * @returns {Dict<Record>} - record id index
+   * @returns {Dict<KegRecord>} - record id index
    */
-  _getIdIndexForType(type: string): Dict<Record> {
+  _getIdIndexForType(type: string): Dict<KegRecord> {
     const { idIndexes } = this;
 
     idIndexes[type] = idIndexes[type] || {};

--- a/packages/data/addon/services/navi-metadata.ts
+++ b/packages/data/addon/services/navi-metadata.ts
@@ -88,6 +88,11 @@ export default class NaviMetadataService extends Service {
     //TODO store promises, so two requests for the same metadata use the same promise
   }
 
+  /**
+   * Provides an array of all loaded models for a given type
+   * @param type - model type
+   * @param dataSourceName - optional name of data source
+   */
   all<K extends keyof MetadataModelRegistry>(type: K, dataSourceName?: string): EmberArray<MetadataModelRegistry[K]> {
     assert(
       `Metadata must have the requested data source loaded: ${dataSourceName}`,
@@ -96,19 +101,33 @@ export default class NaviMetadataService extends Service {
     return this.keg.all(`metadata/${type}`, dataSourceName) as EmberArray<MetadataModelRegistry[K]>;
   }
 
+  /**
+   * Provides a single loaded model instance given an identifier
+   * @param type - model type
+   * @param id - identifier value of model
+   * @param dataSourceName - name of data source
+   */
   getById<K extends keyof MetadataModelRegistry>(
     type: K,
     id: string,
     dataSourceName: string
   ): MetadataModelRegistry[K] | undefined {
+    assert('`dataSourceName` argument required', dataSourceName);
     return this.keg.getById(`metadata/${type}`, id, dataSourceName) as MetadataModelRegistry[K];
   }
 
+  /**
+   * Fetches from data source a single model instance given an identifier
+   * @param type - model type
+   * @param id - identifier value of model
+   * @param dataSourceName - name of data source
+   */
   async fetchById<K extends keyof MetadataModelRegistry>(
     type: K,
     id: string,
     dataSourceName: string
   ): Promise<MetadataModelRegistry[K] | undefined> {
+    assert('`dataSourceName` argument required', dataSourceName);
     const { type: dataSourceType } = this.dataSourceFor(dataSourceName);
     const rawPayload = await this.adapterFor(dataSourceType).fetchById(type, id, { dataSourceName });
     const normalized = rawPayload
@@ -122,11 +141,18 @@ export default class NaviMetadataService extends Service {
     return undefined;
   }
 
+  /**
+   * Provides a single loaded model instance or fetches one, given an identifier
+   * @param type - model type
+   * @param id - identifier value of model
+   * @param dataSourceName - name of data source
+   */
   findById<K extends keyof MetadataModelRegistry>(
     type: K,
     id: string,
     dataSourceName: string
   ): Promise<MetadataModelRegistry[K] | undefined> {
+    assert('`dataSourceName` argument required', dataSourceName);
     const kegRecord = this.keg.getById(`metadata/${type}`, id, dataSourceName);
     if (kegRecord && !kegRecord.partialData) {
       return Promise.resolve(this.getById(type, id, dataSourceName)) as Promise<MetadataModelRegistry[K]>;

--- a/packages/data/addon/services/navi-metadata.ts
+++ b/packages/data/addon/services/navi-metadata.ts
@@ -1,0 +1,143 @@
+/**
+ * Copyright 2020, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+import Service, { inject as service } from '@ember/service';
+import EmberArray from '@ember/array';
+import { setOwner, getOwner } from '@ember/application';
+import { assert } from '@ember/debug';
+import { getDataSource, getDefaultDataSource, DataSource } from 'navi-data/utils/adapter';
+import NaviMetadataSerializer, { EverythingMetadataPayload } from 'navi-data/serializers/metadata/interface';
+import KegService, { KegRecord } from './keg';
+import MetadataModelRegistry from 'navi-data/models/metadata/registry';
+import NaviMetadataAdapter from '../adapters/metadata/interface';
+
+type RequestOptions = {
+  dataSourceName?: string;
+};
+
+export default class NaviMetadataService extends Service {
+  @service
+  private keg!: KegService;
+
+  /**
+   * @property {Array} loadedDataSources - list of data sources in which meta data has already been loaded
+   */
+  loadedDataSources: Set<string> = new Set();
+
+  /**
+   * @param dataSourceType
+   * @returns  adapter instance for type
+   */
+  private adapterFor(dataSourceType: string): NaviMetadataAdapter {
+    return getOwner(this).lookup(`adapter:metadata/${dataSourceType}`);
+  }
+
+  /**
+   * @param dataSourceType
+   * @returns serializer instance for type
+   */
+  private serializerFor(dataSourceType: string): NaviMetadataSerializer {
+    return getOwner(this).lookup(`serializer:metadata/${dataSourceType}`);
+  }
+
+  private dataSourceFor(dataSourceName?: string): DataSource {
+    return dataSourceName ? getDataSource(dataSourceName) : getDefaultDataSource();
+  }
+
+  /**
+   * @param payload
+   * @param dataSourceName
+   */
+  private loadEverythingMetadataIntoKeg(payload: EverythingMetadataPayload, dataSourceName: string) {
+    this.loadMetadataForType('table', payload.tables, dataSourceName);
+    this.loadMetadataForType('dimension', payload.dimensions, dataSourceName);
+    this.loadMetadataForType('timeDimension', payload.timeDimensions, dataSourceName);
+    this.loadMetadataForType('columnFunction', payload.columnFunctions || [], dataSourceName);
+    this.loadMetadataForType('metric', payload.metrics, dataSourceName);
+    this.loadedDataSources.add(dataSourceName);
+  }
+
+  /**
+   * Loads metadata based on type
+   * @param type - type of metadata, table, dimension, or metric
+   * @param metadataObjects - array of metadata objects
+   */
+  private loadMetadataForType<K extends keyof MetadataModelRegistry>(
+    type: K,
+    metadataObjects: Array<KegRecord>,
+    dataSourceName: string
+  ): EmberArray<MetadataModelRegistry[K]> {
+    const owner = getOwner(this);
+    metadataObjects.forEach(obj => setOwner(obj, owner));
+    return this.keg.pushMany(`metadata/${type}`, metadataObjects, {
+      namespace: dataSourceName
+    }) as EmberArray<MetadataModelRegistry[K]>;
+  }
+
+  async loadMetadata(options: RequestOptions = {}) {
+    const { type: dataSourceType, name: dataSourceName } = this.dataSourceFor(options.dataSourceName);
+    if (!this.loadedDataSources.has(dataSourceName)) {
+      const payload = await this.adapterFor(dataSourceType).fetchEverything(options);
+
+      const normalized = this.serializerFor(dataSourceType).normalize('everything', payload, dataSourceName);
+      if (normalized) {
+        this.loadEverythingMetadataIntoKeg(normalized, dataSourceName);
+      }
+    }
+    //TODO store promises, so two requests for the same metadata use the same promise
+  }
+
+  all<K extends keyof MetadataModelRegistry>(type: K, dataSourceName?: string): EmberArray<MetadataModelRegistry[K]> {
+    assert(
+      `Metadata must have the requested data source loaded: ${dataSourceName}`,
+      !dataSourceName || this.loadedDataSources.has(dataSourceName)
+    );
+    return this.keg.all(`metadata/${type}`, dataSourceName) as EmberArray<MetadataModelRegistry[K]>;
+  }
+
+  getById<K extends keyof MetadataModelRegistry>(
+    type: K,
+    id: string,
+    dataSourceName: string
+  ): MetadataModelRegistry[K] | undefined {
+    return this.keg.getById(`metadata/${type}`, id, dataSourceName) as MetadataModelRegistry[K];
+  }
+
+  async fetchById<K extends keyof MetadataModelRegistry>(
+    type: K,
+    id: string,
+    dataSourceName: string
+  ): Promise<MetadataModelRegistry[K] | undefined> {
+    const { type: dataSourceType } = this.dataSourceFor(dataSourceName);
+    const rawPayload = await this.adapterFor(dataSourceType).fetchById(type, id, { dataSourceName });
+    const normalized = rawPayload
+      ? this.serializerFor(dataSourceType).normalize(type, rawPayload, dataSourceName)
+      : undefined;
+
+    if (normalized) {
+      const model = this.loadMetadataForType(type, normalized, dataSourceName);
+      return model?.firstObject as MetadataModelRegistry[K];
+    }
+    return undefined;
+  }
+
+  findById<K extends keyof MetadataModelRegistry>(
+    type: K,
+    id: string,
+    dataSourceName: string
+  ): Promise<MetadataModelRegistry[K] | undefined> {
+    const kegRecord = this.keg.getById(`metadata/${type}`, id, dataSourceName);
+    if (kegRecord && !kegRecord.partialData) {
+      return Promise.resolve(this.getById(type, id, dataSourceName)) as Promise<MetadataModelRegistry[K]>;
+    }
+    return this.fetchById(type, id, dataSourceName);
+  }
+}
+
+// DO NOT DELETE: this is how TypeScript knows how to look up your services.
+declare module '@ember/service' {
+  interface Registry {
+    'navi-metadata': NaviMetadataService;
+  }
+}

--- a/packages/data/addon/utils/adapter.ts
+++ b/packages/data/addon/utils/adapter.ts
@@ -5,7 +5,7 @@
 import config from 'ember-get-config';
 import { assert } from '@ember/debug';
 
-type DataSource = {
+export type DataSource = {
   name: string;
   uri: string;
   type: string;
@@ -15,20 +15,21 @@ export type SourceAdapterOptions = {
 };
 
 /**
- * @param name - name of the data source. falsey name will return default data source
+ * Returns data source object for a data source name
+ * @param dataSourceName
  */
-export function getDataSource(name: string): DataSource {
-  assert('getDataSource should be given a data source name to lookup', name);
+export function getDataSource(dataSourceName: string): DataSource {
+  assert('getDataSource should be given a data source name to lookup', dataSourceName);
 
   const {
     navi: { dataSources }
   } = config;
 
-  const host = dataSources.find((dataSource: DataSource) => dataSource.name === name);
+  const host = dataSources.find((dataSource: DataSource) => dataSource.name === dataSourceName);
   if (host) {
     return host;
   }
-  assert(`Datasource ${name} should be configured in the navi environment`);
+  assert(`Datasource ${dataSourceName} should be configured in the navi environment`);
 }
 
 /**

--- a/packages/data/app/services/navi-metadata.js
+++ b/packages/data/app/services/navi-metadata.js
@@ -1,0 +1,1 @@
+export { default } from 'navi-data/services/navi-metadata';

--- a/packages/data/tests/unit/adapters/metadata/bard-test.ts
+++ b/packages/data/tests/unit/adapters/metadata/bard-test.ts
@@ -64,7 +64,7 @@ module('Unit | Adapter | metadata/bard', function(hooks) {
 
   test('fetchById', async function(assert) {
     const payload = await Adapter.fetchById('metric', 'pageViews');
-    const metric = payload ? payload[0] : payload;
+    const metric = payload?.[0];
     assert.deepEqual(
       metric,
       {

--- a/packages/data/tests/unit/adapters/metadata/bard-test.ts
+++ b/packages/data/tests/unit/adapters/metadata/bard-test.ts
@@ -54,7 +54,7 @@ module('Unit | Adapter | metadata/bard', function(hooks) {
   });
 
   test('fetchAll', async function(assert) {
-    const { tables } = await Adapter.fetchAll('table');
+    const tables = await Adapter.fetchAll('table');
     assert.deepEqual(
       tables.map((t: { name: string }) => t.name),
       ['network', 'tableA', 'tableB', 'protected', 'tableC'],
@@ -63,7 +63,8 @@ module('Unit | Adapter | metadata/bard', function(hooks) {
   });
 
   test('fetchById', async function(assert) {
-    const metric = await Adapter.fetchById('metric', 'pageViews');
+    const payload = await Adapter.fetchById('metric', 'pageViews');
+    const metric = payload ? payload[0] : payload;
     assert.deepEqual(
       metric,
       {

--- a/packages/data/tests/unit/serializers/metadata/bard-test.js
+++ b/packages/data/tests/unit/serializers/metadata/bard-test.js
@@ -2,7 +2,6 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
 const Payload = {
-  source: 'bardOne',
   tables: [
     {
       name: 'tableName',
@@ -288,6 +287,7 @@ const Dimensions = [
   {
     cardinality: 'SMALL',
     category: 'categoryOne',
+    description: undefined,
     id: 'dimensionOne',
     name: 'Dimension One',
     source: 'bardOne',
@@ -300,6 +300,7 @@ const Dimensions = [
   {
     cardinality: 'SMALL',
     category: 'categoryTwo',
+    description: undefined,
     id: 'dimensionTwo',
     name: 'Dimension Two',
     source: 'bardOne',
@@ -320,6 +321,7 @@ const TimeDimensions = [
   {
     cardinality: 'MEDIUM',
     category: 'dateCategory',
+    description: undefined,
     id: 'dimensionThree',
     name: 'Dimension Three',
     source: 'bardOne',
@@ -336,6 +338,7 @@ const Metrics = [
     category: 'category',
     id: 'metricOne',
     columnFunctionId: undefined,
+    description: undefined,
     name: 'Metric One',
     partialData: true,
     source: 'bardOne',
@@ -346,6 +349,7 @@ const Metrics = [
     category: 'category',
     id: 'metricFour',
     columnFunctionId: 'currency|format',
+    description: undefined,
     name: 'Metric Four',
     partialData: true,
     source: 'bardOne',
@@ -356,6 +360,7 @@ const Metrics = [
     category: 'category',
     id: 'metricTwo',
     columnFunctionId: 'currency',
+    description: undefined,
     name: 'Metric Two',
     partialData: true,
     source: 'bardOne',
@@ -366,6 +371,7 @@ const Metrics = [
     category: 'category',
     id: 'metricFive',
     columnFunctionId: 'metricFunctionId take precedence over parameters',
+    description: undefined,
     name: 'Metric Five',
     partialData: true,
     source: 'bardOne',
@@ -376,6 +382,7 @@ const Metrics = [
     category: 'category',
     id: 'metricThree',
     columnFunctionId: undefined,
+    description: undefined,
     name: 'Metric Three',
     partialData: true,
     source: 'bardOne',
@@ -447,7 +454,7 @@ module('Unit | Serializer | metadata/bard', function(hooks) {
 
   test('normalize `everything` with metric legacy `parameters`', function(assert) {
     assert.deepEqual(
-      Serializer.normalize('everything', Payload),
+      Serializer.normalize('everything', Payload, 'bardOne'),
       {
         metrics: Metrics,
         dimensions: Dimensions,
@@ -461,7 +468,6 @@ module('Unit | Serializer | metadata/bard', function(hooks) {
 
   test('normalize `everything` with column functions', function(assert) {
     const MetricFunctionIdsPayload = {
-      source: 'bardOne',
       metricFunctions: [
         {
           id: 'moneyMetric',
@@ -513,7 +519,7 @@ module('Unit | Serializer | metadata/bard', function(hooks) {
       ]
     };
 
-    const { metrics, columnFunctions } = Serializer.normalize('everything', MetricFunctionIdsPayload);
+    const { metrics, columnFunctions } = Serializer.normalize('everything', MetricFunctionIdsPayload, 'bardOne');
 
     assert.deepEqual(
       metrics,
@@ -522,6 +528,7 @@ module('Unit | Serializer | metadata/bard', function(hooks) {
           category: 'category',
           id: 'metricOne',
           name: 'Metric One',
+          description: undefined,
           valueType: 'number',
           source: 'bardOne',
           columnFunctionId: undefined,
@@ -532,6 +539,7 @@ module('Unit | Serializer | metadata/bard', function(hooks) {
           category: 'category',
           id: 'metricTwo',
           name: 'Metric Two',
+          description: undefined,
           valueType: 'money',
           source: 'bardOne',
           columnFunctionId: 'moneyMetric',
@@ -569,7 +577,7 @@ module('Unit | Serializer | metadata/bard', function(hooks) {
     );
   });
 
-  test('_constructDimension', function(assert) {
+  test('normalizeDimensions', function(assert) {
     const rawDimension = {
       category: 'categoryOne',
       name: 'dimensionOne',
@@ -591,24 +599,27 @@ module('Unit | Serializer | metadata/bard', function(hooks) {
     const source = 'bardOne';
 
     assert.deepEqual(
-      Serializer._constructDimension(rawDimension, source),
-      {
-        id: rawDimension.name,
-        name: rawDimension.longName,
-        category: rawDimension.category,
-        valueType: rawDimension.datatype,
-        cardinality: 'SMALL',
-        type: 'field',
-        storageStrategy: null,
-        fields: rawDimension.fields,
-        source,
-        partialData: true
-      },
+      Serializer.normalizeDimensions([rawDimension], source),
+      [
+        {
+          id: rawDimension.name,
+          name: rawDimension.longName,
+          description: undefined,
+          category: rawDimension.category,
+          valueType: rawDimension.datatype,
+          cardinality: 'SMALL',
+          type: 'field',
+          storageStrategy: null,
+          fields: rawDimension.fields,
+          source,
+          partialData: true
+        }
+      ],
       'New dimension is constructed correctly normalized'
     );
   });
 
-  test('_constructMetric', function(assert) {
+  test('normalizeMetrics', function(assert) {
     const source = 'bardOne';
 
     const rawMetric = {
@@ -621,17 +632,20 @@ module('Unit | Serializer | metadata/bard', function(hooks) {
     };
 
     assert.deepEqual(
-      Serializer._constructMetric(rawMetric, source),
-      {
-        id: rawMetric.name,
-        name: rawMetric.longName,
-        category: rawMetric.category,
-        valueType: rawMetric.type,
-        source,
-        columnFunctionId: rawMetric.metricFunctionId,
-        type: 'field',
-        partialData: true
-      },
+      Serializer.normalizeMetrics([rawMetric], source),
+      [
+        {
+          id: rawMetric.name,
+          name: rawMetric.longName,
+          description: undefined,
+          category: rawMetric.category,
+          valueType: rawMetric.type,
+          source,
+          columnFunctionId: rawMetric.metricFunctionId,
+          type: 'field',
+          partialData: true
+        }
+      ],
       'Metric is constructed correctly with no new column function id or parameter'
     );
   });

--- a/packages/data/tests/unit/serializers/metadata/elide-test.ts
+++ b/packages/data/tests/unit/serializers/metadata/elide-test.ts
@@ -189,12 +189,11 @@ module('Unit | Serializer | metadata/elide', function(hooks) {
           }
         ],
         pageInfo: {}
-      },
-      source: 'bardOne'
+      }
     };
 
     assert.deepEqual(
-      Serializer.normalize('everything', tableConnectionPayload),
+      Serializer.normalize('everything', tableConnectionPayload, 'bardOne'),
       {
         tables: [
           {

--- a/packages/data/tests/unit/services/bard-dimensions-test.js
+++ b/packages/data/tests/unit/services/bard-dimensions-test.js
@@ -353,7 +353,7 @@ module('Unit | Service | Dimensions', function(hooks) {
     assert.deepEqual(model.id, 'v1', 'findByid returns the expected dimension value');
 
     const bardTwoModel = await Service.findById('dimensionFour', 'v4', { dataSourceName: 'bardTwo' });
-    assert.deepEqual(bardTwoModel.id, 'v4', 'findByid returns the expected dimension value in a differetn datasource');
+    assert.deepEqual(bardTwoModel.id, 'v4', 'findByid returns the expected dimension value in a different datasource');
   });
 
   test('getById', function(assert) {

--- a/packages/data/tests/unit/services/navi-metadata-test.ts
+++ b/packages/data/tests/unit/services/navi-metadata-test.ts
@@ -1,0 +1,266 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
+import config from 'ember-get-config';
+import NaviMetadataService from 'navi-data/services/navi-metadata';
+import TableMetadataModel from 'navi-data/models/metadata/table';
+//@ts-ignore
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import ElideTwoScenario from 'dummy/mirage/scenarios/elide-two';
+import DimensionMetadataModel from 'navi-data/models/metadata/dimension';
+import MetricMetadataModel from 'navi-data/models/metadata/metric';
+import TimeDimensionMetadataModel from 'navi-data/models/metadata/time-dimension';
+import ColumnFunctionMetadataModel from 'navi-data/models/metadata/column-function';
+
+interface Context extends TestContext {
+  server: TODO;
+  service: NaviMetadataService;
+}
+
+module('Unit | Service | navi-metadata', function(hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+  hooks.beforeEach(function(this: Context) {
+    ElideTwoScenario(this.server);
+    this.service = this.owner.lookup('service:navi-metadata');
+  });
+
+  hooks.afterEach(function(this: Context) {
+    this.server.shutdown();
+  });
+
+  test('loadMetadata - bard', async function(this: Context, assert) {
+    const keg = this.service['keg'];
+
+    assert.equal(this.service.loadedDataSources.size, 0, '`bardTwo` data source is initially not loaded');
+    await this.service.loadMetadata({ dataSourceName: 'bardTwo' });
+
+    const tables = keg.all('metadata/table', 'bardTwo');
+    assert.ok(
+      tables.every(table => table instanceof TableMetadataModel),
+      '`bardTwo` `TableMetadataModel`s are loaded into the keg'
+    );
+    assert.deepEqual(tables.mapBy('id'), ['inventory'], 'All `bardTwo` tables are loaded');
+
+    const dimensions = keg.all('metadata/dimension', 'bardTwo');
+    assert.ok(
+      dimensions.every(dim => dim instanceof DimensionMetadataModel),
+      '`bardTwo` `DimensionMetadataModel`s are loaded into the keg'
+    );
+    assert.deepEqual(
+      dimensions.mapBy('id'),
+      ['item', 'container', 'location', 'requirement', 'recipe', 'displayCurrency', 'eventId', 'parentEventId'],
+      'All `bardTwo` dimensions are loaded'
+    );
+
+    const timeDimensions = keg.all('metadata/timeDimension', 'bardTwo');
+    assert.ok(
+      timeDimensions.every(dim => dim instanceof TimeDimensionMetadataModel),
+      '`bardTwo` `TimeDimensionMetadataModel`s are loaded into the keg'
+    );
+    assert.deepEqual(timeDimensions.mapBy('id'), [], 'All `bardTwo` time dimensions are loaded');
+
+    const metrics = keg.all('metadata/metric', 'bardTwo');
+    assert.ok(
+      metrics.every(metric => metric instanceof MetricMetadataModel),
+      '`bardTwo` `MetricMetadataModel`s are loaded into the keg'
+    );
+    assert.deepEqual(
+      metrics.mapBy('id'),
+      ['ownedQuantity', 'usedAmount', 'personalSold', 'available', 'globallySold', 'revenue'],
+      'All `bardTwo` metrics are loaded'
+    );
+
+    const columnFunctions = keg.all('metadata/columnFunction', 'elideOne');
+    assert.ok(
+      columnFunctions.every(fn => fn instanceof ColumnFunctionMetadataModel),
+      '`bardTwo` `ColumnFunctionMetadataModel`s are loaded into the keg'
+    );
+    assert.deepEqual(columnFunctions.mapBy('id'), [], 'All `bardTwo` column functions are loaded');
+
+    assert.ok(this.service.loadedDataSources.has('bardTwo'), '`bardTwo` data source is loaded');
+  });
+
+  test('loadMetadata - elide', async function(this: Context, assert) {
+    const keg = this.service['keg'];
+
+    assert.equal(this.service.loadedDataSources.size, 0, '`elideOne` data source is initially not loaded');
+    await this.service.loadMetadata({ dataSourceName: 'elideOne' });
+
+    const tables = keg.all('metadata/table', 'elideOne');
+    assert.ok(
+      tables.every(table => table instanceof TableMetadataModel),
+      '`elideOne` `TableMetadataModel`s are loaded into the keg'
+    );
+    assert.deepEqual(tables.mapBy('id'), ['table0', 'table1'], 'All `elideOne` tables are loaded');
+
+    const dimensions = keg.all('metadata/dimension', 'elideOne');
+    assert.ok(
+      dimensions.every(dim => dim instanceof DimensionMetadataModel),
+      '`elideOne` `DimensionMetadataModel`s are loaded into the keg'
+    );
+    assert.deepEqual(
+      dimensions.mapBy('id'),
+      ['dimension0', 'dimension1', 'dimension2', 'dimension3', 'dimension4'],
+      'All `elideOne` dimensions are loaded'
+    );
+
+    const timeDimensions = keg.all('metadata/timeDimension', 'elideOne');
+    assert.ok(
+      timeDimensions.every(dim => dim instanceof TimeDimensionMetadataModel),
+      '`elideOne` `TimeDimensionMetadataModel`s are loaded into the keg'
+    );
+    assert.deepEqual(
+      timeDimensions.mapBy('id'),
+      ['timeDimension0', 'timeDimension1'],
+      'All `elideOne` time dimensions are loaded'
+    );
+
+    const metrics = keg.all('metadata/metric', 'elideOne');
+    assert.ok(
+      metrics.every(metric => metric instanceof MetricMetadataModel),
+      '`elideOne` `MetricMetadataModel`s are loaded into the keg'
+    );
+    assert.deepEqual(metrics.mapBy('id'), ['metric0', 'metric1'], 'All `elideOne` metrics are loaded');
+
+    const columnFunctions = keg.all('metadata/columnFunction', 'elideOne');
+    assert.ok(
+      columnFunctions.every(fn => fn instanceof ColumnFunctionMetadataModel),
+      '`elideOne` `ColumnFunctionMetadataModel`s are loaded into the keg'
+    );
+    assert.deepEqual(columnFunctions.mapBy('id'), [], 'All `elideOne` column functions are loaded');
+
+    assert.ok(this.service.loadedDataSources.has('elideOne'), '`elideOne` data source is loaded');
+  });
+
+  test('loadMetadata - default data source', async function(this: Context, assert) {
+    assert.notOk(this.service.loadedDataSources.has('bardOne'), '`bardOne` data source is initially not loaded');
+    await this.service.loadMetadata();
+    assert.ok(this.service.loadedDataSources.has('bardOne'), 'default data source is loaded');
+  });
+
+  test('loadMetadata - multiple calls', async function(this: Context, assert) {
+    assert.expect(1);
+
+    this.server.urlPrefix = `${config.navi.dataSources[0].uri}/v1`;
+    this.server.get('/tables', function() {
+      assert.ok(true, 'initial metadata load executes a request');
+      return { tables: [] };
+    });
+    await this.service.loadMetadata();
+
+    this.server.get('/tables', function() {
+      assert.notOk(true, 'after metadata is loaded, a fetch request is not executed');
+    });
+  });
+
+  test('all', async function(this: Context, assert) {
+    await this.service.loadMetadata({ dataSourceName: 'bardTwo' });
+    await this.service.loadMetadata({ dataSourceName: 'elideOne' });
+
+    const bardTwoTables = this.service.all('table', 'bardTwo');
+    assert.deepEqual(bardTwoTables.mapBy('id'), ['inventory'], '`all` returns all `elideOne` tables');
+
+    const elideOneTables = this.service.all('table', 'elideOne');
+    assert.deepEqual(elideOneTables.mapBy('id'), ['table0', 'table1'], '`all` return all `elideOne` tables');
+
+    const allTables = this.service.all('table');
+    assert.deepEqual(
+      allTables.mapBy('id'),
+      ['inventory', 'table0', 'table1'],
+      '`all` return all loaded tables when data source is not specified'
+    );
+    assert.ok(
+      allTables.every(table => table instanceof TableMetadataModel),
+      'All returns instances of `TableMetadataModel`s'
+    );
+
+    assert.throws(
+      () => this.service.all('table', 'notLoaded'),
+      /Metadata must have the requested data source loaded: notLoaded/,
+      '`all` throws an error if attempting to get all models from a data source that is not loaded'
+    );
+  });
+
+  test('getById', async function(this: Context, assert) {
+    await this.service.loadMetadata({ dataSourceName: 'elideOne' });
+    await this.service.loadMetadata({ dataSourceName: 'bardTwo' });
+
+    const metricOne = this.service.getById('metric', 'metric1', 'elideOne');
+    assert.ok(
+      metricOne instanceof MetricMetadataModel,
+      '`getById` returns a loaded instance of `MetricMetadataModel` when requesting `metric` type'
+    );
+    assert.equal(metricOne?.name, 'Metric 1', '`getById returns a metadata model given a type, id, & datasource');
+
+    const revenue = this.service.getById('metric', 'revenue', 'bardTwo');
+    assert.ok(
+      revenue instanceof MetricMetadataModel,
+      '`getById` returns a loaded instance of `MetricMetadataModel` when requesting `metric` type'
+    );
+    assert.equal(revenue?.name, 'Revenue', '`getById returns a metadata model given a type, id, & datasource');
+
+    const missing = this.service.getById('metric', 'not a metric', 'bardTwo');
+    assert.equal(missing, undefined, '`getById returns `undefined` if a model by `id` cannot be found');
+
+    const notLoaded = this.service.getById('table', 'table0', 'notLoaded');
+    assert.equal(notLoaded, undefined, '`getById` returns `undefined` when data source is not loaded');
+  });
+
+  test('fetchById - elide', async function(this: Context, assert) {
+    assert.rejects(
+      this.service.fetchById('metric', 'metric1', 'elideOne'),
+      /Type requested in navi-data\/elide-metadata adapter must be defined as a query in the gql\/metadata-queries.js file/,
+      '`fetchById` elide throws an error if attempting to get a model by id'
+    );
+  });
+
+  test('fetchById - fili', async function(this: Context, assert) {
+    const metric = await this.service.fetchById('metric', 'revenue', 'bardTwo');
+    assert.ok(
+      metric instanceof MetricMetadataModel,
+      '`getById` returns an instance of `MetricMetadataModel` when requesting `metric` type'
+    );
+    assert.equal(metric?.name, 'Revenue', '`getById returns a metadata model given a type, id, & datasource');
+
+    const dimension = await this.service.fetchById('dimension', 'currency', 'bardOne');
+    assert.ok(
+      dimension instanceof DimensionMetadataModel,
+      '`getById` returns an instance of `DimensionMetadataModel` when requesting `dimension` type'
+    );
+    assert.equal(dimension?.name, 'Currency', '`getById returns a metadata model given a type, id, & datasource');
+
+    const columnFunction = await this.service.fetchById('columnFunction', 'currency', 'bardOne');
+    assert.equal(columnFunction, undefined, '`getById returns `undefined` if a model `id` cannot be found');
+  });
+
+  test('findById', async function(this: Context, assert) {
+    assert.equal(this.service.loadedDataSources.size, 0, 'no data sources are initially loaded');
+
+    const metric1 = await this.service.findById('metric', 'revenue', 'bardTwo');
+    assert.ok(
+      metric1 instanceof MetricMetadataModel,
+      '`findById` fetches an instance of `MetricMetadataModel` when requesting `metric` type'
+    );
+    assert.equal(metric1?.name, 'Revenue', '`fetchById fetches a metadata model given a type, id, & datasource');
+
+    const metric2 = await this.service.findById('metric', 'revenue', 'bardTwo');
+    assert.equal(metric1, metric2, '`findById` returns a local modal instance if already fetched');
+
+    await this.service.loadMetadata({ dataSourceName: 'bardOne' });
+    const dimension1 = await this.service.getById('dimension', 'currency', 'bardOne');
+    assert.ok(dimension1 !== undefined && dimension1?.description === undefined, 'dimension is partially loaded');
+    const dimension2 = await this.service.findById('dimension', 'currency', 'bardOne');
+    assert.equal(dimension2?.partialData, false, '`findById` fully loaded a partially loaded model');
+    assert.equal(
+      dimension2?.description,
+      'Reiciendis est blanditiis reiciendis nemo ut.',
+      '`findById` fully loaded a partially loaded model'
+    );
+    assert.equal(
+      dimension1,
+      dimension2,
+      'Object reference is stable when going from partially loaded to to fully loaded'
+    );
+  });
+});

--- a/packages/data/tests/unit/services/navi-metadata-test.ts
+++ b/packages/data/tests/unit/services/navi-metadata-test.ts
@@ -152,6 +152,7 @@ module('Unit | Service | navi-metadata', function(hooks) {
     this.server.get('/tables', function() {
       assert.notOk(true, 'after metadata is loaded, a fetch request is not executed');
     });
+    await this.service.loadMetadata();
   });
 
   test('all', async function(this: Context, assert) {
@@ -210,7 +211,7 @@ module('Unit | Service | navi-metadata', function(hooks) {
   test('fetchById - elide', async function(this: Context, assert) {
     assert.rejects(
       this.service.fetchById('metric', 'metric1', 'elideOne'),
-      /Type requested in navi-data\/elide-metadata adapter must be defined as a query in the gql\/metadata-queries.js file/,
+      /Type requested in ElideMetadataAdapter must be defined as a query in the gql\/metadata-queries.js file/,
       '`fetchById` elide throws an error if attempting to get a model by id'
     );
   });

--- a/packages/data/tests/unit/services/navi-metadata-test.ts
+++ b/packages/data/tests/unit/services/navi-metadata-test.ts
@@ -160,7 +160,7 @@ module('Unit | Service | navi-metadata', function(hooks) {
     await this.service.loadMetadata({ dataSourceName: 'elideOne' });
 
     const bardTwoTables = this.service.all('table', 'bardTwo');
-    assert.deepEqual(bardTwoTables.mapBy('id'), ['inventory'], '`all` returns all `elideOne` tables');
+    assert.deepEqual(bardTwoTables.mapBy('id'), ['inventory'], '`all` returns all `bardTwo` tables');
 
     const elideOneTables = this.service.all('table', 'elideOne');
     assert.deepEqual(elideOneTables.mapBy('id'), ['table0', 'table1'], '`all` return all `elideOne` tables');
@@ -169,7 +169,7 @@ module('Unit | Service | navi-metadata', function(hooks) {
     assert.deepEqual(
       allTables.mapBy('id'),
       ['inventory', 'table0', 'table1'],
-      '`all` return all loaded tables when data source is not specified'
+      '`all` returns all loaded tables when data source is not specified'
     );
     assert.ok(
       allTables.every(table => table instanceof TableMetadataModel),

--- a/packages/data/tests/unit/services/navi-metadata-test.ts
+++ b/packages/data/tests/unit/services/navi-metadata-test.ts
@@ -11,9 +11,10 @@ import DimensionMetadataModel from 'navi-data/models/metadata/dimension';
 import MetricMetadataModel from 'navi-data/models/metadata/metric';
 import TimeDimensionMetadataModel from 'navi-data/models/metadata/time-dimension';
 import ColumnFunctionMetadataModel from 'navi-data/models/metadata/column-function';
+import { Server } from 'miragejs';
 
 interface Context extends TestContext {
-  server: TODO;
+  server: Server;
   service: NaviMetadataService;
 }
 
@@ -151,6 +152,7 @@ module('Unit | Service | navi-metadata', function(hooks) {
 
     this.server.get('/tables', function() {
       assert.notOk(true, 'after metadata is loaded, a fetch request is not executed');
+      return { tables: [] };
     });
     await this.service.loadMetadata();
   });


### PR DESCRIPTION
## Description

Navi metadata service

**Note**: Removal of bard and elide metadata services will be done in another PR

## Proposed Changes

-  Fix typos and update names
- Update: Add MetadataModelRegistry
- Update: Bard metadata mirage mocks
  - Remove description field in fullview response
  - Return correct response shape if requesting non fullview table request
  - Use mirage `Response` object for 404 response
- Update: Refactor metadata adapter & serializers
  - Update `normalize` method to take `dataSourceName` argument
  - Bard adapter & serializer works with arrays of models
  - Bard uses the presence of `description` to determine if partial
- Update: Refactor keg types
- Update: Add navi-metadata service

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
