### PR TITLE
Upgrading to Elide 5 PR 15

### DIFF
--- a/packages/webservice/app/build.gradle.kts
+++ b/packages/webservice/app/build.gradle.kts
@@ -16,9 +16,10 @@ repositories {
 dependencies {
     implementation(project(":models"))
     implementation("org.springframework.boot:spring-boot-starter-security")
-    implementation("com.yahoo.elide", "elide-spring-boot-starter", "5.0.0-pr12")
+    implementation("com.yahoo.elide", "elide-spring-boot-starter", "5.0.0-pr15")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("com.h2database", "h2", "1.3.176")
+    implementation( "org.hibernate", "hibernate-validator", "6.1.5.Final")
     implementation("io.micrometer","micrometer-core", "1.5.1")
     testImplementation("org.springframework.boot:spring-boot-starter-test") {
         exclude(group = "org.junit.vintage", module = "junit-vintage-engine")

--- a/packages/webservice/app/src/test/kotlin/com/yahoo/navi/ws/test/integration/UserTest.kt
+++ b/packages/webservice/app/src/test/kotlin/com/yahoo/navi/ws/test/integration/UserTest.kt
@@ -8,11 +8,7 @@ import com.jayway.restassured.RestAssured.given
 import com.yahoo.navi.ws.test.framework.IntegrationTest
 import com.yahoo.navi.ws.test.framework.matchers.RegexMatcher
 import org.apache.http.HttpStatus
-import org.hamcrest.Matchers.empty
-import org.hamcrest.Matchers.equalTo
-import org.hamcrest.Matchers.hasItems
-import org.hamcrest.Matchers.not
-import org.hamcrest.Matchers.nullValue
+import org.hamcrest.Matchers.contains
 import org.junit.jupiter.api.Test
 
 class UserTest : IntegrationTest() {
@@ -77,7 +73,8 @@ class UserTest : IntegrationTest() {
             .post("/users")
             .then()
             .assertThat()
-            .statusCode(HttpStatus.SC_FORBIDDEN)
+            .body("errors.detail", contains("Forbidden User Identity"))
+            .statusCode(HttpStatus.SC_BAD_REQUEST)
 
         /*
          * Registering User1

--- a/packages/webservice/app/src/test/kotlin/com/yahoo/navi/ws/test/integration/UserTest.kt
+++ b/packages/webservice/app/src/test/kotlin/com/yahoo/navi/ws/test/integration/UserTest.kt
@@ -9,6 +9,11 @@ import com.yahoo.navi.ws.test.framework.IntegrationTest
 import com.yahoo.navi.ws.test.framework.matchers.RegexMatcher
 import org.apache.http.HttpStatus
 import org.hamcrest.Matchers.contains
+import org.hamcrest.Matchers.empty
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.hasItems
+import org.hamcrest.Matchers.not
+import org.hamcrest.Matchers.nullValue
 import org.junit.jupiter.api.Test
 
 class UserTest : IntegrationTest() {

--- a/packages/webservice/models/build.gradle.kts
+++ b/packages/webservice/models/build.gradle.kts
@@ -29,7 +29,7 @@ allOpen {
 }
 
 dependencies {
-    implementation("com.yahoo.elide", "elide-core", "5.0.0-pr12")
+    implementation("com.yahoo.elide", "elide-core", "5.0.0-pr15")
     implementation("javax.persistence", "javax.persistence-api", "2.2")
     implementation("org.hibernate", "hibernate-core", "5.4.15.Final")
 }

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/User.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/User.kt
@@ -4,7 +4,10 @@
  */
 package com.yahoo.navi.ws.models.beans
 
-import com.yahoo.elide.annotation.*
+import com.yahoo.elide.annotation.DeletePermission
+import com.yahoo.elide.annotation.Include
+import com.yahoo.elide.annotation.LifeCycleHookBinding
+import com.yahoo.elide.annotation.UpdatePermission
 import com.yahoo.navi.ws.models.checks.DefaultDashboardAuthorCheck.Companion.IS_DASHBOARD_AUTHOR
 import com.yahoo.navi.ws.models.checks.DefaultNobodyCheck.Companion.NOBODY
 import com.yahoo.navi.ws.models.checks.DefaultSameUserCheck.Companion.IS_SAME_USER
@@ -29,9 +32,9 @@ import javax.validation.constraints.NotBlank
 @DeletePermission(expression = NOBODY)
 @UpdatePermission(expression = IS_SAME_USER)
 @LifeCycleHookBinding(
-        operation = LifeCycleHookBinding.Operation.CREATE,
-        phase = LifeCycleHookBinding.TransactionPhase.PRECOMMIT,
-        hook = UserValidationHook::class
+    operation = LifeCycleHookBinding.Operation.CREATE,
+    phase = LifeCycleHookBinding.TransactionPhase.PRECOMMIT,
+    hook = UserValidationHook::class
 )
 class User : HasRoles {
 

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/User.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/User.kt
@@ -4,13 +4,11 @@
  */
 package com.yahoo.navi.ws.models.beans
 
-import com.yahoo.elide.annotation.CreatePermission
-import com.yahoo.elide.annotation.DeletePermission
-import com.yahoo.elide.annotation.Include
-import com.yahoo.elide.annotation.UpdatePermission
+import com.yahoo.elide.annotation.*
 import com.yahoo.navi.ws.models.checks.DefaultDashboardAuthorCheck.Companion.IS_DASHBOARD_AUTHOR
 import com.yahoo.navi.ws.models.checks.DefaultNobodyCheck.Companion.NOBODY
 import com.yahoo.navi.ws.models.checks.DefaultSameUserCheck.Companion.IS_SAME_USER
+import com.yahoo.navi.ws.models.hooks.UserValidationHook
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.UpdateTimestamp
 import org.hibernate.annotations.Where
@@ -29,8 +27,12 @@ import javax.validation.constraints.NotBlank
 @Entity
 @Include(rootLevel = true, type = "users")
 @DeletePermission(expression = NOBODY)
-@CreatePermission(expression = IS_SAME_USER)
 @UpdatePermission(expression = IS_SAME_USER)
+@LifeCycleHookBinding(
+        operation = LifeCycleHookBinding.Operation.CREATE,
+        phase = LifeCycleHookBinding.TransactionPhase.PRECOMMIT,
+        hook = UserValidationHook::class
+)
 class User : HasRoles {
 
     @Id

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/hooks/UserValidationHook.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/hooks/UserValidationHook.kt
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2020, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+
+package com.yahoo.navi.ws.models.hooks
+
+import com.yahoo.elide.annotation.LifeCycleHookBinding
+import com.yahoo.elide.core.exceptions.BadRequestException
+import com.yahoo.elide.functions.LifeCycleHook
+import com.yahoo.elide.security.ChangeSpec
+import com.yahoo.elide.security.RequestScope
+import com.yahoo.navi.ws.models.beans.User
+import java.util.Optional
+
+class UserValidationHook : LifeCycleHook<User> {
+    override fun execute(operation: LifeCycleHookBinding.Operation?,
+                         user: User?,
+                         requestScope: RequestScope?,
+                         changes: Optional<ChangeSpec>?) {
+        val principalName = requestScope?.user?.name
+        val userName = user?.id
+
+        if (userName != principalName) {
+            throw BadRequestException("Forbidden User Identity")
+        }
+    }
+}

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/hooks/UserValidationHook.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/hooks/UserValidationHook.kt
@@ -13,11 +13,18 @@ import com.yahoo.elide.security.RequestScope
 import com.yahoo.navi.ws.models.beans.User
 import java.util.Optional
 
+/**
+ * Validates a User model on creation.  Elide 5 does not support CreatePermission checks
+ * on ID fields - and so this logic is implemented as a hook.  Longer term, Navi should
+ * not overload the ID field - it should be a simple surrogate key.
+ */
 class UserValidationHook : LifeCycleHook<User> {
-    override fun execute(operation: LifeCycleHookBinding.Operation?,
-                         user: User?,
-                         requestScope: RequestScope?,
-                         changes: Optional<ChangeSpec>?) {
+    override fun execute(
+        operation: LifeCycleHookBinding.Operation?,
+        user: User?,
+        requestScope: RequestScope?,
+        changes: Optional<ChangeSpec>?
+    ) {
         val principalName = requestScope?.user?.name
         val userName = user?.id
 


### PR DESCRIPTION
Upgrades to Elide 5 PR 15 build.

There is a security change in PR15 that breaks the User bean create permission.  This is a workaround pending a more expensive modeling change in Navi.

I also added the Hibernate validator (which was missing) which turns on JSR303 validations.

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
