### PR TITLE
Update: Require only one dateTime column/filter and same grain

### DIFF
--- a/packages/data/addon/adapters/facts/bard.ts
+++ b/packages/data/addon/adapters/facts/bard.ts
@@ -18,7 +18,9 @@ import NaviFactAdapter, {
   RequestOptions,
   RequestV2,
   SORT_DIRECTIONS,
-  AsyncQueryResponse
+  AsyncQueryResponse,
+  Column,
+  Sort
 } from './interface';
 import { omit } from 'lodash-es';
 
@@ -56,7 +58,7 @@ export function serializeFilters(filters: Filter[]): string {
     .map(filter => {
       const { field, operator, values, parameters } = filter;
       const serializedValues = values
-        .map(v => String(v).replace(/"/g, '""')) // csv serialize " -> ""
+        .map((v: string | number) => String(v).replace(/"/g, '""')) // csv serialize " -> ""
         .map(v => `"${v}"`) // wrap each "value"
         .join(','); // comma to separate
       const formattedFieldName = formatDimensionFieldName(field, parameters, true);
@@ -64,6 +66,14 @@ export function serializeFilters(filters: Filter[]): string {
       return `${formattedFieldName}-${operator}[${serializedValues}]`;
     })
     .join(',');
+}
+
+/**
+ * Returns true if a column is a timeDimension and ends with `.dateTime`
+ * @param column the column to check if it is a dateTime
+ */
+function isDateTime(column: Column | Filter | Sort) {
+  return column.type === 'timeDimension' && column.field.endsWith('.dateTime');
 }
 
 export default class BardFactsAdapter extends EmberObject implements NaviFactAdapter {
@@ -106,12 +116,19 @@ export default class BardFactsAdapter extends EmberObject implements NaviFactAda
    * @return dateTime param value
    */
   _buildDateTimeParam(request: RequestV2): string {
-    // TODO: Get lowest grain dateTime, handle corner cases
-    const dateTimeFilters = request.filters.filter(
-      fil => fil.type === 'timeDimension' && fil.field === `${request.table}.dateTime`
+    const dateTimeFilters = request.filters.filter(isDateTime);
+    assert(`Only one '${request.table}.dateTime' filter is supported`, dateTimeFilters.length === 1);
+    const filter = dateTimeFilters[0];
+    const dateTime = request.columns.filter(isDateTime)[0];
+    const timeGrain = dateTime?.parameters?.grain || 'all';
+    assert(
+      `The requested filter timeGrain '${filter.parameters.grain}', must match the column timeGrain '${timeGrain}'`,
+      timeGrain === filter.parameters.grain
     );
 
-    return dateTimeFilters.map(filter => `${filter.values[0]}/${filter.values[1]}`).join(',');
+    const [start, end] = filter.values;
+
+    return `${start}/${end}`;
   }
 
   /**
@@ -217,10 +234,10 @@ export default class BardFactsAdapter extends EmberObject implements NaviFactAda
     const host = configHost(options);
     const { namespace } = this;
     const table = request.table;
-    // TODO: Get lowest grain dateTime
-    const timeGrain =
-      request.columns.find(col => col.type === 'timeDimension' && col.field === `${request.table}.dateTime`)?.parameters
-        ?.grain || 'all';
+
+    const dateTimeColumns = request.columns.filter(isDateTime);
+    assert(`At most one '${request.table}.dateTime' column is supported`, dateTimeColumns.length <= 1);
+    const timeGrain = dateTimeColumns[0]?.parameters?.grain || 'all';
     const dimensions = this._buildDimensionsPath(request);
 
     return `${host}/${namespace}/${table}/${timeGrain}${dimensions}/`;
@@ -235,7 +252,7 @@ export default class BardFactsAdapter extends EmberObject implements NaviFactAda
    * @param options
    * @returns query object
    */
-  _buildQuery(request: RequestV2, options: RequestOptions): Query {
+  _buildQuery(request: RequestV2, options?: RequestOptions): Query {
     const { columns } = request;
     const metrics = columns
       .filter(col => col.type === 'metric')
@@ -296,7 +313,7 @@ export default class BardFactsAdapter extends EmberObject implements NaviFactAda
    * @param options
    * @return url
    */
-  urlForFindQuery(request: RequestV2, options: RequestOptions): string {
+  urlForFindQuery(request: RequestV2, options?: RequestOptions): string {
     assert('Request for bard-facts adapter must be version 2', (request.requestVersion || '').startsWith('2.'));
 
     // Decorate and translate the request
@@ -331,7 +348,7 @@ export default class BardFactsAdapter extends EmberObject implements NaviFactAda
    * @param options - options object
    * @returns {Promise} - Promise with the response
    */
-  fetchDataForRequest(request: RequestV2, options: RequestOptions) {
+  fetchDataForRequest(request: RequestV2, options?: RequestOptions): Promise<unknown> {
     assert('Request for bard-facts adapter must be version 2', (request.requestVersion || '').startsWith('2.'));
 
     // Decorate and translate the request

--- a/packages/data/addon/adapters/facts/bard.ts
+++ b/packages/data/addon/adapters/facts/bard.ts
@@ -117,14 +117,19 @@ export default class BardFactsAdapter extends EmberObject implements NaviFactAda
    */
   _buildDateTimeParam(request: RequestV2): string {
     const dateTimeFilters = request.filters.filter(isDateTime);
-    assert(`Only one '${request.table}.dateTime' filter is supported`, dateTimeFilters.length === 1);
+    if (dateTimeFilters.length !== 1) {
+      throw new Error(
+        `Exactly one '${request.table}.dateTime' filter is supported, you have ${dateTimeFilters.length}`
+      );
+    }
     const filter = dateTimeFilters[0];
     const dateTime = request.columns.filter(isDateTime)[0];
     const timeGrain = dateTime?.parameters?.grain || 'all';
-    assert(
-      `The requested filter timeGrain '${filter.parameters.grain}', must match the column timeGrain '${timeGrain}'`,
-      timeGrain === filter.parameters.grain
-    );
+    if (timeGrain !== filter.parameters.grain) {
+      throw new Error(
+        `The requested filter timeGrain '${filter.parameters.grain}', must match the column timeGrain '${timeGrain}'`
+      );
+    }
 
     const [start, end] = filter.values;
 
@@ -236,7 +241,9 @@ export default class BardFactsAdapter extends EmberObject implements NaviFactAda
     const table = request.table;
 
     const dateTimeColumns = request.columns.filter(isDateTime);
-    assert(`At most one '${request.table}.dateTime' column is supported`, dateTimeColumns.length <= 1);
+    if (dateTimeColumns.length > 1) {
+      throw new Error(`At most one '${request.table}.dateTime' column is supported`);
+    }
     const timeGrain = dateTimeColumns[0]?.parameters?.grain || 'all';
     const dimensions = this._buildDimensionsPath(request);
 

--- a/packages/data/addon/adapters/facts/bard.ts
+++ b/packages/data/addon/adapters/facts/bard.ts
@@ -242,7 +242,7 @@ export default class BardFactsAdapter extends EmberObject implements NaviFactAda
 
     const dateTimeColumns = request.columns.filter(isDateTime);
     if (dateTimeColumns.length > 1) {
-      throw new Error(`At most one '${request.table}.dateTime' column is supported`);
+      throw new Error(`Requsting more than one '${request.table}.dateTime' columns is not supported`);
     }
     const timeGrain = dateTimeColumns[0]?.parameters?.grain || 'all';
     const dimensions = this._buildDimensionsPath(request);

--- a/packages/data/addon/adapters/facts/interface.ts
+++ b/packages/data/addon/adapters/facts/interface.ts
@@ -16,7 +16,7 @@ export type RequestOptions = {
   perPage?: number;
   format?: string;
   cache?: boolean;
-  queryParams?: Dict<string>;
+  queryParams?: Dict<string | number>;
   dataSourceName?: string;
 };
 
@@ -40,7 +40,7 @@ export type Filter = {
   parameters: Parameters;
   type: ColumnType;
   operator: string;
-  values: string[];
+  values: (string | number)[];
 };
 
 export type Sort = {

--- a/packages/data/tests/unit/adapters/facts/bard-test.ts
+++ b/packages/data/tests/unit/adapters/facts/bard-test.ts
@@ -235,7 +235,9 @@ module('Unit | Adapter | facts/bard', function(hooks) {
           field: '.dateTime',
           parameters: {
             grain: 'week'
-          }
+          },
+          operator: 'bet',
+          values: []
         }
       ]
     };

--- a/packages/data/tests/unit/adapters/facts/bard-test.ts
+++ b/packages/data/tests/unit/adapters/facts/bard-test.ts
@@ -737,7 +737,7 @@ module('Unit | Adapter | facts/bard', function(hooks) {
       () => {
         Adapter._buildURLPath(twoDateTime);
       },
-      /At most one '.dateTime' column is supported/,
+      /Requsting more than one '.dateTime' columns is not supported/,
       '_buildURLPath throws an error when more than one dateTime column is requested'
     );
 


### PR DESCRIPTION
Resolves #957 

## Description
Fili has strict requirements on how filtered dates align to the timeGrain

## Proposed Changes
- Only allow a single dateTime column and dateTime filter, requiring that they have the same time grain
so these are valid
```js
{
  filters: [{ type: 'timeDimension', field: 'tableName.dateTime', parameters: { grain: 'all' }, operator: 'bet', values: []],
  columns: []
}

{
  filters: [{ type: 'timeDimension', field: 'tableName.dateTime', parameters: { grain: 'all' }, operator: 'bet', values: [] ],
  columns: [{ type: 'timeDimension', field: 'tableName.dateTime', parameters: { grain: 'all' }]
}

{
  filters: [{ type: 'timeDimension', field: 'tableName.dateTime', parameters: { grain: 'day' }, operator: 'bet', values: [] ],
  columns: [{ type: 'timeDimension', field: 'tableName.dateTime', parameters: { grain: 'day' }]
}
```
while this is not
```js
{
  filters: [{ type: 'timeDimension', field: 'tableName.dateTime', parameters: { grain: 'day' }, operator: 'bet', values: [] ],
  columns: [{ type: 'timeDimension', field: 'tableName.dateTime', parameters: { grain: 'month' }]
}

{
  filters: [{ type: 'timeDimension', field: 'tableName.dateTime', parameters: { grain: 'month' }, operator: 'bet', values: [] ],
  columns: [{ type: 'timeDimension', field: 'tableName.dateTime', parameters: { grain: 'day' }]
}
```

We could probably define a way for complex queries to work by using `all` timeGrain if available and formatting the dates to align, but it's not worth it right now

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
