### PR TITLE
Request v2 table date time

### DIFF
--- a/packages/data/addon/adapters/facts/bard.ts
+++ b/packages/data/addon/adapters/facts/bard.ts
@@ -106,7 +106,9 @@ export default class BardFactsAdapter extends EmberObject implements NaviFactAda
    * @return dateTime param value
    */
   _buildDateTimeParam(request: RequestV2): string {
-    const dateTimeFilters = request.filters.filter(fil => fil.field === 'dateTime');
+    const dateTimeFilters = request.filters.filter(
+      fil => fil.type === 'timeDimension' && fil.field === `${request.table}.dateTime`
+    );
 
     return dateTimeFilters.map(filter => `${filter.values[0]}/${filter.values[1]}`).join(',');
   }
@@ -214,7 +216,9 @@ export default class BardFactsAdapter extends EmberObject implements NaviFactAda
     const host = configHost(options);
     const { namespace } = this;
     const table = request.table;
-    const timeGrain = request.columns.find(col => col.field === 'dateTime')?.parameters?.grain || 'all';
+    const timeGrain =
+      request.columns.find(col => col.type === 'timeDimension' && col.field === `${request.table}.dateTime`)?.parameters
+        ?.grain || 'all';
     const dimensions = this._buildDimensionsPath(request);
 
     return `${host}/${namespace}/${table}/${timeGrain}${dimensions}/`;

--- a/packages/data/addon/adapters/facts/bard.ts
+++ b/packages/data/addon/adapters/facts/bard.ts
@@ -106,6 +106,7 @@ export default class BardFactsAdapter extends EmberObject implements NaviFactAda
    * @return dateTime param value
    */
   _buildDateTimeParam(request: RequestV2): string {
+    // TODO: Get lowest grain dateTime, handle corner cases
     const dateTimeFilters = request.filters.filter(
       fil => fil.type === 'timeDimension' && fil.field === `${request.table}.dateTime`
     );
@@ -216,6 +217,7 @@ export default class BardFactsAdapter extends EmberObject implements NaviFactAda
     const host = configHost(options);
     const { namespace } = this;
     const table = request.table;
+    // TODO: Get lowest grain dateTime
     const timeGrain =
       request.columns.find(col => col.type === 'timeDimension' && col.field === `${request.table}.dateTime`)?.parameters
         ?.grain || 'all';

--- a/packages/data/addon/models/metadata/function-parameter.ts
+++ b/packages/data/addon/models/metadata/function-parameter.ts
@@ -12,7 +12,7 @@ import BardDimensionService from 'navi-data/services/bard-dimensions';
 export const INTRINSIC_VALUE_EXPRESSION = 'self';
 
 type FunctionParameterType = 'ref' | 'primitive';
-export type ColumnFunctionParametersValues = TODO[]; //TODO need to normalize
+export type ColumnFunctionParametersValues = { name: string; description?: string; id: string }[]; //TODO need to normalize
 
 type LocalFunctionParameter = FunctionParameterMetadataModel & {
   type: 'ref';
@@ -37,7 +37,6 @@ export interface FunctionParameterMetadataPayload {
   name: string;
   description?: string;
   source: string;
-  valueType: TODO;
   type: FunctionParameterType;
   expression?: string;
   defaultValue?: string;
@@ -78,11 +77,6 @@ export default class FunctionParameterMetadataModel extends EmberObject implemen
   source!: string;
 
   /**
-   * @property {ValueType} valueType
-   */
-  valueType!: TODO;
-
-  /**
    * @property {string} type - either "ref" or "primitive"
    */
   type!: FunctionParameterType;
@@ -95,11 +89,11 @@ export default class FunctionParameterMetadataModel extends EmberObject implemen
 
   /**
    * @private
-   * @property {string[]|undefined} _localValues
+   * @property {ColumnFunctionParametersValues[]|undefined} _localValues
    * if column function ids are not supplied by the metadata endpoint,
    * then enum values provided in the parameter will be placed here
    */
-  _localValues?: string[];
+  _localValues?: ColumnFunctionParametersValues;
 
   /**
    * @property {Promise} values - array of values used for function parameters with an enum type
@@ -111,7 +105,7 @@ export default class FunctionParameterMetadataModel extends EmberObject implemen
 
     const [lookup, dimensionId] = this.expression?.split(':') || [];
     if (this.type === 'ref' && lookup === 'dimension' && dimensionId) {
-      return this.dimensionService.all(dimensionId, this.source).then((results: TODO) => results.toArray?.());
+      return this.dimensionService.all(dimensionId, this.source).then((results: TODO) => results.toArray());
     }
     return undefined;
   }

--- a/packages/data/addon/models/metadata/function-parameter.ts
+++ b/packages/data/addon/models/metadata/function-parameter.ts
@@ -12,7 +12,7 @@ import BardDimensionService from 'navi-data/services/bard-dimensions';
 export const INTRINSIC_VALUE_EXPRESSION = 'self';
 
 type FunctionParameterType = 'ref' | 'primitive';
-export type ColumnFunctionParametersValues = { name: string; description?: string; id: string }[]; //TODO need to normalize
+export type ColumnFunctionParametersValues = { id: string; name?: string; description?: string }[]; //TODO need to normalize
 
 type LocalFunctionParameter = FunctionParameterMetadataModel & {
   type: 'ref';

--- a/packages/data/addon/serializers/metadata/bard.ts
+++ b/packages/data/addon/serializers/metadata/bard.ts
@@ -219,8 +219,9 @@ export default class BardMetadataSerializer extends EmberObject implements NaviM
     const grains = grainIds.sort().join(',');
     const columnFunctionId = `${table.name}.grain(${grains})`;
     let defaultValue;
-    if (grainIds.includes(config.navi.defaultTimeGrain)) {
-      defaultValue = config.navi.defaultTimeGrain;
+    const { defaultTimeGrain } = config.navi;
+    if (defaultTimeGrain && grainIds.includes(defaultTimeGrain)) {
+      defaultValue = defaultTimeGrain;
     } else {
       defaultValue = grainIds[0];
     }
@@ -233,7 +234,7 @@ export default class BardMetadataSerializer extends EmberObject implements NaviM
         {
           id: 'grain',
           name: 'Time Grain',
-          description: 'The Time Grain to group dates by',
+          description: 'The time grain to group dates by',
           source: dataSourceName,
           type: 'ref',
           expression: INTRINSIC_VALUE_EXPRESSION,

--- a/packages/data/addon/serializers/metadata/bard.ts
+++ b/packages/data/addon/serializers/metadata/bard.ts
@@ -215,11 +215,15 @@ export default class BardMetadataSerializer extends EmberObject implements NaviM
    * @param dataSourceName - data source name
    */
   private createTimeGrainColumnFunction(table: RawTablePayload, dataSourceName: string): ColumnFunctionMetadataPayload {
-    const grains = table.timeGrains
-      .map(g => g.name)
-      .sort()
-      .join(',');
+    const grainIds = table.timeGrains.map(g => g.name);
+    const grains = grainIds.sort().join(',');
     const columnFunctionId = `${table.name}.grain(${grains})`;
+    let defaultValue;
+    if (grainIds.includes(config.navi.defaultTimeGrain)) {
+      defaultValue = config.navi.defaultTimeGrain;
+    } else {
+      defaultValue = grainIds[0];
+    }
     return {
       id: columnFunctionId,
       name: 'Time Grain',
@@ -233,7 +237,7 @@ export default class BardMetadataSerializer extends EmberObject implements NaviM
           source: dataSourceName,
           type: 'ref',
           expression: INTRINSIC_VALUE_EXPRESSION,
-          defaultValue: 'day', // TODO: first check navi.defaultTimeGrain, else first (maybe lowest?)
+          defaultValue,
           _localValues: table.timeGrains.map(grain => ({
             id: grain.name,
             description: grain.description || '',

--- a/packages/data/addon/serializers/metadata/column-function.ts
+++ b/packages/data/addon/serializers/metadata/column-function.ts
@@ -34,7 +34,6 @@ export function constructFunctionParameters(
       id: param,
       name: param,
       description,
-      valueType: 'TEXT',
       type: 'ref', // It will always be ref for our case because all our parameters have their valid values defined in a dimension or enum
       expression: type === 'dimension' ? `dimension:${dimensionName}` : INTRINSIC_VALUE_EXPRESSION,
       _localValues: values,

--- a/packages/data/config/navi-config.d.ts
+++ b/packages/data/config/navi-config.d.ts
@@ -9,5 +9,6 @@ declare module 'navi-config' {
     dataSources: NaviDataSource[];
     defaultDataSource?: string;
     searchThresholds: TODO;
+    defaultTimeGrain?: string;
   }
 }

--- a/packages/data/tests/unit/adapters/facts/bard-test.js
+++ b/packages/data/tests/unit/adapters/facts/bard-test.js
@@ -13,8 +13,8 @@ const TestRequest = {
     requestVersion: '2.0',
     filters: [
       {
-        field: 'dateTime',
-        parameters: {},
+        field: 'table1.dateTime',
+        parameters: { grain: 'grain1' },
         type: 'timeDimension',
         operator: 'bet',
         values: ['2015-01-03', '2015-01-04']
@@ -50,7 +50,7 @@ const TestRequest = {
     ],
     columns: [
       {
-        field: 'dateTime',
+        field: 'table1.dateTime',
         parameters: {
           grain: 'grain1'
         },
@@ -178,9 +178,11 @@ module('Unit | Adapter | facts/bard', function(hooks) {
     assert.expect(2);
 
     let singleInterval = {
+      table: 'tableName',
       filters: [
         {
-          field: 'dateTime',
+          field: 'tableName.dateTime',
+          type: 'timeDimension',
           parameters: {},
           operator: 'bet',
           values: ['start', 'end']
@@ -194,15 +196,18 @@ module('Unit | Adapter | facts/bard', function(hooks) {
     );
 
     let manyIntervals = {
+      table: 'tableName',
       filters: [
         {
-          field: 'dateTime',
+          field: 'tableName.dateTime',
+          type: 'timeDimension',
           parameters: {},
           operator: 'bet',
           values: ['start1', 'end1']
         },
         {
-          field: 'dateTime',
+          field: 'tableName.dateTime',
+          type: 'timeDimension',
           parameters: {},
           operator: 'bet',
           values: ['start2', 'end2']
@@ -625,7 +630,7 @@ module('Unit | Adapter | facts/bard', function(hooks) {
     let noFiltersAndNoHavings = assign({}, TestRequest, {
       filters: [
         {
-          field: 'dateTime',
+          field: 'table1.dateTime',
           parameters: {},
           type: 'timeDimension',
           operator: 'bet',
@@ -833,7 +838,15 @@ module('Unit | Adapter | facts/bard', function(hooks) {
     );
 
     let onlyDateFilter = assign({}, TestRequest, {
-      filters: [{ field: 'dateTime', type: 'timeDimension', operator: 'bet', values: ['2015-01-03', '2015-01-04'] }]
+      filters: [
+        {
+          field: 'table1.dateTime',
+          parameters: { grain: 'grain1' },
+          type: 'timeDimension',
+          operator: 'bet',
+          values: ['2015-01-03', '2015-01-04']
+        }
+      ]
     });
     assert.equal(
       decodeURIComponent(Adapter.urlForFindQuery(onlyDateFilter)),
@@ -842,7 +855,15 @@ module('Unit | Adapter | facts/bard', function(hooks) {
     );
 
     let requestWithSort = assign({}, TestRequest, {
-      filters: [{ field: 'dateTime', type: 'timeDimension', operator: 'bet', values: ['2015-01-03', '2015-01-04'] }],
+      filters: [
+        {
+          field: 'table1.dateTime',
+          parameters: { grain: 'grain1' },
+          type: 'timeDimension',
+          operator: 'bet',
+          values: ['2015-01-03', '2015-01-04']
+        }
+      ],
       sorts: [{ field: 'm1' }, { field: 'm2' }]
     });
     assert.equal(

--- a/packages/data/tests/unit/models/metadata/column-function-test.ts
+++ b/packages/data/tests/unit/models/metadata/column-function-test.ts
@@ -2,7 +2,9 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { TestContext } from 'ember-test-helpers';
 import ColumnFunctionMetadataModel, { ColumnFunctionMetadataPayload } from 'navi-data/models/metadata/column-function';
-import { FunctionParameterMetadataPayload } from 'navi-data/models/metadata/function-parameter';
+import FunctionParameterMetadataModel, {
+  FunctionParameterMetadataPayload
+} from 'navi-data/models/metadata/function-parameter';
 
 let Payload: ColumnFunctionMetadataPayload, ColumnFunction: ColumnFunctionMetadataModel;
 
@@ -15,7 +17,6 @@ module('Unit | Metadata Model | Column Function', function(hooks) {
       name: 'Currency',
       description: 'moneyz',
       source: 'bardOne',
-      valueType: 'text',
       type: 'ref',
       expression: 'dimension:displayCurrency',
       defaultValue: 'USD'
@@ -38,8 +39,8 @@ module('Unit | Metadata Model | Column Function', function(hooks) {
     assert.equal(ColumnFunctionMetadataModel.identifierField, 'id', 'identifierField property is set to `id`');
   });
 
-  test('it properly hydrates properties', function(assert) {
-    assert.expect(9);
+  test('it properly hydrates properties', async function(assert) {
+    assert.expect(12);
 
     const { id, name, description, source, parameters } = ColumnFunction;
 
@@ -51,10 +52,21 @@ module('Unit | Metadata Model | Column Function', function(hooks) {
     const param = parameters[0];
     const paramPayload = Payload._parametersPayload?.[0];
 
-    assert.deepEqual(param.valueType, paramPayload?.valueType, 'parameters property is hydrated properly');
-    assert.deepEqual(param.name, paramPayload?.name, 'parameters property is hydrated properly');
-    assert.deepEqual(param.id, paramPayload?.id, 'parameters property is hydrated properly');
-    assert.deepEqual(param.id, paramPayload?.id, 'parameters property is hydrated properly');
-    assert.deepEqual(param.id, paramPayload?.id, 'parameters property is hydrated properly');
+    assert.ok(param instanceof FunctionParameterMetadataModel, 'parameters are loaded into their metadata model');
+    assert.deepEqual(param.id, paramPayload?.id, 'parameters id property is hydrated properly');
+    assert.deepEqual(param.name, paramPayload?.name, 'parameters name property is hydrated properly');
+    assert.deepEqual(
+      param.description,
+      paramPayload?.description,
+      'parameters description property is hydrated properly'
+    );
+    assert.deepEqual(param.source, paramPayload?.source, 'parameters source property is hydrated properly');
+    assert.deepEqual(param.type, paramPayload?.type, 'parameters type property is hydrated properly');
+    assert.deepEqual(param.expression, paramPayload?.expression, 'parameters expression property is hydrated properly');
+    assert.deepEqual(
+      param.defaultValue,
+      paramPayload?.defaultValue,
+      'parameters defaultValue property is hydrated properly'
+    );
   });
 });

--- a/packages/data/tests/unit/models/metadata/column-function-test.ts
+++ b/packages/data/tests/unit/models/metadata/column-function-test.ts
@@ -40,8 +40,6 @@ module('Unit | Metadata Model | Column Function', function(hooks) {
   });
 
   test('it properly hydrates properties', async function(assert) {
-    assert.expect(12);
-
     const { id, name, description, source, parameters } = ColumnFunction;
 
     assert.equal(id, Payload.id, 'id property is hydrated properly');

--- a/packages/data/tests/unit/models/metadata/function-parameter-test.ts
+++ b/packages/data/tests/unit/models/metadata/function-parameter-test.ts
@@ -16,7 +16,7 @@ let Payload: FunctionParameterMetadataPayload;
 let server: Server;
 let FunctionParameter: FunctionParameterMetadataModel;
 
-module('Unit | Metadata Model | Function Argument', function(hooks) {
+module('Unit | Metadata Model | Function Parameter', function(hooks) {
   setupTest(hooks);
 
   hooks.beforeEach(async function(this: TestContext) {
@@ -26,7 +26,6 @@ module('Unit | Metadata Model | Function Argument', function(hooks) {
     Payload = {
       id: 'currency',
       name: 'Currency',
-      valueType: 'TEXT',
       type: 'ref',
       source: 'bardOne',
       expression: 'dimension:dimensionOne',
@@ -48,13 +47,11 @@ module('Unit | Metadata Model | Function Argument', function(hooks) {
   });
 
   test('it properly hydrates properties', function(assert) {
-    assert.expect(7);
+    assert.expect(6);
 
     assert.deepEqual(FunctionParameter.id, Payload.id, 'id property is hydrated properly');
 
     assert.equal(FunctionParameter.name, Payload.name, 'name property was properly hydrated');
-
-    assert.equal(FunctionParameter.valueType, Payload.valueType, 'valueType property was properly hydrated');
 
     assert.equal(FunctionParameter.type, Payload.type, 'type property was properly hydrated');
 
@@ -95,17 +92,18 @@ module('Unit | Metadata Model | Function Argument', function(hooks) {
     const trendArgPayload: FunctionParameterMetadataPayload = {
       id: 'trend',
       name: 'Trend',
-      valueType: 'TEXT',
       source: 'bardOne',
       type: 'ref',
       expression: INTRINSIC_VALUE_EXPRESSION,
       _localValues: [
         {
           id: 'yoy',
+          name: 'YoY',
           description: 'Year Over Year'
         },
         {
           id: 'wow',
+          name: 'WoW',
           description: 'Week Over Week'
         }
       ],
@@ -124,7 +122,6 @@ module('Unit | Metadata Model | Function Argument', function(hooks) {
     const noValuesPayload: FunctionParameterMetadataPayload = {
       id: 'foo',
       name: 'Foo',
-      valueType: 'TEXT',
       type: 'primitive',
       source: 'bardOne',
       expression: undefined,

--- a/packages/data/tests/unit/models/metadata/function-parameter-test.ts
+++ b/packages/data/tests/unit/models/metadata/function-parameter-test.ts
@@ -47,8 +47,6 @@ module('Unit | Metadata Model | Function Parameter', function(hooks) {
   });
 
   test('it properly hydrates properties', function(assert) {
-    assert.expect(6);
-
     assert.deepEqual(FunctionParameter.id, Payload.id, 'id property is hydrated properly');
 
     assert.equal(FunctionParameter.name, Payload.name, 'name property was properly hydrated');

--- a/packages/data/tests/unit/serializers/metadata/bard-test.js
+++ b/packages/data/tests/unit/serializers/metadata/bard-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import config from 'ember-get-config';
 
 const Payload = {
   tables: [
@@ -766,5 +767,33 @@ module('Unit | Serializer | metadata/bard', function(hooks) {
       ],
       'Metric is constructed correctly with no new column function id or parameter'
     );
+  });
+
+  test('configure defaultTimeGrain if it exists', async function(assert) {
+    const originalDefaultTimeGrain = config.navi.defaultTimeGrain;
+
+    const table = {
+      name: 'table',
+      timeGrains: [
+        { name: 'day', longName: 'Day' },
+        { name: 'hour', longName: 'Hour' },
+        { name: 'week', longName: 'Week' },
+        { name: 'month', longName: 'Month' }
+      ]
+    };
+
+    config.navi.defaultTimeGrain = 'week';
+    let columnFunction = Serializer.createTimeGrainColumnFunction(table, 'bardOne');
+    assert.equal(columnFunction._parametersPayload[0].defaultValue, 'week', 'Picks default from config');
+
+    config.navi.defaultTimeGrain = 'year';
+    columnFunction = Serializer.createTimeGrainColumnFunction(table, 'bardOne');
+    assert.equal(columnFunction._parametersPayload[0].defaultValue, 'day', 'Falls back to first defined grain');
+
+    config.navi.defaultTimeGrain = 'hour';
+    columnFunction = Serializer.createTimeGrainColumnFunction(table, 'bardOne');
+    assert.equal(columnFunction._parametersPayload[0].defaultValue, 'hour', 'Picks default from config');
+
+    config.navi.defaultTimeGrain = originalDefaultTimeGrain;
   });
 });

--- a/packages/data/tests/unit/serializers/metadata/bard-test.js
+++ b/packages/data/tests/unit/serializers/metadata/bard-test.js
@@ -495,7 +495,7 @@ const ParameterConvertToMetricFunction = [
     _parametersPayload: [
       {
         defaultValue: 'day',
-        description: 'The Time Grain to group dates by',
+        description: 'The time grain to group dates by',
         expression: 'self',
         id: 'grain',
         name: 'Time Grain',
@@ -516,7 +516,7 @@ const ParameterConvertToMetricFunction = [
     _parametersPayload: [
       {
         defaultValue: 'day',
-        description: 'The Time Grain to group dates by',
+        description: 'The time grain to group dates by',
         expression: 'self',
         id: 'grain',
         name: 'Time Grain',
@@ -675,7 +675,7 @@ module('Unit | Serializer | metadata/bard', function(hooks) {
           _parametersPayload: [
             {
               defaultValue: 'day',
-              description: 'The Time Grain to group dates by',
+              description: 'The time grain to group dates by',
               expression: 'self',
               id: 'grain',
               name: 'Time Grain',

--- a/packages/data/tests/unit/serializers/metadata/bard-test.js
+++ b/packages/data/tests/unit/serializers/metadata/bard-test.js
@@ -266,7 +266,7 @@ const Tables = [
     metricIds: ['metricOne', 'metricFour', 'metricTwo'],
     name: 'tableLongName',
     source: 'bardOne',
-    timeDimensionIds: ['dimensionThree'],
+    timeDimensionIds: ['dimensionThree', 'tableName.dateTime'],
     timeGrainIds: ['day', 'month']
   },
   {
@@ -278,7 +278,7 @@ const Tables = [
     metricIds: ['metricFive', 'metricTwo', 'metricOne', 'metricThree'],
     name: 'Second Table',
     source: 'bardOne',
-    timeDimensionIds: ['dimensionThree'],
+    timeDimensionIds: ['dimensionThree', 'secondTable.dateTime'],
     timeGrainIds: ['day', 'week']
   }
 ];
@@ -330,6 +330,54 @@ const TimeDimensions = [
     valueType: 'date',
     storageStrategy: null,
     partialData: true
+  },
+  {
+    category: 'Date',
+    columnFunctionId: 'tableName.grain(day,month)',
+    description: undefined,
+    fields: undefined,
+    id: 'tableName.dateTime',
+    name: 'Date Time',
+    source: 'bardOne',
+    supportedGrains: [
+      {
+        expression: '',
+        grain: 'DAY',
+        id: 'tableName.dateTime.day'
+      },
+      {
+        expression: '',
+        grain: 'MONTH',
+        id: 'tableName.dateTime.month'
+      }
+    ],
+    timeZone: 'UTC',
+    type: 'field',
+    valueType: 'date'
+  },
+  {
+    category: 'Date',
+    columnFunctionId: 'secondTable.grain(day,week)',
+    description: undefined,
+    fields: undefined,
+    id: 'secondTable.dateTime',
+    name: 'Date Time',
+    source: 'bardOne',
+    supportedGrains: [
+      {
+        expression: '',
+        grain: 'DAY',
+        id: 'secondTable.dateTime.day'
+      },
+      {
+        expression: '',
+        grain: 'WEEK',
+        id: 'secondTable.dateTime.week'
+      }
+    ],
+    timeZone: 'UTC',
+    type: 'field',
+    valueType: 'date'
   }
 ];
 
@@ -402,8 +450,7 @@ const ParameterConvertToMetricFunction = [
         expression: 'dimension:displayCurrency',
         id: 'currency',
         name: 'currency',
-        type: 'ref',
-        valueType: 'TEXT'
+        type: 'ref'
       },
       {
         _localValues: undefined,
@@ -413,8 +460,7 @@ const ParameterConvertToMetricFunction = [
         expression: 'dimension:displayFormat',
         id: 'format',
         name: 'format',
-        type: 'ref',
-        valueType: 'TEXT'
+        type: 'ref'
       }
     ],
     description: '',
@@ -432,14 +478,63 @@ const ParameterConvertToMetricFunction = [
         expression: 'dimension:displayCurrency',
         id: 'currency',
         name: 'currency',
-        type: 'ref',
-        valueType: 'TEXT'
+        type: 'ref'
       }
     ],
     description: '',
     id: 'currency',
     name: '',
     source: 'bardOne'
+  },
+  {
+    id: 'tableName.grain(day,month)',
+    name: 'Time Grain',
+    description: 'Time Grain',
+    source: 'bardOne',
+    _parametersPayload: [
+      {
+        defaultValue: 'day',
+        description: 'The Time Grain to group dates by',
+        expression: 'self',
+        id: 'grain',
+        name: 'Time Grain',
+        source: 'bardOne',
+        type: 'ref',
+        _localValues: [
+          { id: 'day', description: 'The tableName day grain', name: 'Day' },
+          { id: 'month', description: 'The tableName month grain', name: 'MONTH' }
+        ]
+      }
+    ]
+  },
+  {
+    id: 'secondTable.grain(day,week)',
+    name: 'Time Grain',
+    description: 'Time Grain',
+    source: 'bardOne',
+    _parametersPayload: [
+      {
+        defaultValue: 'day',
+        description: 'The Time Grain to group dates by',
+        expression: 'self',
+        id: 'grain',
+        name: 'Time Grain',
+        source: 'bardOne',
+        type: 'ref',
+        _localValues: [
+          {
+            description: 'The secondTable day grain',
+            id: 'day',
+            name: 'Day'
+          },
+          {
+            description: 'The secondTable week grain',
+            id: 'week',
+            name: 'Week'
+          }
+        ]
+      }
+    ]
   }
 ];
 
@@ -563,7 +658,6 @@ module('Unit | Serializer | metadata/bard', function(hooks) {
               id: 'currency',
               name: 'currency',
               type: 'ref',
-              valueType: 'TEXT',
               source: 'bardOne'
             }
           ],
@@ -571,6 +665,30 @@ module('Unit | Serializer | metadata/bard', function(hooks) {
           id: 'moneyMetric',
           name: 'Mo Money',
           source: 'bardOne'
+        },
+        {
+          description: 'Time Grain',
+          id: 'tableName.grain(day)',
+          name: 'Time Grain',
+          source: 'bardOne',
+          _parametersPayload: [
+            {
+              defaultValue: 'day',
+              description: 'The Time Grain to group dates by',
+              expression: 'self',
+              id: 'grain',
+              name: 'Time Grain',
+              source: 'bardOne',
+              type: 'ref',
+              _localValues: [
+                {
+                  description: 'The tableName day grain',
+                  id: 'day',
+                  name: 'Day'
+                }
+              ]
+            }
+          ]
         }
       ],
       'Raw column functions are normalized correctly'

--- a/packages/data/tests/unit/services/navi-facts-test.js
+++ b/packages/data/tests/unit/services/navi-facts-test.js
@@ -9,7 +9,7 @@ const TestRequest = {
   table: 'table1',
   requestVersion: '2.0',
   columns: [
-    { type: 'timeDimension', field: 'dateTime', parameters: { grain: 'grain1' } },
+    { type: 'timeDimension', field: 'table1.dateTime', parameters: { grain: 'grain1' } },
     { type: 'metric', field: 'm1', parameters: {} },
     { type: 'metric', field: 'm2', parameters: {} },
     { type: 'dimension', field: 'd1', parameters: { field: 'id' } },
@@ -18,7 +18,7 @@ const TestRequest = {
   filters: [
     {
       type: 'timeDimension',
-      field: 'dateTime',
+      field: 'table1.dateTime',
       parameters: {
         grain: 'grain1'
       },

--- a/packages/data/tests/unit/services/navi-metadata-test.ts
+++ b/packages/data/tests/unit/services/navi-metadata-test.ts
@@ -59,7 +59,7 @@ module('Unit | Service | navi-metadata', function(hooks) {
       timeDimensions.every(dim => dim instanceof TimeDimensionMetadataModel),
       '`bardTwo` `TimeDimensionMetadataModel`s are loaded into the keg'
     );
-    assert.deepEqual(timeDimensions.mapBy('id'), [], 'All `bardTwo` time dimensions are loaded');
+    assert.deepEqual(timeDimensions.mapBy('id'), ['inventory.dateTime'], 'All `bardTwo` time dimensions are loaded');
 
     const metrics = keg.all('metadata/metric', 'bardTwo');
     assert.ok(


### PR DESCRIPTION
Resolves #938 #916

## Description
Each table in fili can specify a list of timegrains to filter on, so we want to model this as a unique timeDimension for each table

## Proposed Changes
For each table from fili, we now create a `${tableName}.dateTime` with a `columnFunctionId = ${tableName}.grain(${grains})`

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
