### PR TITLE
Rate limit support

### DIFF
--- a/packages/core/addon/utils/error.js
+++ b/packages/core/addon/utils/error.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import { typeOf } from '@ember/utils';

--- a/packages/core/addon/utils/error.js
+++ b/packages/core/addon/utils/error.js
@@ -12,6 +12,10 @@ const MESSAGE_OVERRIDES = {
   'The ajax operation timed out': 'Data Timeout'
 };
 
+const REGEX_OVERRIDES = {
+  '^Rate limit reached\\. .*': 'Rate limit reached, please try again later.'
+};
+
 /**
  * Retrieves error message from error object
  * @function _getErrorText
@@ -41,6 +45,13 @@ export function _getErrorText(error = {}) {
  */
 export function getApiErrMsg(error) {
   let errorText = _getErrorText(error) || UNKNOWN_ERROR;
+
+  Object.keys(REGEX_OVERRIDES).forEach(reg => {
+    let regex = new RegExp(reg, 'gi');
+    if (regex.test(errorText)) {
+      errorText = REGEX_OVERRIDES[reg];
+    }
+  });
 
   if (MESSAGE_OVERRIDES[errorText]) {
     errorText = MESSAGE_OVERRIDES[errorText];

--- a/packages/core/tests/unit/utils/error-test.js
+++ b/packages/core/tests/unit/utils/error-test.js
@@ -28,6 +28,15 @@ module('Unit | Utils | Error', function() {
     );
   });
 
+  test('regular expression matched error', function(assert) {
+    assert.expect(1);
+    assert.equal(
+      getApiErrMsg({ detail: 'Rate limit reached. reject https://foo.com/' }),
+      'Rate limit reached, please try again later.',
+      'The correct error is shown when regular expression overrides match'
+    );
+  });
+
   test('no message', function(assert) {
     assert.expect(3);
 

--- a/packages/reports/addon/templates/reports/report/error.hbs
+++ b/packages/reports/addon/templates/reports/report/error.hbs
@@ -5,7 +5,7 @@
   </span>
   <p>Oops! There was an error with your request.</p>
   <ul class="navi-info-message__error-list">
-    {{#let this.model.payload.description as | error | }}
+    {{#let (if this.model.payload.description this.model.payload.description this.model.payload) as | error | }}
       <li class="navi-info-message__error-list-item">
         <NaviIcon @icon="times" class="navi-info-message__error-list-icon" />
         {{error-message (hash detail=error)}}

--- a/packages/reports/tests/acceptance/error-route-test.js
+++ b/packages/reports/tests/acceptance/error-route-test.js
@@ -36,4 +36,21 @@ module('Acceptance | Navi Report | Error Route', function(hooks) {
 
     config.navi.FEATURES.enableRequestPreview = originalFeatureFlag;
   });
+
+  test('Rate Limited data request', async function(assert) {
+    server.urlPrefix = `${config.navi.dataSources[0].uri}/v1`;
+    server.get(
+      '/data/*path',
+      () => new Response(429, {}, `Rate limit reached. Reject ${config.navi.dataSources[0].uri}/v1/data/network/day`)
+    );
+
+    await visit('/reports/5/view');
+
+    assert
+      .dom('.navi-report-error__info-message')
+      .hasText(
+        'Oops! There was an error with your request. Rate limit reached, please try again later.',
+        'An error message is displayed for an rate limited request'
+      );
+  });
 });


### PR DESCRIPTION
## Description

Fili rate limit errors not being messaged to user properly. Get 'Server Error' instead.

## Proposed Changes

- Add support for error message in plain text in body of response rather than json object
- Add support for regex matching for custom error message overrides.

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
