### PR TITLE
Elide dimension serializer and mock

### DIFF
--- a/packages/data/addon/adapters/facts/elide.ts
+++ b/packages/data/addon/adapters/facts/elide.ts
@@ -18,6 +18,8 @@ import GQLQueries from 'navi-data/gql/fact-queries';
 import { task, timeout } from 'ember-concurrency';
 import { v1 } from 'ember-uuid';
 
+const REMOVE_TABLE_REGEX = /.+?\.(.+)/;
+
 export const OPERATOR_MAP: Dict<string> = {
   eq: '==',
   neq: '!=',
@@ -58,11 +60,17 @@ export default class ElideFactsAdapter extends EmberObject implements NaviFactAd
   private dataQueryFromRequest(request: RequestV2): string {
     const args = [];
     const { table, columns, sorts, limit, filters } = request;
-    const columnsStr = columns.map(col => getElideField(col.field, col.parameters)).join(' ');
+    const columnsStr = columns
+      .map(col => {
+        const fieldWithoutTable = REMOVE_TABLE_REGEX.exec(col.field)?.[1] || col.field;
+        return getElideField(fieldWithoutTable, col.parameters);
+      })
+      .join(' ');
 
     const filterStrings = filters.map(filter => {
       const { field, parameters, operator, values } = filter;
-      const fieldStr = getElideField(field, parameters);
+      const fieldWithoutTable = REMOVE_TABLE_REGEX.exec(field)?.[1] || field;
+      const fieldStr = getElideField(fieldWithoutTable, parameters);
       const operatorStr = OPERATOR_MAP[operator] || `=${operator}=`;
       const valuesStr = `(${values.join(',')})`;
       return `${fieldStr}${operatorStr}${valuesStr}`;
@@ -71,7 +79,8 @@ export default class ElideFactsAdapter extends EmberObject implements NaviFactAd
 
     const sortStrings = sorts.map(sort => {
       const { field, parameters, direction } = sort;
-      const column = getElideField(field, parameters);
+      const fieldWithoutTable = REMOVE_TABLE_REGEX.exec(field)?.[1] || field;
+      const column = getElideField(fieldWithoutTable, parameters);
       return `${direction === 'desc' ? '-' : ''}${column}`;
     });
     sortStrings.length && args.push(`sort: \\"${sortStrings.join(',')}\\"`);

--- a/packages/data/addon/mirage/factories/dimension.js
+++ b/packages/data/addon/mirage/factories/dimension.js
@@ -8,7 +8,8 @@ export default Factory.extend({
   index: i => i,
 
   id() {
-    return `dimension${this.index}`;
+    const id = this.table?.id;
+    return `${id ? id + '.' : ''}dimension${this.index}`;
   },
 
   name() {

--- a/packages/data/addon/mirage/factories/metric.js
+++ b/packages/data/addon/mirage/factories/metric.js
@@ -8,7 +8,8 @@ export default Factory.extend({
   index: i => i,
 
   id() {
-    return `metric${this.index}`;
+    const id = this.table?.id;
+    return `${id ? id + '.' : ''}metric${this.index}`;
   },
 
   name() {

--- a/packages/data/addon/mirage/factories/time-dimension.js
+++ b/packages/data/addon/mirage/factories/time-dimension.js
@@ -8,7 +8,8 @@ export default Factory.extend({
   index: i => i,
 
   id() {
-    return `timeDimension${this.index}`;
+    const id = this.table?.id;
+    return `${id ? id + '.' : ''}timeDimension${this.index}`;
   },
 
   name() {

--- a/packages/data/addon/mirage/handlers/graphql.js
+++ b/packages/data/addon/mirage/handlers/graphql.js
@@ -46,7 +46,12 @@ const FILTER_OPS = {
   [OPERATORS.notIn]: (filterVals, vals) => vals.filter(val => !filterVals.includes(val)),
   [OPERATORS.isNull]: (_, vals) => vals.filter(val => !val),
   [OPERATORS.notNull]: (_, vals) => vals.filter(Boolean),
-  [OPERATORS.eq]: ([filterVal], vals) => vals.filter(val => val === filterVal),
+  [OPERATORS.eq]: ([filterVal], vals) =>
+    vals.filter(val => {
+      //If filterVal is wrapped in wildcard operators, match all values that contain the filterVal
+      const match = /\*(.*)\*/.exec(filterVal);
+      return match ? val.includes(match[1]) : val === filterVal;
+    }),
   [OPERATORS.neq]: ([filterVal], vals) => vals.filter(val => val !== filterVal)
 };
 const FILTER_REGEX = new RegExp(`(.*?)(?:\\((.+?)\\))?(${Object.values(OPERATORS).join('|')})\\((.+?)\\)`);

--- a/packages/data/addon/serializers/dimensions/elide.ts
+++ b/packages/data/addon/serializers/dimensions/elide.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2020, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+
+import NaviDimensionSerializer from './interface';
+import NaviDimensionModel from '../../models/navi-dimension';
+import { DimensionColumn } from '../../adapters/dimensions/interface';
+import { AsyncQueryResponse } from 'navi-data/adapters/facts/interface';
+import EmberObject from '@ember/object';
+
+type ResponseEdge = {
+  node: Dict<string>;
+};
+
+export default class ElideDimensionSerializer extends EmberObject implements NaviDimensionSerializer {
+  normalize(dimension: DimensionColumn, rawPayload: unknown): NaviDimensionModel[] {
+    const responseStr = (rawPayload as AsyncQueryResponse)?.asyncQuery.edges[0].node.result?.responseBody;
+    const { id: dimensionName, tableId } = dimension.columnMetadata;
+
+    if (responseStr && tableId) {
+      const response = JSON.parse(responseStr);
+      return response.data[tableId].edges.map((edge: ResponseEdge) =>
+        NaviDimensionModel.create({
+          value: edge.node[dimensionName], //TODO: Use canonicalized dimension name when Elide supports it
+          dimensionColumn: dimension
+        })
+      );
+    }
+    return [];
+  }
+}

--- a/packages/data/addon/serializers/dimensions/elide.ts
+++ b/packages/data/addon/serializers/dimensions/elide.ts
@@ -7,6 +7,7 @@ import NaviDimensionSerializer from './interface';
 import NaviDimensionModel from '../../models/navi-dimension';
 import { DimensionColumn } from '../../adapters/dimensions/interface';
 import { AsyncQueryResponse } from 'navi-data/adapters/facts/interface';
+import { getElideField } from '../../adapters/facts/elide';
 import EmberObject from '@ember/object';
 
 type ResponseEdge = {
@@ -24,7 +25,7 @@ export default class ElideDimensionSerializer extends EmberObject implements Nav
       const response = JSON.parse(responseStr);
       return response.data[tableId as string].edges.map((edge: ResponseEdge) =>
         NaviDimensionModel.create({
-          value: edge.node[dimensionName], //TODO: Use canonicalized dimension name when Elide supports it
+          value: edge.node[getElideField(dimensionName, dimension.parameters)],
           dimensionColumn: dimension
         })
       );

--- a/packages/data/app/serializers/dimensions/elide.js
+++ b/packages/data/app/serializers/dimensions/elide.js
@@ -1,0 +1,1 @@
+export { default } from 'navi-data/serializers/dimensions/elide';

--- a/packages/data/tests/dummy/mirage/scenarios/elide-one.ts
+++ b/packages/data/tests/dummy/mirage/scenarios/elide-one.ts
@@ -9,15 +9,18 @@ export default function(server: any) {
   server.createList('metric', 3, { table: table0 });
   server.createList('metric', 2, { table: table1 });
   server.createList('dimension', 3, { table: table0 });
+  const timeDimTables = [table1];
   grains.forEach(grain => {
     timeDimIds.forEach(timeDimId => {
-      const idWithGrain = `${timeDimId}${capitalize(grain)}`;
-      let newGrain = server.create('time-dimension-grain', {
-        id: `${idWithGrain}.${grain}`,
-        expression: null,
-        grain: grain.toUpperCase()
+      timeDimTables.forEach(table => {
+        const idWithGrain = `${table.id}.${timeDimId}${capitalize(grain)}`;
+        let newGrain = server.create('time-dimension-grain', {
+          id: `${idWithGrain}.${grain}`,
+          expression: null,
+          grain: grain.toUpperCase()
+        });
+        server.create('time-dimension', { id: idWithGrain, table, supportedGrains: [newGrain] });
       });
-      server.create('time-dimension', { id: idWithGrain, table: table1, supportedGrains: [newGrain] });
     });
   });
 }

--- a/packages/data/tests/dummy/mirage/scenarios/elide-two.ts
+++ b/packages/data/tests/dummy/mirage/scenarios/elide-two.ts
@@ -2,24 +2,27 @@
 import { grains } from './elide-one';
 import { capitalize } from '@ember/string';
 
-const timeDimIds = ['eventTime'];
+const timeDimIds = ['eventTime', 'orderTime'];
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default function(server: any) {
   const [table0, table1] = server.createList('table', 2);
   server.createList('metric', 1, { table: table0 });
-  server.createList('metric', 1, { table: table1 });
+  server.createList('metric', 2, { table: table1 });
   server.createList('dimension', 2, { table: table0 });
-  server.createList('dimension', 3, { table: table1 });
+  server.createList('dimension', 4, { table: table1 });
+  const timeDimTables = [table1];
   grains.forEach(grain => {
     timeDimIds.forEach(timeDimId => {
-      const idWithGrain = `${timeDimId}${capitalize(grain)}`;
-      let newGrain = server.create('time-dimension-grain', {
-        id: `${idWithGrain}.${grain}`,
-        expression: null,
-        grain: grain.toUpperCase()
+      timeDimTables.forEach(table => {
+        const idWithGrain = `${table.id}.${timeDimId}${capitalize(grain)}`;
+        let newGrain = server.create('time-dimension-grain', {
+          id: `${idWithGrain}.${grain}`,
+          expression: null,
+          grain: grain.toUpperCase()
+        });
+        server.create('time-dimension', { id: idWithGrain, table, supportedGrains: [newGrain] });
       });
-      server.create('time-dimension', { id: idWithGrain, table: table1, supportedGrains: [newGrain] });
     });
   });
 }

--- a/packages/data/tests/unit/adapters/dimensions/elide-test.ts
+++ b/packages/data/tests/unit/adapters/dimensions/elide-test.ts
@@ -4,6 +4,18 @@ import ElideDimensionAdapter from 'navi-data/adapters/dimensions/elide';
 import { DimensionColumn } from 'navi-data/adapters/dimensions/interface';
 import { RequestV2, AsyncQueryResponse, QueryStatus, RequestOptions } from 'navi-data/adapters/facts/interface';
 import DimensionMetadataModel from 'navi-data/models/metadata/dimension';
+import NaviMetadataService from 'navi-data/services/navi-metadata';
+import { TestContext as Context } from 'ember-test-helpers';
+import ElideOneScenario from 'dummy/mirage/scenarios/elide-one';
+import ElideTwoScenario from 'dummy/mirage/scenarios/elide-two';
+// @ts-ignore
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { Server } from 'miragejs';
+
+interface TestContext extends Context {
+  metadataService: NaviMetadataService;
+  server: Server;
+}
 
 const fakeResponse: AsyncQueryResponse = {
   asyncQuery: { edges: [{ node: { id: '1', query: 'foo', status: QueryStatus.COMPLETE, result: null } }] }
@@ -11,16 +23,31 @@ const fakeResponse: AsyncQueryResponse = {
 
 module('Unit | Adapter | Dimensions | Elide', function(hooks) {
   setupTest(hooks);
+  setupMirage(hooks);
 
-  test('find', async function(assert) {
+  hooks.beforeEach(async function(this: TestContext) {
+    this.metadataService = this.owner.lookup('service:navi-metadata');
+    ElideOneScenario(this.server);
+    await this.metadataService.loadMetadata({ dataSourceName: 'elideOne' });
+
+    //reset the db so we can set the db up for the elideTwo scenario
+    this.server.db.emptyData();
+    //reset the indexes used by the mirage factories
+    //@ts-ignore
+    this.server.factorySequences = {};
+    ElideTwoScenario(this.server);
+    await this.metadataService.loadMetadata({ dataSourceName: 'elideTwo' });
+  });
+
+  test('find', async function(this: TestContext, assert) {
     assert.expect(2);
 
     const TestDimensionColumn: DimensionColumn = {
-      columnMetadata: DimensionMetadataModel.create({
-        id: 'dimension1',
-        source: 'elideTwo',
-        tableId: 'table1'
-      }),
+      columnMetadata: this.metadataService.getById(
+        'dimension',
+        'table0.dimension1',
+        'elideTwo'
+      ) as DimensionMetadataModel,
       parameters: {
         foo: 'bar'
       }
@@ -28,12 +55,18 @@ module('Unit | Adapter | Dimensions | Elide', function(hooks) {
 
     const originalFactAdapter = this.owner.factoryFor('adapter:facts/elide').class;
     const expectedRequest: RequestV2 = {
-      columns: [{ field: 'dimension1', parameters: { foo: 'bar' }, type: 'dimension' }],
+      columns: [{ field: 'table0.dimension1', parameters: { foo: 'bar' }, type: 'dimension' }],
       filters: [
-        { field: 'dimension1', parameters: { foo: 'bar' }, type: 'dimension', operator: 'in', values: ['v1', 'v2'] }
+        {
+          field: 'table0.dimension1',
+          parameters: { foo: 'bar' },
+          type: 'dimension',
+          operator: 'in',
+          values: ['v1', 'v2']
+        }
       ],
       sorts: [],
-      table: 'table1',
+      table: 'table0',
       limit: null,
       dataSource: 'elideTwo',
       requestVersion: '2.0'
@@ -59,27 +92,27 @@ module('Unit | Adapter | Dimensions | Elide', function(hooks) {
     await adapter.find(TestDimensionColumn, [{ operator: 'in', values: ['v1', 'v2'] }], expectedOptions);
   });
 
-  test('all', async function(assert) {
+  test('all', async function(this: TestContext, assert) {
     assert.expect(2);
 
     const originalFactAdapter = this.owner.factoryFor('adapter:facts/elide').class;
     const TestDimensionColumn: DimensionColumn = {
-      columnMetadata: DimensionMetadataModel.create({
-        id: 'dimension1',
-        source: 'elideOne',
-        tableId: 'table1'
-      }),
+      columnMetadata: this.metadataService.getById(
+        'dimension',
+        'table0.dimension1',
+        'elideTwo'
+      ) as DimensionMetadataModel,
       parameters: {
         foo: 'baz'
       }
     };
     const expectedRequest: RequestV2 = {
-      columns: [{ field: 'dimension1', parameters: { foo: 'baz' }, type: 'dimension' }],
+      columns: [{ field: 'table0.dimension1', parameters: { foo: 'baz' }, type: 'dimension' }],
       filters: [],
       sorts: [],
-      table: 'table1',
+      table: 'table0',
       limit: null,
-      dataSource: 'elideOne',
+      dataSource: 'elideTwo',
       requestVersion: '2.0'
     };
     const expectedOptions = {
@@ -105,16 +138,16 @@ module('Unit | Adapter | Dimensions | Elide', function(hooks) {
     await adapter.all(TestDimensionColumn, expectedOptions);
   });
 
-  test('search', async function(assert) {
+  test('search', async function(this: TestContext, assert) {
     assert.expect(2);
 
     const originalFactAdapter = this.owner.factoryFor('adapter:facts/elide').class;
     const TestDimensionColumn: DimensionColumn = {
-      columnMetadata: DimensionMetadataModel.create({
-        id: 'dimension2',
-        source: 'elideTwo',
-        tableId: 'table3'
-      }),
+      columnMetadata: this.metadataService.getById(
+        'dimension',
+        'table1.dimension2',
+        'elideTwo'
+      ) as DimensionMetadataModel,
       parameters: {
         bang: 'boom'
       }
@@ -122,10 +155,10 @@ module('Unit | Adapter | Dimensions | Elide', function(hooks) {
     const query = 'something';
 
     const expectedRequest: RequestV2 = {
-      columns: [{ field: 'dimension2', parameters: { bang: 'boom' }, type: 'dimension' }],
+      columns: [{ field: 'table1.dimension2', parameters: { bang: 'boom' }, type: 'dimension' }],
       filters: [
         {
-          field: 'dimension2',
+          field: 'table1.dimension2',
           parameters: { bang: 'boom' },
           type: 'dimension',
           operator: 'eq',
@@ -133,7 +166,7 @@ module('Unit | Adapter | Dimensions | Elide', function(hooks) {
         }
       ],
       sorts: [],
-      table: 'table3',
+      table: 'table1',
       limit: null,
       dataSource: 'elideTwo',
       requestVersion: '2.0'

--- a/packages/data/tests/unit/adapters/dimensions/elide-test.ts
+++ b/packages/data/tests/unit/adapters/dimensions/elide-test.ts
@@ -145,8 +145,8 @@ module('Unit | Adapter | Dimensions | Elide', function(hooks) {
     const TestDimensionColumn: DimensionColumn = {
       columnMetadata: this.metadataService.getById(
         'dimension',
-        'table1.dimension2',
-        'elideTwo'
+        'table0.dimension2',
+        'elideOne'
       ) as DimensionMetadataModel,
       parameters: {
         bang: 'boom'
@@ -155,10 +155,10 @@ module('Unit | Adapter | Dimensions | Elide', function(hooks) {
     const query = 'something';
 
     const expectedRequest: RequestV2 = {
-      columns: [{ field: 'table1.dimension2', parameters: { bang: 'boom' }, type: 'dimension' }],
+      columns: [{ field: 'table0.dimension2', parameters: { bang: 'boom' }, type: 'dimension' }],
       filters: [
         {
-          field: 'table1.dimension2',
+          field: 'table0.dimension2',
           parameters: { bang: 'boom' },
           type: 'dimension',
           operator: 'eq',
@@ -166,9 +166,9 @@ module('Unit | Adapter | Dimensions | Elide', function(hooks) {
         }
       ],
       sorts: [],
-      table: 'table1',
+      table: 'table0',
       limit: null,
-      dataSource: 'elideTwo',
+      dataSource: 'elideOne',
       requestVersion: '2.0'
     };
     const expectedOptions = {

--- a/packages/data/tests/unit/adapters/facts/elide-test.ts
+++ b/packages/data/tests/unit/adapters/facts/elide-test.ts
@@ -14,21 +14,21 @@ const uuidRegex = /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[
 const TestRequest: RequestV2 = {
   table: 'table1',
   columns: [
-    { field: 'm1', type: 'metric', parameters: {} },
-    { field: 'm2', type: 'metric', parameters: {} },
-    { field: 'r', type: 'metric', parameters: { p: '123', as: 'a' } },
-    { field: 'd1', type: 'dimension', parameters: {} },
-    { field: 'd2', type: 'dimension', parameters: {} }
+    { field: 'table1.m1', type: 'metric', parameters: {} },
+    { field: 'table1.m2', type: 'metric', parameters: {} },
+    { field: 'table1.r', type: 'metric', parameters: { p: '123', as: 'a' } },
+    { field: 'table1.d1', type: 'dimension', parameters: {} },
+    { field: 'table1.d2', type: 'dimension', parameters: {} }
   ],
   filters: [
-    { field: 'd3', operator: 'in', values: ['v1', 'v2'], type: 'dimension', parameters: {} },
-    { field: 'd4', operator: 'in', values: ['v3', 'v4'], type: 'dimension', parameters: {} },
-    { field: 'd5', operator: 'isnull', values: ['false'], type: 'dimension', parameters: {} },
-    { field: 'time', operator: 'ge', values: ['2015-01-03'], type: 'timeDimension', parameters: {} },
-    { field: 'time', operator: 'lt', values: ['2015-01-04'], type: 'timeDimension', parameters: {} },
-    { field: 'm1', operator: 'gt', values: ['0'], type: 'metric', parameters: {} }
+    { field: 'table1.d3', operator: 'in', values: ['v1', 'v2'], type: 'dimension', parameters: {} },
+    { field: 'table1.d4', operator: 'in', values: ['v3', 'v4'], type: 'dimension', parameters: {} },
+    { field: 'table1.d5', operator: 'isnull', values: ['false'], type: 'dimension', parameters: {} },
+    { field: 'table1.time', operator: 'ge', values: ['2015-01-03'], type: 'timeDimension', parameters: {} },
+    { field: 'table1.time', operator: 'lt', values: ['2015-01-04'], type: 'timeDimension', parameters: {} },
+    { field: 'table1.m1', operator: 'gt', values: ['0'], type: 'metric', parameters: {} }
   ],
-  sorts: [{ field: 'd1', parameters: {}, type: 'dimension', direction: 'asc' }],
+  sorts: [{ field: 'table1.d1', parameters: {}, type: 'dimension', direction: 'asc' }],
   limit: 10000,
   requestVersion: '2.0',
   dataSource: 'elideOne'
@@ -82,8 +82,8 @@ module('Unit | Adapter | facts/elide', function(hooks) {
       adapter['dataQueryFromRequest']({
         table: 'myTable',
         columns: [
-          { field: 'm1', parameters: { p: 'q' }, type: 'metric' },
-          { field: 'd1', parameters: {}, type: 'dimension' }
+          { field: 'myTable.m1', parameters: { p: 'q' }, type: 'metric' },
+          { field: 'myTable.d1', parameters: {}, type: 'dimension' }
         ],
         sorts: [],
         filters: [],
@@ -99,12 +99,12 @@ module('Unit | Adapter | facts/elide', function(hooks) {
       adapter['dataQueryFromRequest']({
         table: 'myTable',
         columns: [
-          { field: 'm1', parameters: { p: 'q' }, type: 'metric' },
-          { field: 'd1', parameters: {}, type: 'dimension' }
+          { field: 'myTable.m1', parameters: { p: 'q' }, type: 'metric' },
+          { field: 'myTable.d1', parameters: {}, type: 'dimension' }
         ],
         sorts: [
-          { field: 'm1', parameters: { p: 'q' }, type: 'metric', direction: 'desc' },
-          { field: 'd1', parameters: {}, type: 'dimension', direction: 'asc' }
+          { field: 'myTable.m1', parameters: { p: 'q' }, type: 'metric', direction: 'desc' },
+          { field: 'myTable.d1', parameters: {}, type: 'dimension', direction: 'asc' }
         ],
         filters: [],
         limit: null,
@@ -119,14 +119,14 @@ module('Unit | Adapter | facts/elide', function(hooks) {
       adapter['dataQueryFromRequest']({
         table: 'myTable',
         columns: [
-          { field: 'm1', parameters: { p: 'q' }, type: 'metric' },
-          { field: 'd1', parameters: {}, type: 'dimension' }
+          { field: 'myTable.m1', parameters: { p: 'q' }, type: 'metric' },
+          { field: 'myTable.d1', parameters: {}, type: 'dimension' }
         ],
         sorts: [],
         filters: [
-          { field: 'm1', parameters: { p: 'q' }, type: 'metric', operator: 'in', values: ['v1', 'v2'] },
-          { field: 'd1', parameters: {}, type: 'dimension', operator: 'neq', values: ['a'] },
-          { field: 'd2', parameters: {}, type: 'dimension', operator: 'eq', values: ['b'] }
+          { field: 'myTable.m1', parameters: { p: 'q' }, type: 'metric', operator: 'in', values: ['v1', 'v2'] },
+          { field: 'myTable.d1', parameters: {}, type: 'dimension', operator: 'neq', values: ['a'] },
+          { field: 'myTable.d2', parameters: {}, type: 'dimension', operator: 'eq', values: ['b'] }
         ],
         requestVersion: '2.0',
         dataSource: 'elideOne',
@@ -142,8 +142,8 @@ module('Unit | Adapter | facts/elide', function(hooks) {
       adapter['dataQueryFromRequest']({
         table: 'myTable',
         columns: [
-          { field: 'm1', parameters: { p: 'q' }, type: 'metric' },
-          { field: 'd1', parameters: {}, type: 'dimension' }
+          { field: 'myTable.m1', parameters: { p: 'q' }, type: 'metric' },
+          { field: 'myTable.d1', parameters: {}, type: 'dimension' }
         ],
         sorts: [],
         filters: [],

--- a/packages/data/tests/unit/adapters/metadata/elide-test.ts
+++ b/packages/data/tests/unit/adapters/metadata/elide-test.ts
@@ -110,7 +110,7 @@ module('Unit | Adapter | metadata/elide', function(hooks) {
         edges: [
           {
             node: {
-              id: 'metric0',
+              id: 'table0.metric0',
               name: 'Metric 0',
               description: 'This is metric 0',
               category: 'categoryOne',
@@ -124,7 +124,7 @@ module('Unit | Adapter | metadata/elide', function(hooks) {
           },
           {
             node: {
-              id: 'metric1',
+              id: 'table0.metric1',
               name: 'Metric 1',
               description: 'This is metric 1',
               category: 'categoryOne',
@@ -138,7 +138,7 @@ module('Unit | Adapter | metadata/elide', function(hooks) {
           },
           {
             node: {
-              id: 'metric2',
+              id: 'table0.metric2',
               name: 'Metric 2',
               description: 'This is metric 2',
               category: 'categoryOne',
@@ -163,7 +163,7 @@ module('Unit | Adapter | metadata/elide', function(hooks) {
           {
             __typename: 'DimensionEdge',
             node: {
-              id: 'dimension0',
+              id: 'table0.dimension0',
               name: 'Dimension 0',
               description: 'This is dimension 0',
               category: 'categoryOne',
@@ -177,7 +177,7 @@ module('Unit | Adapter | metadata/elide', function(hooks) {
           {
             __typename: 'DimensionEdge',
             node: {
-              id: 'dimension1',
+              id: 'table0.dimension1',
               name: 'Dimension 1',
               description: 'This is dimension 1',
               category: 'categoryOne',
@@ -191,7 +191,7 @@ module('Unit | Adapter | metadata/elide', function(hooks) {
           {
             __typename: 'DimensionEdge',
             node: {
-              id: 'dimension2',
+              id: 'table0.dimension2',
               name: 'Dimension 2',
               description: 'This is dimension 2',
               category: 'categoryOne',
@@ -215,7 +215,7 @@ module('Unit | Adapter | metadata/elide', function(hooks) {
         edges: [
           {
             node: {
-              id: 'metric3',
+              id: 'table1.metric3',
               name: 'Metric 3',
               description: 'This is metric 3',
               category: 'categoryOne',
@@ -229,7 +229,7 @@ module('Unit | Adapter | metadata/elide', function(hooks) {
           },
           {
             node: {
-              id: 'metric4',
+              id: 'table1.metric4',
               name: 'Metric 4',
               description: 'This is metric 4',
               category: 'categoryOne',
@@ -282,7 +282,7 @@ module('Unit | Adapter | metadata/elide', function(hooks) {
                   edges: [
                     {
                       node: {
-                        id: 'metric0',
+                        id: 'table0.metric0',
                         name: 'Metric 0',
                         description: 'This is metric 0',
                         category: 'categoryOne',
@@ -296,7 +296,7 @@ module('Unit | Adapter | metadata/elide', function(hooks) {
                     },
                     {
                       node: {
-                        id: 'metric1',
+                        id: 'table0.metric1',
                         name: 'Metric 1',
                         description: 'This is metric 1',
                         category: 'categoryOne',
@@ -310,7 +310,7 @@ module('Unit | Adapter | metadata/elide', function(hooks) {
                     },
                     {
                       node: {
-                        id: 'metric2',
+                        id: 'table0.metric2',
                         name: 'Metric 2',
                         description: 'This is metric 2',
                         category: 'categoryOne',
@@ -329,7 +329,7 @@ module('Unit | Adapter | metadata/elide', function(hooks) {
                   edges: [
                     {
                       node: {
-                        id: 'dimension0',
+                        id: 'table0.dimension0',
                         name: 'Dimension 0',
                         description: 'This is dimension 0',
                         category: 'categoryOne',
@@ -343,7 +343,7 @@ module('Unit | Adapter | metadata/elide', function(hooks) {
                     },
                     {
                       node: {
-                        id: 'dimension1',
+                        id: 'table0.dimension1',
                         name: 'Dimension 1',
                         description: 'This is dimension 1',
                         category: 'categoryOne',
@@ -357,7 +357,7 @@ module('Unit | Adapter | metadata/elide', function(hooks) {
                     },
                     {
                       node: {
-                        id: 'dimension2',
+                        id: 'table0.dimension2',
                         name: 'Dimension 2',
                         description: 'This is dimension 2',
                         category: 'categoryOne',

--- a/packages/data/tests/unit/serializers/dimensions/elide-test.ts
+++ b/packages/data/tests/unit/serializers/dimensions/elide-test.ts
@@ -43,7 +43,7 @@ module('Unit | Serializer | Dimensions | Elide', function(hooks) {
                 httpStatus: 200,
                 resultType: QueryResultType.EMBEDDED,
                 responseBody:
-                  '{"data":{"table0":{"edges":[{"node":{"dimension1":"foo"}},{"node":{"dimension1":"bar"}},{"node":{"dimension1":"baz"}}]}}}'
+                  '{"data":{"table0":{"edges":[{"node":{"dimension1(baddabing: baddaboom)":"foo"}},{"node":{"dimension1(baddabing: baddaboom)":"bar"}},{"node":{"dimension1(baddabing: baddaboom)":"baz"}}]}}}'
               }
             }
           }

--- a/packages/data/tests/unit/services/navi-dimension-test.ts
+++ b/packages/data/tests/unit/services/navi-dimension-test.ts
@@ -27,8 +27,6 @@ module('Unit | Service | navi-dimension', function(hooks) {
   });
 
   test('all', async function(this: TestContext, assert) {
-    assert.expect(1);
-
     const service = this.owner.lookup('service:navi-dimension') as NaviDimensionService;
     const columnMetadata = this.metadataService.getById(
       'dimension',
@@ -47,8 +45,6 @@ module('Unit | Service | navi-dimension', function(hooks) {
   });
 
   test('find', async function(this: TestContext, assert) {
-    assert.expect(1);
-
     const service = this.owner.lookup('service:navi-dimension') as NaviDimensionService;
     const columnMetadata = this.metadataService.getById(
       'dimension',

--- a/packages/data/tests/unit/services/navi-dimension-test.ts
+++ b/packages/data/tests/unit/services/navi-dimension-test.ts
@@ -1,44 +1,15 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import NaviDimensionAdapter, { DimensionColumn, DimensionFilter } from 'navi-data/adapters/dimensions/interface';
+import { DimensionFilter } from 'navi-data/adapters/dimensions/interface';
 import { TestContext as Context } from 'ember-test-helpers';
-import NaviDimensionSerializer from 'navi-data/serializers/dimensions/interface';
 import NaviDimensionModel from 'navi-data/models/navi-dimension';
-import NaviDimensionService, { ServiceOptions } from 'navi-data/services/navi-dimension';
+import NaviDimensionService from 'navi-data/services/navi-dimension';
 import NaviMetadataService from 'navi-data/services/navi-metadata';
 import DimensionMetadataModel from 'navi-data/models/metadata/dimension';
-import EmberObject from '@ember/object';
 // @ts-ignore
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import GraphQLScenario from 'dummy/mirage/scenarios/elide-one';
 import { Server } from 'miragejs';
-
-const dimensions: Record<string, unknown[]> = {
-  dimension1: [1, 2, 3, 4, 5],
-  dimension2: ['foo', 'bar', 'foo-bar']
-};
-
-class TestAdapter extends EmberObject implements NaviDimensionAdapter {
-  async all(dimension: DimensionColumn, _options?: ServiceOptions): Promise<unknown[]> {
-    return dimensions[dimension.columnMetadata.id];
-  }
-
-  async find(dimension: DimensionColumn, predicate: DimensionFilter[], _options?: ServiceOptions): Promise<unknown[]> {
-    const all = await this.all(dimension);
-    return all.filter(d => predicate[0].values.includes(d));
-  }
-
-  async search(dimension: DimensionColumn, query: string, _options?: ServiceOptions): Promise<unknown[]> {
-    const all = await this.all(dimension);
-    return all.filter(d => `${d}`.includes(query));
-  }
-}
-
-class TestSerialier extends EmberObject implements NaviDimensionSerializer {
-  normalize(dimensionColumn: DimensionColumn, rawPayload: unknown[]): NaviDimensionModel[] {
-    return rawPayload.map(value => NaviDimensionModel.create({ value, dimensionColumn }));
-  }
-}
 
 interface TestContext extends Context {
   metadataService: NaviMetadataService;
@@ -50,56 +21,72 @@ module('Unit | Service | navi-dimension', function(hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(async function(this: TestContext) {
-    this.owner.register('adapter:dimensions/elide', TestAdapter);
-    this.owner.register('serializer:dimensions/elide', TestSerialier);
     this.metadataService = this.owner.lookup('service:navi-metadata');
     GraphQLScenario(this.server);
     await this.metadataService.loadMetadata({ dataSourceName: 'elideOne' });
   });
 
   test('all', async function(this: TestContext, assert) {
+    assert.expect(1);
+
     const service = this.owner.lookup('service:navi-dimension') as NaviDimensionService;
     const columnMetadata = this.metadataService.getById(
       'dimension',
       'dimension1',
       'elideOne'
     ) as DimensionMetadataModel;
+    const expectedDimensionModels = [
+      'Incredible Granite Car',
+      'Awesome Plastic Car',
+      'Rustic Plastic Chicken'
+    ].map(dimVal => NaviDimensionModel.create({ value: dimVal, dimensionColumn: { columnMetadata } }));
     const all = await service.all({ columnMetadata });
-    assert.deepEqual(
-      all.map(({ value }) => value),
-      dimensions.dimension1,
-      '`all` calls the correct adapter, serializer, and methods'
-    );
+
+    assert.deepEqual(all, expectedDimensionModels, '`all` gets all the unfiltered values for a dimension');
   });
 
   test('find', async function(this: TestContext, assert) {
+    assert.expect(1);
+
     const service = this.owner.lookup('service:navi-dimension') as NaviDimensionService;
     const columnMetadata = this.metadataService.getById(
       'dimension',
       'dimension1',
       'elideOne'
     ) as DimensionMetadataModel;
-    const filters: DimensionFilter[] = [{ operator: 'in', values: [1, 2] }];
-    const all = await service.find({ columnMetadata }, filters);
+    const findValues = ['Handcrafted Granite Fish', 'Practical Metal Pizza'];
+    const filters: DimensionFilter[] = [{ operator: 'in', values: findValues }];
+    const expectedDimensionModels = findValues.map(dimVal =>
+      NaviDimensionModel.create({ value: dimVal, dimensionColumn: { columnMetadata } })
+    );
+    const find = await service.find({ columnMetadata }, filters);
     assert.deepEqual(
-      all.map(({ value }) => value),
-      [1, 2],
-      '`find` calls the correct adapter, serializer, and methods'
+      find,
+      expectedDimensionModels,
+      '`find` gets all the values for a dimension that match the specified filter'
     );
   });
 
   test('search', async function(this: TestContext, assert) {
+    assert.expect(2);
+
     const service = this.owner.lookup('service:navi-dimension') as NaviDimensionService;
     const columnMetadata = this.metadataService.getById(
       'dimension',
       'dimension2',
       'elideOne'
     ) as DimensionMetadataModel;
-    const all = await service.search({ columnMetadata }, 'foo');
-    assert.deepEqual(
-      all.map(({ value }) => value),
-      ['foo', 'foo-bar'],
-      '`search` calls the correct adapter, serializer, and methods'
+    const search = await service.search({ columnMetadata }, 'Pizza');
+    const expectedDimensionModels = ['Practical Metal Pizza', 'Licensed Wooden Pizza'].map(dimVal =>
+      NaviDimensionModel.create({ value: dimVal, dimensionColumn: { columnMetadata } })
     );
+    assert.deepEqual(
+      search,
+      expectedDimensionModels,
+      '`search` gets all the values for a dimension that contain the query'
+    );
+
+    const noResultSearch = await service.search({ columnMetadata }, 'fuggedaboutit');
+    assert.deepEqual(noResultSearch, [], 'Empty array is returned when no values are found');
   });
 });

--- a/packages/data/tests/unit/services/navi-dimension-test.ts
+++ b/packages/data/tests/unit/services/navi-dimension-test.ts
@@ -32,13 +32,14 @@ module('Unit | Service | navi-dimension', function(hooks) {
     const service = this.owner.lookup('service:navi-dimension') as NaviDimensionService;
     const columnMetadata = this.metadataService.getById(
       'dimension',
-      'dimension1',
+      'table0.dimension1',
       'elideOne'
     ) as DimensionMetadataModel;
     const expectedDimensionModels = [
-      'Incredible Granite Car',
-      'Awesome Plastic Car',
-      'Rustic Plastic Chicken'
+      'Handcrafted Frozen Mouse',
+      'Licensed Soft Ball',
+      'Awesome Concrete Table',
+      'Handcrafted Concrete Mouse'
     ].map(dimVal => NaviDimensionModel.create({ value: dimVal, dimensionColumn: { columnMetadata } }));
     const all = await service.all({ columnMetadata });
 
@@ -51,10 +52,10 @@ module('Unit | Service | navi-dimension', function(hooks) {
     const service = this.owner.lookup('service:navi-dimension') as NaviDimensionService;
     const columnMetadata = this.metadataService.getById(
       'dimension',
-      'dimension1',
+      'table0.dimension1',
       'elideOne'
     ) as DimensionMetadataModel;
-    const findValues = ['Handcrafted Granite Fish', 'Practical Metal Pizza'];
+    const findValues = ['Awesome Plastic Fish', 'Refined Fresh Bacon'];
     const filters: DimensionFilter[] = [{ operator: 'in', values: findValues }];
     const expectedDimensionModels = findValues.map(dimVal =>
       NaviDimensionModel.create({ value: dimVal, dimensionColumn: { columnMetadata } })
@@ -73,11 +74,11 @@ module('Unit | Service | navi-dimension', function(hooks) {
     const service = this.owner.lookup('service:navi-dimension') as NaviDimensionService;
     const columnMetadata = this.metadataService.getById(
       'dimension',
-      'dimension2',
+      'table0.dimension2',
       'elideOne'
     ) as DimensionMetadataModel;
-    const search = await service.search({ columnMetadata }, 'Pizza');
-    const expectedDimensionModels = ['Practical Metal Pizza', 'Licensed Wooden Pizza'].map(dimVal =>
+    const search = await service.search({ columnMetadata }, 'Plastic');
+    const expectedDimensionModels = ['Licensed Plastic Pants', 'Awesome Plastic Fish'].map(dimVal =>
       NaviDimensionModel.create({ value: dimVal, dimensionColumn: { columnMetadata } })
     );
     assert.deepEqual(

--- a/packages/data/tests/unit/services/navi-facts-elide-test.js
+++ b/packages/data/tests/unit/services/navi-facts-elide-test.js
@@ -1,7 +1,7 @@
 import { module, test, skip } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import GraphQLScenario from 'dummy/mirage/scenarios/elide-one';
+import GraphQLScenario from 'dummy/mirage/scenarios/elide-two';
 import moment from 'moment';
 
 const TestRequest = {
@@ -12,20 +12,26 @@ const TestRequest = {
     { field: 'table1.orderTimeDay', parameters: {}, type: 'timeDimension' },
     { field: 'table1.metric1', parameters: {}, type: 'metric' },
     { field: 'table1.metric2', parameters: {}, type: 'metric' },
-    { field: 'table1.dimension1', parameters: {}, type: 'dimension' },
-    { field: 'table1.dimension2', parameters: {}, type: 'dimension' }
+    { field: 'table1.dimension2', parameters: {}, type: 'dimension' },
+    { field: 'table1.dimension3', parameters: {}, type: 'dimension' }
   ],
   filters: [
-    { field: 'table1.dimension1', operator: 'eq', values: ['Small Metal Hat'], parameters: {}, type: 'dimension' },
     {
       field: 'table1.dimension2',
-      operator: 'notin',
-      values: ['Gorgeous Frozen Table', 'Refined Soft Sausages'],
+      operator: 'eq',
+      values: ['Incredible Metal Towels'],
       parameters: {},
       type: 'dimension'
     },
-    { field: 'table1.dimension3', operator: 'in', values: ['v1', 'v2'], parameters: {}, type: 'dimension' },
-    { field: 'table1.dimension4', operator: 'in', values: ['v3', 'v4'], parameters: {}, type: 'dimension' },
+    {
+      field: 'table1.dimension3',
+      operator: 'notin',
+      values: ['Unbranded Soft Sausage', 'Ergonomic Plastic Tuna'],
+      parameters: {},
+      type: 'dimension'
+    },
+    { field: 'table1.dimension4', operator: 'in', values: ['v1', 'v2'], parameters: {}, type: 'dimension' },
+    { field: 'table1.dimension5', operator: 'in', values: ['v3', 'v4'], parameters: {}, type: 'dimension' },
     { field: 'table1.metric1', operator: 'gt', values: ['0'], parameters: {}, type: 'metric' },
     {
       field: 'table1.eventTimeDay',
@@ -58,11 +64,11 @@ const TestRequest = {
   ],
   sorts: [
     { field: 'table1.eventTimeDay', parameters: {}, type: 'timeDimension', direction: 'asc' },
-    { field: 'table1.dimension2', parameters: {}, type: 'dimension', direction: 'desc' }
+    { field: 'table1.dimension3', parameters: {}, type: 'dimension', direction: 'desc' }
   ],
   limit: 15,
   requestVersion: '2.0',
-  dataSource: 'elideOne'
+  dataSource: 'elideTwo'
 };
 
 module('Unit | Service | Navi Facts - Elide', function(hooks) {
@@ -81,144 +87,144 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
     assert.deepEqual(
       response.response,
       {
+        meta: {},
         rows: [
           {
+            'table1.dimension2': 'Incredible Metal Towels',
+            'table1.dimension3': 'Unbranded Soft Sausages',
             'table1.eventTimeDay': '2015-01-29',
             'table1.eventTimeMonth': '2015 Jan',
-            'table1.orderTimeDay': '2014-01-05',
-            'table1.dimension1': 'Small Metal Hat',
-            'table1.dimension2': 'Unbranded Concrete Fish',
-            'table1.metric1': '785.60',
-            'table1.metric2': '590.23'
+            'table1.metric1': '231.96',
+            'table1.metric2': '969.93',
+            'table1.orderTimeDay': '2014-01-05'
           },
           {
+            'table1.dimension2': 'Incredible Metal Towels',
+            'table1.dimension3': 'Unbranded Soft Sausages',
             'table1.eventTimeDay': '2015-01-29',
             'table1.eventTimeMonth': '2015 Jan',
-            'table1.orderTimeDay': '2014-01-06',
-            'table1.dimension1': 'Small Metal Hat',
-            'table1.dimension2': 'Unbranded Concrete Fish',
-            'table1.metric1': '603.55',
-            'table1.metric2': '977.92'
+            'table1.metric1': '236.73',
+            'table1.metric2': '730.45',
+            'table1.orderTimeDay': '2014-01-06'
           },
           {
+            'table1.dimension2': 'Incredible Metal Towels',
+            'table1.dimension3': 'Ergonomic Steel Sausages',
             'table1.eventTimeDay': '2015-01-29',
             'table1.eventTimeMonth': '2015 Jan',
-            'table1.orderTimeDay': '2014-01-05',
-            'table1.dimension1': 'Small Metal Hat',
-            'table1.dimension2': 'Refined Concrete Chair',
-            'table1.metric1': '83.56',
-            'table1.metric2': '774.72'
+            'table1.metric1': '385.95',
+            'table1.metric2': '463.94',
+            'table1.orderTimeDay': '2014-01-05'
           },
           {
+            'table1.dimension2': 'Incredible Metal Towels',
+            'table1.dimension3': 'Ergonomic Steel Sausages',
             'table1.eventTimeDay': '2015-01-29',
             'table1.eventTimeMonth': '2015 Jan',
-            'table1.orderTimeDay': '2014-01-06',
-            'table1.dimension1': 'Small Metal Hat',
-            'table1.dimension2': 'Refined Concrete Chair',
-            'table1.metric1': '685.31',
-            'table1.metric2': '432.90'
+            'table1.metric1': '998.39',
+            'table1.metric2': '433.80',
+            'table1.orderTimeDay': '2014-01-06'
           },
           {
-            'table1.eventTimeDay': '2015-01-29',
-            'table1.eventTimeMonth': '2015 Jan',
-            'table1.orderTimeDay': '2014-01-05',
-            'table1.dimension1': 'Small Metal Hat',
-            'table1.dimension2': 'Licensed Concrete Salad',
-            'table1.metric1': '965.49',
-            'table1.metric2': '534.25'
-          },
-          {
-            'table1.eventTimeDay': '2015-01-29',
-            'table1.eventTimeMonth': '2015 Jan',
-            'table1.orderTimeDay': '2014-01-06',
-            'table1.dimension1': 'Small Metal Hat',
-            'table1.dimension2': 'Licensed Concrete Salad',
-            'table1.metric1': '729.00',
-            'table1.metric2': '611.60'
-          },
-          {
-            'table1.eventTimeDay': '2015-01-29',
-            'table1.eventTimeMonth': '2015 Jan',
-            'table1.orderTimeDay': '2014-01-05',
-            'table1.dimension1': 'Small Metal Hat',
-            'table1.dimension2': 'Awesome Steel Pants',
-            'table1.metric1': '232.35',
-            'table1.metric2': '581.26'
-          },
-          {
-            'table1.eventTimeDay': '2015-01-29',
-            'table1.eventTimeMonth': '2015 Jan',
-            'table1.orderTimeDay': '2014-01-06',
-            'table1.dimension1': 'Small Metal Hat',
-            'table1.dimension2': 'Awesome Steel Pants',
-            'table1.metric1': '276.24',
-            'table1.metric2': '946.29'
-          },
-          {
+            'table1.dimension2': 'Incredible Metal Towels',
+            'table1.dimension3': 'Unbranded Soft Sausages',
             'table1.eventTimeDay': '2015-01-30',
             'table1.eventTimeMonth': '2015 Jan',
-            'table1.orderTimeDay': '2014-01-05',
-            'table1.dimension1': 'Small Metal Hat',
-            'table1.dimension2': 'Unbranded Concrete Fish',
-            'table1.metric1': '517.87',
-            'table1.metric2': '791.83'
+            'table1.metric1': '389.34',
+            'table1.metric2': '661.33',
+            'table1.orderTimeDay': '2014-01-05'
           },
           {
+            'table1.dimension2': 'Incredible Metal Towels',
+            'table1.dimension3': 'Unbranded Soft Sausages',
             'table1.eventTimeDay': '2015-01-30',
             'table1.eventTimeMonth': '2015 Jan',
-            'table1.orderTimeDay': '2014-01-06',
-            'table1.dimension1': 'Small Metal Hat',
-            'table1.dimension2': 'Unbranded Concrete Fish',
-            'table1.metric1': '994.32',
-            'table1.metric2': '602.63'
+            'table1.metric1': '451.75',
+            'table1.metric2': '355.84',
+            'table1.orderTimeDay': '2014-01-06'
           },
           {
+            'table1.dimension2': 'Incredible Metal Towels',
+            'table1.dimension3': 'Ergonomic Steel Sausages',
             'table1.eventTimeDay': '2015-01-30',
             'table1.eventTimeMonth': '2015 Jan',
-            'table1.orderTimeDay': '2014-01-05',
-            'table1.dimension1': 'Small Metal Hat',
-            'table1.dimension2': 'Refined Concrete Chair',
-            'table1.metric1': '186.96',
-            'table1.metric2': '146.24'
+            'table1.metric1': '723.84',
+            'table1.metric2': '196.83',
+            'table1.orderTimeDay': '2014-01-05'
           },
           {
+            'table1.dimension2': 'Incredible Metal Towels',
+            'table1.dimension3': 'Ergonomic Steel Sausages',
             'table1.eventTimeDay': '2015-01-30',
             'table1.eventTimeMonth': '2015 Jan',
-            'table1.orderTimeDay': '2014-01-05',
-            'table1.dimension1': 'Small Metal Hat',
-            'table1.dimension2': 'Licensed Concrete Salad',
-            'table1.metric1': '48.48',
-            'table1.metric2': '456.50'
+            'table1.metric1': '476.87',
+            'table1.metric2': '676.99',
+            'table1.orderTimeDay': '2014-01-06'
           },
           {
-            'table1.eventTimeDay': '2015-01-30',
+            'table1.dimension2': 'Incredible Metal Towels',
+            'table1.dimension3': 'Unbranded Soft Sausages',
+            'table1.eventTimeDay': '2015-01-31',
             'table1.eventTimeMonth': '2015 Jan',
-            'table1.orderTimeDay': '2014-01-06',
-            'table1.dimension1': 'Small Metal Hat',
-            'table1.dimension2': 'Licensed Concrete Salad',
-            'table1.metric1': '520.67',
-            'table1.metric2': '591.28'
+            'table1.metric1': '545.26',
+            'table1.metric2': '114.62',
+            'table1.orderTimeDay': '2014-01-05'
           },
           {
-            'table1.eventTimeDay': '2015-01-30',
+            'table1.dimension2': 'Incredible Metal Towels',
+            'table1.dimension3': 'Unbranded Soft Sausages',
+            'table1.eventTimeDay': '2015-01-31',
             'table1.eventTimeMonth': '2015 Jan',
-            'table1.orderTimeDay': '2014-01-05',
-            'table1.dimension1': 'Small Metal Hat',
-            'table1.dimension2': 'Awesome Steel Pants',
-            'table1.metric1': '137.87',
-            'table1.metric2': '826.68'
+            'table1.metric1': '589.71',
+            'table1.metric2': '496.48',
+            'table1.orderTimeDay': '2014-01-06'
           },
           {
-            'table1.eventTimeDay': '2015-01-30',
+            'table1.dimension2': 'Incredible Metal Towels',
+            'table1.dimension3': 'Ergonomic Steel Sausages',
+            'table1.eventTimeDay': '2015-01-31',
             'table1.eventTimeMonth': '2015 Jan',
-            'table1.orderTimeDay': '2014-01-06',
-            'table1.dimension1': 'Small Metal Hat',
-            'table1.dimension2': 'Awesome Steel Pants',
-            'table1.metric1': '578.79',
-            'table1.metric2': '441.69'
+            'table1.metric1': '432.79',
+            'table1.metric2': '246.23',
+            'table1.orderTimeDay': '2014-01-05'
+          },
+          {
+            'table1.dimension2': 'Incredible Metal Towels',
+            'table1.dimension3': 'Ergonomic Steel Sausages',
+            'table1.eventTimeDay': '2015-01-31',
+            'table1.eventTimeMonth': '2015 Jan',
+            'table1.metric1': '104.97',
+            'table1.metric2': '682.74',
+            'table1.orderTimeDay': '2014-01-06'
+          },
+          {
+            'table1.dimension2': 'Incredible Metal Towels',
+            'table1.dimension3': 'Unbranded Soft Sausages',
+            'table1.eventTimeDay': '2015-02-01',
+            'table1.eventTimeMonth': '2015 Feb',
+            'table1.metric1': '861.11',
+            'table1.metric2': '824.58',
+            'table1.orderTimeDay': '2014-01-05'
+          },
+          {
+            'table1.dimension2': 'Incredible Metal Towels',
+            'table1.dimension3': 'Unbranded Soft Sausages',
+            'table1.eventTimeDay': '2015-02-01',
+            'table1.eventTimeMonth': '2015 Feb',
+            'table1.metric1': '486.71',
+            'table1.metric2': '482.62',
+            'table1.orderTimeDay': '2014-01-06'
+          },
+          {
+            'table1.dimension2': 'Incredible Metal Towels',
+            'table1.dimension3': 'Ergonomic Steel Sausages',
+            'table1.eventTimeDay': '2015-02-01',
+            'table1.eventTimeMonth': '2015 Feb',
+            'table1.metric1': '308.03',
+            'table1.metric2': '227.94',
+            'table1.orderTimeDay': '2014-01-05'
           }
-        ],
-        meta: {}
+        ]
       },
       'Request V2 query is properly sent with all necessary arguments supplied'
     );
@@ -238,14 +244,14 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
         sorts: [{ field: 'table1.metric2', parameters: {}, type: 'metric', direction: 'asc' }],
         limit: 15,
         requestVersion: '2.0',
-        dataSource: 'elideOne'
+        dataSource: 'elideTwo'
       },
-      { dataSourceName: 'elideOne' }
+      { dataSourceName: 'elideTwo' }
     );
 
     assert.deepEqual(
       response.response,
-      { rows: [{ 'table1.metric1': '384.77', 'table1.metric2': '897.01' }], meta: {} },
+      { rows: [{ 'table1.metric1': '823.11', 'table1.metric2': '823.38' }], meta: {} },
       'Request with only metrics is formatted correctly'
     );
   });
@@ -295,9 +301,9 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
         sorts: [],
         limit: null,
         requestVersion: '2.0',
-        dataSource: 'elideOne'
+        dataSource: 'elideTwo'
       },
-      { dataSourceName: 'elideOne' }
+      { dataSourceName: 'elideTwo' }
     );
 
     assert.deepEqual(
@@ -317,14 +323,14 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
         sorts: [],
         limit: null,
         requestVersion: '2.0',
-        dataSource: 'elideOne'
+        dataSource: 'elideTwo'
       },
-      { dataSourceName: 'elideOne' }
+      { dataSourceName: 'elideTwo' }
     );
     assert.deepEqual(
       noTimeDimResponse.response,
       {
-        rows: [{ 'table1.metric1': '97.53' }],
+        rows: [{ 'table1.metric1': '307.93' }],
         meta: {}
       },
       'An invalid filter on a non-requested field does not affect the response'
@@ -353,17 +359,17 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
         sorts: [],
         limit: null,
         requestVersion: '2.0',
-        dataSource: 'elideOne'
+        dataSource: 'elideTwo'
       },
-      { dataSourceName: 'elideOne' }
+      { dataSourceName: 'elideTwo' }
     );
 
     assert.deepEqual(
       response.response,
       {
         rows: [
-          { 'table1.eventTimeMonth': '2015 Jan', 'table1.metric1': '38.56' },
-          { 'table1.eventTimeMonth': '2015 Feb', 'table1.metric1': '195.76' }
+          { 'table1.eventTimeMonth': '2015 Jan', 'table1.metric1': '17.49' },
+          { 'table1.eventTimeMonth': '2015 Feb', 'table1.metric1': '426.48' }
         ],
         meta: {}
       },
@@ -389,16 +395,16 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
         sorts: [],
         limit: null,
         requestVersion: '2.0',
-        dataSource: 'elideOne'
+        dataSource: 'elideTwo'
       },
-      { dataSourceName: 'elideOne' }
+      { dataSourceName: 'elideTwo' }
     );
     assert.deepEqual(
       noStartDateResponse.response,
       {
         rows: [
-          { 'table1.eventTimeMonth': '2014 Nov', 'table1.metric1': '38.56' },
-          { 'table1.eventTimeMonth': '2014 Dec', 'table1.metric1': '195.76' }
+          { 'table1.eventTimeMonth': '2014 Nov', 'table1.metric1': '17.49' },
+          { 'table1.eventTimeMonth': '2014 Dec', 'table1.metric1': '426.48' }
         ],
         meta: {}
       },
@@ -426,9 +432,9 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
         sorts: [],
         limit: null,
         requestVersion: '2.0',
-        dataSource: 'elideOne'
+        dataSource: 'elideTwo'
       },
-      { dataSourceName: 'elideOne' }
+      { dataSourceName: 'elideTwo' }
     );
 
     assert.deepEqual(
@@ -484,20 +490,29 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
         sorts: [{ field: 'table1.metric1', parameters: {}, type: 'metric', direction: 'asc' }],
         limit: null,
         requestVersion: '2.0',
-        dataSource: 'elideOne'
+        dataSource: 'elideTwo'
       },
-      { dataSourceName: 'elideOne' }
+      { dataSourceName: 'elideTwo' }
     );
 
     assert.deepEqual(
       response.response,
       {
+        meta: {},
         rows: [
-          { 'table1.eventTimeDay': '2015-01-02', 'table1.metric1': '139.22' },
-          { 'table1.eventTimeDay': '2015-01-03', 'table1.metric1': '464.10' },
-          { 'table1.eventTimeDay': '2015-01-01', 'table1.metric1': '944.50' }
-        ],
-        meta: {}
+          {
+            'table1.eventTimeDay': '2015-01-03',
+            'table1.metric1': '44.71'
+          },
+          {
+            'table1.eventTimeDay': '2015-01-02',
+            'table1.metric1': '327.11'
+          },
+          {
+            'table1.eventTimeDay': '2015-01-01',
+            'table1.metric1': '675.73'
+          }
+        ]
       },
       'Response is sorted as specified by the request'
     );
@@ -506,88 +521,88 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
       {
         table: 'table1',
         columns: [
-          { field: 'table1.dimension1', parameters: {}, type: 'dimension' },
           { field: 'table1.dimension2', parameters: {}, type: 'dimension' },
+          { field: 'table1.dimension3', parameters: {}, type: 'dimension' },
           { field: 'table1.metric1', parameters: {}, type: 'metric' }
         ],
         filters: [],
         sorts: [
-          { field: 'table1.dimension1', parameters: {}, type: 'metric', direction: 'asc' },
-          { field: 'table1.dimension2', parameters: {}, type: 'metric', direction: 'asc' }
+          { field: 'table1.dimension2', parameters: {}, type: 'metric', direction: 'asc' },
+          { field: 'table1.dimension3', parameters: {}, type: 'metric', direction: 'asc' }
         ],
         limit: null,
         requestVersion: '2.0',
-        dataSource: 'elideOne'
+        dataSource: 'elideTwo'
       },
-      { dataSourceName: 'elideOne' }
+      { dataSourceName: 'elideTwo' }
     );
 
     assert.deepEqual(
       multiSortResponse.response,
       {
+        meta: {},
         rows: [
           {
-            'table1.dimension1': 'Licensed Cotton Computer',
-            'table1.dimension2': 'Gorgeous Frozen Sausages',
-            'table1.metric1': '990.67'
+            'table1.dimension2': 'Handmade Rubber Fish',
+            'table1.dimension3': 'Awesome Cotton Sausages',
+            'table1.metric1': '913.34'
           },
           {
-            'table1.dimension1': 'Licensed Cotton Computer',
-            'table1.dimension2': 'Licensed Granite Sausages',
-            'table1.metric1': '825.82'
+            'table1.dimension2': 'Handmade Rubber Fish',
+            'table1.dimension3': 'Handcrafted Concrete Pizza',
+            'table1.metric1': '220.58'
           },
           {
-            'table1.dimension1': 'Licensed Cotton Computer',
-            'table1.dimension2': 'Sleek Metal Tuna',
-            'table1.metric1': '414.83'
+            'table1.dimension2': 'Handmade Rubber Fish',
+            'table1.dimension3': 'Small Metal Mouse',
+            'table1.metric1': '286.62'
           },
           {
-            'table1.dimension1': 'Refined Rubber Soap',
-            'table1.dimension2': 'Gorgeous Frozen Sausages',
-            'table1.metric1': '946.26'
+            'table1.dimension2': 'Handmade Rubber Fish',
+            'table1.dimension3': 'Unbranded Wooden Pizza',
+            'table1.metric1': '188.92'
           },
           {
-            'table1.dimension1': 'Refined Rubber Soap',
-            'table1.dimension2': 'Licensed Granite Sausages',
-            'table1.metric1': '247.63'
+            'table1.dimension2': 'Incredible Rubber Tuna',
+            'table1.dimension3': 'Awesome Cotton Sausages',
+            'table1.metric1': '403.35'
           },
           {
-            'table1.dimension1': 'Refined Rubber Soap',
-            'table1.dimension2': 'Sleek Metal Tuna',
-            'table1.metric1': '335.55'
+            'table1.dimension2': 'Incredible Rubber Tuna',
+            'table1.dimension3': 'Handcrafted Concrete Pizza',
+            'table1.metric1': '500.33'
           },
           {
-            'table1.dimension1': 'Sleek Cotton Shoes',
-            'table1.dimension2': 'Gorgeous Frozen Sausages',
-            'table1.metric1': '344.62'
+            'table1.dimension2': 'Incredible Rubber Tuna',
+            'table1.dimension3': 'Small Metal Mouse',
+            'table1.metric1': '131.54'
           },
           {
-            'table1.dimension1': 'Sleek Cotton Shoes',
-            'table1.dimension2': 'Licensed Granite Sausages',
-            'table1.metric1': '252.27'
+            'table1.dimension2': 'Incredible Rubber Tuna',
+            'table1.dimension3': 'Unbranded Wooden Pizza',
+            'table1.metric1': '441.55'
           },
           {
-            'table1.dimension1': 'Sleek Cotton Shoes',
-            'table1.dimension2': 'Sleek Metal Tuna',
-            'table1.metric1': '628.05'
+            'table1.dimension2': 'Licensed Concrete Fish',
+            'table1.dimension3': 'Awesome Cotton Sausages',
+            'table1.metric1': '528.84'
           },
           {
-            'table1.dimension1': 'Small Soft Bacon',
-            'table1.dimension2': 'Gorgeous Frozen Sausages',
-            'table1.metric1': '919.59'
+            'table1.dimension2': 'Licensed Concrete Fish',
+            'table1.dimension3': 'Handcrafted Concrete Pizza',
+            'table1.metric1': '992.46'
           },
           {
-            'table1.dimension1': 'Small Soft Bacon',
-            'table1.dimension2': 'Licensed Granite Sausages',
-            'table1.metric1': '469.79'
+            'table1.dimension2': 'Licensed Concrete Fish',
+            'table1.dimension3': 'Small Metal Mouse',
+            'table1.metric1': '337.40'
           },
           {
-            'table1.dimension1': 'Small Soft Bacon',
-            'table1.dimension2': 'Sleek Metal Tuna',
-            'table1.metric1': '233.23'
+            'table1.dimension2': 'Licensed Concrete Fish',
+            'table1.dimension3': 'Unbranded Wooden Pizza',
+            'table1.metric1': '974.83'
           }
-        ],
-        meta: {}
+        ]
       },
       'Multiple sorts are handled properly in order'
     );
@@ -622,20 +637,29 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
         sorts: [],
         limit: 3,
         requestVersion: '2.0',
-        dataSource: 'elideOne'
+        dataSource: 'elideTwo'
       },
-      { dataSourceName: 'elideOne' }
+      { dataSourceName: 'elideTwo' }
     );
 
     assert.deepEqual(
       response.response,
       {
+        meta: {},
         rows: [
-          { 'table1.eventTimeDay': '2015-01-01', 'table1.metric1': '384.77' },
-          { 'table1.eventTimeDay': '2015-01-02', 'table1.metric1': '897.01' },
-          { 'table1.eventTimeDay': '2015-01-03', 'table1.metric1': '859.71' }
-        ],
-        meta: {}
+          {
+            'table1.eventTimeDay': '2015-01-01',
+            'table1.metric1': '823.11'
+          },
+          {
+            'table1.eventTimeDay': '2015-01-02',
+            'table1.metric1': '823.38'
+          },
+          {
+            'table1.eventTimeDay': '2015-01-03',
+            'table1.metric1': '26.11'
+          }
+        ]
       },
       'Limit in the request determines the max number of rows returned'
     );
@@ -666,26 +690,53 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
         sorts: [],
         limit: null,
         requestVersion: '2.0',
-        dataSource: 'elideOne'
+        dataSource: 'elideTwo'
       },
-      { dataSourceName: 'elideOne' }
+      { dataSourceName: 'elideTwo' }
     );
 
     assert.deepEqual(
       limitless.response,
       {
+        meta: {},
         rows: [
-          { 'table1.eventTimeDay': '2015-01-01', 'table1.metric1': '858.89' },
-          { 'table1.eventTimeDay': '2015-01-02', 'table1.metric1': '59.65' },
-          { 'table1.eventTimeDay': '2015-01-03', 'table1.metric1': '372.71' },
-          { 'table1.eventTimeDay': '2015-01-04', 'table1.metric1': '421.04' },
-          { 'table1.eventTimeDay': '2015-01-05', 'table1.metric1': '555.13' },
-          { 'table1.eventTimeDay': '2015-01-06', 'table1.metric1': '330.39' },
-          { 'table1.eventTimeDay': '2015-01-07', 'table1.metric1': '955.66' },
-          { 'table1.eventTimeDay': '2015-01-08', 'table1.metric1': '754.00' },
-          { 'table1.eventTimeDay': '2015-01-09', 'table1.metric1': '736.67' }
-        ],
-        meta: {}
+          {
+            'table1.eventTimeDay': '2015-01-01',
+            'table1.metric1': '783.84'
+          },
+          {
+            'table1.eventTimeDay': '2015-01-02',
+            'table1.metric1': '258.04'
+          },
+          {
+            'table1.eventTimeDay': '2015-01-03',
+            'table1.metric1': '634.84'
+          },
+          {
+            'table1.eventTimeDay': '2015-01-04',
+            'table1.metric1': '684.22'
+          },
+          {
+            'table1.eventTimeDay': '2015-01-05',
+            'table1.metric1': '249.04'
+          },
+          {
+            'table1.eventTimeDay': '2015-01-06',
+            'table1.metric1': '917.34'
+          },
+          {
+            'table1.eventTimeDay': '2015-01-07',
+            'table1.metric1': '758.08'
+          },
+          {
+            'table1.eventTimeDay': '2015-01-08',
+            'table1.metric1': '204.93'
+          },
+          {
+            'table1.eventTimeDay': '2015-01-09',
+            'table1.metric1': '313.08'
+          }
+        ]
       },
       'A null limit in the request results in no row limit'
     );

--- a/packages/data/tests/unit/services/navi-metadata-test.ts
+++ b/packages/data/tests/unit/services/navi-metadata-test.ts
@@ -102,7 +102,14 @@ module('Unit | Service | navi-metadata', function(hooks) {
     );
     assert.deepEqual(
       dimensions.mapBy('id'),
-      ['dimension0', 'dimension1', 'dimension2', 'dimension3', 'dimension4'],
+      [
+        'table0.dimension0',
+        'table0.dimension1',
+        'table1.dimension2',
+        'table1.dimension3',
+        'table1.dimension4',
+        'table1.dimension5'
+      ],
       'All `elideOne` dimensions are loaded'
     );
 
@@ -113,7 +120,20 @@ module('Unit | Service | navi-metadata', function(hooks) {
     );
     assert.deepEqual(
       timeDimensions.mapBy('id'),
-      ['eventTimeHour', 'eventTimeDay', 'eventTimeWeek', 'eventTimeMonth', 'eventTimeQuarter', 'eventTimeYear'],
+      [
+        'table1.eventTimeHour',
+        'table1.orderTimeHour',
+        'table1.eventTimeDay',
+        'table1.orderTimeDay',
+        'table1.eventTimeWeek',
+        'table1.orderTimeWeek',
+        'table1.eventTimeMonth',
+        'table1.orderTimeMonth',
+        'table1.eventTimeQuarter',
+        'table1.orderTimeQuarter',
+        'table1.eventTimeYear',
+        'table1.orderTimeYear'
+      ],
       'All `elideOne` time dimensions are loaded'
     );
 
@@ -122,7 +142,11 @@ module('Unit | Service | navi-metadata', function(hooks) {
       metrics.every(metric => metric instanceof MetricMetadataModel),
       '`elideOne` `MetricMetadataModel`s are loaded into the keg'
     );
-    assert.deepEqual(metrics.mapBy('id'), ['metric0', 'metric1'], 'All `elideOne` metrics are loaded');
+    assert.deepEqual(
+      metrics.mapBy('id'),
+      ['table0.metric0', 'table1.metric1', 'table1.metric2'],
+      'All `elideOne` metrics are loaded'
+    );
 
     const columnFunctions = keg.all('metadata/columnFunction', 'elideOne');
     assert.ok(
@@ -189,7 +213,7 @@ module('Unit | Service | navi-metadata', function(hooks) {
     await this.service.loadMetadata({ dataSourceName: 'elideOne' });
     await this.service.loadMetadata({ dataSourceName: 'bardTwo' });
 
-    const metricOne = this.service.getById('metric', 'metric1', 'elideOne');
+    const metricOne = this.service.getById('metric', 'table1.metric1', 'elideOne');
     assert.ok(
       metricOne instanceof MetricMetadataModel,
       '`getById` returns a loaded instance of `MetricMetadataModel` when requesting `metric` type'


### PR DESCRIPTION
Closes #949 
Closes #948 

<!-- The above line will close the issue upon merge -->

## Description
We need to serialize dimension value payloads from the elide dimension adapter.

## Proposed Changes

- Add elide dimension serializer
- Update graphql handler to handle dimension value search
- Test navi-dimension-service using the graphql mocks

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
