### PR TITLE
Update: Change columnTags to tags in metadata schema

### DIFF
--- a/packages/data/addon/gql/fragments/table.ts
+++ b/packages/data/addon/gql/fragments/table.ts
@@ -19,7 +19,7 @@ const fragment = gql`
           description
           category
           valueType
-          columnTags
+          tags
           columnType
           expression
         }
@@ -33,7 +33,7 @@ const fragment = gql`
           description
           category
           valueType
-          columnTags
+          tags
           columnType
           expression
         }
@@ -47,7 +47,7 @@ const fragment = gql`
           description
           category
           valueType
-          columnTags
+          tags
           columnType
           expression
           supportedGrain {

--- a/packages/data/addon/gql/schema.js
+++ b/packages/data/addon/gql/schema.js
@@ -75,7 +75,7 @@ const schema = gql`
     table: Table
     category: String
     valueType: com_yahoo_elide_datastores_aggregation_metadata_enums_ValueType
-    columnTags: [String!]
+    tags: [String!]
     columnType: ColumnType
     expression: String
   }
@@ -87,7 +87,7 @@ const schema = gql`
     table: Table
     category: String
     valueType: com_yahoo_elide_datastores_aggregation_metadata_enums_ValueType
-    columnTags: [String!]
+    tags: [String!]
     defaultFormat: String
     metricFunction: metricFunction
     columnType: ColumnType
@@ -101,7 +101,7 @@ const schema = gql`
     table: Table
     category: String
     valueType: com_yahoo_elide_datastores_aggregation_metadata_enums_ValueType
-    columnTags: [String!]
+    tags: [String!]
     columnType: ColumnType
     expression: String
   }
@@ -113,7 +113,7 @@ const schema = gql`
     table: Table
     category: String
     valueType: com_yahoo_elide_datastores_aggregation_metadata_enums_ValueType
-    columnTags: [String!]
+    tags: [String!]
     columnType: ColumnType
     expression: String
     supportedGrain: TimeDimensionGrainConnnection

--- a/packages/data/addon/mirage/factories/dimension.js
+++ b/packages/data/addon/mirage/factories/dimension.js
@@ -24,7 +24,7 @@ export default Factory.extend({
 
   valueType: 'TEXT',
 
-  columnTags: () => ['DISPLAY'],
+  tags: () => ['DISPLAY'],
 
   columnType: 'field',
 

--- a/packages/data/addon/mirage/factories/metric.js
+++ b/packages/data/addon/mirage/factories/metric.js
@@ -24,7 +24,7 @@ export default Factory.extend({
 
   valueType: 'NUMBER',
 
-  columnTags: () => ['DISPLAY'],
+  tags: () => ['DISPLAY'],
 
   defaultFormat: 'number',
 

--- a/packages/data/addon/mirage/factories/time-dimension.js
+++ b/packages/data/addon/mirage/factories/time-dimension.js
@@ -24,7 +24,7 @@ export default Factory.extend({
 
   valueType: 'TIME',
 
-  columnTags: () => ['DISPLAY'],
+  tags: () => ['DISPLAY'],
 
   columnType: 'field',
 

--- a/packages/data/addon/serializers/metadata/elide.ts
+++ b/packages/data/addon/serializers/metadata/elide.ts
@@ -30,7 +30,7 @@ type ColumnNode = {
   description: string;
   category: string;
   valueType: TODO<string>;
-  columnTags: string[];
+  tags: string[];
   columnType: RawColumnType;
   expression: string;
 };
@@ -144,7 +144,7 @@ export default class ElideMetadataSerializer extends EmberObject implements Navi
         valueType: node.valueType,
         tableId,
         source,
-        tags: node.columnTags,
+        tags: node.tags,
         defaultFormat: node.defaultFormat,
         type: node.columnType,
         expression: node.expression
@@ -174,7 +174,7 @@ export default class ElideMetadataSerializer extends EmberObject implements Navi
         valueType: node.valueType,
         tableId,
         source,
-        tags: node.columnTags,
+        tags: node.tags,
         type: node.columnType,
         expression: node.expression
       };
@@ -207,7 +207,7 @@ export default class ElideMetadataSerializer extends EmberObject implements Navi
           tableId,
           columnFunctionId: columnFunction.id,
           source,
-          tags: node.columnTags,
+          tags: node.tags,
           supportedGrains: node.supportedGrain.edges.map(edge => edge.node),
           timeZone: node.timeZone,
           type: node.columnType,

--- a/packages/data/tests/unit/adapters/metadata/elide-test.ts
+++ b/packages/data/tests/unit/adapters/metadata/elide-test.ts
@@ -115,7 +115,7 @@ module('Unit | Adapter | metadata/elide', function(hooks) {
               description: 'This is metric 0',
               category: 'categoryOne',
               valueType: 'NUMBER',
-              columnTags: ['DISPLAY'],
+              tags: ['DISPLAY'],
               columnType: 'field',
               expression: null,
               __typename: 'Metric'
@@ -129,7 +129,7 @@ module('Unit | Adapter | metadata/elide', function(hooks) {
               description: 'This is metric 1',
               category: 'categoryOne',
               valueType: 'NUMBER',
-              columnTags: ['DISPLAY'],
+              tags: ['DISPLAY'],
               columnType: 'field',
               expression: null,
               __typename: 'Metric'
@@ -143,7 +143,7 @@ module('Unit | Adapter | metadata/elide', function(hooks) {
               description: 'This is metric 2',
               category: 'categoryOne',
               valueType: 'NUMBER',
-              columnTags: ['DISPLAY'],
+              tags: ['DISPLAY'],
               columnType: 'field',
               expression: null,
               __typename: 'Metric'
@@ -168,7 +168,7 @@ module('Unit | Adapter | metadata/elide', function(hooks) {
               description: 'This is dimension 0',
               category: 'categoryOne',
               valueType: 'TEXT',
-              columnTags: ['DISPLAY'],
+              tags: ['DISPLAY'],
               columnType: 'field',
               expression: null,
               __typename: 'Dimension'
@@ -182,7 +182,7 @@ module('Unit | Adapter | metadata/elide', function(hooks) {
               description: 'This is dimension 1',
               category: 'categoryOne',
               valueType: 'TEXT',
-              columnTags: ['DISPLAY'],
+              tags: ['DISPLAY'],
               columnType: 'field',
               expression: null,
               __typename: 'Dimension'
@@ -196,7 +196,7 @@ module('Unit | Adapter | metadata/elide', function(hooks) {
               description: 'This is dimension 2',
               category: 'categoryOne',
               valueType: 'TEXT',
-              columnTags: ['DISPLAY'],
+              tags: ['DISPLAY'],
               columnType: 'field',
               expression: null,
               __typename: 'Dimension'
@@ -220,7 +220,7 @@ module('Unit | Adapter | metadata/elide', function(hooks) {
               description: 'This is metric 3',
               category: 'categoryOne',
               valueType: 'NUMBER',
-              columnTags: ['DISPLAY'],
+              tags: ['DISPLAY'],
               columnType: 'field',
               expression: null,
               __typename: 'Metric'
@@ -234,7 +234,7 @@ module('Unit | Adapter | metadata/elide', function(hooks) {
               description: 'This is metric 4',
               category: 'categoryOne',
               valueType: 'NUMBER',
-              columnTags: ['DISPLAY'],
+              tags: ['DISPLAY'],
               columnType: 'field',
               expression: null,
               __typename: 'Metric'
@@ -287,7 +287,7 @@ module('Unit | Adapter | metadata/elide', function(hooks) {
                         description: 'This is metric 0',
                         category: 'categoryOne',
                         valueType: 'NUMBER',
-                        columnTags: ['DISPLAY'],
+                        tags: ['DISPLAY'],
                         columnType: 'field',
                         expression: null,
                         __typename: 'Metric'
@@ -301,7 +301,7 @@ module('Unit | Adapter | metadata/elide', function(hooks) {
                         description: 'This is metric 1',
                         category: 'categoryOne',
                         valueType: 'NUMBER',
-                        columnTags: ['DISPLAY'],
+                        tags: ['DISPLAY'],
                         columnType: 'field',
                         expression: null,
                         __typename: 'Metric'
@@ -315,7 +315,7 @@ module('Unit | Adapter | metadata/elide', function(hooks) {
                         description: 'This is metric 2',
                         category: 'categoryOne',
                         valueType: 'NUMBER',
-                        columnTags: ['DISPLAY'],
+                        tags: ['DISPLAY'],
                         columnType: 'field',
                         expression: null,
                         __typename: 'Metric'
@@ -334,7 +334,7 @@ module('Unit | Adapter | metadata/elide', function(hooks) {
                         description: 'This is dimension 0',
                         category: 'categoryOne',
                         valueType: 'TEXT',
-                        columnTags: ['DISPLAY'],
+                        tags: ['DISPLAY'],
                         columnType: 'field',
                         expression: null,
                         __typename: 'Dimension'
@@ -348,7 +348,7 @@ module('Unit | Adapter | metadata/elide', function(hooks) {
                         description: 'This is dimension 1',
                         category: 'categoryOne',
                         valueType: 'TEXT',
-                        columnTags: ['DISPLAY'],
+                        tags: ['DISPLAY'],
                         columnType: 'field',
                         expression: null,
                         __typename: 'Dimension'
@@ -362,7 +362,7 @@ module('Unit | Adapter | metadata/elide', function(hooks) {
                         description: 'This is dimension 2',
                         category: 'categoryOne',
                         valueType: 'TEXT',
-                        columnTags: ['DISPLAY'],
+                        tags: ['DISPLAY'],
                         columnType: 'field',
                         expression: null,
                         __typename: 'Dimension'

--- a/packages/data/tests/unit/serializers/metadata/elide-test.ts
+++ b/packages/data/tests/unit/serializers/metadata/elide-test.ts
@@ -42,7 +42,7 @@ module('Unit | Serializer | metadata/elide', function(hooks) {
                       description: 'Table A Metric 1',
                       category: 'cat1',
                       valueType: 'NUMBER',
-                      columnTags: ['IMPORTANT'],
+                      tags: ['IMPORTANT'],
                       defaultFormat: 'NONE',
                       columnType: 'field',
                       expression: ''
@@ -61,7 +61,7 @@ module('Unit | Serializer | metadata/elide', function(hooks) {
                       description: 'Table A Dimension 1',
                       category: 'cat1',
                       valueType: 'TEXT',
-                      columnTags: ['IMPORTANT'],
+                      tags: ['IMPORTANT'],
                       columnType: 'field',
                       expression: ''
                     },
@@ -74,7 +74,7 @@ module('Unit | Serializer | metadata/elide', function(hooks) {
                       description: 'Table A Dimension 2',
                       category: 'cat1',
                       valueType: 'TEXT',
-                      columnTags: ['IMPORTANT'],
+                      tags: ['IMPORTANT'],
                       columnType: 'field',
                       expression: ''
                     },
@@ -92,7 +92,7 @@ module('Unit | Serializer | metadata/elide', function(hooks) {
                       description: 'Table A Time Dimension 1',
                       category: 'cat1',
                       valueType: 'DATE',
-                      columnTags: ['IMPORTANT'],
+                      tags: ['IMPORTANT'],
                       supportedGrain: {
                         edges: [
                           { node: { id: 'day', grain: 'DAY', expression: '' }, cursor: '' },
@@ -128,7 +128,7 @@ module('Unit | Serializer | metadata/elide', function(hooks) {
                       description: 'Table B Metric 2',
                       category: 'cat2',
                       valueType: 'NUMBER',
-                      columnTags: ['IMPORTANT'],
+                      tags: ['IMPORTANT'],
                       defaultFormat: 'NONE',
                       columnType: 'field',
                       expression: ''
@@ -142,7 +142,7 @@ module('Unit | Serializer | metadata/elide', function(hooks) {
                       description: 'Table B Metric 3',
                       category: 'cat2',
                       valueType: 'NUMBER',
-                      columnTags: ['IMPORTANT'],
+                      tags: ['IMPORTANT'],
                       defaultFormat: 'NONE',
                       columnType: 'field',
                       expression: ''
@@ -161,7 +161,7 @@ module('Unit | Serializer | metadata/elide', function(hooks) {
                       description: 'Table B Dimension 1',
                       category: 'cat2',
                       valueType: 'TEXT',
-                      columnTags: ['IMPORTANT'],
+                      tags: ['IMPORTANT'],
                       columnType: 'field',
                       expression: ''
                     },
@@ -174,7 +174,7 @@ module('Unit | Serializer | metadata/elide', function(hooks) {
                       description: 'Table B Dimension 2',
                       category: 'cat2',
                       valueType: 'TEXT',
-                      columnTags: ['IMPORTANT'],
+                      tags: ['IMPORTANT'],
                       columnType: 'field',
                       expression: ''
                     },
@@ -381,7 +381,7 @@ module('Unit | Serializer | metadata/elide', function(hooks) {
             description: 'Clicks',
             category: 'userMetrics',
             valueType: 'NUMBER',
-            columnTags: ['IMPORTANT'],
+            tags: ['IMPORTANT'],
             defaultFormat: 'NONE',
             columnType: 'field',
             expression: ''
@@ -395,7 +395,7 @@ module('Unit | Serializer | metadata/elide', function(hooks) {
             description: 'Impressions',
             category: 'userMetrics',
             valueType: 'NUMBER',
-            columnTags: ['DISPLAY'],
+            tags: ['DISPLAY'],
             defaultFormat: 'NONE',
             columnType: 'field',
             expression: ''
@@ -458,7 +458,7 @@ module('Unit | Serializer | metadata/elide', function(hooks) {
             description: 'User Age',
             category: 'userDimensions',
             valueType: 'TEXT',
-            columnTags: ['IMPORTANT'],
+            tags: ['IMPORTANT'],
             columnType: 'field',
             expression: ''
           },
@@ -471,7 +471,7 @@ module('Unit | Serializer | metadata/elide', function(hooks) {
             description: 'User Gender',
             category: 'userDimensions',
             valueType: 'TEXT',
-            columnTags: ['DISPLAY'],
+            tags: ['DISPLAY'],
             columnType: 'field',
             expression: ''
           },
@@ -531,7 +531,7 @@ module('Unit | Serializer | metadata/elide', function(hooks) {
             description: 'Date that the user signed up',
             category: 'userDimensions',
             valueType: 'DATE',
-            columnTags: ['DISPLAY'],
+            tags: ['DISPLAY'],
             supportedGrain: {
               edges: [
                 { node: { id: 'day', grain: 'DAY', expression: '' }, cursor: '' },
@@ -553,7 +553,7 @@ module('Unit | Serializer | metadata/elide', function(hooks) {
             description: 'Month an order was placed',
             category: 'userDimensions',
             valueType: 'DATE',
-            columnTags: ['DISPLAY'],
+            tags: ['DISPLAY'],
             supportedGrain: {
               edges: [{ node: { id: 'month', grain: 'MONTH', expression: '' }, cursor: '' }],
               pageInfo: []


### PR DESCRIPTION
## Description
Metadata queries aren't working with graphql right now

## Proposed Changes

- `columnTags` => `tags`

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
