### PR TITLE
Update: Publish beta webservice to artifactory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,8 +73,7 @@ jobs:
       node_js: '8'
       name: 'NPM'
       script: bash ./scripts/npm-publish.sh
-    - stage: 'Publish'
-      if: branch = request-v2 AND repo = yahoo/navi AND type = push
+    - if: branch = request-v2 AND repo = yahoo/navi AND type = push
       node_js: '8'
       name: 'NPM Beta'
       script: bash ./scripts/npm-publish-beta.sh
@@ -90,3 +89,7 @@ jobs:
       name: 'Artifactory'
       node_js: '8'
       if: branch = master AND repo = yahoo/navi AND type = push
+    - if: branch = request-v2 AND repo = yahoo/navi AND type = push
+      node_js: '8'
+      name: 'Artifactory Beta'
+      script: bash ./scripts/artifactory-publish-beta.sh

--- a/packages/webservice/models/build.gradle.kts
+++ b/packages/webservice/models/build.gradle.kts
@@ -70,7 +70,11 @@ publishing {
 
 gradle.taskGraph.whenReady {
     if (hasTask(":models:artifactoryPublish")) {
-        version = "$version-SNAPSHOT"
+        var tag = ""
+        if(project.hasProperty("publishTag")) {
+            tag = "-${project.property("publishTag")}"
+        }
+        version = "${version}${tag}-SNAPSHOT"
         println("Overriding version as $version for artifactory")
     }
 }

--- a/scripts/artifactory-publish-beta.sh
+++ b/scripts/artifactory-publish-beta.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e # Exit with nonzero exit code if anything fails
+
+echo 'Deploying navi webservice models to artifactory'
+
+cd packages/webservice
+
+./gradlew -PpublishTag=beta -p models artifactoryPublish


### PR DESCRIPTION
Resolves #994 

## Description
Upcoming cid change in #982 will only be visible on the `request-v2` branch which does not get published

## Proposed Changes
- set up extra publishing step for `request-v2` only as `0.2.0-beta-SNAPSHOT`


## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
