### PR TITLE
Fix: Missing dependent key in base cell renderer

### DIFF
--- a/packages/core/addon/components/navi-cell-renderers/base.ts
+++ b/packages/core/addon/components/navi-cell-renderers/base.ts
@@ -18,7 +18,7 @@ export default class BaseCellRenderer extends Component<CellRendererArgs> {
   /**
    * value of the column
    */
-  @computed('args.column.fragment.canonicalName')
+  @computed('args.{data,column.fragment.canonicalName}')
   get columnValue() {
     const { column, data } = this.args;
     const { canonicalName } = column.fragment;


### PR DESCRIPTION
Resolves #1037 

<!-- The above line will close the issue upon merge -->

## Description
Table occlusion was causing cells to reorder on scroll because cells weren't updating when their data changed, only when their canonical name changed

## Proposed Changes

- Update cell renderer value to update when data argument changes

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
