### PR TITLE
Fix: Build npm install taking a bit o time.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
   - if [[ "${PACKAGE}" == "navi-webservice" ]]; then
     pushd packages/webservice && ./gradlew assemble && popd;
     else
-    npm ci;
+    travis_wait npm ci;
     fi
 script:
   - if [[ "${PACKAGE}" != "navi-app" && "${PACKAGE}" != "navi-webservice" ]]; then


### PR DESCRIPTION
## Description

npm ci be taking it's time timing out the output wait in travis

## Proposed Changes

- add travis_wait to npm ci

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
