### PR TITLE
New: Elide Dimension Adapter

### DIFF
--- a/packages/data/addon/adapters/dimensions/elide.ts
+++ b/packages/data/addon/adapters/dimensions/elide.ts
@@ -13,9 +13,9 @@ import ElideFactsAdapter from '../facts/elide';
 
 export default class ElideDimensionAdapter extends EmberObject implements NaviDimensionAdapter {
   /**
-   * @property adapter - the elide fact adapter that will send asyncQuery requests for the dimension values
+   * The elide fact adapter that will send asyncQuery requests for the dimension values
    */
-  factAdapter: ElideFactsAdapter = getOwner(this).lookup('adapter:facts/elide');
+  private factAdapter: ElideFactsAdapter = getOwner(this).lookup('adapter:facts/elide');
 
   all(dimension: DimensionColumn, options: ServiceOptions = {}): Promise<unknown> {
     return this.find(dimension, [], options);

--- a/packages/data/addon/adapters/dimensions/elide.ts
+++ b/packages/data/addon/adapters/dimensions/elide.ts
@@ -9,12 +9,13 @@ import EmberObject from '@ember/object';
 import NaviDimensionAdapter, { DimensionColumn, DimensionFilter } from './interface';
 import { ServiceOptions } from 'navi-data/services/navi-dimension';
 import { RequestV2 } from '../facts/interface';
+import ElideFactsAdapter from '../facts/elide';
 
 export default class ElideDimensionAdapter extends EmberObject implements NaviDimensionAdapter {
   /**
    * @property adapter - the elide fact adapter that will send asyncQuery requests for the dimension values
    */
-  factAdapter = getOwner(this).lookup('adapter:facts/elide');
+  factAdapter: ElideFactsAdapter = getOwner(this).lookup('adapter:facts/elide');
 
   all(dimension: DimensionColumn, options: ServiceOptions = {}): Promise<unknown> {
     return this.find(dimension, [], options);
@@ -30,7 +31,7 @@ export default class ElideDimensionAdapter extends EmberObject implements NaviDi
     // Create a request with only one dimension and its appropriate filters
     const request: RequestV2 = {
       table: tableId || '',
-      columns: [{ field: id, parameters: parameters || {}, type: 'dimension' }],
+      columns: [{ field: id, parameters, type: 'dimension' }],
       filters: predicate.map(pred => ({
         field: id,
         parameters,

--- a/packages/data/addon/adapters/dimensions/elide.ts
+++ b/packages/data/addon/adapters/dimensions/elide.ts
@@ -24,9 +24,8 @@ export default class ElideDimensionAdapter extends EmberObject implements NaviDi
   find(dimension: DimensionColumn, predicate: DimensionFilter[] = [], options: ServiceOptions = {}): Promise<unknown> {
     const {
       columnMetadata: { id, source, tableId },
-      parameters: params
+      parameters = {}
     } = dimension;
-    const parameters = params || {};
 
     // Create a request with only one dimension and its appropriate filters
     const request: RequestV2 = {

--- a/packages/data/addon/adapters/dimensions/elide.ts
+++ b/packages/data/addon/adapters/dimensions/elide.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2020, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ *
+ * Description: The adapter for the Elide dimension model.
+ */
+import { getOwner } from '@ember/application';
+import EmberObject from '@ember/object';
+import NaviDimensionAdapter, { DimensionColumn, DimensionFilter } from './interface';
+import { ServiceOptions } from 'navi-data/services/navi-dimension';
+import { RequestV2 } from '../facts/interface';
+
+export default class ElideDimensionAdapter extends EmberObject implements NaviDimensionAdapter {
+  /**
+   * @property adapter - the elide fact adapter that will send asyncQuery requests for the dimension values
+   */
+  factAdapter = getOwner(this).lookup('adapter:facts/elide');
+
+  all(dimension: DimensionColumn, options: ServiceOptions = {}): Promise<unknown> {
+    return this.find(dimension, [], options);
+  }
+
+  find(dimension: DimensionColumn, predicate: DimensionFilter[] = [], options: ServiceOptions = {}): Promise<unknown> {
+    const {
+      columnMetadata: { id, source, tableId },
+      parameters: params
+    } = dimension;
+    const parameters = params || {};
+
+    // Create a request with only one dimension and its appropriate filters
+    const request: RequestV2 = {
+      table: tableId || '',
+      columns: [{ field: id, parameters: parameters || {}, type: 'dimension' }],
+      filters: predicate.map(pred => ({
+        field: id,
+        parameters,
+        type: 'dimension',
+        operator: pred.operator,
+        values: pred.values.map(String)
+      })),
+      sorts: [],
+      dataSource: source,
+      limit: null,
+      requestVersion: '2.0'
+    };
+
+    return this.factAdapter.fetchDataForRequest(request, options);
+  }
+
+  search(dimension: DimensionColumn, query: string, options: ServiceOptions = {}): Promise<unknown> {
+    const predicate: DimensionFilter[] = query.length
+      ? [
+          {
+            operator: 'eq',
+            values: [`*${query}*`]
+          }
+        ]
+      : [];
+
+    return this.find(dimension, predicate, options);
+  }
+}

--- a/packages/data/addon/adapters/dimensions/interface.ts
+++ b/packages/data/addon/adapters/dimensions/interface.ts
@@ -8,7 +8,7 @@ import EmberObject from '@ember/object';
 import { ServiceOptions } from 'navi-data/services/navi-dimension';
 
 export type DimensionFilter = {
-  operator: TODO;
+  operator: TODO<string>;
   values: unknown[];
 };
 

--- a/packages/data/addon/adapters/dimensions/interface.ts
+++ b/packages/data/addon/adapters/dimensions/interface.ts
@@ -2,13 +2,13 @@
  * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
-import { Parameters } from '../facts/interface';
+import { Parameters, FilterOperator } from '../facts/interface';
 import DimensionMetadataModel from 'navi-data/models/metadata/dimension';
 import EmberObject from '@ember/object';
 import { ServiceOptions } from 'navi-data/services/navi-dimension';
 
 export type DimensionFilter = {
-  operator: TODO<string>;
+  operator: FilterOperator;
   values: unknown[];
 };
 

--- a/packages/data/addon/adapters/dimensions/interface.ts
+++ b/packages/data/addon/adapters/dimensions/interface.ts
@@ -8,7 +8,7 @@ import EmberObject from '@ember/object';
 import { ServiceOptions } from 'navi-data/services/navi-dimension';
 
 export type DimensionFilter = {
-  operator: TODO<'in'>;
+  operator: TODO;
   values: unknown[];
 };
 

--- a/packages/data/addon/adapters/facts/elide.ts
+++ b/packages/data/addon/adapters/facts/elide.ts
@@ -12,6 +12,7 @@ import NaviFactAdapter, {
   QueryStatus,
   RequestV2
 } from './interface';
+import { getDefaultDataSource } from '../../utils/adapter';
 import { DocumentNode } from 'graphql';
 import GQLQueries from 'navi-data/gql/fact-queries';
 import { task, timeout } from 'ember-concurrency';
@@ -105,8 +106,9 @@ export default class ElideFactsAdapter extends EmberObject implements NaviFactAd
    * @param id
    * @returns Promise with the updated asyncQuery's id and status
    */
-  cancelAsyncQuery(id: string, dataSourceName: string) {
+  cancelAsyncQuery(id: string, dataSourceName?: string) {
     const mutation: DocumentNode = GQLQueries['asyncFactsCancel'];
+    dataSourceName = dataSourceName || getDefaultDataSource().name;
     return this.apollo.mutate({ mutation, variables: { id }, context: { dataSourceName } });
   }
 
@@ -114,8 +116,9 @@ export default class ElideFactsAdapter extends EmberObject implements NaviFactAd
    * @param id
    * @returns Promise that resolves to the result of the AsyncQuery fetch query
    */
-  fetchAsyncQuery(id: string, dataSourceName: string) {
+  fetchAsyncQuery(id: string, dataSourceName?: string) {
     const query: DocumentNode = GQLQueries['asyncFactsQuery'];
+    dataSourceName = dataSourceName || getDefaultDataSource().name;
     return this.apollo.query({ query, variables: { ids: [id] }, context: { dataSourceName } });
   }
 
@@ -154,7 +157,7 @@ export default class ElideFactsAdapter extends EmberObject implements NaviFactAd
   fetchDataForRequest(
     this: ElideFactsAdapter,
     request: RequestV2,
-    options: RequestOptions
+    options: RequestOptions = {}
   ): Promise<AsyncQueryResponse> {
     return this.fetchDataForRequestTask.perform(request, options);
   }

--- a/packages/data/addon/adapters/facts/interface.ts
+++ b/packages/data/addon/adapters/facts/interface.ts
@@ -41,7 +41,7 @@ export type Filter = {
   field: string;
   parameters: Parameters;
   type: ColumnType;
-  operator: FilterOperator;
+  operator: string;
   values: (string | number)[];
 };
 

--- a/packages/data/addon/adapters/facts/interface.ts
+++ b/packages/data/addon/adapters/facts/interface.ts
@@ -20,6 +20,8 @@ export type RequestOptions = {
   dataSourceName?: string;
 };
 
+export type FilterOperator = 'eq' | 'neq' | 'in' | 'notin' | 'lt' | 'le' | 'gt' | 'ge' | 'isnull' | 'notnull' | 'bet';
+
 export const SORT_DIRECTIONS = ['desc', 'asc'];
 
 export type Parameters = Dict<string>;
@@ -39,7 +41,7 @@ export type Filter = {
   field: string;
   parameters: Parameters;
   type: ColumnType;
-  operator: string;
+  operator: FilterOperator;
   values: (string | number)[];
 };
 

--- a/packages/data/app/adapters/dimensions/elide.js
+++ b/packages/data/app/adapters/dimensions/elide.js
@@ -1,0 +1,1 @@
+export { default } from 'navi-data/adapters/dimensions/elide';

--- a/packages/data/tests/unit/adapters/dimensions/elide-test.ts
+++ b/packages/data/tests/unit/adapters/dimensions/elide-test.ts
@@ -57,9 +57,6 @@ module('Unit | Adapter | Dimensions | Elide', function(hooks) {
     const adapter = this.owner.lookup('adapter:dimensions/elide');
 
     await adapter.find(TestDimensionColumn, [{ operator: 'in', values: ['v1', 'v2'] }], expectedOptions);
-
-    this.owner.unregister('adapter:facts/elide');
-    this.owner.register('adapter:facts/elide', originalFactAdapter);
   });
 
   test('all', async function(assert) {
@@ -106,9 +103,6 @@ module('Unit | Adapter | Dimensions | Elide', function(hooks) {
 
     const adapter: ElideDimensionAdapter = this.owner.lookup('adapter:dimensions/elide');
     await adapter.all(TestDimensionColumn, expectedOptions);
-
-    this.owner.unregister('adapter:facts/elide');
-    this.owner.register('adapter:facts/elide', originalFactAdapter);
   });
 
   test('search', async function(assert) {
@@ -167,8 +161,5 @@ module('Unit | Adapter | Dimensions | Elide', function(hooks) {
 
     const adapter: ElideDimensionAdapter = this.owner.lookup('adapter:dimensions/elide');
     await adapter.search(TestDimensionColumn, query, expectedOptions);
-
-    this.owner.unregister('adapter:facts/elide');
-    this.owner.register('adapter:facts/elide', originalFactAdapter);
   });
 });

--- a/packages/data/tests/unit/adapters/dimensions/elide-test.ts
+++ b/packages/data/tests/unit/adapters/dimensions/elide-test.ts
@@ -1,0 +1,277 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import config from 'ember-get-config';
+import { asyncFactsMutationStr } from 'navi-data/gql/mutations/async-facts';
+import { asyncFactsQueryStr } from 'navi-data/gql/queries/async-facts';
+import Pretender from 'pretender';
+
+let Server: Pretender;
+
+module('Unit | Adapter | Dimensions | Elide', function(hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function() {
+    Server = new Pretender();
+  });
+
+  hooks.afterEach(function() {
+    //shutdown pretender
+    Server.shutdown();
+  });
+
+  test('find', async function(assert) {
+    assert.expect(6);
+    const {
+      navi: { dataSources }
+    } = config;
+    const adapter = this.owner.lookup('adapter:dimensions/elide');
+    const TestDimensionColumn = {
+      columnMetadata: {
+        id: 'dimension1',
+        source: 'elideTwo',
+        tableId: 'table1'
+      },
+      parameters: {
+        foo: 'bar'
+      }
+    };
+    const HOST = dataSources.find(d => d.name === 'elideTwo') || dataSources[0];
+
+    let callCount = 0;
+    let queryVariable: string;
+    let queryId: string;
+
+    let response: TODO;
+    Server.post(`${HOST.uri}/graphql`, function({ requestBody }) {
+      callCount++;
+      let result = null;
+      let status = 'QUEUED';
+      const requestObj = JSON.parse(requestBody);
+
+      if (callCount === 1) {
+        queryId = requestObj.variables.id;
+        queryVariable = requestObj.variables.query;
+
+        assert.deepEqual(
+          Object.keys(requestObj.variables),
+          ['id', 'query'],
+          'find sends id and query request variables'
+        );
+
+        const expectedTable = TestDimensionColumn.columnMetadata.tableId;
+        const expectedColumns = 'dimension1(foo: bar)';
+        const expectedArgs = '(filter: \\"dimension1(foo: bar)=in=(v1,v2)\\")';
+
+        assert.equal(
+          requestObj.variables.query.replace(/[ \t\r\n]+/g, ' '),
+          JSON.stringify({
+            query: `{ ${expectedTable}${expectedArgs} { edges { node { ${expectedColumns} } } } }`
+          }).replace(/[ \t\r\n]+/g, ' '),
+          'find sends the correct query variable string (with filter) to the datasource specified in the metadata'
+        );
+
+        assert.equal(
+          requestObj.query.replace(/__typename/g, '').replace(/[ \t\r\n]+/g, ''),
+          asyncFactsMutationStr.replace(/[ \t\r\n]+/g, ''),
+          'find sends the correct mutation to create a new asyncQuery'
+        );
+      } else {
+        status = 'COMPLETE';
+        assert.equal(
+          requestObj.query.replace(/__typename/g, '').replace(/[ \t\r\n]+/g, ''),
+          asyncFactsQueryStr.replace(/[ \t\r\n]+/g, ''),
+          'find polls for the asyncQuery to complete'
+        );
+        assert.equal(
+          requestObj.variables.ids[0],
+          queryId,
+          'when the find function polls, it requests the same asyncQuery id as the one it created'
+        );
+        const values = ['v1', 'v2'];
+
+        result = {
+          httpStatus: 200,
+          contentLength: 1,
+          responseBody: JSON.stringify({
+            data: {
+              table1: {
+                edges: values.map(v => ({
+                  node: { dimension1: v }
+                }))
+              }
+            }
+          })
+        };
+      }
+
+      response = {
+        asyncQuery: {
+          edges: [
+            {
+              node: {
+                id: queryId,
+                query: queryVariable,
+                queryType: 'GRAPHQL_V1_0',
+                status,
+                result
+              }
+            }
+          ]
+        }
+      };
+
+      return [
+        200,
+        { 'Content-Type': 'application/json' },
+        JSON.stringify({
+          data: response
+        })
+      ];
+    });
+    const find = await adapter.find(TestDimensionColumn, [{ operator: 'in', values: ['v1', 'v2'] }]);
+
+    assert.deepEqual(find, response, 'find returns the correct response payload');
+  });
+
+  test('all', async function(assert) {
+    assert.expect(2);
+    const {
+      navi: { dataSources }
+    } = config;
+    const adapter = this.owner.lookup('adapter:dimensions/elide');
+    const TestDimensionColumn = {
+      columnMetadata: {
+        id: 'dimension1',
+        source: 'elideOne',
+        tableId: 'table1'
+      },
+      parameters: {
+        foo: 'bar'
+      }
+    };
+    const myDataSource = dataSources.find(d => d.name === 'elideOne') || dataSources[0];
+    let response;
+
+    Server.post(`${myDataSource.uri}/graphql`, function({ requestBody }) {
+      const requestObj = JSON.parse(requestBody);
+      const expectedTable = TestDimensionColumn.columnMetadata.tableId;
+      const expectedColumns = 'dimension1(foo: bar)';
+
+      assert.equal(
+        requestObj.variables.query.replace(/[ \t\r\n]+/g, ' '),
+        JSON.stringify({
+          query: `{ ${expectedTable} { edges { node { ${expectedColumns} } } } }`
+        }).replace(/[ \t\r\n]+/g, ' '),
+        'all sends the correct query variable string (with filter) to the datasource specified in the metadata'
+      );
+      const values = ['v1', 'v2', 'something cool', 'bad something'];
+      response = {
+        asyncQuery: {
+          edges: [
+            {
+              node: {
+                id: requestObj.variables.id,
+                query: requestObj.variables.query,
+                queryType: 'GRAPHQL_V1_0',
+                status: 'COMPLETE',
+                result: {
+                  httpStatus: 200,
+                  contentLength: 1,
+                  responseBody: JSON.stringify({
+                    data: {
+                      table1: {
+                        edges: values.map(v => ({
+                          node: { dimension1: v }
+                        }))
+                      }
+                    }
+                  })
+                }
+              }
+            }
+          ]
+        }
+      };
+      return [200, { 'Content-Type': 'application/json' }, JSON.stringify({ data: response })];
+    });
+
+    const adapterResponse = await adapter.all(TestDimensionColumn);
+
+    assert.deepEqual(adapterResponse, response, 'all returns the payload from graphql');
+  });
+
+  test('search', async function(assert) {
+    assert.expect(2);
+    const {
+      navi: { dataSources }
+    } = config;
+    const adapter = this.owner.lookup('adapter:dimensions/elide');
+    const TestDimensionColumn = {
+      columnMetadata: {
+        id: 'dimension2',
+        source: 'elideTwo',
+        tableId: 'table2'
+      },
+      parameters: {
+        foo: 'baz'
+      }
+    };
+    const myDataSource = dataSources.find(d => d.name === 'elideTwo') || dataSources[0];
+    let response;
+
+    Server.post(`${myDataSource.uri}/graphql`, function({ requestBody }) {
+      const requestObj = JSON.parse(requestBody);
+      const expectedTable = TestDimensionColumn.columnMetadata.tableId;
+      const expectedColumns = 'dimension2(foo: baz)';
+      const expectedArgs = '(filter: \\"dimension2(foo: baz)==(*something*)\\")';
+
+      assert.equal(
+        requestObj.variables.query.replace(/[ \t\r\n]+/g, ' '),
+        JSON.stringify({
+          query: `{ ${expectedTable}${expectedArgs} { edges { node { ${expectedColumns} } } } }`
+        }).replace(/[ \t\r\n]+/g, ' '),
+        'search sends the correct query variable string (with search filter) to the datasource specified in the metadata'
+      );
+      const values = ['something cool', 'bad something'];
+      response = {
+        asyncQuery: {
+          edges: [
+            {
+              node: {
+                id: requestObj.variables.id,
+                query: requestObj.variables.query,
+                queryType: 'GRAPHQL_V1_0',
+                status: 'COMPLETE',
+                result: {
+                  httpStatus: 200,
+                  contentLength: 1,
+                  responseBody: JSON.stringify({
+                    data: {
+                      table2: {
+                        edges: values.map(v => ({
+                          node: { dimension2: v }
+                        }))
+                      }
+                    }
+                  })
+                }
+              }
+            }
+          ]
+        }
+      };
+
+      return [
+        200,
+        { 'Content-Type': 'application/json' },
+        JSON.stringify({
+          data: response
+        })
+      ];
+    });
+
+    const adapterResponse = await adapter.search(TestDimensionColumn, 'something');
+
+    assert.deepEqual(adapterResponse, response, 'search returns the payload from graphql');
+  });
+});

--- a/packages/data/tests/unit/adapters/dimensions/elide-test.ts
+++ b/packages/data/tests/unit/adapters/dimensions/elide-test.ts
@@ -1,34 +1,22 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import config from 'ember-get-config';
-import { asyncFactsMutationStr } from 'navi-data/gql/mutations/async-facts';
-import { asyncFactsQueryStr } from 'navi-data/gql/queries/async-facts';
 import ElideDimensionAdapter from 'navi-data/adapters/dimensions/elide';
 import { DimensionColumn } from 'navi-data/adapters/dimensions/interface';
+import { RequestV2, AsyncQueryResponse, QueryStatus, RequestOptions } from 'navi-data/adapters/facts/interface';
 import DimensionMetadataModel from 'navi-data/models/metadata/dimension';
-import { Response } from 'miragejs';
-// @ts-ignore
-import { setupMirage } from 'ember-cli-mirage/test-support';
-import { TestContext } from 'ember-test-helpers';
 
-interface MirageTestContext extends TestContext {
-  server: TODO;
-}
-
-type ServerRequest = {
-  requestBody: string;
+const fakeResponse: AsyncQueryResponse = {
+  asyncQuery: { edges: [{ node: { id: '1', query: 'foo', status: QueryStatus.COMPLETE, result: null } }] }
 };
 
 module('Unit | Adapter | Dimensions | Elide', function(hooks) {
   setupTest(hooks);
-  setupMirage(hooks);
 
-  test('find', async function(this: MirageTestContext, assert) {
-    assert.expect(6);
-    const {
-      navi: { dataSources }
-    } = config;
+  test('find', async function(assert) {
+    assert.expect(2);
+
     const adapter: ElideDimensionAdapter = this.owner.lookup('adapter:dimensions/elide');
+    const originalFactAdapter = adapter['factAdapter'];
     const TestDimensionColumn: DimensionColumn = {
       columnMetadata: DimensionMetadataModel.create({
         id: 'dimension1',
@@ -39,104 +27,44 @@ module('Unit | Adapter | Dimensions | Elide', function(hooks) {
         foo: 'bar'
       }
     };
-    const HOST = dataSources.find(d => d.name === 'elideTwo') || dataSources[0];
 
-    let callCount = 0;
-    let queryVariable: string;
-    let queryId: string;
+    const expectedRequest: RequestV2 = {
+      columns: [{ field: 'dimension1', parameters: { foo: 'bar' }, type: 'dimension' }],
+      filters: [
+        { field: 'dimension1', parameters: { foo: 'bar' }, type: 'dimension', operator: 'in', values: ['v1', 'v2'] }
+      ],
+      sorts: [],
+      table: 'table1',
+      limit: null,
+      dataSource: 'elideTwo',
+      requestVersion: '2.0'
+    };
+    const expectedOptions = {
+      timeout: 30000,
+      page: 6,
+      perPage: 24
+    };
 
-    let response: TODO;
-    this.server.post(`${HOST.uri}/graphql`, function(_: TODO, { requestBody }: ServerRequest) {
-      callCount++;
-      let result = null;
-      let status = 'QUEUED';
-      const requestObj = JSON.parse(requestBody);
+    //@ts-ignore
+    adapter['factAdapter'] = {
+      fetchDataForRequest(request: RequestV2, options?: RequestOptions) {
+        assert.deepEqual(request, expectedRequest, 'Correct request is sent to elide fact adapter for find');
 
-      if (callCount === 1) {
-        queryId = requestObj.variables.id;
-        queryVariable = requestObj.variables.query;
-
-        assert.deepEqual(
-          Object.keys(requestObj.variables),
-          ['id', 'query'],
-          'find sends id and query request variables'
-        );
-
-        const expectedTable = TestDimensionColumn.columnMetadata.tableId;
-        const expectedColumns = 'dimension1(foo: bar)';
-        const expectedArgs = '(filter: \\"dimension1(foo: bar)=in=(v1,v2)\\")';
-
-        assert.equal(
-          requestObj.variables.query.replace(/[ \t\r\n]+/g, ' '),
-          JSON.stringify({
-            query: `{ ${expectedTable}${expectedArgs} { edges { node { ${expectedColumns} } } } }`
-          }).replace(/[ \t\r\n]+/g, ' '),
-          'find sends the correct query variable string (with filter) to the datasource specified in the metadata'
-        );
-
-        assert.equal(
-          requestObj.query.replace(/__typename/g, '').replace(/[ \t\r\n]+/g, ''),
-          asyncFactsMutationStr.replace(/[ \t\r\n]+/g, ''),
-          'find sends the correct mutation to create a new asyncQuery'
-        );
-      } else {
-        status = 'COMPLETE';
-        assert.equal(
-          requestObj.query.replace(/__typename/g, '').replace(/[ \t\r\n]+/g, ''),
-          asyncFactsQueryStr.replace(/[ \t\r\n]+/g, ''),
-          'find polls for the asyncQuery to complete'
-        );
-        assert.equal(
-          requestObj.variables.ids[0],
-          queryId,
-          'when the find function polls, it requests the same asyncQuery id as the one it created'
-        );
-        const values = ['v1', 'v2'];
-
-        result = {
-          httpStatus: 200,
-          contentLength: 1,
-          responseBody: JSON.stringify({
-            data: {
-              table1: {
-                edges: values.map(v => ({
-                  node: { dimension1: v }
-                }))
-              }
-            }
-          })
-        };
+        assert.deepEqual(options, expectedOptions, 'Options are passed through to the fact adapter');
+        return Promise.resolve(fakeResponse);
       }
+    };
 
-      response = {
-        asyncQuery: {
-          edges: [
-            {
-              node: {
-                id: queryId,
-                query: queryVariable,
-                queryType: 'GRAPHQL_V1_0',
-                status,
-                result
-              }
-            }
-          ]
-        }
-      };
+    await adapter.find(TestDimensionColumn, [{ operator: 'in', values: ['v1', 'v2'] }], expectedOptions);
 
-      return new Response(200, { 'Content-Type': 'application/json' }, { data: response });
-    });
-    const find = await adapter.find(TestDimensionColumn, [{ operator: 'in', values: ['v1', 'v2'] }]);
-
-    assert.deepEqual(find, response, 'find returns the correct response payload');
+    adapter['factAdapter'] = originalFactAdapter;
   });
 
-  test('all', async function(this: MirageTestContext, assert) {
+  test('all', async function(assert) {
     assert.expect(2);
-    const {
-      navi: { dataSources }
-    } = config;
+
     const adapter: ElideDimensionAdapter = this.owner.lookup('adapter:dimensions/elide');
+    const originalFactAdapter = adapter['factAdapter'];
     const TestDimensionColumn: DimensionColumn = {
       columnMetadata: DimensionMetadataModel.create({
         id: 'dimension1',
@@ -144,126 +72,97 @@ module('Unit | Adapter | Dimensions | Elide', function(hooks) {
         tableId: 'table1'
       }),
       parameters: {
-        foo: 'bar'
+        foo: 'baz'
       }
     };
-    const myDataSource = dataSources.find(d => d.name === 'elideOne') || dataSources[0];
-    let response;
 
-    this.server.post(`${myDataSource.uri}/graphql`, function(_: TODO, { requestBody }: ServerRequest) {
-      const requestObj = JSON.parse(requestBody);
-      const expectedTable = TestDimensionColumn.columnMetadata.tableId;
-      const expectedColumns = 'dimension1(foo: bar)';
+    const expectedRequest: RequestV2 = {
+      columns: [{ field: 'dimension1', parameters: { foo: 'baz' }, type: 'dimension' }],
+      filters: [],
+      sorts: [],
+      table: 'table1',
+      limit: null,
+      dataSource: 'elideOne',
+      requestVersion: '2.0'
+    };
+    const expectedOptions = {
+      timeout: 30000
+    };
 
-      assert.equal(
-        requestObj.variables.query.replace(/[ \t\r\n]+/g, ' '),
-        JSON.stringify({
-          query: `{ ${expectedTable} { edges { node { ${expectedColumns} } } } }`
-        }).replace(/[ \t\r\n]+/g, ' '),
-        'all sends the correct query variable string (with filter) to the datasource specified in the metadata'
-      );
-      const values = ['v1', 'v2', 'something cool', 'bad something'];
-      response = {
-        asyncQuery: {
-          edges: [
-            {
-              node: {
-                id: requestObj.variables.id,
-                query: requestObj.variables.query,
-                queryType: 'GRAPHQL_V1_0',
-                status: 'COMPLETE',
-                result: {
-                  httpStatus: 200,
-                  contentLength: 1,
-                  responseBody: JSON.stringify({
-                    data: {
-                      table1: {
-                        edges: values.map(v => ({
-                          node: { dimension1: v }
-                        }))
-                      }
-                    }
-                  })
-                }
-              }
-            }
-          ]
-        }
-      };
-      return new Response(200, { 'Content-Type': 'application/json' }, { data: response });
-    });
+    //@ts-ignore
+    adapter['factAdapter'] = {
+      fetchDataForRequest(request: RequestV2, options?: RequestOptions) {
+        assert.deepEqual(
+          request,
+          expectedRequest,
+          'Correct request is sent to elide fact adapter for all dimension values'
+        );
 
-    const adapterResponse = await adapter.all(TestDimensionColumn);
+        assert.deepEqual(options, expectedOptions, 'Options are passed through to the fact adapter');
+        return Promise.resolve(fakeResponse);
+      }
+    };
 
-    assert.deepEqual(adapterResponse, response, 'all returns the payload from graphql');
+    await adapter.all(TestDimensionColumn, expectedOptions);
+
+    adapter['factAdapter'] = originalFactAdapter;
   });
 
-  test('search', async function(this: MirageTestContext, assert) {
+  test('search', async function(assert) {
     assert.expect(2);
-    const {
-      navi: { dataSources }
-    } = config;
+
     const adapter: ElideDimensionAdapter = this.owner.lookup('adapter:dimensions/elide');
+    const originalFactAdapter = adapter['factAdapter'];
     const TestDimensionColumn: DimensionColumn = {
       columnMetadata: DimensionMetadataModel.create({
         id: 'dimension2',
         source: 'elideTwo',
-        tableId: 'table2'
+        tableId: 'table3'
       }),
       parameters: {
-        foo: 'baz'
+        bang: 'boom'
       }
     };
-    const myDataSource = dataSources.find(d => d.name === 'elideTwo') || dataSources[0];
-    let response;
+    const query = 'something';
 
-    this.server.post(`${myDataSource.uri}/graphql`, function(_: TODO, { requestBody }: ServerRequest) {
-      const requestObj = JSON.parse(requestBody);
-      const expectedTable = TestDimensionColumn.columnMetadata.tableId;
-      const expectedColumns = 'dimension2(foo: baz)';
-      const expectedArgs = '(filter: \\"dimension2(foo: baz)==(*something*)\\")';
-
-      assert.equal(
-        requestObj.variables.query.replace(/[ \t\r\n]+/g, ' '),
-        JSON.stringify({
-          query: `{ ${expectedTable}${expectedArgs} { edges { node { ${expectedColumns} } } } }`
-        }).replace(/[ \t\r\n]+/g, ' '),
-        'search sends the correct query variable string (with search filter) to the datasource specified in the metadata'
-      );
-      const values = ['something cool', 'bad something'];
-      response = {
-        asyncQuery: {
-          edges: [
-            {
-              node: {
-                id: requestObj.variables.id,
-                query: requestObj.variables.query,
-                queryType: 'GRAPHQL_V1_0',
-                status: 'COMPLETE',
-                result: {
-                  httpStatus: 200,
-                  contentLength: 1,
-                  responseBody: JSON.stringify({
-                    data: {
-                      table2: {
-                        edges: values.map(v => ({
-                          node: { dimension2: v }
-                        }))
-                      }
-                    }
-                  })
-                }
-              }
-            }
-          ]
+    const expectedRequest: RequestV2 = {
+      columns: [{ field: 'dimension2', parameters: { bang: 'boom' }, type: 'dimension' }],
+      filters: [
+        {
+          field: 'dimension2',
+          parameters: { bang: 'boom' },
+          type: 'dimension',
+          operator: 'eq',
+          values: ['*something*']
         }
-      };
+      ],
+      sorts: [],
+      table: 'table3',
+      limit: null,
+      dataSource: 'elideTwo',
+      requestVersion: '2.0'
+    };
+    const expectedOptions = {
+      timeout: 30000,
+      perPage: 48
+    };
 
-      return new Response(200, { 'Content-Type': 'application/json' }, { data: response });
-    });
+    //@ts-ignore
+    adapter['factAdapter'] = {
+      fetchDataForRequest(request: RequestV2, options?: RequestOptions) {
+        assert.deepEqual(
+          request,
+          expectedRequest,
+          'Correct request is sent to elide fact adapter for search of dimension values'
+        );
 
-    const adapterResponse = await adapter.search(TestDimensionColumn, 'something');
+        assert.deepEqual(options, expectedOptions, 'Options are passed through to the fact adapter');
+        return Promise.resolve(fakeResponse);
+      }
+    };
 
-    assert.deepEqual(adapterResponse, response, 'search returns the payload from graphql');
+    await adapter.search(TestDimensionColumn, query, expectedOptions);
+
+    adapter['factAdapter'] = originalFactAdapter;
   });
 });

--- a/packages/data/tests/unit/adapters/dimensions/elide-test.ts
+++ b/packages/data/tests/unit/adapters/dimensions/elide-test.ts
@@ -4,9 +4,9 @@ import config from 'ember-get-config';
 import { asyncFactsMutationStr } from 'navi-data/gql/mutations/async-facts';
 import { asyncFactsQueryStr } from 'navi-data/gql/queries/async-facts';
 import Pretender from 'pretender';
-import ElideDimensionAdapter from 'dummy/adapters/dimensions/elide';
+import ElideDimensionAdapter from 'navi-data/adapters/dimensions/elide';
 import { DimensionColumn } from 'navi-data/adapters/dimensions/interface';
-import DimensionMetadataModel from 'dummy/models/metadata/dimension';
+import DimensionMetadataModel from 'navi-data/models/metadata/dimension';
 
 let Server: Pretender;
 

--- a/packages/data/tests/unit/adapters/dimensions/elide-test.ts
+++ b/packages/data/tests/unit/adapters/dimensions/elide-test.ts
@@ -15,8 +15,6 @@ module('Unit | Adapter | Dimensions | Elide', function(hooks) {
   test('find', async function(assert) {
     assert.expect(2);
 
-    const adapter: ElideDimensionAdapter = this.owner.lookup('adapter:dimensions/elide');
-    const originalFactAdapter = adapter['factAdapter'];
     const TestDimensionColumn: DimensionColumn = {
       columnMetadata: DimensionMetadataModel.create({
         id: 'dimension1',
@@ -28,6 +26,7 @@ module('Unit | Adapter | Dimensions | Elide', function(hooks) {
       }
     };
 
+    const originalFactAdapter = this.owner.factoryFor('adapter:facts/elide').class;
     const expectedRequest: RequestV2 = {
       columns: [{ field: 'dimension1', parameters: { foo: 'bar' }, type: 'dimension' }],
       filters: [
@@ -45,26 +44,28 @@ module('Unit | Adapter | Dimensions | Elide', function(hooks) {
       perPage: 24
     };
 
-    //@ts-ignore
-    adapter['factAdapter'] = {
+    class TestAdapter extends originalFactAdapter {
       fetchDataForRequest(request: RequestV2, options?: RequestOptions) {
         assert.deepEqual(request, expectedRequest, 'Correct request is sent to elide fact adapter for find');
 
         assert.deepEqual(options, expectedOptions, 'Options are passed through to the fact adapter');
         return Promise.resolve(fakeResponse);
       }
-    };
+    }
+    this.owner.unregister('adapter:facts/elide');
+    this.owner.register('adapter:facts/elide', TestAdapter);
+    const adapter = this.owner.lookup('adapter:dimensions/elide');
 
     await adapter.find(TestDimensionColumn, [{ operator: 'in', values: ['v1', 'v2'] }], expectedOptions);
 
-    adapter['factAdapter'] = originalFactAdapter;
+    this.owner.unregister('adapter:facts/elide');
+    this.owner.register('adapter:facts/elide', originalFactAdapter);
   });
 
   test('all', async function(assert) {
     assert.expect(2);
 
-    const adapter: ElideDimensionAdapter = this.owner.lookup('adapter:dimensions/elide');
-    const originalFactAdapter = adapter['factAdapter'];
+    const originalFactAdapter = this.owner.factoryFor('adapter:facts/elide').class;
     const TestDimensionColumn: DimensionColumn = {
       columnMetadata: DimensionMetadataModel.create({
         id: 'dimension1',
@@ -75,7 +76,6 @@ module('Unit | Adapter | Dimensions | Elide', function(hooks) {
         foo: 'baz'
       }
     };
-
     const expectedRequest: RequestV2 = {
       columns: [{ field: 'dimension1', parameters: { foo: 'baz' }, type: 'dimension' }],
       filters: [],
@@ -88,9 +88,7 @@ module('Unit | Adapter | Dimensions | Elide', function(hooks) {
     const expectedOptions = {
       timeout: 30000
     };
-
-    //@ts-ignore
-    adapter['factAdapter'] = {
+    class TestAdapter extends originalFactAdapter {
       fetchDataForRequest(request: RequestV2, options?: RequestOptions) {
         assert.deepEqual(
           request,
@@ -101,18 +99,22 @@ module('Unit | Adapter | Dimensions | Elide', function(hooks) {
         assert.deepEqual(options, expectedOptions, 'Options are passed through to the fact adapter');
         return Promise.resolve(fakeResponse);
       }
-    };
+    }
 
+    this.owner.unregister('adapter:facts/elide');
+    this.owner.register('adapter:facts/elide', TestAdapter);
+
+    const adapter: ElideDimensionAdapter = this.owner.lookup('adapter:dimensions/elide');
     await adapter.all(TestDimensionColumn, expectedOptions);
 
-    adapter['factAdapter'] = originalFactAdapter;
+    this.owner.unregister('adapter:facts/elide');
+    this.owner.register('adapter:facts/elide', originalFactAdapter);
   });
 
   test('search', async function(assert) {
     assert.expect(2);
 
-    const adapter: ElideDimensionAdapter = this.owner.lookup('adapter:dimensions/elide');
-    const originalFactAdapter = adapter['factAdapter'];
+    const originalFactAdapter = this.owner.factoryFor('adapter:facts/elide').class;
     const TestDimensionColumn: DimensionColumn = {
       columnMetadata: DimensionMetadataModel.create({
         id: 'dimension2',
@@ -147,8 +149,7 @@ module('Unit | Adapter | Dimensions | Elide', function(hooks) {
       perPage: 48
     };
 
-    //@ts-ignore
-    adapter['factAdapter'] = {
+    class TestAdapter extends originalFactAdapter {
       fetchDataForRequest(request: RequestV2, options?: RequestOptions) {
         assert.deepEqual(
           request,
@@ -159,10 +160,15 @@ module('Unit | Adapter | Dimensions | Elide', function(hooks) {
         assert.deepEqual(options, expectedOptions, 'Options are passed through to the fact adapter');
         return Promise.resolve(fakeResponse);
       }
-    };
+    }
 
+    this.owner.unregister('adapter:facts/elide');
+    this.owner.register('adapter:facts/elide', TestAdapter);
+
+    const adapter: ElideDimensionAdapter = this.owner.lookup('adapter:dimensions/elide');
     await adapter.search(TestDimensionColumn, query, expectedOptions);
 
-    adapter['factAdapter'] = originalFactAdapter;
+    this.owner.unregister('adapter:facts/elide');
+    this.owner.register('adapter:facts/elide', originalFactAdapter);
   });
 });

--- a/packages/data/tests/unit/adapters/dimensions/elide-test.ts
+++ b/packages/data/tests/unit/adapters/dimensions/elide-test.ts
@@ -4,6 +4,9 @@ import config from 'ember-get-config';
 import { asyncFactsMutationStr } from 'navi-data/gql/mutations/async-facts';
 import { asyncFactsQueryStr } from 'navi-data/gql/queries/async-facts';
 import Pretender from 'pretender';
+import ElideDimensionAdapter from 'dummy/adapters/dimensions/elide';
+import { DimensionColumn } from 'navi-data/adapters/dimensions/interface';
+import DimensionMetadataModel from 'dummy/models/metadata/dimension';
 
 let Server: Pretender;
 
@@ -24,13 +27,13 @@ module('Unit | Adapter | Dimensions | Elide', function(hooks) {
     const {
       navi: { dataSources }
     } = config;
-    const adapter = this.owner.lookup('adapter:dimensions/elide');
-    const TestDimensionColumn = {
-      columnMetadata: {
+    const adapter: ElideDimensionAdapter = this.owner.lookup('adapter:dimensions/elide');
+    const TestDimensionColumn: DimensionColumn = {
+      columnMetadata: DimensionMetadataModel.create({
         id: 'dimension1',
         source: 'elideTwo',
         tableId: 'table1'
-      },
+      }),
       parameters: {
         foo: 'bar'
       }
@@ -138,13 +141,13 @@ module('Unit | Adapter | Dimensions | Elide', function(hooks) {
     const {
       navi: { dataSources }
     } = config;
-    const adapter = this.owner.lookup('adapter:dimensions/elide');
-    const TestDimensionColumn = {
-      columnMetadata: {
+    const adapter: ElideDimensionAdapter = this.owner.lookup('adapter:dimensions/elide');
+    const TestDimensionColumn: DimensionColumn = {
+      columnMetadata: DimensionMetadataModel.create({
         id: 'dimension1',
         source: 'elideOne',
         tableId: 'table1'
-      },
+      }),
       parameters: {
         foo: 'bar'
       }
@@ -205,13 +208,13 @@ module('Unit | Adapter | Dimensions | Elide', function(hooks) {
     const {
       navi: { dataSources }
     } = config;
-    const adapter = this.owner.lookup('adapter:dimensions/elide');
-    const TestDimensionColumn = {
-      columnMetadata: {
+    const adapter: ElideDimensionAdapter = this.owner.lookup('adapter:dimensions/elide');
+    const TestDimensionColumn: DimensionColumn = {
+      columnMetadata: DimensionMetadataModel.create({
         id: 'dimension2',
         source: 'elideTwo',
         tableId: 'table2'
-      },
+      }),
       parameters: {
         foo: 'baz'
       }

--- a/packages/data/tests/unit/adapters/facts/elide-test.ts
+++ b/packages/data/tests/unit/adapters/facts/elide-test.ts
@@ -147,7 +147,7 @@ module('Unit | Adapter | facts/elide', function(hooks) {
         ],
         sorts: [],
         filters: [],
-        limit: '5',
+        limit: 5,
         requestVersion: '2.0',
         dataSource: 'elideOne'
       }),

--- a/packages/data/tests/unit/adapters/facts/elide-test.ts
+++ b/packages/data/tests/unit/adapters/facts/elide-test.ts
@@ -6,7 +6,7 @@ import { asyncFactsQueryStr } from 'navi-data/gql/queries/async-facts';
 import { RequestV2 } from 'navi-data/adapters/facts/interface';
 import Pretender from 'pretender';
 import config from 'ember-get-config';
-import { getElideField } from 'navi-data/adapters/facts/elide';
+import ElideFactsAdapter, { getElideField } from 'navi-data/adapters/facts/elide';
 
 const HOST = config.navi.dataSources[0].uri;
 const uuidRegex = /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
@@ -68,8 +68,8 @@ module('Unit | Adapter | facts/elide', function(hooks) {
   });
 
   test('dataQueryFromRequest', function(assert) {
-    const adapter = this.owner.lookup('adapter:facts/elide');
-    const queryStr = adapter.dataQueryFromRequest(TestRequest);
+    const adapter: ElideFactsAdapter = this.owner.lookup('adapter:facts/elide');
+    const queryStr = adapter['dataQueryFromRequest'](TestRequest);
     assert.equal(
       queryStr,
       escapeQuotes(
@@ -79,7 +79,7 @@ module('Unit | Adapter | facts/elide', function(hooks) {
     );
 
     assert.equal(
-      adapter.dataQueryFromRequest({
+      adapter['dataQueryFromRequest']({
         table: 'myTable',
         columns: [
           { field: 'm1', parameters: { p: 'q' }, type: 'metric' },
@@ -87,6 +87,7 @@ module('Unit | Adapter | facts/elide', function(hooks) {
         ],
         sorts: [],
         filters: [],
+        limit: null,
         requestVersion: '2.0',
         dataSource: 'elideOne'
       }),
@@ -95,7 +96,7 @@ module('Unit | Adapter | facts/elide', function(hooks) {
     );
 
     assert.equal(
-      adapter.dataQueryFromRequest({
+      adapter['dataQueryFromRequest']({
         table: 'myTable',
         columns: [
           { field: 'm1', parameters: { p: 'q' }, type: 'metric' },
@@ -106,6 +107,7 @@ module('Unit | Adapter | facts/elide', function(hooks) {
           { field: 'd1', parameters: {}, type: 'dimension', direction: 'asc' }
         ],
         filters: [],
+        limit: null,
         requestVersion: '2.0',
         dataSource: 'elideOne'
       }),
@@ -114,7 +116,7 @@ module('Unit | Adapter | facts/elide', function(hooks) {
     );
 
     assert.equal(
-      adapter.dataQueryFromRequest({
+      adapter['dataQueryFromRequest']({
         table: 'myTable',
         columns: [
           { field: 'm1', parameters: { p: 'q' }, type: 'metric' },
@@ -127,7 +129,8 @@ module('Unit | Adapter | facts/elide', function(hooks) {
           { field: 'd2', parameters: {}, type: 'dimension', operator: 'eq', values: ['b'] }
         ],
         requestVersion: '2.0',
-        dataSource: 'elideOne'
+        dataSource: 'elideOne',
+        limit: null
       }),
       escapeQuotes(
         `{"query":"{ myTable(filter: \\"m1(p: q)=in=(v1,v2);d1!=(a);d2==(b)\\") { edges { node { m1(p: q) d1 } } } }"}`
@@ -136,7 +139,7 @@ module('Unit | Adapter | facts/elide', function(hooks) {
     );
 
     assert.equal(
-      adapter.dataQueryFromRequest({
+      adapter['dataQueryFromRequest']({
         table: 'myTable',
         columns: [
           { field: 'm1', parameters: { p: 'q' }, type: 'metric' },
@@ -155,7 +158,7 @@ module('Unit | Adapter | facts/elide', function(hooks) {
 
   test('createAsyncQuery - success', async function(assert) {
     assert.expect(5);
-    const adapter = this.owner.lookup('adapter:facts/elide');
+    const adapter: ElideFactsAdapter = this.owner.lookup('adapter:facts/elide');
 
     let response;
     Server.post(`${HOST}/graphql`, function({ requestBody }) {
@@ -215,7 +218,7 @@ module('Unit | Adapter | facts/elide', function(hooks) {
   test('createAsyncQuery - error', async function(assert) {
     assert.expect(1);
 
-    const adapter = this.owner.lookup('adapter:facts/elide');
+    const adapter: ElideFactsAdapter = this.owner.lookup('adapter:facts/elide');
 
     const response = { errors: [{ message: 'Error in graphql query' }] };
     Server.post(`${HOST}/graphql`, () => [200, { 'Content-Type': 'application/json' }, JSON.stringify(response)]);
@@ -230,7 +233,7 @@ module('Unit | Adapter | facts/elide', function(hooks) {
   test('cancelAsyncQuery - success', async function(assert) {
     assert.expect(2);
 
-    const adapter = this.owner.lookup('adapter:facts/elide');
+    const adapter: ElideFactsAdapter = this.owner.lookup('adapter:facts/elide');
 
     let response;
     Server.post(`${HOST}/graphql`, function({ requestBody }) {
@@ -265,7 +268,7 @@ module('Unit | Adapter | facts/elide', function(hooks) {
   test('fetchAsyncQuery - success', async function(assert) {
     assert.expect(2);
 
-    const adapter = this.owner.lookup('adapter:facts/elide');
+    const adapter: ElideFactsAdapter = this.owner.lookup('adapter:facts/elide');
 
     let response;
     Server.post(`${HOST}/graphql`, function({ requestBody }) {
@@ -318,7 +321,7 @@ module('Unit | Adapter | facts/elide', function(hooks) {
   test('fetchDataForRequest - success', async function(assert) {
     assert.expect(10);
 
-    const adapter = this.owner.lookup('adapter:facts/elide');
+    const adapter: ElideFactsAdapter = this.owner.lookup('adapter:facts/elide');
     adapter._pollingInterval = 300;
 
     let callCount = 0;
@@ -401,7 +404,7 @@ module('Unit | Adapter | facts/elide', function(hooks) {
 
   test('fetchDataForRequest - error', async function(assert) {
     assert.expect(1);
-    const adapter = this.owner.lookup('adapter:facts/elide');
+    const adapter: ElideFactsAdapter = this.owner.lookup('adapter:facts/elide');
 
     let errors = [{ message: 'Bad request' }];
     Server.post(`${HOST}/graphql`, () => [400, { 'Content-Type': 'application/json' }, JSON.stringify({ errors })]);


### PR DESCRIPTION
Resolves #950 

<!-- The above line will close the issue upon merge -->

## Description
We need to be able to fetch dimension values from elide so we can support type ahead search in the filter builder.

## Proposed Changes

- Create elide dimension adapter
- Update elide facts adapter to request against the right uri for the given datasource
- Remove some RequestV1 stuff

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
