### PR TITLE
Update: Create columnFunction for dimension fields

### DIFF
--- a/packages/data/addon/mirage/fixtures/bard-meta-dimensions.js
+++ b/packages/data/addon/mirage/fixtures/bard-meta-dimensions.js
@@ -1,3 +1,8 @@
+const defaultFields = [
+  { name: 'id', description: 'Dimension ID' },
+  { name: 'desc', description: 'Dimension Description' }
+];
+
 export default {
   defaultDims: [
     {
@@ -6,7 +11,8 @@ export default {
       cardinality: 100,
       category: 'test',
       datatype: 'text',
-      storageStrategy: 'loaded'
+      storageStrategy: 'loaded',
+      fields: defaultFields
     },
     {
       name: 'userDeviceType',
@@ -14,7 +20,8 @@ export default {
       cardinality: 100,
       category: 'test',
       datatype: 'text',
-      storageStrategy: 'loaded'
+      storageStrategy: 'loaded',
+      fields: defaultFields
     },
     {
       name: 'age',
@@ -22,7 +29,8 @@ export default {
       cardinality: 100,
       category: 'test',
       datatype: 'text',
-      storageStrategy: 'loaded'
+      storageStrategy: 'loaded',
+      fields: defaultFields
     },
     {
       name: 'currency',
@@ -30,7 +38,8 @@ export default {
       cardinality: 500,
       category: 'test',
       datatype: 'text',
-      storageStrategy: 'loaded'
+      storageStrategy: 'loaded',
+      fields: defaultFields
     },
     {
       name: 'displayCurrency',
@@ -38,7 +47,8 @@ export default {
       cardinality: 54,
       category: 'test',
       datatype: 'text',
-      storageStrategy: 'loaded'
+      storageStrategy: 'loaded',
+      fields: defaultFields
     },
     {
       name: 'gender',
@@ -46,7 +56,8 @@ export default {
       cardinality: 100,
       category: 'test',
       datatype: 'text',
-      storageStrategy: 'loaded'
+      storageStrategy: 'loaded',
+      fields: defaultFields
     },
     {
       name: 'propertyCountry',
@@ -54,7 +65,8 @@ export default {
       cardinality: 100,
       category: 'test',
       datatype: 'text',
-      storageStrategy: 'loaded'
+      storageStrategy: 'loaded',
+      fields: defaultFields
     },
     {
       name: 'loginState',
@@ -62,7 +74,8 @@ export default {
       cardinality: 100,
       category: 'test',
       datatype: 'text',
-      storageStrategy: 'loaded'
+      storageStrategy: 'loaded',
+      fields: defaultFields
     },
     {
       name: 'platform',
@@ -70,7 +83,8 @@ export default {
       cardinality: 100,
       category: 'test',
       datatype: 'text',
-      storageStrategy: 'loaded'
+      storageStrategy: 'loaded',
+      fields: defaultFields
     },
     {
       name: 'userDeviceTypeV3',
@@ -78,7 +92,8 @@ export default {
       cardinality: 100,
       category: 'test',
       datatype: 'text',
-      storageStrategy: 'loaded'
+      storageStrategy: 'loaded',
+      fields: defaultFields
     },
     {
       name: 'productFamily',
@@ -86,7 +101,8 @@ export default {
       cardinality: 100,
       category: 'Asset',
       datatype: 'text',
-      storageStrategy: 'loaded'
+      storageStrategy: 'loaded',
+      fields: defaultFields
     },
     {
       name: 'property',
@@ -94,7 +110,8 @@ export default {
       cardinality: 5000,
       category: 'Asset',
       datatype: 'text',
-      storageStrategy: 'loaded'
+      storageStrategy: 'loaded',
+      fields: defaultFields
     },
     {
       name: 'browser',
@@ -102,7 +119,8 @@ export default {
       cardinality: 100,
       category: 'test',
       datatype: 'text',
-      storageStrategy: 'loaded'
+      storageStrategy: 'loaded',
+      fields: defaultFields
     },
     {
       name: 'browserVersion',
@@ -110,7 +128,8 @@ export default {
       cardinality: 100,
       category: 'test',
       datatype: 'text',
-      storageStrategy: 'loaded'
+      storageStrategy: 'loaded',
+      fields: defaultFields
     },
     {
       name: 'productRegion',
@@ -118,7 +137,8 @@ export default {
       cardinality: 100,
       category: 'test',
       datatype: 'text',
-      storageStrategy: 'loaded'
+      storageStrategy: 'loaded',
+      fields: defaultFields
     },
     {
       name: 'platformVersion',
@@ -126,7 +146,8 @@ export default {
       cardinality: 100,
       category: 'test',
       datatype: 'text',
-      storageStrategy: 'loaded'
+      storageStrategy: 'loaded',
+      fields: defaultFields
     },
     {
       name: 'screenType',
@@ -134,7 +155,8 @@ export default {
       cardinality: 100,
       category: 'test',
       datatype: 'text',
-      storageStrategy: 'loaded'
+      storageStrategy: 'loaded',
+      fields: defaultFields
     },
     {
       name: 'lang',
@@ -142,7 +164,8 @@ export default {
       cardinality: 100,
       category: 'test',
       datatype: 'text',
-      storageStrategy: 'loaded'
+      storageStrategy: 'loaded',
+      fields: defaultFields
     },
     {
       name: 'userCountry',
@@ -150,7 +173,8 @@ export default {
       cardinality: 100,
       category: 'test',
       datatype: 'text',
-      storageStrategy: 'loaded'
+      storageStrategy: 'loaded',
+      fields: defaultFields
     },
     {
       name: 'userRegion',
@@ -158,7 +182,8 @@ export default {
       cardinality: 100,
       category: 'test',
       datatype: 'text',
-      storageStrategy: 'loaded'
+      storageStrategy: 'loaded',
+      fields: defaultFields
     },
     {
       name: 'userSubRegion',
@@ -166,7 +191,8 @@ export default {
       cardinality: 100,
       category: 'test',
       datatype: 'text',
-      storageStrategy: 'loaded'
+      storageStrategy: 'loaded',
+      fields: defaultFields
     },
     {
       name: 'productSubRegion',
@@ -174,7 +200,8 @@ export default {
       cardinality: 100,
       category: 'test',
       datatype: 'text',
-      storageStrategy: 'loaded'
+      storageStrategy: 'loaded',
+      fields: defaultFields
     },
     {
       name: 'outflowChannel',
@@ -182,7 +209,8 @@ export default {
       cardinality: 100,
       category: 'test',
       datatype: 'text',
-      storageStrategy: 'loaded'
+      storageStrategy: 'loaded',
+      fields: defaultFields
     },
     {
       name: 'outflowSite',
@@ -190,7 +218,8 @@ export default {
       cardinality: 100,
       category: 'test',
       datatype: 'text',
-      storageStrategy: 'loaded'
+      storageStrategy: 'loaded',
+      fields: defaultFields
     },
     {
       name: 'contextId',
@@ -198,7 +227,8 @@ export default {
       cardinality: 0,
       category: 'test',
       datatype: 'text',
-      storageStrategy: 'none'
+      storageStrategy: 'none',
+      fields: defaultFields
     },
     {
       name: 'multiSystemId',
@@ -219,7 +249,8 @@ export default {
       cardinality: 39896,
       category: 'test',
       datatype: 'date',
-      storageStrategy: 'loaded'
+      storageStrategy: 'loaded',
+      fields: defaultFields
     },
     {
       name: 'commaDim',
@@ -227,7 +258,8 @@ export default {
       cardinality: 2,
       category: 'test',
       datatype: 'text',
-      storageStrategy: 'loaded'
+      storageStrategy: 'loaded',
+      fields: defaultFields
     },
     {
       name: 'Budget',
@@ -235,7 +267,8 @@ export default {
       cardinality: 462664,
       category: 'test',
       datatype: 'number',
-      storageStrategy: 'loaded'
+      storageStrategy: 'loaded',
+      fields: defaultFields
     }
   ],
 
@@ -246,7 +279,8 @@ export default {
       cardinality: 9999999,
       category: 'Asset',
       datatype: 'text',
-      storageStrategy: 'loaded'
+      storageStrategy: 'loaded',
+      fields: defaultFields
     },
     {
       name: 'parentEventId',
@@ -254,7 +288,8 @@ export default {
       cardinality: 9999999,
       category: 'Asset',
       datatype: 'text',
-      storageStrategy: 'loaded'
+      storageStrategy: 'loaded',
+      fields: defaultFields
     }
   ],
 
@@ -265,7 +300,8 @@ export default {
       cardinality: 100,
       category: 'Personal',
       datatype: 'text',
-      storageStrategy: 'loaded'
+      storageStrategy: 'loaded',
+      fields: defaultFields
     },
     {
       name: 'container',
@@ -273,7 +309,8 @@ export default {
       cardinality: 100,
       category: 'Personal',
       datatype: 'text',
-      storageStrategy: 'loaded'
+      storageStrategy: 'loaded',
+      fields: defaultFields
     },
     {
       name: 'location',
@@ -281,7 +318,8 @@ export default {
       cardinality: 100,
       category: 'World',
       datatype: 'text',
-      storageStrategy: 'loaded'
+      storageStrategy: 'loaded',
+      fields: defaultFields
     },
     {
       name: 'requirement',
@@ -289,7 +327,8 @@ export default {
       cardinality: 100,
       category: 'World',
       datatype: 'text',
-      storageStrategy: 'loaded'
+      storageStrategy: 'loaded',
+      fields: defaultFields
     },
     {
       name: 'recipe',
@@ -297,7 +336,8 @@ export default {
       cardinality: 100,
       category: 'Personal',
       datatype: 'text',
-      storageStrategy: 'loaded'
+      storageStrategy: 'loaded',
+      fields: defaultFields
     },
     {
       name: 'displayCurrency',
@@ -305,7 +345,8 @@ export default {
       cardinality: 34,
       category: 'Personal',
       datatype: 'text',
-      storageStrategy: 'loaded'
+      storageStrategy: 'loaded',
+      fields: defaultFields
     }
   ]
 };

--- a/packages/data/addon/models/metadata/dimension.ts
+++ b/packages/data/addon/models/metadata/dimension.ts
@@ -23,7 +23,7 @@ export interface DimensionMetadata extends ColumnMetadata {
 export interface DimensionMetadataPayload extends ColumnMetadataPayload {
   fields?: Field[];
   cardinality?: Cardinality;
-  storageStrategy?: 'loaded' | 'none';
+  storageStrategy?: TODO<'loaded' | 'none' | null>;
 }
 
 export default class DimensionMetadataModel extends ColumnMetadataModel
@@ -133,7 +133,7 @@ export default class DimensionMetadataModel extends ColumnMetadataModel
     return field?.name || this.primaryKeyFieldName;
   }
 
-  storageStrategy?: 'loaded' | 'none';
+  storageStrategy?: TODO<'loaded' | 'none' | null>;
 
   /**
    * @property {Promise} extended - extended metadata for the dimension that isn't provided in initial table fullView metadata load

--- a/packages/data/addon/models/metadata/function-parameter.ts
+++ b/packages/data/addon/models/metadata/function-parameter.ts
@@ -39,7 +39,7 @@ export interface FunctionParameterMetadataPayload {
   source: string;
   type: FunctionParameterType;
   expression?: string;
-  defaultValue?: string;
+  defaultValue?: string | null;
   _localValues?: ColumnFunctionParametersValues;
 }
 
@@ -113,5 +113,5 @@ export default class FunctionParameterMetadataModel extends EmberObject implemen
   /**
    * @property {string} defaultValue
    */
-  defaultValue?: string;
+  defaultValue?: string | null;
 }

--- a/packages/data/addon/serializers/metadata/bard.ts
+++ b/packages/data/addon/serializers/metadata/bard.ts
@@ -17,7 +17,6 @@ import {
   INTRINSIC_VALUE_EXPRESSION,
   ColumnFunctionParametersValues
 } from 'navi-data/models/metadata/function-parameter';
-import { bind } from 'lodash-es';
 
 const LOAD_CARDINALITY = config.navi.searchThresholds.contains;
 const MAX_LOAD_CARDINALITY = config.navi.searchThresholds.in;
@@ -38,12 +37,11 @@ type RawColumnPayload = {
   description?: string;
   longName: string;
   category?: string;
-  uri?: string;
 };
 
 export type RawDimensionPayload = RawColumnPayload & {
   datatype: TODO<'text' | 'date'>;
-  storageStrategy?: TODO<'loaded' | 'none' | null>;
+  storageStrategy?: TODO<'loaded' | 'none'>;
   cardinality: number;
   fields: RawDimensionField[];
 };
@@ -87,7 +85,7 @@ export type RawTablePayload = {
 };
 
 export default class BardMetadataSerializer extends EmberObject implements NaviMetadataSerializer {
-  private namespace = '_fili_generated_';
+  private namespace = 'normalizer-generated';
 
   /**
    * Transform the bard metadata into a shape that our internal data models can use
@@ -121,7 +119,8 @@ export default class BardMetadataSerializer extends EmberObject implements NaviM
             const isTimeDimension = dimension.datatype === 'date';
 
             const normalize = isTimeDimension
-              ? bind(this.normalizeTimeDimensions, this, table) // call function with table partially applied
+              ? (dims: RawDimensionPayload[], dataSourceName: string) =>
+                  this.normalizeTimeDimensions(table, dims, dataSourceName) // call function with table partially applied
               : this.normalizeDimensions;
             const accDimensionList = isTimeDimension ? currentTimeDimensions : currentDimensions;
             const accTableDimensionList = isTimeDimension ? tableTimeDimensionIds : tableDimensionIds;

--- a/packages/data/addon/serializers/metadata/column-function.ts
+++ b/packages/data/addon/serializers/metadata/column-function.ts
@@ -27,16 +27,17 @@ export function constructFunctionParameters(
   parameters: RawColumnFunctionArguments,
   source: string
 ): FunctionParameterMetadataPayload[] {
-  return Object.keys(parameters).map(param => {
-    const { type, defaultValue, values, dimensionName, description } = parameters[param];
+  return Object.keys(parameters).map(paramName => {
+    const param = parameters[paramName];
+    const { defaultValue, description } = param;
 
     const normalized: FunctionParameterMetadataPayload = {
-      id: param,
-      name: param,
+      id: paramName,
+      name: paramName,
       description,
       type: 'ref', // It will always be ref for our case because all our parameters have their valid values defined in a dimension or enum
-      expression: type === 'dimension' ? `dimension:${dimensionName}` : INTRINSIC_VALUE_EXPRESSION,
-      _localValues: values,
+      expression: param.type === 'dimension' ? `dimension:${param.dimensionName}` : INTRINSIC_VALUE_EXPRESSION,
+      _localValues: param.type === 'enum' ? param.values : undefined,
       source,
       defaultValue
     };

--- a/packages/data/test-support/helpers/metadata-routes.js
+++ b/packages/data/test-support/helpers/metadata-routes.js
@@ -78,8 +78,11 @@ export const DimensionOne = {
   name: 'dimensionOne',
   longName: 'Dimension One',
   description: 'This is Dimension One',
-  cardinality: 60
-  //No Fields
+  cardinality: 60,
+  fields: [
+    { name: 'id', description: 'Dimension ID' },
+    { name: 'desc', description: 'Dimension Description' }
+  ]
 };
 
 export const DimensionTwo = {

--- a/packages/data/tests/unit/models/metadata/dimension-test.ts
+++ b/packages/data/tests/unit/models/metadata/dimension-test.ts
@@ -1,19 +1,25 @@
 import { module, test } from 'qunit';
-import DimensionMetadataModel from 'navi-data/models/metadata/dimension';
+import DimensionMetadataModel, { DimensionMetadataPayload } from 'navi-data/models/metadata/dimension';
 import { setupTest } from 'ember-qunit';
 import Pretender from 'pretender';
+import { TestContext } from 'ember-test-helpers';
+//@ts-ignore
 import metadataRoutes from '../../../helpers/metadata-routes';
 
-let Payload, Dimension;
+let Payload: DimensionMetadataPayload, Dimension: DimensionMetadataModel;
 
 module('Unit | Metadata Model | Dimension', function(hooks) {
   setupTest(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function(this: TestContext) {
     Payload = {
       id: 'age',
       name: 'Age',
       category: 'Audience',
+      source: 'bardOne',
+      valueType: 'text',
+      type: 'field',
+      storageStrategy: null,
       fields: [
         {
           name: 'id',
@@ -56,7 +62,7 @@ module('Unit | Metadata Model | Dimension', function(hooks) {
 
     assert.deepEqual(
       Dimension.getTagsForField('id'),
-      Payload.fields[0].tags,
+      Payload.fields?.[0].tags,
       'getTagsForField returns the correct tags for `id` field'
     );
 
@@ -78,6 +84,7 @@ module('Unit | Metadata Model | Dimension', function(hooks) {
       'getTagsForField returns an empty array when `fields` property is missing'
     );
 
+    //@ts-expect-error
     assert.deepEqual(Dimension.getTagsForField(), [], 'getTagsForField returns an empty array when field is undefined');
   });
 
@@ -86,19 +93,19 @@ module('Unit | Metadata Model | Dimension', function(hooks) {
 
     assert.deepEqual(
       Dimension.getFieldsForTag('primaryKey'),
-      [Payload.fields[0]],
+      [Payload.fields?.[0]],
       'getFieldsForTag returns the correct field for tag `primaryKey`'
     );
 
     assert.deepEqual(
       Dimension.getFieldsForTag('description'),
-      [Payload.fields[1]],
+      [Payload.fields?.[1]],
       'getFieldsForTag returns the correct field for tag `description`'
     );
 
     assert.deepEqual(
       Dimension.getFieldsForTag('display'),
-      [Payload.fields[0], Payload.fields[1]],
+      [Payload.fields?.[0], Payload.fields?.[1]],
       'getFieldsForTag returns the correct fields for tag `display`'
     );
 
@@ -108,6 +115,7 @@ module('Unit | Metadata Model | Dimension', function(hooks) {
       'getFieldsForTag returns an empty array when tag is missing'
     );
 
+    //@ts-expect-error
     assert.deepEqual(Dimension.getFieldsForTag(), [], 'getFieldsForTag returns an empty array when tag is undefined');
   });
 
@@ -221,13 +229,18 @@ module('Unit | Metadata Model | Dimension', function(hooks) {
 
     const dimension2 = DimensionMetadataModel.create(this.owner.ownerInjection(), {
       cardinality: 'MEDIUM',
-      type: 'somethingElse'
+      type: 'ref'
     });
 
-    assert.strictEqual(dimension2.cardinality, undefined, 'Dimension returns undefined for non-field type dimension');
+    assert.strictEqual(
+      dimension2.cardinality,
+      undefined,
+      'Dimension cardinality returns undefined for non-field type dimension'
+    );
 
     assert.throws(
       () => {
+        //@ts-expect-error
         dimension2.cardinality = 'chicago cubity';
       },
       /Dimension cardinality should be set to a value included in CARDINALITY_SIZES/,

--- a/packages/data/tests/unit/serializers/metadata/bard-test.ts
+++ b/packages/data/tests/unit/serializers/metadata/bard-test.ts
@@ -30,14 +30,12 @@ const Payload: RawEverythingPayload = {
               category: 'category',
               name: 'metricOne',
               longName: 'Metric One',
-              uri: 'https://metric-one-url',
               type: 'number'
             },
             {
               category: 'category',
               name: 'metricFour',
               longName: 'Metric Four',
-              uri: 'https://metric-four-url',
               type: 'money',
               parameters: {
                 currency: {
@@ -60,7 +58,6 @@ const Payload: RawEverythingPayload = {
               category: 'categoryOne',
               name: 'dimensionOne',
               longName: 'Dimension One',
-              uri: 'https://host:port/namespace/dimensions/dimensionOne',
               cardinality: 10,
               datatype: 'text',
               fields: [
@@ -78,7 +75,6 @@ const Payload: RawEverythingPayload = {
               category: 'categoryTwo',
               name: 'dimensionTwo',
               longName: 'Dimension Two',
-              uri: 'https://host:port/namespace/dimensions/dimensionTwo',
               cardinality: 5,
               datatype: 'text',
               fields: [
@@ -92,7 +88,6 @@ const Payload: RawEverythingPayload = {
               category: 'dateCategory',
               name: 'dimensionThree',
               longName: 'Dimension Three',
-              uri: 'https://host:port/namespace/dimensions/dimensionThree',
               cardinality: 50000,
               datatype: 'date',
               fields: [
@@ -112,14 +107,12 @@ const Payload: RawEverythingPayload = {
               category: 'category',
               name: 'metricOne',
               longName: 'Metric One',
-              uri: 'https://metric-one-url',
               type: 'number'
             },
             {
               category: 'category',
               name: 'metricTwo',
               longName: 'Metric Two',
-              uri: 'https://metric-two-url',
               type: 'money',
               parameters: {
                 currency: {
@@ -137,7 +130,6 @@ const Payload: RawEverythingPayload = {
               category: 'categoryOne',
               name: 'dimensionOne',
               longName: 'Dimension One',
-              uri: 'https://host:port/namespace/dimensions/dimensionOne',
               cardinality: 10,
               datatype: 'text',
               fields: [
@@ -155,7 +147,6 @@ const Payload: RawEverythingPayload = {
               category: 'categoryTwo',
               name: 'dimensionTwo',
               longName: 'Dimension Two',
-              uri: 'https://host:port/namespace/dimensions/dimensionTwo',
               cardinality: 5,
               datatype: 'text',
               fields: [
@@ -169,7 +160,6 @@ const Payload: RawEverythingPayload = {
               category: 'dateCategory',
               name: 'dimensionThree',
               longName: 'Dimension Three',
-              uri: 'https://host:port/namespace/dimensions/dimensionThree',
               cardinality: 50000,
               datatype: 'date',
               fields: [
@@ -199,7 +189,6 @@ const Payload: RawEverythingPayload = {
               category: 'category',
               name: 'metricFive',
               longName: 'Metric Five',
-              uri: 'https://metric-five-url',
               type: 'number',
               metricFunctionId: 'metricFunctionId take precedence over parameters',
               parameters: {
@@ -214,7 +203,6 @@ const Payload: RawEverythingPayload = {
               category: 'category',
               name: 'metricTwo',
               longName: 'Metric Two',
-              uri: 'https://metric-two-url',
               type: 'money',
               parameters: {
                 currency: {
@@ -230,7 +218,6 @@ const Payload: RawEverythingPayload = {
               category: 'categoryTwo',
               name: 'dimensionTwo',
               longName: 'Dimension Two',
-              uri: 'https://host:port/namespace/dimensions/dimensionTwo',
               cardinality: 5,
               datatype: 'text',
               fields: [
@@ -244,7 +231,6 @@ const Payload: RawEverythingPayload = {
               category: 'dateCategory',
               name: 'dimensionThree',
               longName: 'Dimension Three',
-              uri: 'https://host:port/namespace/dimensions/dimensionThree',
               cardinality: 50000,
               datatype: 'date',
               fields: [
@@ -266,14 +252,12 @@ const Payload: RawEverythingPayload = {
               category: 'category',
               name: 'metricOne',
               longName: 'Metric One',
-              uri: 'https://metric-one-url',
               type: 'number'
             },
             {
               category: 'category',
               name: 'metricThree',
               longName: 'Metric Three',
-              uri: 'https://metric-three-url',
               type: 'number'
             }
           ],
@@ -282,7 +266,6 @@ const Payload: RawEverythingPayload = {
               category: 'categoryTwo',
               name: 'dimensionTwo',
               longName: 'Dimension Two',
-              uri: 'https://host:port/namespace/dimensions/dimensionTwo',
               cardinality: 5,
               datatype: 'text',
               fields: [
@@ -296,7 +279,6 @@ const Payload: RawEverythingPayload = {
               category: 'dateCategory',
               name: 'dimensionThree',
               longName: 'Dimension Three',
-              uri: 'https://host:port/namespace/dimensions/dimensionThree',
               cardinality: 50000,
               datatype: 'date',
               fields: [
@@ -344,7 +326,7 @@ const Dimensions: DimensionMetadataPayload[] = [
   {
     cardinality: 'SMALL',
     category: 'categoryOne',
-    columnFunctionId: '_fili_generated_:dimensionField(fields=desc,id)',
+    columnFunctionId: 'normalizer-generated:dimensionField(fields=desc,id)',
     description: undefined,
     id: 'dimensionOne',
     name: 'Dimension One',
@@ -367,7 +349,7 @@ const Dimensions: DimensionMetadataPayload[] = [
   {
     cardinality: 'SMALL',
     category: 'categoryTwo',
-    columnFunctionId: '_fili_generated_:dimensionField(fields=foo)',
+    columnFunctionId: 'normalizer-generated:dimensionField(fields=foo)',
     description: undefined,
     id: 'dimensionTwo',
     name: 'Dimension Two',
@@ -390,7 +372,7 @@ const TimeDimensions: TimeDimensionMetadataPayload[] = [
     cardinality: 'MEDIUM',
     category: 'dateCategory',
     description: undefined,
-    columnFunctionId: '_fili_generated_:dimensionField(fields=id)',
+    columnFunctionId: 'normalizer-generated:dimensionField(fields=id)',
     id: 'dimensionThree',
     name: 'Dimension Three',
     source: 'bardOne',
@@ -415,7 +397,7 @@ const TimeDimensions: TimeDimensionMetadataPayload[] = [
   },
   {
     category: 'Date',
-    columnFunctionId: '_fili_generated_:timeGrain(table=tableName;grains=day,month)',
+    columnFunctionId: 'normalizer-generated:timeGrain(table=tableName;grains=day,month)',
     description: undefined,
     fields: undefined,
     id: 'tableName.dateTime',
@@ -439,7 +421,7 @@ const TimeDimensions: TimeDimensionMetadataPayload[] = [
   },
   {
     category: 'Date',
-    columnFunctionId: '_fili_generated_:timeGrain(table=secondTable;grains=day,week)',
+    columnFunctionId: 'normalizer-generated:timeGrain(table=secondTable;grains=day,week)',
     description: undefined,
     fields: undefined,
     id: 'secondTable.dateTime',
@@ -478,7 +460,7 @@ const Metrics: MetricMetadataPayload[] = [
   {
     category: 'category',
     id: 'metricFour',
-    columnFunctionId: '_fili_generated_:columnFunction(parameters=currency,format)',
+    columnFunctionId: 'normalizer-generated:columnFunction(parameters=currency,format)',
     description: undefined,
     name: 'Metric Four',
     partialData: true,
@@ -489,7 +471,7 @@ const Metrics: MetricMetadataPayload[] = [
   {
     category: 'category',
     id: 'metricTwo',
-    columnFunctionId: '_fili_generated_:columnFunction(parameters=currency)',
+    columnFunctionId: 'normalizer-generated:columnFunction(parameters=currency)',
     description: undefined,
     name: 'Metric Two',
     partialData: true,
@@ -547,7 +529,7 @@ const ParameterConvertToColumnFunction: ColumnFunctionMetadataPayload[] = [
       }
     ],
     description: 'Dimension Field',
-    id: '_fili_generated_:dimensionField(fields=desc,id)',
+    id: 'normalizer-generated:dimensionField(fields=desc,id)',
     name: 'Dimension Field',
     source: 'bardOne'
   },
@@ -571,7 +553,7 @@ const ParameterConvertToColumnFunction: ColumnFunctionMetadataPayload[] = [
       }
     ],
     description: 'Dimension Field',
-    id: '_fili_generated_:dimensionField(fields=foo)',
+    id: 'normalizer-generated:dimensionField(fields=foo)',
     name: 'Dimension Field',
     source: 'bardOne'
   },
@@ -595,7 +577,7 @@ const ParameterConvertToColumnFunction: ColumnFunctionMetadataPayload[] = [
       }
     ],
     description: 'Dimension Field',
-    id: '_fili_generated_:dimensionField(fields=id)',
+    id: 'normalizer-generated:dimensionField(fields=id)',
     name: 'Dimension Field',
     source: 'bardOne'
   },
@@ -623,7 +605,7 @@ const ParameterConvertToColumnFunction: ColumnFunctionMetadataPayload[] = [
       }
     ],
     description: '',
-    id: '_fili_generated_:columnFunction(parameters=currency,format)',
+    id: 'normalizer-generated:columnFunction(parameters=currency,format)',
     name: '',
     source: 'bardOne'
   },
@@ -641,12 +623,12 @@ const ParameterConvertToColumnFunction: ColumnFunctionMetadataPayload[] = [
       }
     ],
     description: '',
-    id: '_fili_generated_:columnFunction(parameters=currency)',
+    id: 'normalizer-generated:columnFunction(parameters=currency)',
     name: '',
     source: 'bardOne'
   },
   {
-    id: '_fili_generated_:timeGrain(table=tableName;grains=day,month)',
+    id: 'normalizer-generated:timeGrain(table=tableName;grains=day,month)',
     name: 'Time Grain',
     description: 'Time Grain',
     source: 'bardOne',
@@ -667,7 +649,7 @@ const ParameterConvertToColumnFunction: ColumnFunctionMetadataPayload[] = [
     ]
   },
   {
-    id: '_fili_generated_:timeGrain(table=secondTable;grains=day,week)',
+    id: 'normalizer-generated:timeGrain(table=secondTable;grains=day,week)',
     name: 'Time Grain',
     description: 'Time Grain',
     source: 'bardOne',
@@ -755,14 +737,12 @@ module('Unit | Serializer | metadata/bard', function(hooks) {
                   category: 'category',
                   name: 'metricOne',
                   longName: 'Metric One',
-                  uri: 'https://metric-one-url',
                   type: 'number'
                 },
                 {
                   category: 'category',
                   name: 'metricTwo',
                   longName: 'Metric Two',
-                  uri: 'https://metric-two-url',
                   type: 'money',
                   metricFunctionId: 'moneyMetric'
                 }
@@ -833,7 +813,7 @@ module('Unit | Serializer | metadata/bard', function(hooks) {
         },
         {
           description: 'Time Grain',
-          id: '_fili_generated_:timeGrain(table=tableName;grains=day)',
+          id: 'normalizer-generated:timeGrain(table=tableName;grains=day)',
           name: 'Time Grain',
           source: 'bardOne',
           _parametersPayload: [
@@ -865,7 +845,6 @@ module('Unit | Serializer | metadata/bard', function(hooks) {
       category: 'categoryOne',
       name: 'dimensionOne',
       longName: 'Dimension One',
-      uri: 'https://host:port/namespace/dimensions/dimensionOne',
       cardinality: 10,
       fields: [
         {
@@ -909,7 +888,6 @@ module('Unit | Serializer | metadata/bard', function(hooks) {
       category: 'categoryOne',
       name: 'metricOne',
       longName: 'Metric One',
-      uri: 'https://metric-one-url',
       type: 'number',
       metricFunctionId: 'money'
     };

--- a/packages/data/tests/unit/serializers/metadata/bard-test.ts
+++ b/packages/data/tests/unit/serializers/metadata/bard-test.ts
@@ -1,8 +1,20 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import config from 'ember-get-config';
+import { TestContext } from 'ember-test-helpers';
+import BardMetadataSerializer, {
+  RawEverythingPayload,
+  RawDimensionPayload,
+  RawMetricPayload,
+  RawTablePayload
+} from 'navi-data/serializers/metadata/bard';
+import { TableMetadataPayload } from 'navi-data/models/metadata/table';
+import { DimensionMetadataPayload } from 'navi-data/models/metadata/dimension';
+import { TimeDimensionMetadataPayload } from 'navi-data/models/metadata/time-dimension';
+import { MetricMetadataPayload } from 'navi-data/models/metadata/metric';
+import { ColumnFunctionMetadataPayload } from 'navi-data/models/metadata/column-function';
 
-const Payload = {
+const Payload: RawEverythingPayload = {
   tables: [
     {
       name: 'tableName',
@@ -49,30 +61,46 @@ const Payload = {
               name: 'dimensionOne',
               longName: 'Dimension One',
               uri: 'https://host:port/namespace/dimensions/dimensionOne',
-              cardinality: '10',
-              datatype: 'text'
+              cardinality: 10,
+              datatype: 'text',
+              fields: [
+                {
+                  name: 'id',
+                  description: 'Dimension ID'
+                },
+                {
+                  name: 'desc',
+                  description: 'Dimension Description'
+                }
+              ]
             },
             {
               category: 'categoryTwo',
               name: 'dimensionTwo',
               longName: 'Dimension Two',
               uri: 'https://host:port/namespace/dimensions/dimensionTwo',
-              cardinality: '5',
+              cardinality: 5,
+              datatype: 'text',
               fields: [
                 {
                   name: 'foo',
                   description: 'bar'
                 }
-              ],
-              datatype: 'text'
+              ]
             },
             {
               category: 'dateCategory',
               name: 'dimensionThree',
               longName: 'Dimension Three',
               uri: 'https://host:port/namespace/dimensions/dimensionThree',
-              cardinality: '50000',
-              datatype: 'date'
+              cardinality: 50000,
+              datatype: 'date',
+              fields: [
+                {
+                  name: 'id',
+                  description: 'Dimension ID'
+                }
+              ]
             }
           ]
         },
@@ -110,15 +138,25 @@ const Payload = {
               name: 'dimensionOne',
               longName: 'Dimension One',
               uri: 'https://host:port/namespace/dimensions/dimensionOne',
-              cardinality: '10',
-              datatype: 'text'
+              cardinality: 10,
+              datatype: 'text',
+              fields: [
+                {
+                  name: 'id',
+                  description: 'Dimension ID'
+                },
+                {
+                  name: 'desc',
+                  description: 'Dimension Description'
+                }
+              ]
             },
             {
               category: 'categoryTwo',
               name: 'dimensionTwo',
               longName: 'Dimension Two',
               uri: 'https://host:port/namespace/dimensions/dimensionTwo',
-              cardinality: '5',
+              cardinality: 5,
               datatype: 'text',
               fields: [
                 {
@@ -132,8 +170,14 @@ const Payload = {
               name: 'dimensionThree',
               longName: 'Dimension Three',
               uri: 'https://host:port/namespace/dimensions/dimensionThree',
-              cardinality: '50000',
-              datatype: 'date'
+              cardinality: 50000,
+              datatype: 'date',
+              fields: [
+                {
+                  name: 'id',
+                  description: 'Dimension ID'
+                }
+              ]
             }
           ]
         }
@@ -187,7 +231,7 @@ const Payload = {
               name: 'dimensionTwo',
               longName: 'Dimension Two',
               uri: 'https://host:port/namespace/dimensions/dimensionTwo',
-              cardinality: '5',
+              cardinality: 5,
               datatype: 'text',
               fields: [
                 {
@@ -201,8 +245,14 @@ const Payload = {
               name: 'dimensionThree',
               longName: 'Dimension Three',
               uri: 'https://host:port/namespace/dimensions/dimensionThree',
-              cardinality: '50000',
-              datatype: 'date'
+              cardinality: 50000,
+              datatype: 'date',
+              fields: [
+                {
+                  name: 'id',
+                  description: 'Dimension ID'
+                }
+              ]
             }
           ]
         },
@@ -233,7 +283,7 @@ const Payload = {
               name: 'dimensionTwo',
               longName: 'Dimension Two',
               uri: 'https://host:port/namespace/dimensions/dimensionTwo',
-              cardinality: '5',
+              cardinality: 5,
               datatype: 'text',
               fields: [
                 {
@@ -247,8 +297,14 @@ const Payload = {
               name: 'dimensionThree',
               longName: 'Dimension Three',
               uri: 'https://host:port/namespace/dimensions/dimensionThree',
-              cardinality: '50000',
-              datatype: 'date'
+              cardinality: 50000,
+              datatype: 'date',
+              fields: [
+                {
+                  name: 'id',
+                  description: 'Dimension ID'
+                }
+              ]
             }
           ]
         }
@@ -257,7 +313,7 @@ const Payload = {
   ]
 };
 // list of table objects, with table->timegrains->dimensions+metrics
-const Tables = [
+const Tables: TableMetadataPayload[] = [
   {
     cardinality: 'MEDIUM',
     category: 'General',
@@ -284,23 +340,34 @@ const Tables = [
   }
 ];
 
-const Dimensions = [
+const Dimensions: DimensionMetadataPayload[] = [
   {
     cardinality: 'SMALL',
     category: 'categoryOne',
+    columnFunctionId: '_fili_generated_:dimensionField(fields=desc,id)',
     description: undefined,
     id: 'dimensionOne',
     name: 'Dimension One',
     source: 'bardOne',
     type: 'field',
     valueType: 'text',
-    fields: undefined,
     storageStrategy: null,
-    partialData: true
+    partialData: true,
+    fields: [
+      {
+        name: 'id',
+        description: 'Dimension ID'
+      },
+      {
+        name: 'desc',
+        description: 'Dimension Description'
+      }
+    ]
   },
   {
     cardinality: 'SMALL',
     category: 'categoryTwo',
+    columnFunctionId: '_fili_generated_:dimensionField(fields=foo)',
     description: undefined,
     id: 'dimensionTwo',
     name: 'Dimension Two',
@@ -318,23 +385,37 @@ const Dimensions = [
   }
 ];
 
-const TimeDimensions = [
+const TimeDimensions: TimeDimensionMetadataPayload[] = [
   {
     cardinality: 'MEDIUM',
     category: 'dateCategory',
     description: undefined,
+    columnFunctionId: '_fili_generated_:dimensionField(fields=id)',
     id: 'dimensionThree',
     name: 'Dimension Three',
     source: 'bardOne',
     type: 'field',
-    fields: undefined,
+    fields: [
+      {
+        name: 'id',
+        description: 'Dimension ID'
+      }
+    ],
     valueType: 'date',
     storageStrategy: null,
-    partialData: true
+    partialData: true,
+    supportedGrains: [
+      {
+        expression: '',
+        grain: 'DAY',
+        id: 'secondTable.grain.day'
+      }
+    ],
+    timeZone: 'utc'
   },
   {
     category: 'Date',
-    columnFunctionId: 'tableName.grain(day,month)',
+    columnFunctionId: '_fili_generated_:timeGrain(table=tableName;grains=day,month)',
     description: undefined,
     fields: undefined,
     id: 'tableName.dateTime',
@@ -358,7 +439,7 @@ const TimeDimensions = [
   },
   {
     category: 'Date',
-    columnFunctionId: 'secondTable.grain(day,week)',
+    columnFunctionId: '_fili_generated_:timeGrain(table=secondTable;grains=day,week)',
     description: undefined,
     fields: undefined,
     id: 'secondTable.dateTime',
@@ -382,7 +463,7 @@ const TimeDimensions = [
   }
 ];
 
-const Metrics = [
+const Metrics: MetricMetadataPayload[] = [
   {
     category: 'category',
     id: 'metricOne',
@@ -397,7 +478,7 @@ const Metrics = [
   {
     category: 'category',
     id: 'metricFour',
-    columnFunctionId: 'currency|format',
+    columnFunctionId: '_fili_generated_:columnFunction(parameters=currency,format)',
     description: undefined,
     name: 'Metric Four',
     partialData: true,
@@ -408,7 +489,7 @@ const Metrics = [
   {
     category: 'category',
     id: 'metricTwo',
-    columnFunctionId: 'currency',
+    columnFunctionId: '_fili_generated_:columnFunction(parameters=currency)',
     description: undefined,
     name: 'Metric Two',
     partialData: true,
@@ -440,7 +521,84 @@ const Metrics = [
   }
 ];
 
-const ParameterConvertToMetricFunction = [
+const ParameterConvertToColumnFunction: ColumnFunctionMetadataPayload[] = [
+  {
+    _parametersPayload: [
+      {
+        _localValues: [
+          {
+            description: undefined,
+            id: 'id',
+            name: 'id'
+          },
+          {
+            description: undefined,
+            id: 'desc',
+            name: 'desc'
+          }
+        ],
+        defaultValue: 'id',
+        description: 'The field to be projected for this dimension',
+        expression: 'self',
+        id: 'field',
+        name: 'Dimension Field',
+        source: 'bardOne',
+        type: 'ref'
+      }
+    ],
+    description: 'Dimension Field',
+    id: '_fili_generated_:dimensionField(fields=desc,id)',
+    name: 'Dimension Field',
+    source: 'bardOne'
+  },
+  {
+    _parametersPayload: [
+      {
+        _localValues: [
+          {
+            description: undefined,
+            id: 'foo',
+            name: 'foo'
+          }
+        ],
+        defaultValue: 'foo',
+        description: 'The field to be projected for this dimension',
+        expression: 'self',
+        id: 'field',
+        name: 'Dimension Field',
+        source: 'bardOne',
+        type: 'ref'
+      }
+    ],
+    description: 'Dimension Field',
+    id: '_fili_generated_:dimensionField(fields=foo)',
+    name: 'Dimension Field',
+    source: 'bardOne'
+  },
+  {
+    _parametersPayload: [
+      {
+        _localValues: [
+          {
+            description: undefined,
+            id: 'id',
+            name: 'id'
+          }
+        ],
+        defaultValue: 'id',
+        description: 'The field to be projected for this dimension',
+        expression: 'self',
+        id: 'field',
+        name: 'Dimension Field',
+        source: 'bardOne',
+        type: 'ref'
+      }
+    ],
+    description: 'Dimension Field',
+    id: '_fili_generated_:dimensionField(fields=id)',
+    name: 'Dimension Field',
+    source: 'bardOne'
+  },
   {
     _parametersPayload: [
       {
@@ -465,7 +623,7 @@ const ParameterConvertToMetricFunction = [
       }
     ],
     description: '',
-    id: 'currency|format',
+    id: '_fili_generated_:columnFunction(parameters=currency,format)',
     name: '',
     source: 'bardOne'
   },
@@ -483,12 +641,12 @@ const ParameterConvertToMetricFunction = [
       }
     ],
     description: '',
-    id: 'currency',
+    id: '_fili_generated_:columnFunction(parameters=currency)',
     name: '',
     source: 'bardOne'
   },
   {
-    id: 'tableName.grain(day,month)',
+    id: '_fili_generated_:timeGrain(table=tableName;grains=day,month)',
     name: 'Time Grain',
     description: 'Time Grain',
     source: 'bardOne',
@@ -509,7 +667,7 @@ const ParameterConvertToMetricFunction = [
     ]
   },
   {
-    id: 'secondTable.grain(day,week)',
+    id: '_fili_generated_:timeGrain(table=secondTable;grains=day,week)',
     name: 'Time Grain',
     description: 'Time Grain',
     source: 'bardOne',
@@ -539,12 +697,12 @@ const ParameterConvertToMetricFunction = [
   }
 ];
 
-let Serializer;
+let Serializer: BardMetadataSerializer;
 
 module('Unit | Serializer | metadata/bard', function(hooks) {
   setupTest(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function(this: TestContext) {
     Serializer = this.owner.lookup('serializer:metadata/bard');
   });
 
@@ -556,14 +714,14 @@ module('Unit | Serializer | metadata/bard', function(hooks) {
         dimensions: Dimensions,
         timeDimensions: TimeDimensions,
         tables: Tables,
-        columnFunctions: ParameterConvertToMetricFunction
+        columnFunctions: ParameterConvertToColumnFunction
       },
       'One column function is created for all metrics with only the currency parameter'
     );
   });
 
   test('normalize `everything` with column functions', function(assert) {
-    const MetricFunctionIdsPayload = {
+    const MetricFunctionIdsPayload: RawEverythingPayload = {
       metricFunctions: [
         {
           id: 'moneyMetric',
@@ -573,7 +731,10 @@ module('Unit | Serializer | metadata/bard', function(hooks) {
             currency: {
               type: 'enum',
               defaultValue: null,
-              values: ['USD', 'CAN'],
+              values: [
+                { id: 'USD', name: 'USD' },
+                { id: 'CAN', name: 'CAN' }
+              ],
               description: 'Currency Parameter'
             }
           }
@@ -615,7 +776,7 @@ module('Unit | Serializer | metadata/bard', function(hooks) {
       ]
     };
 
-    const { metrics, columnFunctions } = Serializer.normalize('everything', MetricFunctionIdsPayload, 'bardOne');
+    const { metrics, columnFunctions } = Serializer.normalize('everything', MetricFunctionIdsPayload, 'bardOne') || {};
 
     assert.deepEqual(
       metrics,
@@ -652,7 +813,10 @@ module('Unit | Serializer | metadata/bard', function(hooks) {
         {
           _parametersPayload: [
             {
-              _localValues: ['USD', 'CAN'],
+              _localValues: [
+                { id: 'USD', name: 'USD' },
+                { id: 'CAN', name: 'CAN' }
+              ],
               defaultValue: null,
               description: 'Currency Parameter',
               expression: 'self',
@@ -669,7 +833,7 @@ module('Unit | Serializer | metadata/bard', function(hooks) {
         },
         {
           description: 'Time Grain',
-          id: 'tableName.grain(day)',
+          id: '_fili_generated_:timeGrain(table=tableName;grains=day)',
           name: 'Time Grain',
           source: 'bardOne',
           _parametersPayload: [
@@ -697,12 +861,12 @@ module('Unit | Serializer | metadata/bard', function(hooks) {
   });
 
   test('normalizeDimensions', function(assert) {
-    const rawDimension = {
+    const rawDimension: RawDimensionPayload = {
       category: 'categoryOne',
       name: 'dimensionOne',
       longName: 'Dimension One',
       uri: 'https://host:port/namespace/dimensions/dimensionOne',
-      cardinality: '10',
+      cardinality: 10,
       fields: [
         {
           name: 'foo',
@@ -718,7 +882,7 @@ module('Unit | Serializer | metadata/bard', function(hooks) {
     const source = 'bardOne';
 
     assert.deepEqual(
-      Serializer.normalizeDimensions([rawDimension], source),
+      Serializer['normalizeDimensions']([rawDimension], source),
       [
         {
           id: rawDimension.name,
@@ -741,17 +905,17 @@ module('Unit | Serializer | metadata/bard', function(hooks) {
   test('normalizeMetrics', function(assert) {
     const source = 'bardOne';
 
-    const rawMetric = {
+    const rawMetric: RawMetricPayload = {
       category: 'categoryOne',
       name: 'metricOne',
       longName: 'Metric One',
       uri: 'https://metric-one-url',
       type: 'number',
-      columnFunctionId: 'money'
+      metricFunctionId: 'money'
     };
 
     assert.deepEqual(
-      Serializer.normalizeMetrics([rawMetric], source),
+      Serializer['normalizeMetrics']([rawMetric], source),
       [
         {
           id: rawMetric.name,
@@ -772,27 +936,28 @@ module('Unit | Serializer | metadata/bard', function(hooks) {
   test('configure defaultTimeGrain if it exists', async function(assert) {
     const originalDefaultTimeGrain = config.navi.defaultTimeGrain;
 
-    const table = {
+    const table: RawTablePayload = {
       name: 'table',
+      longName: 'Table',
       timeGrains: [
-        { name: 'day', longName: 'Day' },
-        { name: 'hour', longName: 'Hour' },
-        { name: 'week', longName: 'Week' },
-        { name: 'month', longName: 'Month' }
+        { name: 'day', longName: 'Day', metrics: [], dimensions: [] },
+        { name: 'hour', longName: 'Hour', metrics: [], dimensions: [] },
+        { name: 'week', longName: 'Week', metrics: [], dimensions: [] },
+        { name: 'month', longName: 'Month', metrics: [], dimensions: [] }
       ]
     };
 
     config.navi.defaultTimeGrain = 'week';
-    let columnFunction = Serializer.createTimeGrainColumnFunction(table, 'bardOne');
-    assert.equal(columnFunction._parametersPayload[0].defaultValue, 'week', 'Picks default from config');
+    let columnFunction = Serializer['createTimeGrainColumnFunction'](table, 'bardOne');
+    assert.equal(columnFunction._parametersPayload?.[0].defaultValue, 'week', 'Picks default from config');
 
     config.navi.defaultTimeGrain = 'year';
-    columnFunction = Serializer.createTimeGrainColumnFunction(table, 'bardOne');
-    assert.equal(columnFunction._parametersPayload[0].defaultValue, 'day', 'Falls back to first defined grain');
+    columnFunction = Serializer['createTimeGrainColumnFunction'](table, 'bardOne');
+    assert.equal(columnFunction._parametersPayload?.[0].defaultValue, 'day', 'Falls back to first defined grain');
 
     config.navi.defaultTimeGrain = 'hour';
-    columnFunction = Serializer.createTimeGrainColumnFunction(table, 'bardOne');
-    assert.equal(columnFunction._parametersPayload[0].defaultValue, 'hour', 'Picks default from config');
+    columnFunction = Serializer['createTimeGrainColumnFunction'](table, 'bardOne');
+    assert.equal(columnFunction._parametersPayload?.[0].defaultValue, 'hour', 'Picks default from config');
 
     config.navi.defaultTimeGrain = originalDefaultTimeGrain;
   });


### PR DESCRIPTION
Resolves #921 

## Description
Currently in request v2, we have no way of selecting the `field` parameter on dimension columns. Since we've made columnFunction generic, we can now link to it from a dimension and create a function for picking from those dimension fields

## Proposed Changes
Create a columnFunction for every unique set of dimension fields and link to them as a `field` parameter on dimensions

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
