### PR TITLE
Elide "bet" operator

### DIFF
--- a/packages/data/addon/adapters/facts/elide.ts
+++ b/packages/data/addon/adapters/facts/elide.ts
@@ -66,7 +66,7 @@ export default class ElideFactsAdapter extends EmberObject implements NaviFactAd
 
       // TODO: Remove this when Elide supports the "between" filter operator
       if (operator === 'bet') {
-        return `${fieldStr}=ge=(${values[0]});${fieldStr}=lt=(${values[1]})`;
+        return `${fieldStr}=ge=(${values[0]});${fieldStr}=le=(${values[1]})`;
       }
 
       const operatorStr = OPERATOR_MAP[operator] || `=${operator}=`;

--- a/packages/data/addon/adapters/facts/elide.ts
+++ b/packages/data/addon/adapters/facts/elide.ts
@@ -63,6 +63,12 @@ export default class ElideFactsAdapter extends EmberObject implements NaviFactAd
     const filterStrings = filters.map(filter => {
       const { field, parameters, operator, values } = filter;
       const fieldStr = getElideField(field, parameters);
+
+      // TODO: Remove this when Elide supports the "between" filter operator
+      if (operator === 'bet') {
+        return `${fieldStr}=ge=(${values[0]});${fieldStr}=lt=(${values[1]})`;
+      }
+
       const operatorStr = OPERATOR_MAP[operator] || `=${operator}=`;
       const valuesStr = `(${values.join(',')})`;
       return `${fieldStr}${operatorStr}${valuesStr}`;

--- a/packages/data/tests/unit/adapters/facts/elide-test.ts
+++ b/packages/data/tests/unit/adapters/facts/elide-test.ts
@@ -145,6 +145,27 @@ module('Unit | Adapter | facts/elide', function(hooks) {
       `{"query":"{ myTable(first: \\"5\\") { edges { node { m1(p: q) d1 } } } }"}`,
       'Request with limit is queried correctly'
     );
+
+    assert.equal(
+      adapter['dataQueryFromRequest']({
+        table: 'myTable',
+        columns: [
+          { field: 'myTable.m1', parameters: { p: 'q' }, type: 'metric' },
+          { field: 'myTable.d1', parameters: {}, type: 'dimension' }
+        ],
+        sorts: [],
+        filters: [
+          { field: 'myTable.m1', parameters: { p: 'q' }, type: 'metric', operator: 'bet', values: ['v1', 'v2'] },
+        ],
+        requestVersion: '2.0',
+        dataSource: 'elideOne',
+        limit: null
+      }),
+      escapeQuotes(
+        `{"query":"{ myTable(filter: \\"m1(p: q)=ge=(v1);m1(p: q)=lt=(v2)\\") { edges { node { m1(p: q) d1 } } } }"}`
+      ),
+      'Request with "between" filter operator splits the filter into two correctly'
+    );
   });
 
   test('createAsyncQuery - success', async function(assert) {

--- a/packages/data/tests/unit/adapters/facts/elide-test.ts
+++ b/packages/data/tests/unit/adapters/facts/elide-test.ts
@@ -162,7 +162,7 @@ module('Unit | Adapter | facts/elide', function(hooks) {
         limit: null
       }),
       escapeQuotes(
-        `{"query":"{ myTable(filter: \\"m1(p: q)=ge=(v1);m1(p: q)=lt=(v2)\\") { edges { node { m1(p: q) d1 } } } }"}`
+        `{"query":"{ myTable(filter: \\"m1(p: q)=ge=(v1);m1(p: q)=le=(v2)\\") { edges { node { m1(p: q) d1 } } } }"}`
       ),
       'Request with "between" filter operator splits the filter into two correctly'
     );

--- a/packages/data/tests/unit/adapters/facts/elide-test.ts
+++ b/packages/data/tests/unit/adapters/facts/elide-test.ts
@@ -155,7 +155,7 @@ module('Unit | Adapter | facts/elide', function(hooks) {
         ],
         sorts: [],
         filters: [
-          { field: 'myTable.m1', parameters: { p: 'q' }, type: 'metric', operator: 'bet', values: ['v1', 'v2'] },
+          { field: 'myTable.m1', parameters: { p: 'q' }, type: 'metric', operator: 'bet', values: ['v1', 'v2'] }
         ],
         requestVersion: '2.0',
         dataSource: 'elideOne',

--- a/packages/data/tests/unit/adapters/facts/elide-test.ts
+++ b/packages/data/tests/unit/adapters/facts/elide-test.ts
@@ -161,9 +161,7 @@ module('Unit | Adapter | facts/elide', function(hooks) {
         dataSource: 'elideOne',
         limit: null
       }),
-      escapeQuotes(
-        `{"query":"{ myTable(filter: \\"m1(p: q)=ge=(v1);m1(p: q)=le=(v2)\\") { edges { node { m1(p: q) d1 } } } }"}`
-      ),
+      `{"query":"{ myTable(filter: \\"m1(p: q)=ge=(v1);m1(p: q)=le=(v2)\\") { edges { node { m1(p: q) d1 } } } }"}`,
       'Request with "between" filter operator splits the filter into two correctly'
     );
   });


### PR DESCRIPTION
Resolves #995 

<!-- The above line will close the issue upon merge -->

## Description
The between operator is not currently supported by Elide.

## Proposed Changes

- Split a filter with "bet" as the operator into two filters of `>= ${v1}` and `< ${v2}`

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
