### PR TITLE
Fix: GraphQL Metadata queries after API update

### DIFF
--- a/packages/data/addon/gql/fragments/table.ts
+++ b/packages/data/addon/gql/fragments/table.ts
@@ -51,7 +51,7 @@ const fragment = gql`
           columnTags
           columnType
           expression
-          supportedGrains {
+          supportedGrain {
             edges {
               node {
                 grain

--- a/packages/data/addon/gql/queries/table.ts
+++ b/packages/data/addon/gql/queries/table.ts
@@ -53,7 +53,7 @@ const query = gql`
                 columnTags
                 columnType
                 expression
-                supportedGrains {
+                supportedGrain {
                   edges {
                     node {
                       grain

--- a/packages/data/addon/gql/queries/tables.ts
+++ b/packages/data/addon/gql/queries/tables.ts
@@ -53,7 +53,7 @@ const query = gql`
                 columnTags
                 columnType
                 expression
-                supportedGrains {
+                supportedGrain {
                   edges {
                     node {
                       grain

--- a/packages/data/addon/gql/schema.js
+++ b/packages/data/addon/gql/schema.js
@@ -116,7 +116,7 @@ const schema = gql`
     columnTags: [String!]
     columnType: ColumnType
     expression: String
-    supportedGrains: TimeDimensionGrainConnnection
+    supportedGrain: TimeDimensionGrainConnnection
     timeZone: TimeZone
   }
 
@@ -133,6 +133,7 @@ const schema = gql`
   type TimeDimensionGrain implements Node {
     id: DeferredID!
     expression: String
+    format: String
     grain: TimeGrain
   }
 

--- a/packages/data/addon/serializers/metadata/elide.ts
+++ b/packages/data/addon/serializers/metadata/elide.ts
@@ -33,7 +33,7 @@ type ColumnNode = {
 export type MetricNode = ColumnNode & { defaultFormat: string };
 export type DimensionNode = ColumnNode;
 export type TimeDimensionNode = DimensionNode & {
-  supportedGrains: Connection<TimeDimensionGrainNode>;
+  supportedGrain: Connection<TimeDimensionGrainNode>;
   timeZone: string;
 };
 type TimeDimensionGrainNode = {
@@ -190,7 +190,7 @@ export default class ElideMetadataSerializer extends EmberObject implements Navi
         tableId,
         source,
         tags: node.columnTags,
-        supportedGrains: node.supportedGrains.edges.map(edge => edge.node),
+        supportedGrains: node.supportedGrain.edges.map(edge => edge.node),
         timeZone: node.timeZone,
         type: node.columnType,
         expression: node.expression

--- a/packages/data/tests/dummy/mirage/scenarios/elide-one.ts
+++ b/packages/data/tests/dummy/mirage/scenarios/elide-one.ts
@@ -19,7 +19,7 @@ export default function(server: any) {
           expression: null,
           grain: grain.toUpperCase()
         });
-        server.create('time-dimension', { id: idWithGrain, table, supportedGrains: [newGrain] });
+        server.create('time-dimension', { id: idWithGrain, table, supportedGrain: [newGrain] });
       });
     });
   });

--- a/packages/data/tests/dummy/mirage/scenarios/elide-two.ts
+++ b/packages/data/tests/dummy/mirage/scenarios/elide-two.ts
@@ -21,7 +21,7 @@ export default function(server: any) {
           expression: null,
           grain: grain.toUpperCase()
         });
-        server.create('time-dimension', { id: idWithGrain, table, supportedGrains: [newGrain] });
+        server.create('time-dimension', { id: idWithGrain, table, supportedGrain: [newGrain] });
       });
     });
   });

--- a/packages/data/tests/unit/serializers/metadata/elide-test.ts
+++ b/packages/data/tests/unit/serializers/metadata/elide-test.ts
@@ -90,7 +90,7 @@ module('Unit | Serializer | metadata/elide', function(hooks) {
                       category: 'cat1',
                       valueType: 'DATE',
                       columnTags: ['IMPORTANT'],
-                      supportedGrains: {
+                      supportedGrain: {
                         edges: [
                           { node: { id: 'day', grain: 'DAY', expression: '' }, cursor: '' },
                           { node: { id: 'week', grain: 'WEEK', expression: '' }, cursor: '' }
@@ -497,7 +497,7 @@ module('Unit | Serializer | metadata/elide', function(hooks) {
             category: 'userDimensions',
             valueType: 'DATE',
             columnTags: ['DISPLAY'],
-            supportedGrains: {
+            supportedGrain: {
               edges: [
                 { node: { id: 'day', grain: 'DAY', expression: '' }, cursor: '' },
                 { node: { id: 'week', grain: 'WEEK', expression: '' }, cursor: '' },
@@ -519,7 +519,7 @@ module('Unit | Serializer | metadata/elide', function(hooks) {
             category: 'userDimensions',
             valueType: 'DATE',
             columnTags: ['DISPLAY'],
-            supportedGrains: {
+            supportedGrain: {
               edges: [{ node: { id: 'month', grain: 'MONTH', expression: '' }, cursor: '' }],
               pageInfo: []
             },


### PR DESCRIPTION
## Description
Elide updated its schema for metadata recently

## Proposed Changes

- `supportedGrains` -> `supportedGrain`
Left it as an array as `supportedGrain` is still a collection in Elide

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
