### PR TITLE
Update: PNG export

### DIFF
--- a/packages/app/config/environment.js
+++ b/packages/app/config/environment.js
@@ -28,7 +28,7 @@ module.exports = function(environment) {
       defaultDataSource: 'default',
       FEATURES: {
         enableDashboardFilters: true,
-        enableMultipleExport: false,
+        multipleExportFileTypes: [],
         enableTableEditing: true
       }
     }

--- a/packages/dashboards/addon/components/dashboard-actions/export.js
+++ b/packages/dashboards/addon/components/dashboard-actions/export.js
@@ -32,11 +32,11 @@ export default class DashboardMultipleFormatExport extends MultipleFormatExport 
   csvHref = undefined;
 
   /**
-   * @property {Promise} pdfHref - Promise resolving to pdf download link
+   * @property {Promise} exportHref - Promise resolving to export to file link
    * @override
    */
   @computed('dashboard.id')
-  get pdfHref() {
+  get exportHref() {
     return Promise.resolve(`/export?dashboard=${this.dashboard.id}`);
   }
 
@@ -44,7 +44,7 @@ export default class DashboardMultipleFormatExport extends MultipleFormatExport 
    * @property {Array} exportFormats - A list of export formats
    * @override
    */
-  @computed('pdfHref')
+  @computed('exportHref')
   get exportFormats() {
     return super.exportFormats.filter(format => format.type !== 'CSV');
   }

--- a/packages/dashboards/addon/components/dashboard-actions/export.js
+++ b/packages/dashboards/addon/components/dashboard-actions/export.js
@@ -1,53 +1,51 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Usage:
- *   {{#dashboard-actions/export
- *      dashboard=dashboard
- *   }}
+ *    <DashboardActions::Export
+ *      @dashboard={{@dashboard}}
+ *      @title={{@dashboard.title}}
+ *      @disabled={{not @dashboard.validations.isTruelyValid}}
+ *    >
  *      Inner template
- *   {{/dashboard-actions/export}}
+ *    </DashboardActions::Export>
  */
 
-import { computed, get } from '@ember/object';
-import { dasherize } from '@ember/string';
-import ExportAction from 'navi-reports/components/report-actions/export';
-import { inject as service } from '@ember/service';
+import { computed } from '@ember/object';
+import MultipleFormatExport from 'navi-reports/components/report-actions/multiple-format-export';
 
-export default ExportAction.extend({
+export default class DashboardMultipleFormatExport extends MultipleFormatExport {
   /**
-   * @property {Service} naviNotifications
+   * @property {String} filename - filename for the downloaded file
+   * @override
    */
-  naviNotifications: service(),
-
-  /**
-   * @property {String} href - API link for the report
-   */
-  href: computed('dashboard', 'disabled', function() {
-    // Void the href on a should disabled
-    if (get(this, 'disabled')) {
-      return 'javascript:void(0);';
-    }
-
-    return `/export?dashboard=${get(this, 'dashboard.id')}`;
-  }),
-
-  /**
-   * @property {String} download - suggested filename
-   */
-  download: computed('dashboard', function() {
-    return dasherize(get(this, 'dashboard.title')) + '-dashboard';
-  }),
-
-  /**
-   * @method click
-   */
-  click() {
-    get(this, 'naviNotifications').add({
-      message: `The download should begin soon.`,
-      type: 'info',
-      timeout: 'medium'
-    });
+  @computed('dashboard.title')
+  get filename() {
+    return `${this.dashboard.title}-dashboard`;
   }
-});
+
+  /**
+   * @property {undefined} csvHref - CSV export is not available for dashboards
+   * @override
+   */
+  csvHref = undefined;
+
+  /**
+   * @property {Promise} pdfHref - Promise resolving to pdf download link
+   * @override
+   */
+  @computed('dashboard.id')
+  get pdfHref() {
+    return Promise.resolve(`/export?dashboard=${this.dashboard.id}`);
+  }
+
+  /**
+   * @property {Array} exportFormats - A list of export formats
+   * @override
+   */
+  @computed('pdfHref')
+  get exportFormats() {
+    return super.exportFormats.filter(format => format.type !== 'CSV');
+  }
+}

--- a/packages/dashboards/addon/components/dashboard-actions/schedule.js
+++ b/packages/dashboards/addon/components/dashboard-actions/schedule.js
@@ -16,11 +16,15 @@
 
 import { A as arr } from '@ember/array';
 import ScheduleActionComponent from 'navi-reports/components/common-actions/schedule';
+import { computed } from '@ember/object';
 
 export default class DashboardScheduleActionComponent extends ScheduleActionComponent {
   /**
    * @property {Array} formats
    * @override
    */
-  formats = arr(['pdf', 'png']);
+  @computed
+  get formats() {
+    return arr(super.formats.without('csv'));
+  }
 }

--- a/packages/dashboards/addon/components/dashboard-actions/schedule.js
+++ b/packages/dashboards/addon/components/dashboard-actions/schedule.js
@@ -1,24 +1,26 @@
 /**
- * Copyright 2018, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Usage:
- *   {{#dashboard-actions/schedule
- *      model=dashboard
- *      onSave=(action 'onSave')
- *      onRevert=(action 'onRevert')
- *      onDelete=(action 'onDelete')
- *   }}
- *      Inner template
- *   {{/dashboard-actions/schedule}}
+ *   <DashboardActions::Schedule
+ *     @model={{@dashboard}}
+ *     @disabled={{not @dashboard.validations.isTruelyValid}}
+ *     @onSave={{this.onSave}}
+ *     @onRevert={{this.onRevert}}
+ *     @onDelete={{this.onDelete}}
+ *   >
+ *     Inner template
+ *   </DashboardActions::Schedule>
  */
 
 import { A as arr } from '@ember/array';
-import ScheduleAction from 'navi-reports/components/common-actions/schedule';
+import ScheduleActionComponent from 'navi-reports/components/common-actions/schedule';
 
-export default ScheduleAction.extend({
+export default class DashboardScheduleActionComponent extends ScheduleActionComponent {
   /**
    * @property {Array} formats
+   * @override
    */
-  formats: arr(['pdf'])
-});
+  formats = arr(['pdf', 'png']);
+}

--- a/packages/dashboards/addon/templates/components/dashboard-action-list.hbs
+++ b/packages/dashboards/addon/templates/components/dashboard-action-list.hbs
@@ -12,13 +12,13 @@
     {{#if (feature-flag "enableDashboardExport")}}
       {{!-- Export action enabled if the dashboard is valid --}}
       <li class="action">
+        <EmberTooltip @text="Export the dashboard"/>
         <DashboardActions::Export
-          class="export btn"
+          class="export btn {{unless dashboard.validations.isTruelyValid "disabled"}}"
           @dashboard={{dashboard}}
           @disabled={{not dashboard.validations.isTruelyValid}}
         >
           <NaviIcon @icon="download" class="navi-icon__download" />
-          <EmberTooltip @text="Export the dashboard"/>
         </DashboardActions::Export>
       </li>
     {{/if}}

--- a/packages/dashboards/addon/templates/components/navi-dashboard.hbs
+++ b/packages/dashboards/addon/templates/components/navi-dashboard.hbs
@@ -44,12 +44,12 @@
     {{#if (feature-flag "enableDashboardExport")}}
       {{!-- Export action enabled if the dashboard is valid --}}
       <DashboardActions::Export
-        class="action export btn"
+        class="action export btn {{unless @dashboard.validations.isTruelyValid "disabled"}}"
         @dashboard={{@dashboard}}
         @disabled={{not @dashboard.validations.isTruelyValid}}
       >
         <NaviIcon @icon="download" class="navi-icon__download" />
-        PDF Export
+        Export
       </DashboardActions::Export>
     {{/if}}
 

--- a/packages/dashboards/addon/templates/dashboards/dashboard/widgets/widget.hbs
+++ b/packages/dashboards/addon/templates/dashboards/dashboard/widgets/widget.hbs
@@ -53,7 +53,7 @@
 
       <li class="navi-report-widget__action">
         {{!-- Export action is only enabled when request is valid --}}
-        {{#let (component (concat "report-actions/" (if (and (feature-flag "enableMultipleExport") (not (is-empty (feature-flag "multiExportFileTypes")))) "multiple-format-export" "export"))) as |ExportAction|}}
+        {{#let (component (concat "report-actions/" (unless (is-empty (feature-flag "multipleExportFileTypes")) "multiple-format-export" "export"))) as |ExportAction|}}
           <ExportAction
             class="navi-report-widget__action-link {{unless @model.validations.isTruelyValid "navi-report-widget__action-link--is-disabled"}}"
             @report={{@model}}

--- a/packages/dashboards/addon/templates/dashboards/dashboard/widgets/widget.hbs
+++ b/packages/dashboards/addon/templates/dashboards/dashboard/widgets/widget.hbs
@@ -53,7 +53,7 @@
 
       <li class="navi-report-widget__action">
         {{!-- Export action is only enabled when request is valid --}}
-        {{#let (component (concat "report-actions/" (if (feature-flag "enableMultipleExport") "multiple-format-export" "export"))) as |ExportAction|}}
+        {{#let (component (concat "report-actions/" (if (and (feature-flag "enableMultipleExport") (not (is-empty (feature-flag "multiExportFileTypes")))) "multiple-format-export" "export"))) as |ExportAction|}}
           <ExportAction
             class="navi-report-widget__action-link {{unless @model.validations.isTruelyValid "navi-report-widget__action-link--is-disabled"}}"
             @report={{@model}}

--- a/packages/dashboards/app/styles/navi-dashboards/components/navi-dashboard.less
+++ b/packages/dashboards/app/styles/navi-dashboards/components/navi-dashboard.less
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 
@@ -76,9 +76,15 @@
       cursor: pointer;
       font-family: @font-family-sans-serif;
       margin-right: 15px;
+      padding: 0;
 
       a {
         color: @navi-gray-800;
+      }
+
+      &.disabled {
+        color: @disabled-gray;
+        cursor: not-allowed;
       }
     }
 

--- a/packages/dashboards/app/styles/navi-dashboards/views/print-navi-dashboard.less
+++ b/packages/dashboards/app/styles/navi-dashboards/views/print-navi-dashboard.less
@@ -13,7 +13,7 @@
   .navi-widget {
     flex: unset;
     max-width: none;
-    width: 11in - (2 * @print-margin);
+    width: 10.75in - (2 * @print-margin);
     height: 8in - (2 * @print-margin);
     page-break-after: always;
   }

--- a/packages/dashboards/app/styles/navi-dashboards/views/print-navi-dashboard.less
+++ b/packages/dashboards/app/styles/navi-dashboards/views/print-navi-dashboard.less
@@ -5,7 +5,7 @@
 
 .navi-dashboard.navi-dashboard--print {
   overflow: visible;
-  
+
   .navi-dashboard__body {
     overflow-y: visible;
   }

--- a/packages/dashboards/tests/acceptance/explore-widget-test.js
+++ b/packages/dashboards/tests/acceptance/explore-widget-test.js
@@ -159,10 +159,10 @@ module('Acceptance | Exploring Widgets', function(hooks) {
   test('Export action', async function(assert) {
     assert.expect(3);
 
-    let originalFeatureFlag = config.navi.FEATURES.enableMultipleExport;
+    let originalFeatureFlag = config.navi.FEATURES.multipleExportFileTypes;
 
     // Turn flag off
-    config.navi.FEATURES.enableMultipleExport = false;
+    config.navi.FEATURES.multipleExportFileTypes = [];
 
     await visit('/dashboards/1/widgets/2/view');
 
@@ -188,7 +188,7 @@ module('Acceptance | Exploring Widgets', function(hooks) {
         'Export action is disabled when request is not valid'
       );
 
-    config.navi.FEATURES.enableMultipleExport = originalFeatureFlag;
+    config.navi.FEATURES.multipleExportFileTypes = originalFeatureFlag;
   });
 
   test('Multi export action', async function(assert) {

--- a/packages/dashboards/tests/acceptance/schedule-modal-test.js
+++ b/packages/dashboards/tests/acceptance/schedule-modal-test.js
@@ -1,15 +1,16 @@
-import { blur, click, fillIn, triggerEvent, visit } from '@ember/test-helpers';
+import { blur, click, fillIn, findAll, triggerEvent, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import $ from 'jquery';
+import { clickTrigger } from 'ember-power-select/test-support/helpers';
 
 module('Acceptances | Navi Dashboard Schedule Modal', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
   test('schedule modal save new schedule', async function(assert) {
-    assert.expect(11);
+    assert.expect(12);
     await visit('/dashboards');
 
     await triggerEvent('.navi-collection__row0', 'mouseenter');
@@ -36,6 +37,13 @@ module('Acceptances | Navi Dashboard Schedule Modal', function(hooks) {
     assert
       .dom('.schedule-modal__dropdown--format .ember-power-select-selected-item')
       .hasText('pdf', 'Format field is set to the default value when creating a new schedule');
+
+    await clickTrigger('.schedule-modal__dropdown--format');
+    assert.deepEqual(
+      findAll('.ember-power-select-option').map(el => el.textContent.trim()),
+      ['pdf', 'png'],
+      'Schedule format should have correct options'
+    );
 
     await fillIn('.js-ember-tag-input-new', 'navi_user@navi.io');
     await blur('.js-ember-tag-input-new');

--- a/packages/dashboards/tests/dummy/config/environment.js
+++ b/packages/dashboards/tests/dummy/config/environment.js
@@ -31,8 +31,7 @@ module.exports = function(environment) {
       ],
       FEATURES: {
         enableDashboardExport: true,
-        enableMultipleExport: true,
-        multiExportFileTypes: ['pdf', 'png'],
+        multipleExportFileTypes: ['pdf', 'png'],
         enableScheduleDashboards: true,
         enableDashboardFilters: true
       }

--- a/packages/dashboards/tests/dummy/config/environment.js
+++ b/packages/dashboards/tests/dummy/config/environment.js
@@ -32,6 +32,7 @@ module.exports = function(environment) {
       FEATURES: {
         enableDashboardExport: true,
         enableMultipleExport: true,
+        multiExportFileTypes: ['pdf', 'png'],
         enableScheduleDashboards: true,
         enableDashboardFilters: true
       }

--- a/packages/dashboards/tests/integration/components/dashboard-actions/export-test.js
+++ b/packages/dashboards/tests/integration/components/dashboard-actions/export-test.js
@@ -1,86 +1,66 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import $ from 'jquery';
+import { clickTrigger } from 'ember-basic-dropdown/test-support/helpers';
+
+const TEMPLATE = hbs`
+  <DashboardActions::Export
+    @dashboard={{this.dashboard}}
+    @disabled={{this.disabled}}
+  >
+    Export
+  </DashboardActions::Export>
+`;
 
 module('Integration | Component | dashboard actions/export', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('export href', async function(assert) {
-    assert.expect(1);
+  hooks.beforeEach(async function() {
+    this.set('dashboard', { id: 123, title: 'Akkala Tech Lab Weekly Reports' });
+    this.set('disabled', false);
+    await render(TEMPLATE);
+  });
 
-    this.dashboard = { id: 123, title: 'Akkala Tech Lab Weekly Reports' };
+  test('export links', async function(assert) {
+    assert.expect(3);
 
-    await render(hbs`
-      {{dashboard-actions/export
-        dashboard=dashboard
-      }}
-    `);
+    assert.dom('.ember-basic-dropdown-trigger').hasText('Export', 'Component yields content as expected');
 
-    assert
-      .dom('a')
-      .hasAttribute(
-        'href',
-        '/export?dashboard=123',
-        'Export actions links to export service and gives the dashboard id'
-      );
+    await clickTrigger();
+
+    assert.equal(
+      $('.multiple-format-export__dropdown a:contains("PDF")').attr('href'),
+      '/export?dashboard=123',
+      'Export to PDF action has a correct download link'
+    );
+
+    assert.equal(
+      $('.multiple-format-export__dropdown a:contains("PNG")').attr('href'),
+      '/export?dashboard=123&fileType=png',
+      'Export to PNG action has a correct download link'
+    );
   });
 
   test('export filename', async function(assert) {
     assert.expect(1);
 
-    this.dashboard = { id: 123, title: 'Akkala Tech Lab Weekly Reports' };
-
-    await render(hbs`
-      {{dashboard-actions/export
-        dashboard=dashboard
-      }}
-    `);
-
-    assert
-      .dom('a')
-      .hasAttribute(
-        'download',
-        'akkala-tech-lab-weekly-reports-dashboard',
-        'Download attribute is set to the dasherized dashboard name, appended with -dashboard'
-      );
+    await clickTrigger();
+    assert.equal(
+      $('.multiple-format-export__dropdown a:contains("PDF")').attr('download'),
+      'akkala-tech-lab-weekly-reports-dashboard',
+      'Download attribute is set to the dasherized dashboard name, appended with -dashboard'
+    );
   });
 
   test('disabled', async function(assert) {
     assert.expect(1);
 
-    this.dashboard = { id: 123, title: 'Akkala Tech Lab Weekly Reports' };
+    this.set('disabled', true);
+    await render(TEMPLATE);
+    await clickTrigger();
 
-    await render(hbs`
-      {{dashboard-actions/export
-        dashboard=dashboard
-        disabled=true
-      }}
-    `);
-
-    assert
-      .dom('a')
-      .hasAttribute('href', 'unsafe:javascript:void(0);', 'When disabled, the export action href has no effect');
-  });
-
-  test('notifications', async function(assert) {
-    assert.expect(1);
-
-    this.dashboard = { id: 123, title: 'Akkala Tech Lab Weekly Reports' };
-
-    this.mockNotifications = {
-      add({ message }) {
-        assert.equal(message, 'The download should begin soon.', 'A notification is added when export is clicked.');
-      }
-    };
-
-    await render(hbs`
-      {{dashboard-actions/export
-        dashboard=dashboard
-        naviNotifications=mockNotifications
-      }}
-    `);
-
-    await click('a');
+    assert.dom('.ember-basic-dropdown-content-placeholder').isNotVisible('Dropdown should not be visible');
   });
 });

--- a/packages/dashboards/tests/integration/components/dashboard-actions/export-test.js
+++ b/packages/dashboards/tests/integration/components/dashboard-actions/export-test.js
@@ -24,11 +24,16 @@ module('Integration | Component | dashboard actions/export', function(hooks) {
   });
 
   test('export links', async function(assert) {
-    assert.expect(3);
+    assert.expect(4);
 
     assert.dom('.ember-basic-dropdown-trigger').hasText('Export', 'Component yields content as expected');
 
     await clickTrigger();
+
+    assert.notOk(
+      !!$('.multiple-format-export__dropdown a:contains("CSV")').length,
+      'Export to CSV is not available for dashboards'
+    );
 
     assert.equal(
       $('.multiple-format-export__dropdown a:contains("PDF")').attr('href'),

--- a/packages/reports/addon/components/common-actions/schedule.js
+++ b/packages/reports/addon/components/common-actions/schedule.js
@@ -73,11 +73,9 @@ export default class ScheduleActionComponent extends Component {
 
     if (!formats) {
       formats = defaultFormats.slice();
-      if (featureFlag('enableMultipleExport')) {
-        const supportedFormats = featureFlag('multiExportFileTypes');
-        if (Array.isArray(supportedFormats)) {
-          formats = [...formats, ...supportedFormats];
-        }
+      const supportedFormats = featureFlag('multipleExportFileTypes');
+      if (Array.isArray(supportedFormats)) {
+        formats = [...formats, ...supportedFormats];
       }
     }
 

--- a/packages/reports/addon/components/common-actions/schedule.js
+++ b/packages/reports/addon/components/common-actions/schedule.js
@@ -21,6 +21,7 @@ import { get, set, computed, setProperties, action } from '@ember/object';
 import RSVP from 'rsvp';
 import { capitalize } from 'lodash-es';
 import { layout as templateLayout, tagName } from '@ember-decorators/component';
+import { featureFlag } from 'navi-core/helpers/feature-flag';
 
 const defaultFrequencies = ['day', 'week', 'month', 'quarter', 'year'];
 const defaultFormats = ['csv'];
@@ -72,8 +73,11 @@ export default class ScheduleActionComponent extends Component {
 
     if (!formats) {
       formats = defaultFormats.slice();
-      if (get(config, 'navi.FEATURES.enableMultipleExport')) {
-        formats = [...formats, 'pdf', 'png'];
+      if (featureFlag('enableMultipleExport')) {
+        const supportedFormats = featureFlag('multiExportFileTypes');
+        if (Array.isArray(supportedFormats)) {
+          formats = [...formats, ...supportedFormats];
+        }
       }
     }
 

--- a/packages/reports/addon/components/common-actions/schedule.js
+++ b/packages/reports/addon/components/common-actions/schedule.js
@@ -73,7 +73,7 @@ export default class ScheduleActionComponent extends Component {
     if (!formats) {
       formats = defaultFormats.slice();
       if (get(config, 'navi.FEATURES.enableMultipleExport')) {
-        formats.push('pdf');
+        formats = [...formats, 'pdf', 'png'];
       }
     }
 

--- a/packages/reports/addon/components/report-actions/multiple-format-export.js
+++ b/packages/reports/addon/components/report-actions/multiple-format-export.js
@@ -47,7 +47,7 @@ export default class MultipleFormatExport extends Component {
   /**
    * @property {Array} supportedFileTypes - supported file types for export
    */
-  supportedFileTypes = featureFlag('multiExportFileTypes');
+  supportedFileTypes = featureFlag('multipleExportFileTypes');
 
   /**
    * @property {String} csvHref - CSV download link for the report

--- a/packages/reports/addon/components/report-actions/multiple-format-export.js
+++ b/packages/reports/addon/components/report-actions/multiple-format-export.js
@@ -11,6 +11,7 @@
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed, action } from '@ember/object';
+import { readOnly } from '@ember/object/computed';
 import layout from '../../templates/components/report-actions/multiple-format-export';
 import { layout as templateLayout, tagName } from '@ember-decorators/component';
 
@@ -36,6 +37,11 @@ export default class MultipleFormatExport extends Component {
    * @property {Service} naviNotifications
    */
   @service naviNotifications;
+
+  /**
+   * @property {String} filename - filename for the downloaded file
+   */
+  @readOnly('report.title') filename;
 
   /**
    * @property {String} csvHref - CSV download link for the report
@@ -82,6 +88,11 @@ export default class MultipleFormatExport extends Component {
         type: 'PDF',
         href: this.pdfHref,
         icon: 'file-pdf-o'
+      },
+      {
+        type: 'PNG',
+        href: this.pdfHref.then(href => `${href}&fileType=png`),
+        icon: 'file-image-o'
       }
     ];
   }

--- a/packages/reports/addon/components/report-actions/multiple-format-export.js
+++ b/packages/reports/addon/components/report-actions/multiple-format-export.js
@@ -59,10 +59,10 @@ export default class MultipleFormatExport extends Component {
   }
 
   /**
-   * @property {Promise} pdfHref - Promise resolving to pdf download link
+   * @property {Promise} exportHref - Promise resolving to export to file link
    */
   @computed('report.{request,visualization,validations.isTruelyValid}')
-  get pdfHref() {
+  get exportHref() {
     const { report: model, compression, store } = this;
     const clonedModel = model.toJSON();
 
@@ -82,7 +82,7 @@ export default class MultipleFormatExport extends Component {
   /**
    * @property {Array} exportFormats - A list of export formats
    */
-  @computed('csvHref', 'pdfHref', 'supportedFileTypes')
+  @computed('csvHref', 'exportHref', 'supportedFileTypes')
   get exportFormats() {
     const { supportedFileTypes } = this;
 
@@ -98,7 +98,7 @@ export default class MultipleFormatExport extends Component {
       if (supportedFileTypes.includes('pdf') || supportedFileTypes.includes('PDF')) {
         exportFormats.push({
           type: 'PDF',
-          href: this.pdfHref,
+          href: this.exportHref,
           icon: 'file-pdf-o'
         });
       }
@@ -106,7 +106,7 @@ export default class MultipleFormatExport extends Component {
       if (supportedFileTypes.includes('png') || supportedFileTypes.includes('PNG')) {
         exportFormats.push({
           type: 'PNG',
-          href: this.pdfHref.then(href => `${href}&fileType=png`),
+          href: this.exportHref.then(href => `${href}&fileType=png`),
           icon: 'file-image-o'
         });
       }

--- a/packages/reports/addon/components/report-actions/multiple-format-export.js
+++ b/packages/reports/addon/components/report-actions/multiple-format-export.js
@@ -14,6 +14,7 @@ import { computed, action } from '@ember/object';
 import { readOnly } from '@ember/object/computed';
 import layout from '../../templates/components/report-actions/multiple-format-export';
 import { layout as templateLayout, tagName } from '@ember-decorators/component';
+import { featureFlag } from 'navi-core/helpers/feature-flag';
 
 @templateLayout(layout)
 @tagName('')
@@ -42,6 +43,11 @@ export default class MultipleFormatExport extends Component {
    * @property {String} filename - filename for the downloaded file
    */
   @readOnly('report.title') filename;
+
+  /**
+   * @property {Array} supportedFileTypes - supported file types for export
+   */
+  supportedFileTypes = featureFlag('multiExportFileTypes');
 
   /**
    * @property {String} csvHref - CSV download link for the report
@@ -76,25 +82,37 @@ export default class MultipleFormatExport extends Component {
   /**
    * @property {Array} exportFormats - A list of export formats
    */
-  @computed('csvHref', 'pdfHref')
+  @computed('csvHref', 'pdfHref', 'supportedFileTypes')
   get exportFormats() {
-    return [
+    const { supportedFileTypes } = this;
+
+    const exportFormats = [
       {
         type: 'CSV',
         href: this.csvHref,
         icon: 'file-text-o'
-      },
-      {
-        type: 'PDF',
-        href: this.pdfHref,
-        icon: 'file-pdf-o'
-      },
-      {
-        type: 'PNG',
-        href: this.pdfHref.then(href => `${href}&fileType=png`),
-        icon: 'file-image-o'
       }
     ];
+
+    if (Array.isArray(supportedFileTypes)) {
+      if (supportedFileTypes.includes('pdf') || supportedFileTypes.includes('PDF')) {
+        exportFormats.push({
+          type: 'PDF',
+          href: this.pdfHref,
+          icon: 'file-pdf-o'
+        });
+      }
+
+      if (supportedFileTypes.includes('png') || supportedFileTypes.includes('PNG')) {
+        exportFormats.push({
+          type: 'PNG',
+          href: this.pdfHref.then(href => `${href}&fileType=png`),
+          icon: 'file-image-o'
+        });
+      }
+    }
+
+    return exportFormats;
   }
 
   /**

--- a/packages/reports/addon/templates/components/navi-action-list.hbs
+++ b/packages/reports/addon/templates/components/navi-action-list.hbs
@@ -23,7 +23,7 @@
 
   <li class="action">
   {{!-- Export only enabled on a validated report --}}
-    {{#let (component (concat "report-actions/" (if (feature-flag "enableMultipleExport") "multiple-format-export" "export"))) as |ExportAction|}}
+    {{#let (component (concat "report-actions/" (if (and (feature-flag "enableMultipleExport") (not (is-empty (feature-flag "multiExportFileTypes")))) "multiple-format-export" "export"))) as |ExportAction|}}
       <ExportAction
         id={{concat "navi-report-action-export-" @index}}
         class="navi-reports-index__report-control export {{unless @item.request.validations.isTruelyValid "navi-report__action-link--force-disabled"}}"

--- a/packages/reports/addon/templates/components/navi-action-list.hbs
+++ b/packages/reports/addon/templates/components/navi-action-list.hbs
@@ -23,7 +23,7 @@
 
   <li class="action">
   {{!-- Export only enabled on a validated report --}}
-    {{#let (component (concat "report-actions/" (if (and (feature-flag "enableMultipleExport") (not (is-empty (feature-flag "multiExportFileTypes")))) "multiple-format-export" "export"))) as |ExportAction|}}
+    {{#let (component (concat "report-actions/" (unless (is-empty (feature-flag "multipleExportFileTypes")) "multiple-format-export" "export"))) as |ExportAction|}}
       <ExportAction
         id={{concat "navi-report-action-export-" @index}}
         class="navi-reports-index__report-control export {{unless @item.request.validations.isTruelyValid "navi-report__action-link--force-disabled"}}"

--- a/packages/reports/addon/templates/components/report-actions.hbs
+++ b/packages/reports/addon/templates/components/report-actions.hbs
@@ -46,7 +46,7 @@
 
 {{!-- Export only enabled on a valid report --}}
 <li class="navi-report__action">
-  {{#let (component (concat "report-actions/" (if (feature-flag "enableMultipleExport") "multiple-format-export" "export"))) as |ExportAction|}}
+  {{#let (component (concat "report-actions/" (if (and (feature-flag "enableMultipleExport") (not (is-empty (feature-flag "multiExportFileTypes")))) "multiple-format-export" "export"))) as |ExportAction|}}
     <ExportAction
       class="navi-report__action-link {{unless @model.validations.isTruelyValid "navi-report__action-link--force-disabled"}}"
       @report={{@model}}

--- a/packages/reports/addon/templates/components/report-actions.hbs
+++ b/packages/reports/addon/templates/components/report-actions.hbs
@@ -46,7 +46,7 @@
 
 {{!-- Export only enabled on a valid report --}}
 <li class="navi-report__action">
-  {{#let (component (concat "report-actions/" (if (and (feature-flag "enableMultipleExport") (not (is-empty (feature-flag "multiExportFileTypes")))) "multiple-format-export" "export"))) as |ExportAction|}}
+  {{#let (component (concat "report-actions/" (unless (is-empty (feature-flag "multipleExportFileTypes")) "multiple-format-export" "export"))) as |ExportAction|}}
     <ExportAction
       class="navi-report__action-link {{unless @model.validations.isTruelyValid "navi-report__action-link--force-disabled"}}"
       @report={{@model}}

--- a/packages/reports/addon/templates/components/report-actions/multiple-format-export.hbs
+++ b/packages/reports/addon/templates/components/report-actions/multiple-format-export.hbs
@@ -12,7 +12,7 @@
             <li>
               <NaviIcon @icon={{exportFormat.icon}} />
               <a
-                download={{dasherize @report.title}}
+                download={{dasherize this.filename}}
                 href={{await exportFormat.href}}
                 {{on "click" (queue (fn this.notify exportFormat.type) (fn this.close dd))}}
               >

--- a/packages/reports/app/styles/navi-reports/common/report-controls.less
+++ b/packages/reports/app/styles/navi-reports/common/report-controls.less
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 
@@ -24,5 +24,6 @@
 
   &.disabled {
     color: @disabled-gray;
+    cursor: not-allowed;
   }
 }

--- a/packages/reports/config/environment.js
+++ b/packages/reports/config/environment.js
@@ -31,8 +31,7 @@ module.exports = function(/* environment, appConfig */) {
         frequencies: null
       },
       FEATURES: {
-        enableMultipleExport: false,
-        multiExportFileTypes: ['pdf'],
+        multipleExportFileTypes: [],
         enabledNotifyIfData: false
       }
     }

--- a/packages/reports/config/environment.js
+++ b/packages/reports/config/environment.js
@@ -32,6 +32,7 @@ module.exports = function(/* environment, appConfig */) {
       },
       FEATURES: {
         enableMultipleExport: false,
+        multiExportFileTypes: ['pdf'],
         enabledNotifyIfData: false
       }
     }

--- a/packages/reports/tests/acceptance/report-test.js
+++ b/packages/reports/tests/acceptance/report-test.js
@@ -526,10 +526,10 @@ module('Acceptance | Navi Report', function(hooks) {
   test('Export action - href', async function(assert) {
     assert.expect(4);
 
-    let originalFeatureFlag = config.navi.FEATURES.enableMultipleExport;
+    let originalFeatureFlag = config.navi.FEATURES.multipleExportFileTypes;
 
     // Turn flag off
-    config.navi.FEATURES.enableMultipleExport = false;
+    config.navi.FEATURES.multipleExportFileTypes = [];
 
     await visit('/reports/1/view');
 
@@ -573,7 +573,7 @@ module('Acceptance | Navi Report', function(hooks) {
       'Filter updates are automatically included in export url'
     );
 
-    config.navi.FEATURES.enableMultipleExport = originalFeatureFlag;
+    config.navi.FEATURES.multipleExportFileTypes = originalFeatureFlag;
   });
 
   test('Multi export action - csv href', async function(assert) {

--- a/packages/reports/tests/acceptance/report-test.js
+++ b/packages/reports/tests/acceptance/report-test.js
@@ -635,8 +635,8 @@ module('Acceptance | Navi Report', function(hooks) {
     await visit('/reports/1/view');
     await clickTrigger('.multiple-format-export');
 
-    const pdfHref = $('.multiple-format-export__dropdown a:contains("PDF")').attr('href');
-    let encodedModel = pdfHref.split('/export?reportModel=')[1];
+    const exportHref = $('.multiple-format-export__dropdown a:contains("PDF")').attr('href');
+    let encodedModel = exportHref.split('/export?reportModel=')[1];
 
     const actualModel = (await CompressionService.decompressModel(encodedModel)).serialize();
     const expectedModel = (await store.findRecord('report', 1)).serialize();
@@ -646,8 +646,8 @@ module('Acceptance | Navi Report', function(hooks) {
 
     assert.deepEqual(actualModel, expectedModel, 'PDF link has appropriate link to export service');
 
-    const pngHref = $('.multiple-format-export__dropdown a:contains("PNG")').attr('href');
-    assert.equal(`${pdfHref}&fileType=png`, pngHref, 'PNG link has appropriate link to export service');
+    const exportToPngHref = $('.multiple-format-export__dropdown a:contains("PNG")').attr('href');
+    assert.equal(`${exportHref}&fileType=png`, exportToPngHref, 'PNG link has appropriate link to export service');
 
     /* == Add groupby == */
     await clickItem('dimension', 'Product Family');

--- a/packages/reports/tests/dummy/config/environment.js
+++ b/packages/reports/tests/dummy/config/environment.js
@@ -45,8 +45,7 @@ module.exports = function(environment) {
       },
       FEATURES: {
         enableScheduleReports: true,
-        enableMultipleExport: true,
-        multiExportFileTypes: ['pdf', 'png'],
+        multipleExportFileTypes: ['pdf', 'png'],
         enabledNotifyIfData: true,
         enableContains: true,
         enableTableEditing: true

--- a/packages/reports/tests/dummy/config/environment.js
+++ b/packages/reports/tests/dummy/config/environment.js
@@ -46,6 +46,7 @@ module.exports = function(environment) {
       FEATURES: {
         enableScheduleReports: true,
         enableMultipleExport: true,
+        multiExportFileTypes: ['pdf', 'png'],
         enabledNotifyIfData: true,
         enableContains: true,
         enableTableEditing: true

--- a/packages/reports/tests/integration/components/common-actions/schedule-test.js
+++ b/packages/reports/tests/integration/components/common-actions/schedule-test.js
@@ -335,7 +335,7 @@ module('Integration | Component | common actions/schedule', function(hooks) {
   test('format options - config enableMultipleExport true', async function(assert) {
     assert.expect(1);
 
-    let originalFeatureFlag = config.navi.FEATURES.enableMultipleExport;
+    const originalFeatureFlag = config.navi.FEATURES.enableMultipleExport;
     config.navi.FEATURES.enableMultipleExport = true;
 
     this.set('model', TestModel);
@@ -346,7 +346,7 @@ module('Integration | Component | common actions/schedule', function(hooks) {
     await clickTrigger('.schedule-modal__dropdown--format');
     assert.deepEqual(
       findAll('.ember-power-select-option').map(el => el.textContent.trim()),
-      ['csv', 'pdf'],
+      ['csv', 'pdf', 'png'],
       'Schedule format should have correct options'
     );
 

--- a/packages/reports/tests/integration/components/common-actions/schedule-test.js
+++ b/packages/reports/tests/integration/components/common-actions/schedule-test.js
@@ -332,7 +332,7 @@ module('Integration | Component | common actions/schedule', function(hooks) {
     config.navi.schedule = originalSchedule;
   });
 
-  test('format options - fallback to `multiExportFileTypes`', async function(assert) {
+  test('format options - fallback to `multipleExportFileTypes`', async function(assert) {
     assert.expect(1);
 
     this.set('model', TestModel);
@@ -348,11 +348,11 @@ module('Integration | Component | common actions/schedule', function(hooks) {
     );
   });
 
-  test('format options - config enableMultipleExport false', async function(assert) {
+  test('format options - config multipleExportFileTypes is empty', async function(assert) {
     assert.expect(2);
 
-    let originalFeatureFlag = config.navi.FEATURES.enableMultipleExport;
-    config.navi.FEATURES.enableMultipleExport = false;
+    let originalFeatureFlag = config.navi.FEATURES.multipleExportFileTypes;
+    config.navi.FEATURES.multipleExportFileTypes = [];
 
     this.set('model', TestModel);
 
@@ -367,6 +367,6 @@ module('Integration | Component | common actions/schedule', function(hooks) {
       .dom('.schedule-modal__dropdown--format .ember-power-select-selected-item')
       .includesText('csv', 'Schedule format should have correct default option');
 
-    config.navi.FEATURES.enableMultipleExport = originalFeatureFlag;
+    config.navi.FEATURES.multipleExportFileTypes = originalFeatureFlag;
   });
 });

--- a/packages/reports/tests/integration/components/common-actions/schedule-test.js
+++ b/packages/reports/tests/integration/components/common-actions/schedule-test.js
@@ -332,11 +332,8 @@ module('Integration | Component | common actions/schedule', function(hooks) {
     config.navi.schedule = originalSchedule;
   });
 
-  test('format options - config enableMultipleExport true', async function(assert) {
+  test('format options - fallback to `multiExportFileTypes`', async function(assert) {
     assert.expect(1);
-
-    const originalFeatureFlag = config.navi.FEATURES.enableMultipleExport;
-    config.navi.FEATURES.enableMultipleExport = true;
 
     this.set('model', TestModel);
     await render(TEMPLATE);
@@ -349,8 +346,6 @@ module('Integration | Component | common actions/schedule', function(hooks) {
       ['csv', 'pdf', 'png'],
       'Schedule format should have correct options'
     );
-
-    config.navi.FEATURES.enableMultipleExport = originalFeatureFlag;
   });
 
   test('format options - config enableMultipleExport false', async function(assert) {

--- a/packages/reports/tests/integration/components/report-actions/multiple-format-export-test.js
+++ b/packages/reports/tests/integration/components/report-actions/multiple-format-export-test.js
@@ -7,13 +7,14 @@ import hbs from 'htmlbars-inline-precompile';
 import { clickTrigger } from 'ember-basic-dropdown/test-support/helpers';
 
 const TEMPLATE = hbs`
-    {{#report-actions/multiple-format-export
-        report=report
-        disabled=disabled
-        naviNotifications=mockNotifications
-    }}
-        Export
-    {{/report-actions/multiple-format-export}}
+    <ReportActions::MultipleFormatExport
+      @report={{this.report}}
+      @title={{this.title}}
+      @disabled={{this.disabled}}
+      @naviNotifications={{this.mockNotifications}}
+    >
+      Export
+    </ReportActions::MultipleFormatExport>
     `;
 
 let Store;
@@ -42,7 +43,7 @@ module('Integration | Component | report actions - multiple-format-export', func
   });
 
   test('export links', async function(assert) {
-    assert.expect(3);
+    assert.expect(4);
 
     const factService = this.owner.lookup('service:navi-facts');
     const compressionService = this.owner.lookup('service:compression');
@@ -60,9 +61,8 @@ module('Integration | Component | report actions - multiple-format-export', func
       'CSV link has appropriate link to API'
     );
 
-    const encodedModel = $('.multiple-format-export__dropdown a:contains("PDF")')
-      .attr('href')
-      .split('/export?reportModel=')[1];
+    const pdfHref = $('.multiple-format-export__dropdown a:contains("PDF")').attr('href');
+    const encodedModel = pdfHref.split('/export?reportModel=')[1];
 
     const actualModel = (await compressionService.decompressModel(encodedModel)).serialize();
     const expectedModel = this.report.serialize();
@@ -71,6 +71,9 @@ module('Integration | Component | report actions - multiple-format-export', func
     delete expectedModel.data.relationships;
 
     assert.deepEqual(actualModel, expectedModel, 'PDF link has appropriate link to export service');
+
+    const pngHref = $('.multiple-format-export__dropdown a:contains("PNG")').attr('href');
+    assert.equal(`${pdfHref}&fileType=png`, pngHref, 'PNG link has appropriate link to export service');
   });
 
   test('filename', async function(assert) {
@@ -157,14 +160,14 @@ module('Integration | Component | report actions - multiple-format-export', func
       }
     ]);
     await render(hbs`
-      {{#report-actions/multiple-format-export
-          report=report
-          disabled=disabled
-          naviNotifications=mockNotifications
-          exportFormats=exportFormats
-      }}
-          Export
-      {{/report-actions/multiple-format-export}}
+      <ReportActions::MultipleFormatExport
+        @report={{this.report}}
+        @disabled={{this.disabled}}
+        @naviNotifications={{this.mockNotifications}}
+        @exportFormats={{this.exportFormats}}
+      >
+        Export
+      </ReportActions::MultipleFormatExport>
     `);
 
     await clickTrigger();

--- a/packages/reports/tests/integration/components/report-actions/multiple-format-export-test.js
+++ b/packages/reports/tests/integration/components/report-actions/multiple-format-export-test.js
@@ -61,8 +61,8 @@ module('Integration | Component | report actions - multiple-format-export', func
       'CSV link has appropriate link to API'
     );
 
-    const pdfHref = $('.multiple-format-export__dropdown a:contains("PDF")').attr('href');
-    const encodedModel = pdfHref.split('/export?reportModel=')[1];
+    const exportHref = $('.multiple-format-export__dropdown a:contains("PDF")').attr('href');
+    const encodedModel = exportHref.split('/export?reportModel=')[1];
 
     const actualModel = (await compressionService.decompressModel(encodedModel)).serialize();
     const expectedModel = this.report.serialize();
@@ -73,7 +73,7 @@ module('Integration | Component | report actions - multiple-format-export', func
     assert.deepEqual(actualModel, expectedModel, 'PDF link has appropriate link to export service');
 
     const pngHref = $('.multiple-format-export__dropdown a:contains("PNG")').attr('href');
-    assert.equal(`${pdfHref}&fileType=png`, pngHref, 'PNG link has appropriate link to export service');
+    assert.equal(`${exportHref}&fileType=png`, pngHref, 'PNG link has appropriate link to export service');
   });
 
   test('filename', async function(assert) {


### PR DESCRIPTION
## Description

Add PNG export.

## Proposed Changes

- add PNG option to `multiple-format-export` component
- use in dashboards instead of the single export button
- add to schedule formats

❗not to be merged until fully supported on back end❗ 

## Screenshots

![Oct-01-2020 22-08-12](https://user-images.githubusercontent.com/13946669/94890092-270def80-0433-11eb-8717-b427054fba33.gif)

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
