### PR TITLE
Fix: Save-as custom title doesn't save

### DIFF
--- a/packages/reports/addon/components/report-actions/save-as.js
+++ b/packages/reports/addon/components/report-actions/save-as.js
@@ -12,6 +12,7 @@ import Component from '@ember/component';
 import layout from '../../templates/components/report-actions/save-as';
 import { action, set } from '@ember/object';
 import { layout as templateLayout, tagName } from '@ember-decorators/component';
+import { isBlank } from '@ember/utils';
 
 @templateLayout(layout)
 @tagName('')
@@ -22,10 +23,20 @@ export default class ReportActionSaveAs extends Component {
   showModal = false;
 
   /**
+   * @private
+   * @property {string} state holder for overriding default reportName
+   */
+  _reportTitle = '';
+
+  /**
    * @property {String} reportName - report name/title
    */
   get reportName() {
-    return `(New Copy) ${this.model.title}`.substring(0, 150);
+    return isBlank(this._reportTitle) ? `(New Copy) ${this.model.title}`.substring(0, 150) : this._reportTitle;
+  }
+
+  set reportName(value) {
+    this._reportTitle = value;
   }
 
   /**

--- a/packages/reports/tests/acceptance/report-test.js
+++ b/packages/reports/tests/acceptance/report-test.js
@@ -369,6 +369,44 @@ module('Acceptance | Navi Report', function(hooks) {
     assert.dom('.navi-report__title').hasText('Hyrule News', 'Old Report with unchanged title is being viewed.');
   });
 
+  test('Save As change title manually', async function(assert) {
+    assert.expect(6);
+    await visit('/reports/1');
+    // Change the Dim
+    await clickItem('timeGrain', 'Month');
+
+    // And click Save AS the report
+    await click('.navi-report__save-as-btn');
+
+    // The Modal with buttons is Visible
+    assert.dom('.save-as__save-as-modal-btn').isVisible('Save As Modal is visible with save as key');
+
+    //fill in new title
+    await fillIn('.navi-modal .text-input.dashboard-title', 'Title of Hyrule');
+
+    // Press the save as
+    await click('.save-as__save-as-modal-btn');
+
+    assert.ok(!!$('.filter-builder__subject:contains(Month)').length, 'The new Dim is shown in the new report.');
+
+    // New Report is run
+    let emberId = find('.report-view.ember-view').id,
+      component = this.owner.lookup('-view-registry:main')[emberId];
+    assert.equal(
+      component.get('report.visualization.type'),
+      'table',
+      'Report has a valid visualization type after running then reverting.'
+    );
+
+    assert.dom('.navi-report__title').hasText('Title of Hyrule', 'New Saved Report is being viewed');
+
+    await visit('/reports/1');
+
+    assert.ok(!!$('.filter-builder__subject:contains(Day)').length, 'Old unsaved report have the old DIM.');
+
+    assert.dom('.navi-report__title').hasText('Hyrule News', 'Old Report with unchanged title is being viewed.');
+  });
+
   test('Save As on failure', async function(assert) {
     assert.expect(3);
 


### PR DESCRIPTION
<!-- The above line will close the issue upon merge -->

## Description

Noticed that changing title in save as modal, still creates a report of `(Copy Of) Old Title` regardless of changes.

## Proposed Changes

- The value bound to Input just has a getter that returns default.
- Added setter and private state variable to override default value in getter.
- Added test to catch this misbehavior in the future.

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
