### PR TITLE
Update: Fix elide request and response names

### DIFF
--- a/packages/data/addon/serializers/facts/elide.ts
+++ b/packages/data/addon/serializers/facts/elide.ts
@@ -8,19 +8,43 @@
 import EmberObject from '@ember/object';
 import NaviFactSerializer, { ResponseV1 } from './interface';
 import { AsyncQueryResponse, RequestV2 } from 'navi-data/adapters/facts/interface';
+import { getElideField } from 'navi-data/adapters/facts/elide';
+import { canonicalizeMetric } from 'navi-data/utils/metric';
 
 export default class ElideFactsSerializer extends EmberObject implements NaviFactSerializer {
-  normalize(payload: AsyncQueryResponse, request: RequestV2): ResponseV1 | undefined {
-    const requestTable = request.table;
-    const responseStr = payload?.asyncQuery.edges[0].node.result?.responseBody;
-    if (responseStr) {
-      const response = JSON.parse(responseStr);
-      const rawRows = response.data[requestTable].edges;
-      return {
-        rows: rawRows.map((row: { node: TODO }) => row.node),
-        meta: {}
-      };
+  /**
+   * @param payload - raw payload string
+   * @param request - request object
+   */
+  private processResponse(payload: string, request: RequestV2): ResponseV1 {
+    const response = JSON.parse(payload);
+
+    const { table } = request;
+    const elideFields = request.columns.map(({ field, parameters }) => getElideField(field, parameters));
+    const normalizedFields = request.columns.map(({ field: metric, parameters }) =>
+      // TODO rename with generic canonicalizeColumn
+      canonicalizeMetric({ metric, parameters })
+    );
+
+    const rawRows = response.data[table].edges;
+    const totalRows = rawRows.length;
+    const totalFields = normalizedFields.length;
+    const rows = new Array(totalRows);
+
+    let r = totalRows;
+    while (r--) {
+      const rawRow = rawRows[r].node;
+      const newRow: Record<string, unknown> = (rows[r] = {});
+      let f = totalFields;
+      while (f--) {
+        newRow[normalizedFields[f]] = rawRow[elideFields[f]];
+      }
     }
-    return undefined;
+    return { rows, meta: {} };
+  }
+
+  normalize(payload: AsyncQueryResponse, request: RequestV2): ResponseV1 | undefined {
+    const responseStr = payload?.asyncQuery.edges[0].node.result?.responseBody;
+    return responseStr ? this.processResponse(responseStr, request) : undefined;
   }
 }

--- a/packages/data/addon/serializers/facts/elide.ts
+++ b/packages/data/addon/serializers/facts/elide.ts
@@ -20,6 +20,7 @@ export default class ElideFactsSerializer extends EmberObject implements NaviFac
     const response = JSON.parse(payload);
 
     const { table } = request;
+    // TODO revisit when Elide adds parameter support
     const elideFields = request.columns.map(({ field, parameters }) => getElideField(field, parameters));
     const normalizedFields = request.columns.map(({ field: metric, parameters }) =>
       // TODO rename with generic canonicalizeColumn

--- a/packages/data/tests/unit/adapters/facts/elide-test.ts
+++ b/packages/data/tests/unit/adapters/facts/elide-test.ts
@@ -6,6 +6,7 @@ import { asyncFactsQueryStr } from 'navi-data/gql/queries/async-facts';
 import { RequestV2 } from 'navi-data/adapters/facts/interface';
 import Pretender from 'pretender';
 import config from 'ember-get-config';
+import { getElideField } from 'navi-data/adapters/facts/elide';
 
 const HOST = config.navi.dataSources[0].uri;
 const uuidRegex = /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
@@ -70,19 +71,13 @@ module('Unit | Adapter | facts/elide', function(hooks) {
   });
 
   test('queryStrForField', function(assert) {
-    const adapter = this.owner.lookup('adapter:facts/elide');
-
+    assert.equal(getElideField('foo', { bar: 'baz' }), 'foo(bar: baz)', 'Field with parameter is formatted correctly');
     assert.equal(
-      adapter.queryStrForField('foo', { bar: 'baz' }),
-      'foo(bar: baz)',
-      'Field with parameter is formatted correctly'
-    );
-    assert.equal(
-      adapter.queryStrForField('foo', { bar: 'baz', bang: 'boom' }),
+      getElideField('foo', { bar: 'baz', bang: 'boom' }),
       'foo(bar: baz,bang: boom)',
       'Field with multiple parameters is formatted correctly'
     );
-    assert.equal(adapter.queryStrForField('foo'), 'foo', 'Name is returned for field with no parameters');
+    assert.equal(getElideField('foo'), 'foo', 'Name is returned for field with no parameters');
   });
 
   test('dataQueryFromRequest', function(assert) {
@@ -258,7 +253,7 @@ module('Unit | Adapter | facts/elide', function(hooks) {
       assert.ok(uuidRegex.exec(requestObj.variables.id), 'A uuid is generated for the request id');
 
       const expectedTable = TestRequestV2.table;
-      const expectedColumns = TestRequestV2.columns.map(c => adapter.queryStrForField(c.field, c.parameters)).join(' ');
+      const expectedColumns = TestRequestV2.columns.map(c => getElideField(c.field, c.parameters)).join(' ');
       const expectedArgs =
         '(filter: \\"d3=in=(v1,v2);d4=in=(v3,v4);d5=isnull=(false);time=ge=(2015-01-03);time=lt=(2015-01-04);m1=gt=(0)\\",sort: \\"d1\\",first: \\"10000\\")';
 

--- a/packages/data/tests/unit/serializers/facts/elide-test.ts
+++ b/packages/data/tests/unit/serializers/facts/elide-test.ts
@@ -25,7 +25,10 @@ const Payload: AsyncQueryResponse = {
 };
 
 const Request: RequestV2 = {
-  columns: [{ field: 'user_count', parameters: {}, type: 'metric' }],
+  columns: [
+    { field: 'datestamp', parameters: {}, type: 'timeDimension' },
+    { field: 'userCount', parameters: {}, type: 'metric' }
+  ],
   table: 'tableA',
   filters: [],
   sorts: [],

--- a/packages/data/tests/unit/services/navi-facts-elide-test.js
+++ b/packages/data/tests/unit/services/navi-facts-elide-test.js
@@ -7,49 +7,49 @@ import moment from 'moment';
 const TestRequest = {
   table: 'table1',
   columns: [
-    { field: 'eventTimeDay', parameters: {}, type: 'timeDimension' },
-    { field: 'eventTimeMonth', parameters: {}, type: 'timeDimension' },
-    { field: 'orderTimeDay', parameters: {}, type: 'timeDimension' },
-    { field: 'metric1', parameters: {}, type: 'metric' },
-    { field: 'metric2', parameters: {}, type: 'metric' },
-    { field: 'dimension1', parameters: {}, type: 'dimension' },
-    { field: 'dimension2', parameters: {}, type: 'dimension' }
+    { field: 'table1.eventTimeDay', parameters: {}, type: 'timeDimension' },
+    { field: 'table1.eventTimeMonth', parameters: {}, type: 'timeDimension' },
+    { field: 'table1.orderTimeDay', parameters: {}, type: 'timeDimension' },
+    { field: 'table1.metric1', parameters: {}, type: 'metric' },
+    { field: 'table1.metric2', parameters: {}, type: 'metric' },
+    { field: 'table1.dimension1', parameters: {}, type: 'dimension' },
+    { field: 'table1.dimension2', parameters: {}, type: 'dimension' }
   ],
   filters: [
-    { field: 'dimension1', operator: 'eq', values: ['Small Metal Hat'], parameters: {}, type: 'dimension' },
+    { field: 'table1.dimension1', operator: 'eq', values: ['Small Metal Hat'], parameters: {}, type: 'dimension' },
     {
-      field: 'dimension2',
+      field: 'table1.dimension2',
       operator: 'notin',
       values: ['Gorgeous Frozen Table', 'Refined Soft Sausages'],
       parameters: {},
       type: 'dimension'
     },
-    { field: 'dimension3', operator: 'in', values: ['v1', 'v2'], parameters: {}, type: 'dimension' },
-    { field: 'dimension4', operator: 'in', values: ['v3', 'v4'], parameters: {}, type: 'dimension' },
-    { field: 'metric1', operator: 'gt', values: ['0'], parameters: {}, type: 'metric' },
+    { field: 'table1.dimension3', operator: 'in', values: ['v1', 'v2'], parameters: {}, type: 'dimension' },
+    { field: 'table1.dimension4', operator: 'in', values: ['v3', 'v4'], parameters: {}, type: 'dimension' },
+    { field: 'table1.metric1', operator: 'gt', values: ['0'], parameters: {}, type: 'metric' },
     {
-      field: 'eventTimeDay',
+      field: 'table1.eventTimeDay',
       operator: 'ge',
       values: ['2015-01-29'],
       parameters: {},
       type: 'timeDimension'
     },
     {
-      field: 'eventTimeDay',
+      field: 'table1.eventTimeDay',
       operator: 'lt',
       values: ['2015-02-04'],
       parameters: {},
       type: 'timeDimension'
     },
     {
-      field: 'orderTimeDay',
+      field: 'table1.orderTimeDay',
       operator: 'ge',
       values: ['2014-01-05'],
       parameters: {},
       type: 'timeDimension'
     },
     {
-      field: 'orderTimeDay',
+      field: 'table1.orderTimeDay',
       operator: 'lt',
       values: ['2014-01-07'],
       parameters: {},
@@ -57,8 +57,8 @@ const TestRequest = {
     }
   ],
   sorts: [
-    { field: 'eventTimeDay', parameters: {}, type: 'timeDimension', direction: 'asc' },
-    { field: 'dimension2', parameters: {}, type: 'dimension', direction: 'desc' }
+    { field: 'table1.eventTimeDay', parameters: {}, type: 'timeDimension', direction: 'asc' },
+    { field: 'table1.dimension2', parameters: {}, type: 'dimension', direction: 'desc' }
   ],
   limit: 15,
   requestVersion: '2.0',
@@ -83,139 +83,139 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
       {
         rows: [
           {
-            eventTimeDay: '2015-01-29',
-            eventTimeMonth: '2015 Jan',
-            orderTimeDay: '2014-01-05',
-            dimension1: 'Small Metal Hat',
-            dimension2: 'Unbranded Concrete Fish',
-            metric1: '785.60',
-            metric2: '590.23'
+            'table1.eventTimeDay': '2015-01-29',
+            'table1.eventTimeMonth': '2015 Jan',
+            'table1.orderTimeDay': '2014-01-05',
+            'table1.dimension1': 'Small Metal Hat',
+            'table1.dimension2': 'Unbranded Concrete Fish',
+            'table1.metric1': '785.60',
+            'table1.metric2': '590.23'
           },
           {
-            eventTimeDay: '2015-01-29',
-            eventTimeMonth: '2015 Jan',
-            orderTimeDay: '2014-01-06',
-            dimension1: 'Small Metal Hat',
-            dimension2: 'Unbranded Concrete Fish',
-            metric1: '603.55',
-            metric2: '977.92'
+            'table1.eventTimeDay': '2015-01-29',
+            'table1.eventTimeMonth': '2015 Jan',
+            'table1.orderTimeDay': '2014-01-06',
+            'table1.dimension1': 'Small Metal Hat',
+            'table1.dimension2': 'Unbranded Concrete Fish',
+            'table1.metric1': '603.55',
+            'table1.metric2': '977.92'
           },
           {
-            eventTimeDay: '2015-01-29',
-            eventTimeMonth: '2015 Jan',
-            orderTimeDay: '2014-01-05',
-            dimension1: 'Small Metal Hat',
-            dimension2: 'Refined Concrete Chair',
-            metric1: '83.56',
-            metric2: '774.72'
+            'table1.eventTimeDay': '2015-01-29',
+            'table1.eventTimeMonth': '2015 Jan',
+            'table1.orderTimeDay': '2014-01-05',
+            'table1.dimension1': 'Small Metal Hat',
+            'table1.dimension2': 'Refined Concrete Chair',
+            'table1.metric1': '83.56',
+            'table1.metric2': '774.72'
           },
           {
-            eventTimeDay: '2015-01-29',
-            eventTimeMonth: '2015 Jan',
-            orderTimeDay: '2014-01-06',
-            dimension1: 'Small Metal Hat',
-            dimension2: 'Refined Concrete Chair',
-            metric1: '685.31',
-            metric2: '432.90'
+            'table1.eventTimeDay': '2015-01-29',
+            'table1.eventTimeMonth': '2015 Jan',
+            'table1.orderTimeDay': '2014-01-06',
+            'table1.dimension1': 'Small Metal Hat',
+            'table1.dimension2': 'Refined Concrete Chair',
+            'table1.metric1': '685.31',
+            'table1.metric2': '432.90'
           },
           {
-            eventTimeDay: '2015-01-29',
-            eventTimeMonth: '2015 Jan',
-            orderTimeDay: '2014-01-05',
-            dimension1: 'Small Metal Hat',
-            dimension2: 'Licensed Concrete Salad',
-            metric1: '965.49',
-            metric2: '534.25'
+            'table1.eventTimeDay': '2015-01-29',
+            'table1.eventTimeMonth': '2015 Jan',
+            'table1.orderTimeDay': '2014-01-05',
+            'table1.dimension1': 'Small Metal Hat',
+            'table1.dimension2': 'Licensed Concrete Salad',
+            'table1.metric1': '965.49',
+            'table1.metric2': '534.25'
           },
           {
-            eventTimeDay: '2015-01-29',
-            eventTimeMonth: '2015 Jan',
-            orderTimeDay: '2014-01-06',
-            dimension1: 'Small Metal Hat',
-            dimension2: 'Licensed Concrete Salad',
-            metric1: '729.00',
-            metric2: '611.60'
+            'table1.eventTimeDay': '2015-01-29',
+            'table1.eventTimeMonth': '2015 Jan',
+            'table1.orderTimeDay': '2014-01-06',
+            'table1.dimension1': 'Small Metal Hat',
+            'table1.dimension2': 'Licensed Concrete Salad',
+            'table1.metric1': '729.00',
+            'table1.metric2': '611.60'
           },
           {
-            eventTimeDay: '2015-01-29',
-            eventTimeMonth: '2015 Jan',
-            orderTimeDay: '2014-01-05',
-            dimension1: 'Small Metal Hat',
-            dimension2: 'Awesome Steel Pants',
-            metric1: '232.35',
-            metric2: '581.26'
+            'table1.eventTimeDay': '2015-01-29',
+            'table1.eventTimeMonth': '2015 Jan',
+            'table1.orderTimeDay': '2014-01-05',
+            'table1.dimension1': 'Small Metal Hat',
+            'table1.dimension2': 'Awesome Steel Pants',
+            'table1.metric1': '232.35',
+            'table1.metric2': '581.26'
           },
           {
-            eventTimeDay: '2015-01-29',
-            eventTimeMonth: '2015 Jan',
-            orderTimeDay: '2014-01-06',
-            dimension1: 'Small Metal Hat',
-            dimension2: 'Awesome Steel Pants',
-            metric1: '276.24',
-            metric2: '946.29'
+            'table1.eventTimeDay': '2015-01-29',
+            'table1.eventTimeMonth': '2015 Jan',
+            'table1.orderTimeDay': '2014-01-06',
+            'table1.dimension1': 'Small Metal Hat',
+            'table1.dimension2': 'Awesome Steel Pants',
+            'table1.metric1': '276.24',
+            'table1.metric2': '946.29'
           },
           {
-            eventTimeDay: '2015-01-30',
-            eventTimeMonth: '2015 Jan',
-            orderTimeDay: '2014-01-05',
-            dimension1: 'Small Metal Hat',
-            dimension2: 'Unbranded Concrete Fish',
-            metric1: '517.87',
-            metric2: '791.83'
+            'table1.eventTimeDay': '2015-01-30',
+            'table1.eventTimeMonth': '2015 Jan',
+            'table1.orderTimeDay': '2014-01-05',
+            'table1.dimension1': 'Small Metal Hat',
+            'table1.dimension2': 'Unbranded Concrete Fish',
+            'table1.metric1': '517.87',
+            'table1.metric2': '791.83'
           },
           {
-            eventTimeDay: '2015-01-30',
-            eventTimeMonth: '2015 Jan',
-            orderTimeDay: '2014-01-06',
-            dimension1: 'Small Metal Hat',
-            dimension2: 'Unbranded Concrete Fish',
-            metric1: '994.32',
-            metric2: '602.63'
+            'table1.eventTimeDay': '2015-01-30',
+            'table1.eventTimeMonth': '2015 Jan',
+            'table1.orderTimeDay': '2014-01-06',
+            'table1.dimension1': 'Small Metal Hat',
+            'table1.dimension2': 'Unbranded Concrete Fish',
+            'table1.metric1': '994.32',
+            'table1.metric2': '602.63'
           },
           {
-            eventTimeDay: '2015-01-30',
-            eventTimeMonth: '2015 Jan',
-            orderTimeDay: '2014-01-05',
-            dimension1: 'Small Metal Hat',
-            dimension2: 'Refined Concrete Chair',
-            metric1: '186.96',
-            metric2: '146.24'
+            'table1.eventTimeDay': '2015-01-30',
+            'table1.eventTimeMonth': '2015 Jan',
+            'table1.orderTimeDay': '2014-01-05',
+            'table1.dimension1': 'Small Metal Hat',
+            'table1.dimension2': 'Refined Concrete Chair',
+            'table1.metric1': '186.96',
+            'table1.metric2': '146.24'
           },
           {
-            eventTimeDay: '2015-01-30',
-            eventTimeMonth: '2015 Jan',
-            orderTimeDay: '2014-01-05',
-            dimension1: 'Small Metal Hat',
-            dimension2: 'Licensed Concrete Salad',
-            metric1: '48.48',
-            metric2: '456.50'
+            'table1.eventTimeDay': '2015-01-30',
+            'table1.eventTimeMonth': '2015 Jan',
+            'table1.orderTimeDay': '2014-01-05',
+            'table1.dimension1': 'Small Metal Hat',
+            'table1.dimension2': 'Licensed Concrete Salad',
+            'table1.metric1': '48.48',
+            'table1.metric2': '456.50'
           },
           {
-            eventTimeDay: '2015-01-30',
-            eventTimeMonth: '2015 Jan',
-            orderTimeDay: '2014-01-06',
-            dimension1: 'Small Metal Hat',
-            dimension2: 'Licensed Concrete Salad',
-            metric1: '520.67',
-            metric2: '591.28'
+            'table1.eventTimeDay': '2015-01-30',
+            'table1.eventTimeMonth': '2015 Jan',
+            'table1.orderTimeDay': '2014-01-06',
+            'table1.dimension1': 'Small Metal Hat',
+            'table1.dimension2': 'Licensed Concrete Salad',
+            'table1.metric1': '520.67',
+            'table1.metric2': '591.28'
           },
           {
-            eventTimeDay: '2015-01-30',
-            eventTimeMonth: '2015 Jan',
-            orderTimeDay: '2014-01-05',
-            dimension1: 'Small Metal Hat',
-            dimension2: 'Awesome Steel Pants',
-            metric1: '137.87',
-            metric2: '826.68'
+            'table1.eventTimeDay': '2015-01-30',
+            'table1.eventTimeMonth': '2015 Jan',
+            'table1.orderTimeDay': '2014-01-05',
+            'table1.dimension1': 'Small Metal Hat',
+            'table1.dimension2': 'Awesome Steel Pants',
+            'table1.metric1': '137.87',
+            'table1.metric2': '826.68'
           },
           {
-            eventTimeDay: '2015-01-30',
-            eventTimeMonth: '2015 Jan',
-            orderTimeDay: '2014-01-06',
-            dimension1: 'Small Metal Hat',
-            dimension2: 'Awesome Steel Pants',
-            metric1: '578.79',
-            metric2: '441.69'
+            'table1.eventTimeDay': '2015-01-30',
+            'table1.eventTimeMonth': '2015 Jan',
+            'table1.orderTimeDay': '2014-01-06',
+            'table1.dimension1': 'Small Metal Hat',
+            'table1.dimension2': 'Awesome Steel Pants',
+            'table1.metric1': '578.79',
+            'table1.metric2': '441.69'
           }
         ],
         meta: {}
@@ -231,11 +231,11 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
       {
         table: 'table1',
         columns: [
-          { field: 'metric1', parameters: {}, type: 'metric' },
-          { field: 'metric2', parameters: {}, type: 'metric' }
+          { field: 'table1.metric1', parameters: {}, type: 'metric' },
+          { field: 'table1.metric2', parameters: {}, type: 'metric' }
         ],
-        filters: [{ field: 'metric1', operator: 'gt', values: ['100'], parameters: {}, type: 'metric' }],
-        sorts: [{ field: 'metric2', parameters: {}, type: 'metric', direction: 'asc' }],
+        filters: [{ field: 'table1.metric1', operator: 'gt', values: ['100'], parameters: {}, type: 'metric' }],
+        sorts: [{ field: 'table1.metric2', parameters: {}, type: 'metric', direction: 'asc' }],
         limit: 15,
         requestVersion: '2.0',
         dataSource: 'elideOne'
@@ -245,7 +245,7 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
 
     assert.deepEqual(
       response.response,
-      { rows: [{ metric1: '384.77', metric2: '897.01' }], meta: {} },
+      { rows: [{ 'table1.metric1': '384.77', 'table1.metric2': '897.01' }], meta: {} },
       'Request with only metrics is formatted correctly'
     );
   });
@@ -255,28 +255,28 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
 
     const filters = [
       {
-        field: 'eventTimeDay',
+        field: 'table1.eventTimeDay',
         operator: 'ge',
         values: ['2015-01-29'],
         parameters: {},
         type: 'timeDimension'
       },
       {
-        field: 'eventTimeDay',
+        field: 'table1.eventTimeDay',
         operator: 'lt',
         values: ['2015-02-04'],
         parameters: {},
         type: 'timeDimension'
       },
       {
-        field: 'eventTimeDay',
+        field: 'table1.eventTimeDay',
         operator: 'ge',
         values: ['2015-02-05'],
         parameters: {},
         type: 'timeDimension'
       },
       {
-        field: 'eventTimeDay',
+        field: 'table1.eventTimeDay',
         operator: 'lt',
         values: ['2015-02-06'],
         parameters: {},
@@ -288,8 +288,8 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
       {
         table: 'table1',
         columns: [
-          { field: 'metric1', parameters: {}, type: 'metric' },
-          { field: 'eventTimeDay', parameters: {}, type: 'timeDimension' }
+          { field: 'table1.metric1', parameters: {}, type: 'metric' },
+          { field: 'table1.eventTimeDay', parameters: {}, type: 'timeDimension' }
         ],
         filters,
         sorts: [],
@@ -312,7 +312,7 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
     const noTimeDimResponse = await this.service.fetch(
       {
         table: 'table1',
-        columns: [{ field: 'metric1', parameters: {}, type: 'metric' }],
+        columns: [{ field: 'table1.metric1', parameters: {}, type: 'metric' }],
         filters,
         sorts: [],
         limit: null,
@@ -324,7 +324,7 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
     assert.deepEqual(
       noTimeDimResponse.response,
       {
-        rows: [{ metric1: '97.53' }],
+        rows: [{ 'table1.metric1': '97.53' }],
         meta: {}
       },
       'An invalid filter on a non-requested field does not affect the response'
@@ -338,12 +338,12 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
       {
         table: 'table1',
         columns: [
-          { field: 'metric1', parameters: {}, type: 'metric' },
-          { field: 'eventTimeMonth', parameters: {}, type: 'timeDimension' }
+          { field: 'table1.metric1', parameters: {}, type: 'metric' },
+          { field: 'table1.eventTimeMonth', parameters: {}, type: 'timeDimension' }
         ],
         filters: [
           {
-            field: 'eventTimeMonth',
+            field: 'table1.eventTimeMonth',
             operator: 'ge',
             values: ['2015-01-01'],
             parameters: {},
@@ -362,8 +362,8 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
       response.response,
       {
         rows: [
-          { eventTimeMonth: '2015 Jan', metric1: '38.56' },
-          { eventTimeMonth: '2015 Feb', metric1: '195.76' }
+          { 'table1.eventTimeMonth': '2015 Jan', 'table1.metric1': '38.56' },
+          { 'table1.eventTimeMonth': '2015 Feb', 'table1.metric1': '195.76' }
         ],
         meta: {}
       },
@@ -374,12 +374,12 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
       {
         table: 'table1',
         columns: [
-          { field: 'metric1', parameters: {}, type: 'metric' },
-          { field: 'eventTimeMonth', parameters: {}, type: 'timeDimension' }
+          { field: 'table1.metric1', parameters: {}, type: 'metric' },
+          { field: 'table1.eventTimeMonth', parameters: {}, type: 'timeDimension' }
         ],
         filters: [
           {
-            field: 'eventTimeMonth',
+            field: 'table1.eventTimeMonth',
             operator: 'lt',
             values: ['2015-01-01'],
             parameters: {},
@@ -397,8 +397,8 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
       noStartDateResponse.response,
       {
         rows: [
-          { eventTimeMonth: '2014 Nov', metric1: '38.56' },
-          { eventTimeMonth: '2014 Dec', metric1: '195.76' }
+          { 'table1.eventTimeMonth': '2014 Nov', 'table1.metric1': '38.56' },
+          { 'table1.eventTimeMonth': '2014 Dec', 'table1.metric1': '195.76' }
         ],
         meta: {}
       },
@@ -409,10 +409,10 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
     const dateToCurrentResponse = await this.service.fetch(
       {
         table: 'table1',
-        columns: [{ field: 'eventTimeDay', parameters: {}, type: 'timeDimension' }],
+        columns: [{ field: 'table1.eventTimeDay', parameters: {}, type: 'timeDimension' }],
         filters: [
           {
-            field: 'eventTimeDay',
+            field: 'table1.eventTimeDay',
             operator: 'ge',
             values: [
               moment()
@@ -436,17 +436,17 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
       {
         rows: [
           {
-            eventTimeDay: moment()
+            'table1.eventTimeDay': moment()
               .subtract(2, 'days')
               .format(DAY_FORMAT)
           },
           {
-            eventTimeDay: moment()
+            'table1.eventTimeDay': moment()
               .subtract(1, 'days')
               .format(DAY_FORMAT)
           },
           {
-            eventTimeDay: moment().format(DAY_FORMAT)
+            'table1.eventTimeDay': moment().format(DAY_FORMAT)
           }
         ],
         meta: {}
@@ -462,26 +462,26 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
       {
         table: 'table1',
         columns: [
-          { field: 'metric1', parameters: {}, type: 'metric' },
-          { field: 'eventTimeDay', parameters: {}, type: 'timeDimension' }
+          { field: 'table1.metric1', parameters: {}, type: 'metric' },
+          { field: 'table1.eventTimeDay', parameters: {}, type: 'timeDimension' }
         ],
         filters: [
           {
-            field: 'eventTimeDay',
+            field: 'table1.eventTimeDay',
             operator: 'ge',
             values: ['2015-01-01'],
             parameters: {},
             type: 'timeDimension'
           },
           {
-            field: 'eventTimeDay',
+            field: 'table1.eventTimeDay',
             operator: 'lt',
             values: ['2015-01-04'],
             parameters: {},
             type: 'timeDimension'
           }
         ],
-        sorts: [{ field: 'metric1', parameters: {}, type: 'metric', direction: 'asc' }],
+        sorts: [{ field: 'table1.metric1', parameters: {}, type: 'metric', direction: 'asc' }],
         limit: null,
         requestVersion: '2.0',
         dataSource: 'elideOne'
@@ -493,9 +493,9 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
       response.response,
       {
         rows: [
-          { eventTimeDay: '2015-01-02', metric1: '139.22' },
-          { eventTimeDay: '2015-01-03', metric1: '464.10' },
-          { eventTimeDay: '2015-01-01', metric1: '944.50' }
+          { 'table1.eventTimeDay': '2015-01-02', 'table1.metric1': '139.22' },
+          { 'table1.eventTimeDay': '2015-01-03', 'table1.metric1': '464.10' },
+          { 'table1.eventTimeDay': '2015-01-01', 'table1.metric1': '944.50' }
         ],
         meta: {}
       },
@@ -506,14 +506,14 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
       {
         table: 'table1',
         columns: [
-          { field: 'dimension1', parameters: {}, type: 'dimension' },
-          { field: 'dimension2', parameters: {}, type: 'dimension' },
-          { field: 'metric1', parameters: {}, type: 'metric' }
+          { field: 'table1.dimension1', parameters: {}, type: 'dimension' },
+          { field: 'table1.dimension2', parameters: {}, type: 'dimension' },
+          { field: 'table1.metric1', parameters: {}, type: 'metric' }
         ],
         filters: [],
         sorts: [
-          { field: 'dimension1', parameters: {}, type: 'metric', direction: 'asc' },
-          { field: 'dimension2', parameters: {}, type: 'metric', direction: 'asc' }
+          { field: 'table1.dimension1', parameters: {}, type: 'metric', direction: 'asc' },
+          { field: 'table1.dimension2', parameters: {}, type: 'metric', direction: 'asc' }
         ],
         limit: null,
         requestVersion: '2.0',
@@ -526,18 +526,66 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
       multiSortResponse.response,
       {
         rows: [
-          { dimension1: 'Licensed Cotton Computer', dimension2: 'Gorgeous Frozen Sausages', metric1: '990.67' },
-          { dimension1: 'Licensed Cotton Computer', dimension2: 'Licensed Granite Sausages', metric1: '825.82' },
-          { dimension1: 'Licensed Cotton Computer', dimension2: 'Sleek Metal Tuna', metric1: '414.83' },
-          { dimension1: 'Refined Rubber Soap', dimension2: 'Gorgeous Frozen Sausages', metric1: '946.26' },
-          { dimension1: 'Refined Rubber Soap', dimension2: 'Licensed Granite Sausages', metric1: '247.63' },
-          { dimension1: 'Refined Rubber Soap', dimension2: 'Sleek Metal Tuna', metric1: '335.55' },
-          { dimension1: 'Sleek Cotton Shoes', dimension2: 'Gorgeous Frozen Sausages', metric1: '344.62' },
-          { dimension1: 'Sleek Cotton Shoes', dimension2: 'Licensed Granite Sausages', metric1: '252.27' },
-          { dimension1: 'Sleek Cotton Shoes', dimension2: 'Sleek Metal Tuna', metric1: '628.05' },
-          { dimension1: 'Small Soft Bacon', dimension2: 'Gorgeous Frozen Sausages', metric1: '919.59' },
-          { dimension1: 'Small Soft Bacon', dimension2: 'Licensed Granite Sausages', metric1: '469.79' },
-          { dimension1: 'Small Soft Bacon', dimension2: 'Sleek Metal Tuna', metric1: '233.23' }
+          {
+            'table1.dimension1': 'Licensed Cotton Computer',
+            'table1.dimension2': 'Gorgeous Frozen Sausages',
+            'table1.metric1': '990.67'
+          },
+          {
+            'table1.dimension1': 'Licensed Cotton Computer',
+            'table1.dimension2': 'Licensed Granite Sausages',
+            'table1.metric1': '825.82'
+          },
+          {
+            'table1.dimension1': 'Licensed Cotton Computer',
+            'table1.dimension2': 'Sleek Metal Tuna',
+            'table1.metric1': '414.83'
+          },
+          {
+            'table1.dimension1': 'Refined Rubber Soap',
+            'table1.dimension2': 'Gorgeous Frozen Sausages',
+            'table1.metric1': '946.26'
+          },
+          {
+            'table1.dimension1': 'Refined Rubber Soap',
+            'table1.dimension2': 'Licensed Granite Sausages',
+            'table1.metric1': '247.63'
+          },
+          {
+            'table1.dimension1': 'Refined Rubber Soap',
+            'table1.dimension2': 'Sleek Metal Tuna',
+            'table1.metric1': '335.55'
+          },
+          {
+            'table1.dimension1': 'Sleek Cotton Shoes',
+            'table1.dimension2': 'Gorgeous Frozen Sausages',
+            'table1.metric1': '344.62'
+          },
+          {
+            'table1.dimension1': 'Sleek Cotton Shoes',
+            'table1.dimension2': 'Licensed Granite Sausages',
+            'table1.metric1': '252.27'
+          },
+          {
+            'table1.dimension1': 'Sleek Cotton Shoes',
+            'table1.dimension2': 'Sleek Metal Tuna',
+            'table1.metric1': '628.05'
+          },
+          {
+            'table1.dimension1': 'Small Soft Bacon',
+            'table1.dimension2': 'Gorgeous Frozen Sausages',
+            'table1.metric1': '919.59'
+          },
+          {
+            'table1.dimension1': 'Small Soft Bacon',
+            'table1.dimension2': 'Licensed Granite Sausages',
+            'table1.metric1': '469.79'
+          },
+          {
+            'table1.dimension1': 'Small Soft Bacon',
+            'table1.dimension2': 'Sleek Metal Tuna',
+            'table1.metric1': '233.23'
+          }
         ],
         meta: {}
       },
@@ -552,19 +600,19 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
       {
         table: 'table1',
         columns: [
-          { field: 'metric1', parameters: {}, type: 'metric' },
-          { field: 'eventTimeDay', parameters: {}, type: 'timeDimension' }
+          { field: 'table1.metric1', parameters: {}, type: 'metric' },
+          { field: 'table1.eventTimeDay', parameters: {}, type: 'timeDimension' }
         ],
         filters: [
           {
-            field: 'eventTimeDay',
+            field: 'table1.eventTimeDay',
             operator: 'ge',
             values: ['2015-01-01'],
             parameters: {},
             type: 'timeDimension'
           },
           {
-            field: 'eventTimeDay',
+            field: 'table1.eventTimeDay',
             operator: 'lt',
             values: ['2015-01-10'],
             parameters: {},
@@ -583,9 +631,9 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
       response.response,
       {
         rows: [
-          { eventTimeDay: '2015-01-01', metric1: '384.77' },
-          { eventTimeDay: '2015-01-02', metric1: '897.01' },
-          { eventTimeDay: '2015-01-03', metric1: '859.71' }
+          { 'table1.eventTimeDay': '2015-01-01', 'table1.metric1': '384.77' },
+          { 'table1.eventTimeDay': '2015-01-02', 'table1.metric1': '897.01' },
+          { 'table1.eventTimeDay': '2015-01-03', 'table1.metric1': '859.71' }
         ],
         meta: {}
       },
@@ -596,19 +644,19 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
       {
         table: 'table1',
         columns: [
-          { field: 'metric1', parameters: {}, type: 'metric' },
-          { field: 'eventTimeDay', parameters: {}, type: 'timeDimension' }
+          { field: 'table1.metric1', parameters: {}, type: 'metric' },
+          { field: 'table1.eventTimeDay', parameters: {}, type: 'timeDimension' }
         ],
         filters: [
           {
-            field: 'eventTimeDay',
+            field: 'table1.eventTimeDay',
             operator: 'ge',
             values: ['2015-01-01'],
             parameters: {},
             type: 'timeDimension'
           },
           {
-            field: 'eventTimeDay',
+            field: 'table1.eventTimeDay',
             operator: 'lt',
             values: ['2015-01-10'],
             parameters: {},
@@ -627,15 +675,15 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
       limitless.response,
       {
         rows: [
-          { eventTimeDay: '2015-01-01', metric1: '858.89' },
-          { eventTimeDay: '2015-01-02', metric1: '59.65' },
-          { eventTimeDay: '2015-01-03', metric1: '372.71' },
-          { eventTimeDay: '2015-01-04', metric1: '421.04' },
-          { eventTimeDay: '2015-01-05', metric1: '555.13' },
-          { eventTimeDay: '2015-01-06', metric1: '330.39' },
-          { eventTimeDay: '2015-01-07', metric1: '955.66' },
-          { eventTimeDay: '2015-01-08', metric1: '754.00' },
-          { eventTimeDay: '2015-01-09', metric1: '736.67' }
+          { 'table1.eventTimeDay': '2015-01-01', 'table1.metric1': '858.89' },
+          { 'table1.eventTimeDay': '2015-01-02', 'table1.metric1': '59.65' },
+          { 'table1.eventTimeDay': '2015-01-03', 'table1.metric1': '372.71' },
+          { 'table1.eventTimeDay': '2015-01-04', 'table1.metric1': '421.04' },
+          { 'table1.eventTimeDay': '2015-01-05', 'table1.metric1': '555.13' },
+          { 'table1.eventTimeDay': '2015-01-06', 'table1.metric1': '330.39' },
+          { 'table1.eventTimeDay': '2015-01-07', 'table1.metric1': '955.66' },
+          { 'table1.eventTimeDay': '2015-01-08', 'table1.metric1': '754.00' },
+          { 'table1.eventTimeDay': '2015-01-09', 'table1.metric1': '736.67' }
         ],
         meta: {}
       },


### PR DESCRIPTION
Resolves #953 
Resolves #961


## Description

Update: Fix elide request and response names

## Proposed Changes

- Update elide adapter and serializer
- Move `queryStrForField` private method to export function `getElideField`

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
