### PR TITLE
Elide time dimension col funcs

### DIFF
--- a/packages/data/addon/gql/fragments/table.ts
+++ b/packages/data/addon/gql/fragments/table.ts
@@ -20,7 +20,6 @@ const fragment = gql`
           category
           valueType
           columnTags
-          defaultFormat
           columnType
           expression
         }
@@ -58,7 +57,6 @@ const fragment = gql`
               }
             }
           }
-          timeZone
         }
       }
     }

--- a/packages/data/addon/gql/queries/table.ts
+++ b/packages/data/addon/gql/queries/table.ts
@@ -3,70 +3,19 @@
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import gql from 'graphql-tag';
+import TableFragment from '../fragments/table';
 
 const query = gql`
   query($ids: [String!]) {
     table(ids: $ids) {
       edges {
         node {
-          id
-          name
-          description
-          category
-          cardinality
-          metrics {
-            edges {
-              node {
-                id
-                name
-                description
-                category
-                valueType
-                columnTags
-                columnType
-                expression
-              }
-            }
-          }
-          dimensions {
-            edges {
-              node {
-                id
-                name
-                description
-                category
-                valueType
-                columnTags
-                columnType
-                expression
-              }
-            }
-          }
-          timeDimensions {
-            edges {
-              node {
-                id
-                name
-                description
-                category
-                valueType
-                columnTags
-                columnType
-                expression
-                supportedGrain {
-                  edges {
-                    node {
-                      grain
-                    }
-                  }
-                }
-              }
-            }
-          }
+          ...TableFragment
         }
       }
     }
   }
+  ${TableFragment}
 `;
 
 export default query;

--- a/packages/data/addon/gql/queries/tables.ts
+++ b/packages/data/addon/gql/queries/tables.ts
@@ -3,70 +3,19 @@
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import gql from 'graphql-tag';
+import TableFragment from '../fragments/table';
 
 const query = gql`
   query {
     table {
       edges {
         node {
-          id
-          name
-          description
-          category
-          cardinality
-          metrics {
-            edges {
-              node {
-                id
-                name
-                description
-                category
-                valueType
-                columnTags
-                columnType
-                expression
-              }
-            }
-          }
-          dimensions {
-            edges {
-              node {
-                id
-                name
-                description
-                category
-                valueType
-                columnTags
-                columnType
-                expression
-              }
-            }
-          }
-          timeDimensions {
-            edges {
-              node {
-                id
-                name
-                description
-                category
-                valueType
-                columnTags
-                columnType
-                expression
-                supportedGrain {
-                  edges {
-                    node {
-                      grain
-                    }
-                  }
-                }
-              }
-            }
-          }
+          ...TableFragment
         }
       }
     }
   }
+  ${TableFragment}
 `;
 
 export default query;

--- a/packages/data/addon/mirage/factories/time-dimension-grain.js
+++ b/packages/data/addon/mirage/factories/time-dimension-grain.js
@@ -4,14 +4,4 @@
  */
 import { Factory } from 'ember-cli-mirage';
 
-export default Factory.extend({
-  index: i => i,
-
-  id() {
-    return `timeDimensionGrain${this.index}`;
-  },
-
-  expression: null,
-
-  grain: 'DAY'
-});
+export default Factory.extend({});

--- a/packages/data/addon/mirage/handlers/graphql.js
+++ b/packages/data/addon/mirage/handlers/graphql.js
@@ -418,6 +418,32 @@ function _getResponseBody(db, parent) {
 
 const OPTIONS = {
   fieldsMap: {
+    TimeDimension: {
+      supportedGrain(resolved, db, parent) {
+        // ember-cli-mirage-graphql fails to fetch the correct grain for some reason, so we do it manually here
+        const fields = Object.keys(resolved[0].edges[0].node);
+        const correctGrain = db.timeDimensionGrains.find(parent.supportedGrain[0].id);
+        const record = fields.reduce((obj, field) => {
+          obj[field] = correctGrain[field];
+          return obj;
+        }, {});
+
+        return [
+          {
+            __typename: 'TimeDimensionGrainConnection',
+            edges: [
+              {
+                __typename: 'TimeDimensionGrainEdge',
+                node: {
+                  ...record,
+                  __typename: 'TimeDimensionGrain'
+                }
+              }
+            ]
+          }
+        ];
+      }
+    },
     AsyncQuery: {
       result(_, db, parent) {
         return {

--- a/packages/data/addon/serializers/metadata/elide.ts
+++ b/packages/data/addon/serializers/metadata/elide.ts
@@ -3,13 +3,17 @@
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import EmberObject from '@ember/object';
+import config from 'ember-get-config';
 import CARDINALITY_SIZES from '../../utils/enums/cardinality-sizes';
+import { ColumnFunctionMetadataPayload } from '../../models/metadata/column-function';
 import { ColumnType } from '../../models/metadata/column';
 import { TableMetadataPayload } from '../../models/metadata/table';
 import { MetricMetadataPayload } from '../../models/metadata/metric';
 import { DimensionMetadataPayload } from '../../models/metadata/dimension';
 import { TimeDimensionMetadataPayload } from '../../models/metadata/time-dimension';
 import NaviMetadataSerializer, { MetadataPayloadMap, EverythingMetadataPayload } from './interface';
+import { upperFirst } from 'lodash-es';
+import { INTRINSIC_VALUE_EXPRESSION } from 'navi-data/models/metadata/function-parameter';
 import { assert } from '@ember/debug';
 
 type Edge<T> = {
@@ -36,7 +40,7 @@ export type TimeDimensionNode = DimensionNode & {
   supportedGrain: Connection<TimeDimensionGrainNode>;
   timeZone: string;
 };
-type TimeDimensionGrainNode = {
+export type TimeDimensionGrainNode = {
   id: string;
   expression: string;
   grain: string;
@@ -57,6 +61,8 @@ export interface TablePayload {
 }
 
 export default class ElideMetadataSerializer extends EmberObject implements NaviMetadataSerializer {
+  private namespace = 'normalizer-generated';
+
   /**
    * Transform the elide metadata into a shape that our internal data models can use
    * @private
@@ -70,6 +76,7 @@ export default class ElideMetadataSerializer extends EmberObject implements Navi
     let metrics: MetricMetadataPayload[] = [];
     let dimensions: DimensionMetadataPayload[] = [];
     let timeDimensions: TimeDimensionMetadataPayload[] = [];
+    let columnFunctions: ColumnFunctionMetadataPayload[] = [];
 
     const tables = edges.map(({ node: table }) => {
       const newTable: TableMetadataPayload = {
@@ -86,15 +93,22 @@ export default class ElideMetadataSerializer extends EmberObject implements Navi
 
       const newTableMetrics = this._normalizeTableMetrics(table.metrics, table.id, source);
       const newTableDimensions = this._normalizeTableDimensions(table.dimensions, table.id, source);
-      const newTableTimeDimensions = this._normalizeTableTimeDimensions(table.timeDimensions, table.id, source);
+      const newTableTimeDimensionsAndColFuncs = this._normalizeTableTimeDimensions(
+        table.timeDimensions,
+        table.id,
+        source
+      );
+      const newTableTimeDimensions = newTableTimeDimensionsAndColFuncs.map(obj => obj.timeDimension);
+      const newTableTimeDimensionColFuncs = newTableTimeDimensionsAndColFuncs.map(obj => obj.columnFunction);
 
       newTable.metricIds = newTableMetrics.map(m => m.id);
       newTable.dimensionIds = newTableDimensions.map(d => d.id);
       newTable.timeDimensionIds = newTableTimeDimensions.map(d => d.id);
 
-      metrics = metrics.concat(newTableMetrics);
-      dimensions = dimensions.concat(newTableDimensions);
-      timeDimensions = timeDimensions.concat(newTableTimeDimensions);
+      metrics = [...metrics, ...newTableMetrics];
+      dimensions = [...dimensions, ...newTableDimensions];
+      timeDimensions = [...timeDimensions, ...newTableTimeDimensions];
+      columnFunctions = [...columnFunctions, ...newTableTimeDimensionColFuncs];
 
       return newTable;
     });
@@ -103,8 +117,8 @@ export default class ElideMetadataSerializer extends EmberObject implements Navi
       tables,
       metrics,
       dimensions,
-      timeDimensions
-      // TODO: Support metric functions once it is supported by Elide
+      timeDimensions,
+      columnFunctions
     };
   }
 
@@ -178,24 +192,75 @@ export default class ElideMetadataSerializer extends EmberObject implements Navi
     timeDimensionConnection: Connection<TimeDimensionNode>,
     tableId: string,
     source: string
-  ): TimeDimensionMetadataPayload[] {
+  ): { timeDimension: TimeDimensionMetadataPayload; columnFunction: ColumnFunctionMetadataPayload }[] {
     return timeDimensionConnection.edges.map((edge: Edge<TimeDimensionNode>) => {
       const { node } = edge;
+      const supportedGrains = node.supportedGrain.edges.map(edge => edge.node);
+      const columnFunction = this.createTimeGrainColumnFunction(node.id, supportedGrains, source);
       return {
-        id: node.id,
-        name: node.name,
-        description: node.description,
-        category: node.category,
-        valueType: node.valueType,
-        tableId,
-        source,
-        tags: node.columnTags,
-        supportedGrains: node.supportedGrain.edges.map(edge => edge.node),
-        timeZone: node.timeZone,
-        type: node.columnType,
-        expression: node.expression
+        timeDimension: {
+          id: node.id,
+          name: node.name,
+          description: node.description,
+          category: node.category,
+          valueType: node.valueType,
+          tableId,
+          columnFunctionId: columnFunction.id,
+          source,
+          tags: node.columnTags,
+          supportedGrains: node.supportedGrain.edges.map(edge => edge.node),
+          timeZone: node.timeZone,
+          type: node.columnType,
+          expression: node.expression
+        },
+        columnFunction
       };
     });
+  }
+
+  /**
+   * @param timeDimensionId
+   * @param grainNodes
+   * @param dataSourceName
+   * @returns new column function with the supported grains as parameters
+   */
+  private createTimeGrainColumnFunction(
+    timeDimensionId: string,
+    grainNodes: TimeDimensionGrainNode[],
+    dataSourceName: string
+  ): ColumnFunctionMetadataPayload {
+    const grainIds = grainNodes.map(g => g.grain.toLowerCase());
+    const grains = grainIds.sort().join(',');
+    const columnFunctionId = `${this.namespace}:timeGrain(column=${timeDimensionId};grains=${grains})`;
+    let defaultValue;
+    const { defaultTimeGrain } = config.navi;
+    if (defaultTimeGrain && grainIds.includes(defaultTimeGrain)) {
+      defaultValue = defaultTimeGrain;
+    } else {
+      defaultValue = grainIds[0];
+    }
+    return {
+      id: columnFunctionId,
+      name: 'Time Grain',
+      source: dataSourceName,
+      description: 'Time Grain',
+      _parametersPayload: [
+        {
+          id: 'grain',
+          name: 'Time Grain',
+          description: 'The time grain to group dates by',
+          source: dataSourceName,
+          type: 'ref',
+          expression: INTRINSIC_VALUE_EXPRESSION,
+          defaultValue,
+          _localValues: grainNodes.map(grain => ({
+            id: grain.id,
+            description: upperFirst(grain.grain.toLowerCase()),
+            name: grain.grain.toLowerCase()
+          }))
+        }
+      ]
+    };
   }
 
   private supportedTypes = new Set<keyof MetadataPayloadMap>(['everything']);

--- a/packages/data/tests/unit/services/navi-metadata-test.ts
+++ b/packages/data/tests/unit/services/navi-metadata-test.ts
@@ -72,7 +72,7 @@ module('Unit | Service | navi-metadata', function(hooks) {
       'All `bardTwo` metrics are loaded'
     );
 
-    const columnFunctions = keg.all('metadata/columnFunction', 'elideOne');
+    const columnFunctions = keg.all('metadata/columnFunction', 'elideTwo');
     assert.ok(
       columnFunctions.every(fn => fn instanceof ColumnFunctionMetadataModel),
       '`bardTwo` `ColumnFunctionMetadataModel`s are loaded into the keg'
@@ -85,20 +85,20 @@ module('Unit | Service | navi-metadata', function(hooks) {
   test('loadMetadata - elide', async function(this: Context, assert) {
     const keg = this.service['keg'];
 
-    assert.equal(this.service.loadedDataSources.size, 0, '`elideOne` data source is initially not loaded');
-    await this.service.loadMetadata({ dataSourceName: 'elideOne' });
+    assert.equal(this.service.loadedDataSources.size, 0, '`elideTwo` data source is initially not loaded');
+    await this.service.loadMetadata({ dataSourceName: 'elideTwo' });
 
-    const tables = keg.all('metadata/table', 'elideOne');
+    const tables = keg.all('metadata/table', 'elideTwo');
     assert.ok(
       tables.every(table => table instanceof TableMetadataModel),
-      '`elideOne` `TableMetadataModel`s are loaded into the keg'
+      '`elideTwo` `TableMetadataModel`s are loaded into the keg'
     );
-    assert.deepEqual(tables.mapBy('id'), ['table0', 'table1'], 'All `elideOne` tables are loaded');
+    assert.deepEqual(tables.mapBy('id'), ['table0', 'table1'], 'All `elideTwo` tables are loaded');
 
-    const dimensions = keg.all('metadata/dimension', 'elideOne');
+    const dimensions = keg.all('metadata/dimension', 'elideTwo');
     assert.ok(
       dimensions.every(dim => dim instanceof DimensionMetadataModel),
-      '`elideOne` `DimensionMetadataModel`s are loaded into the keg'
+      '`elideTwo` `DimensionMetadataModel`s are loaded into the keg'
     );
     assert.deepEqual(
       dimensions.mapBy('id'),
@@ -110,13 +110,13 @@ module('Unit | Service | navi-metadata', function(hooks) {
         'table1.dimension4',
         'table1.dimension5'
       ],
-      'All `elideOne` dimensions are loaded'
+      'All `elideTwo` dimensions are loaded'
     );
 
-    const timeDimensions = keg.all('metadata/timeDimension', 'elideOne');
+    const timeDimensions = keg.all('metadata/timeDimension', 'elideTwo');
     assert.ok(
       timeDimensions.every(dim => dim instanceof TimeDimensionMetadataModel),
-      '`elideOne` `TimeDimensionMetadataModel`s are loaded into the keg'
+      '`elideTwo` `TimeDimensionMetadataModel`s are loaded into the keg'
     );
     assert.deepEqual(
       timeDimensions.mapBy('id'),
@@ -134,28 +134,45 @@ module('Unit | Service | navi-metadata', function(hooks) {
         'table1.eventTimeYear',
         'table1.orderTimeYear'
       ],
-      'All `elideOne` time dimensions are loaded'
+      'All `elideTwo` time dimensions are loaded'
     );
 
-    const metrics = keg.all('metadata/metric', 'elideOne');
+    const metrics = keg.all('metadata/metric', 'elideTwo');
     assert.ok(
       metrics.every(metric => metric instanceof MetricMetadataModel),
-      '`elideOne` `MetricMetadataModel`s are loaded into the keg'
+      '`elideTwo` `MetricMetadataModel`s are loaded into the keg'
     );
     assert.deepEqual(
       metrics.mapBy('id'),
       ['table0.metric0', 'table1.metric1', 'table1.metric2'],
-      'All `elideOne` metrics are loaded'
+      'All `elideTwo` metrics are loaded'
     );
 
-    const columnFunctions = keg.all('metadata/columnFunction', 'elideOne');
+    const columnFunctions = keg.all('metadata/columnFunction', 'elideTwo');
     assert.ok(
       columnFunctions.every(fn => fn instanceof ColumnFunctionMetadataModel),
-      '`elideOne` `ColumnFunctionMetadataModel`s are loaded into the keg'
+      '`elideTwo` `ColumnFunctionMetadataModel`s are loaded into the keg'
     );
-    assert.deepEqual(columnFunctions.mapBy('id'), [], 'All `elideOne` column functions are loaded');
+    assert.deepEqual(
+      columnFunctions.mapBy('id'),
+      [
+        'normalizer-generated:timeGrain(column=table1.eventTimeHour;grains=hour)',
+        'normalizer-generated:timeGrain(column=table1.orderTimeHour;grains=hour)',
+        'normalizer-generated:timeGrain(column=table1.eventTimeDay;grains=day)',
+        'normalizer-generated:timeGrain(column=table1.orderTimeDay;grains=day)',
+        'normalizer-generated:timeGrain(column=table1.eventTimeWeek;grains=week)',
+        'normalizer-generated:timeGrain(column=table1.orderTimeWeek;grains=week)',
+        'normalizer-generated:timeGrain(column=table1.eventTimeMonth;grains=month)',
+        'normalizer-generated:timeGrain(column=table1.orderTimeMonth;grains=month)',
+        'normalizer-generated:timeGrain(column=table1.eventTimeQuarter;grains=quarter)',
+        'normalizer-generated:timeGrain(column=table1.orderTimeQuarter;grains=quarter)',
+        'normalizer-generated:timeGrain(column=table1.eventTimeYear;grains=year)',
+        'normalizer-generated:timeGrain(column=table1.orderTimeYear;grains=year)'
+      ],
+      'All `elideTwo` column functions are loaded'
+    );
 
-    assert.ok(this.service.loadedDataSources.has('elideOne'), '`elideOne` data source is loaded');
+    assert.ok(this.service.loadedDataSources.has('elideTwo'), '`elideTwo` data source is loaded');
   });
 
   test('loadMetadata - default data source', async function(this: Context, assert) {
@@ -183,13 +200,13 @@ module('Unit | Service | navi-metadata', function(hooks) {
 
   test('all', async function(this: Context, assert) {
     await this.service.loadMetadata({ dataSourceName: 'bardTwo' });
-    await this.service.loadMetadata({ dataSourceName: 'elideOne' });
+    await this.service.loadMetadata({ dataSourceName: 'elideTwo' });
 
     const bardTwoTables = this.service.all('table', 'bardTwo');
     assert.deepEqual(bardTwoTables.mapBy('id'), ['inventory'], '`all` returns all `bardTwo` tables');
 
-    const elideOneTables = this.service.all('table', 'elideOne');
-    assert.deepEqual(elideOneTables.mapBy('id'), ['table0', 'table1'], '`all` return all `elideOne` tables');
+    const elideTwoTables = this.service.all('table', 'elideTwo');
+    assert.deepEqual(elideTwoTables.mapBy('id'), ['table0', 'table1'], '`all` return all `elideTwo` tables');
 
     const allTables = this.service.all('table');
     assert.deepEqual(
@@ -210,10 +227,10 @@ module('Unit | Service | navi-metadata', function(hooks) {
   });
 
   test('getById', async function(this: Context, assert) {
-    await this.service.loadMetadata({ dataSourceName: 'elideOne' });
+    await this.service.loadMetadata({ dataSourceName: 'elideTwo' });
     await this.service.loadMetadata({ dataSourceName: 'bardTwo' });
 
-    const metricOne = this.service.getById('metric', 'table1.metric1', 'elideOne');
+    const metricOne = this.service.getById('metric', 'table1.metric1', 'elideTwo');
     assert.ok(
       metricOne instanceof MetricMetadataModel,
       '`getById` returns a loaded instance of `MetricMetadataModel` when requesting `metric` type'
@@ -236,7 +253,7 @@ module('Unit | Service | navi-metadata', function(hooks) {
 
   test('fetchById - elide', async function(this: Context, assert) {
     assert.rejects(
-      this.service.fetchById('metric', 'metric1', 'elideOne'),
+      this.service.fetchById('metric', 'metric1', 'elideTwo'),
       /Type requested in ElideMetadataAdapter must be defined as a query in the gql\/metadata-queries.js file/,
       '`fetchById` elide throws an error if attempting to get a model by id'
     );


### PR DESCRIPTION
Resolves #977 

<!-- The above line will close the issue upon merge -->

## Description
We need a columnFunction for each time dimension so that the metadata has a uniform property for its supported grains regardless of what the data source is

## Proposed Changes

- add createTimeGrainColumnFunction to elide metadata serializer
- add custom handler to mirage graphql config for timeDimensionGrains since the addon can't do it properly
- bring fragments back to the graphql table queries because they're supported now by elide

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
