### PR TITLE
Response methods

### DIFF
--- a/packages/data/addon/adapters/dimensions/bard.ts
+++ b/packages/data/addon/adapters/dimensions/bard.ts
@@ -11,9 +11,9 @@ import { configHost } from '../../utils/adapter';
 import { serializeFilters } from '../facts/bard';
 import { Filter } from '../facts/interface';
 import NaviMetadataService from 'navi-data/services/navi-metadata';
-import NaviDimensionAdapter, { DimensionColumn, DimensionFilter } from './interface';
+import NaviDimensionAdapter, { DimensionFilter } from './interface';
 import { ServiceOptions } from 'navi-data/services/navi-dimension';
-import DimensionMetadataModel from 'navi-data/models/metadata/dimension';
+import DimensionMetadataModel, { DimensionColumn } from 'navi-data/models/metadata/dimension';
 import { getDefaultDataSourceName } from 'navi-data/utils/adapter';
 
 const SUPPORTED_FILTER_OPERATORS = ['in', 'notin', 'startswith', 'contains'];

--- a/packages/data/addon/adapters/dimensions/elide.ts
+++ b/packages/data/addon/adapters/dimensions/elide.ts
@@ -6,10 +6,11 @@
  */
 import { getOwner } from '@ember/application';
 import EmberObject from '@ember/object';
-import NaviDimensionAdapter, { DimensionColumn, DimensionFilter } from './interface';
+import NaviDimensionAdapter, { DimensionFilter } from './interface';
 import { ServiceOptions } from 'navi-data/services/navi-dimension';
 import { RequestV2 } from '../facts/interface';
 import ElideFactsAdapter from '../facts/elide';
+import { DimensionColumn } from 'navi-data/models/metadata/dimension';
 
 export default class ElideDimensionAdapter extends EmberObject implements NaviDimensionAdapter {
   /**

--- a/packages/data/addon/adapters/dimensions/interface.ts
+++ b/packages/data/addon/adapters/dimensions/interface.ts
@@ -2,20 +2,15 @@
  * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
-import { Parameters, FilterOperator } from '../facts/interface';
-import DimensionMetadataModel from 'navi-data/models/metadata/dimension';
+import { FilterOperator } from '../facts/interface';
 import EmberObject from '@ember/object';
 import { ServiceOptions } from 'navi-data/services/navi-dimension';
+import { DimensionColumn } from 'navi-data/models/metadata/dimension';
 
 export type DimensionFilter = {
   operator: FilterOperator;
   values: (string | number)[];
 };
-
-export interface DimensionColumn {
-  columnMetadata: DimensionMetadataModel;
-  parameters?: Parameters;
-}
 
 export default interface NaviDimensionAdapter extends EmberObject {
   /**

--- a/packages/data/addon/models/metadata/column.ts
+++ b/packages/data/addon/models/metadata/column.ts
@@ -30,6 +30,11 @@ export interface ColumnMetadataPayload {
   partialData?: boolean; //TODO refactor me
 }
 
+export interface ColumnInstance<T extends ColumnMetadataModel> {
+  columnMetadata: T;
+  parameters?: Parameters;
+}
+
 // Shape of public properties on model
 export interface ColumnMetadata {
   id: string;

--- a/packages/data/addon/models/metadata/column.ts
+++ b/packages/data/addon/models/metadata/column.ts
@@ -10,6 +10,8 @@ import Table from './table';
 import ColumnFunction from './column-function';
 import FunctionParameter from './function-parameter';
 import NaviMetadataService, { MetadataModelTypes } from 'navi-data/services/navi-metadata';
+import { canonicalizeMetric } from 'navi-data/utils/metric';
+import { Parameters } from 'navi-data/adapters/facts/interface';
 
 export type RawColumnType = 'ref' | 'formula' | 'field';
 export type ColumnType = Extract<MetadataModelTypes, 'metric' | 'dimension' | 'timeDimension'>;
@@ -180,5 +182,11 @@ export default class ColumnMetadataModel extends EmberObject implements ColumnMe
       }
       return acc;
     }, {});
+  }
+
+  getCanonicalName(parameters?: Parameters) {
+    const { id: metric } = this;
+    // TODO rename with generic canonicalizeColumn
+    return canonicalizeMetric({ metric, parameters });
   }
 }

--- a/packages/data/addon/models/metadata/dimension.ts
+++ b/packages/data/addon/models/metadata/dimension.ts
@@ -3,7 +3,7 @@
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import { assert } from '@ember/debug';
-import ColumnMetadataModel, { ColumnMetadata, ColumnMetadataPayload, ColumnType } from './column';
+import ColumnMetadataModel, { ColumnInstance, ColumnMetadata, ColumnMetadataPayload, ColumnType } from './column';
 import CARDINALITY_SIZES from '../../utils/enums/cardinality-sizes';
 
 type Cardinality = typeof CARDINALITY_SIZES[number] | undefined;
@@ -25,6 +25,8 @@ export interface DimensionMetadataPayload extends ColumnMetadataPayload {
   cardinality?: Cardinality;
   storageStrategy?: TODO<'loaded' | 'none' | null>;
 }
+
+export type DimensionColumn = ColumnInstance<DimensionMetadataModel>;
 
 export default class DimensionMetadataModel extends ColumnMetadataModel
   implements DimensionMetadata, DimensionMetadataPayload {

--- a/packages/data/addon/models/metadata/metric.ts
+++ b/packages/data/addon/models/metadata/metric.ts
@@ -2,7 +2,7 @@
  * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
-import ColumnMetadataModel, { ColumnMetadata, ColumnMetadataPayload, ColumnType } from './column';
+import ColumnMetadataModel, { ColumnInstance, ColumnMetadata, ColumnMetadataPayload, ColumnType } from './column';
 
 // Shape of public properties on model
 export interface MetricMetadata extends ColumnMetadata {
@@ -13,6 +13,8 @@ export interface MetricMetadata extends ColumnMetadata {
 export interface MetricMetadataPayload extends ColumnMetadataPayload {
   defaultFormat?: string;
 }
+
+export type MetricColumn = ColumnInstance<MetricMetadataModel>;
 
 export default class MetricMetadataModel extends ColumnMetadataModel implements MetricMetadata, MetricMetadataPayload {
   /**

--- a/packages/data/addon/models/metadata/time-dimension.ts
+++ b/packages/data/addon/models/metadata/time-dimension.ts
@@ -3,7 +3,7 @@
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import DimensionMetadataModel, { DimensionMetadata, DimensionMetadataPayload } from './dimension';
-import { ColumnType } from './column';
+import { ColumnInstance, ColumnType } from './column';
 
 interface TimeDimensionGrain {
   id: string;
@@ -20,6 +20,8 @@ export interface TimeDimensionMetadataPayload extends DimensionMetadataPayload {
   supportedGrains: TimeDimensionGrain[];
   timeZone: TODO;
 }
+
+export type TimeDimensionColumn = ColumnInstance<TimeDimensionMetadataModel>;
 
 export default class TimeDimensionMetadataModel extends DimensionMetadataModel
   implements TimeDimensionMetadata, TimeDimensionMetadataPayload {

--- a/packages/data/addon/models/navi-dimension.ts
+++ b/packages/data/addon/models/navi-dimension.ts
@@ -3,7 +3,7 @@
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import EmberObject from '@ember/object';
-import { DimensionColumn } from 'navi-data/adapters/dimensions/interface';
+import { DimensionColumn } from './metadata/dimension';
 import { isEqual } from 'lodash-es';
 
 export default class NaviDimensionModel extends EmberObject {

--- a/packages/data/addon/models/navi-fact-response.ts
+++ b/packages/data/addon/models/navi-fact-response.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2020, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+
+import EmberObject from '@ember/object';
+import { ResponseV1 } from 'navi-data/serializers/facts/interface';
+import moment, { Moment, MomentInput } from 'moment';
+import { TimeDimensionColumn } from './metadata/time-dimension';
+
+function notNull<T>(t: T | null): t is T {
+  return t !== null;
+}
+
+export default class NaviFactResponse extends EmberObject implements ResponseV1 {
+  rows!: ResponseV1['rows'];
+  meta!: ResponseV1['meta'];
+
+  private getTimeDimensionAsMoments(column: TimeDimensionColumn): Moment[] {
+    const { columnMetadata, parameters } = column;
+    const field = columnMetadata.getCanonicalName(parameters);
+    const { rows = [] } = this;
+    return rows
+      .map(row => {
+        const value = row[field];
+        return value ? moment(value as MomentInput) : null;
+      })
+      .filter(notNull);
+  }
+
+  /**
+   * Get the max dateTime value for a column in moment form
+   */
+  getMaxTimeDimension(column: TimeDimensionColumn): Moment | null {
+    const moments = this.getTimeDimensionAsMoments(column);
+    return moments.length ? moment.max(moments) : null;
+  }
+
+  /**
+   * Get the min dateTime value for a column in moment form
+   */
+  getMinTimeDimension(column: TimeDimensionColumn): Moment | null {
+    const moments = this.getTimeDimensionAsMoments(column);
+    return moments.length ? moment.min(moments) : null;
+  }
+}

--- a/packages/data/addon/models/navi-fact-response.ts
+++ b/packages/data/addon/models/navi-fact-response.ts
@@ -13,8 +13,8 @@ function notNull<T>(t: T | null): t is T {
 }
 
 export default class NaviFactResponse extends EmberObject implements ResponseV1 {
-  rows!: ResponseV1['rows'];
-  meta!: ResponseV1['meta'];
+  readonly rows: ResponseV1['rows'] = [];
+  readonly meta: ResponseV1['meta'] = {};
 
   private getTimeDimensionAsMoments(column: TimeDimensionColumn): Moment[] {
     const { columnMetadata, parameters } = column;

--- a/packages/data/addon/models/navi-fact-response.ts
+++ b/packages/data/addon/models/navi-fact-response.ts
@@ -33,7 +33,11 @@ export default class NaviFactResponse extends EmberObject implements ResponseV1 
    */
   getMaxTimeDimension(column: TimeDimensionColumn): Moment | null {
     const moments = this.getTimeDimensionAsMoments(column);
-    return moments.length ? moment.max(moments) : null;
+    if (moments.length) {
+      const max = moment.max(moments);
+      return max.isValid() ? max : null;
+    }
+    return null;
   }
 
   /**
@@ -41,6 +45,10 @@ export default class NaviFactResponse extends EmberObject implements ResponseV1 
    */
   getMinTimeDimension(column: TimeDimensionColumn): Moment | null {
     const moments = this.getTimeDimensionAsMoments(column);
-    return moments.length ? moment.min(moments) : null;
+    if (moments.length) {
+      const min = moment.min(moments);
+      return min.isValid() ? min : null;
+    }
+    return null;
   }
 }

--- a/packages/data/addon/models/navi-facts.ts
+++ b/packages/data/addon/models/navi-facts.ts
@@ -6,8 +6,8 @@
  */
 
 import EmberObject from '@ember/object';
-import { ResponseV1 } from 'navi-data/serializers/facts/interface';
 import { RequestV2 } from 'navi-data/adapters/facts/interface';
+import NaviFactResponse from './navi-fact-response';
 
 export default class NaviFacts extends EmberObject {
   /**
@@ -18,7 +18,7 @@ export default class NaviFacts extends EmberObject {
   /**
    * @property {ResponseV1} response - response for request
    */
-  response?: ResponseV1;
+  response?: NaviFactResponse;
 
   /**
    * @property {Service} _factsService - instance of the facts service passed in on create

--- a/packages/data/addon/serializers/dimensions/bard.ts
+++ b/packages/data/addon/serializers/dimensions/bard.ts
@@ -5,9 +5,9 @@
 
 import EmberObject from '@ember/object';
 import NaviDimensionSerializer from './interface';
-import { DimensionColumn } from 'navi-data/adapters/dimensions/interface';
 import NaviDimensionModel from '../../models/navi-dimension';
 import { FiliDimensionResponse, DefaultField } from 'navi-data/adapters/dimensions/bard';
+import { DimensionColumn } from 'navi-data/models/metadata/dimension';
 
 export default class BardDimensionSerializer extends EmberObject implements NaviDimensionSerializer {
   normalize(dimensionColumn: DimensionColumn, rawPayload: FiliDimensionResponse): NaviDimensionModel[] {

--- a/packages/data/addon/serializers/dimensions/elide.ts
+++ b/packages/data/addon/serializers/dimensions/elide.ts
@@ -5,10 +5,10 @@
 
 import NaviDimensionSerializer from './interface';
 import NaviDimensionModel from '../../models/navi-dimension';
-import { DimensionColumn } from '../../adapters/dimensions/interface';
 import { AsyncQueryResponse } from 'navi-data/adapters/facts/interface';
 import { getElideField } from '../../adapters/facts/elide';
 import EmberObject from '@ember/object';
+import { DimensionColumn } from 'navi-data/models/metadata/dimension';
 
 type ResponseEdge = {
   node: Dict<string>;

--- a/packages/data/addon/serializers/dimensions/interface.ts
+++ b/packages/data/addon/serializers/dimensions/interface.ts
@@ -3,8 +3,8 @@
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import NaviDimensionModel from '../../models/navi-dimension';
-import { DimensionColumn } from '../../adapters/dimensions/interface';
 import EmberObject from '@ember/object';
+import { DimensionColumn } from 'navi-data/models/metadata/dimension';
 
 export default interface NaviDimensionSerializer extends EmberObject {
   normalize(dimension: DimensionColumn, rawPayload: unknown): NaviDimensionModel[];

--- a/packages/data/addon/serializers/facts/bard.ts
+++ b/packages/data/addon/serializers/facts/bard.ts
@@ -9,6 +9,7 @@ import EmberObject from '@ember/object';
 import NaviFactSerializer, { ResponseV1 } from './interface';
 import { RequestV2, Column } from 'navi-data/adapters/facts/interface';
 import { canonicalizeMetric } from 'navi-data/utils/metric';
+import NaviFactResponse from 'navi-data/models/navi-fact-response';
 
 export default class BardFactsSerializer extends EmberObject implements NaviFactSerializer {
   /**
@@ -33,7 +34,7 @@ export default class BardFactsSerializer extends EmberObject implements NaviFact
    * @param payload - raw payload string
    * @param request - request v2 object
    */
-  private processResponse(payload: ResponseV1, request: RequestV2): ResponseV1 {
+  private processResponse(payload: ResponseV1, request: RequestV2): NaviFactResponse {
     const filiFields = request.columns.map(column => this.getFiliField(column));
     const normalizedFields = request.columns.map(({ field: metric, parameters }) =>
       // TODO rename with generic canonicalizeColumn
@@ -55,17 +56,20 @@ export default class BardFactsSerializer extends EmberObject implements NaviFact
       }
     }
 
-    return { rows, meta: payload.meta || {} };
+    return NaviFactResponse.create({
+      rows,
+      meta: payload.meta || {}
+    });
   }
 
-  normalize(payload: ResponseV1, request: RequestV2): ResponseV1 | undefined {
+  normalize(payload: ResponseV1, request: RequestV2): NaviFactResponse | undefined {
     if (payload && request) {
       return this.processResponse(payload, request);
     } else if (payload) {
-      return {
+      return NaviFactResponse.create({
         rows: [],
         meta: payload.meta || {}
-      };
+      });
     }
     return undefined;
   }

--- a/packages/data/addon/serializers/facts/bard.ts
+++ b/packages/data/addon/serializers/facts/bard.ts
@@ -41,7 +41,7 @@ export default class BardFactsSerializer extends EmberObject implements NaviFact
       canonicalizeMetric({ metric, parameters })
     );
 
-    const rawRows = payload.rows;
+    const { rows: rawRows, meta } = payload;
     const totalRows = rawRows.length;
     const totalFields = normalizedFields.length;
     const rows = new Array(totalRows);
@@ -56,21 +56,10 @@ export default class BardFactsSerializer extends EmberObject implements NaviFact
       }
     }
 
-    return NaviFactResponse.create({
-      rows,
-      meta: payload.meta || {}
-    });
+    return NaviFactResponse.create({ rows, meta });
   }
 
   normalize(payload: ResponseV1, request: RequestV2): NaviFactResponse | undefined {
-    if (payload && request) {
-      return this.processResponse(payload, request);
-    } else if (payload) {
-      return NaviFactResponse.create({
-        rows: [],
-        meta: payload.meta || {}
-      });
-    }
-    return undefined;
+    return payload ? this.processResponse(payload, request) : undefined;
   }
 }

--- a/packages/data/addon/serializers/facts/elide.ts
+++ b/packages/data/addon/serializers/facts/elide.ts
@@ -6,17 +6,18 @@
  */
 
 import EmberObject from '@ember/object';
-import NaviFactSerializer, { ResponseV1 } from './interface';
+import NaviFactSerializer from './interface';
 import { AsyncQueryResponse, RequestV2 } from 'navi-data/adapters/facts/interface';
 import { getElideField } from 'navi-data/adapters/facts/elide';
 import { canonicalizeMetric } from 'navi-data/utils/metric';
+import NaviFactResponse from 'navi-data/models/navi-fact-response';
 
 export default class ElideFactsSerializer extends EmberObject implements NaviFactSerializer {
   /**
    * @param payload - raw payload string
    * @param request - request object
    */
-  private processResponse(payload: string, request: RequestV2): ResponseV1 {
+  private processResponse(payload: string, request: RequestV2): NaviFactResponse {
     const response = JSON.parse(payload);
 
     const { table } = request;
@@ -41,10 +42,11 @@ export default class ElideFactsSerializer extends EmberObject implements NaviFac
         newRow[normalizedFields[f]] = rawRow[elideFields[f]];
       }
     }
-    return { rows, meta: {} };
+
+    return NaviFactResponse.create({ rows, meta: {} });
   }
 
-  normalize(payload: AsyncQueryResponse, request: RequestV2): ResponseV1 | undefined {
+  normalize(payload: AsyncQueryResponse, request: RequestV2): NaviFactResponse | undefined {
     const responseStr = payload?.asyncQuery.edges[0].node.result?.responseBody;
     return responseStr ? this.processResponse(responseStr, request) : undefined;
   }

--- a/packages/data/addon/serializers/facts/interface.ts
+++ b/packages/data/addon/serializers/facts/interface.ts
@@ -9,7 +9,7 @@ import NaviFactResponse from 'navi-data/models/navi-fact-response';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ResponsePayload = any;
 
-export interface ResponseV1 {
+export interface ResponseV1 ReadOnly<{
   readonly rows: Array<Record<string, unknown>>;
   readonly meta: {
     pagination?: {

--- a/packages/data/addon/serializers/facts/interface.ts
+++ b/packages/data/addon/serializers/facts/interface.ts
@@ -4,6 +4,7 @@
  */
 
 import { RequestV1, RequestV2 } from 'navi-data/adapters/facts/interface';
+import NaviFactResponse from 'navi-data/models/navi-fact-response';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ResponsePayload = any;
@@ -26,5 +27,5 @@ export default interface NaviFactSerializer {
    * @param payload - payload to normalize
    * @param request - request for response payload
    */
-  normalize(payload: ResponsePayload, request: RequestV1 | RequestV2): ResponseV1 | undefined;
+  normalize(payload: ResponsePayload, request: RequestV1 | RequestV2): NaviFactResponse | undefined;
 }

--- a/packages/data/addon/serializers/facts/interface.ts
+++ b/packages/data/addon/serializers/facts/interface.ts
@@ -10,8 +10,8 @@ import NaviFactResponse from 'navi-data/models/navi-fact-response';
 type ResponsePayload = any;
 
 export interface ResponseV1 {
-  rows: Array<Record<string, unknown>>;
-  meta: {
+  readonly rows: Array<Record<string, unknown>>;
+  readonly meta: {
     pagination?: {
       currentPage: number;
       rowsPerPage: number;

--- a/packages/data/addon/serializers/facts/interface.ts
+++ b/packages/data/addon/serializers/facts/interface.ts
@@ -9,7 +9,7 @@ import NaviFactResponse from 'navi-data/models/navi-fact-response';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ResponsePayload = any;
 
-export interface ResponseV1 ReadOnly<{
+export interface ResponseV1 {
   readonly rows: Array<Record<string, unknown>>;
   readonly meta: {
     pagination?: {

--- a/packages/data/addon/services/navi-dimension.ts
+++ b/packages/data/addon/services/navi-dimension.ts
@@ -4,10 +4,11 @@
  */
 import Service from '@ember/service';
 import NaviDimensionSerializer from 'navi-data/serializers/dimensions/interface';
-import NaviDimensionAdapter, { DimensionColumn, DimensionFilter } from 'navi-data/adapters/dimensions/interface';
+import NaviDimensionAdapter, { DimensionFilter } from 'navi-data/adapters/dimensions/interface';
 import { getOwner } from '@ember/application';
 import { getDataSource } from 'navi-data/utils/adapter';
 import NaviDimensionModel from 'navi-data/models/navi-dimension';
+import { DimensionColumn } from 'navi-data/models/metadata/dimension';
 
 export type ServiceOptions = {
   timeout?: number;

--- a/packages/data/tests/unit/adapters/dimensions/elide-test.ts
+++ b/packages/data/tests/unit/adapters/dimensions/elide-test.ts
@@ -1,9 +1,8 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import ElideDimensionAdapter from 'navi-data/adapters/dimensions/elide';
-import { DimensionColumn } from 'navi-data/adapters/dimensions/interface';
 import { RequestV2, AsyncQueryResponse, QueryStatus, RequestOptions } from 'navi-data/adapters/facts/interface';
-import DimensionMetadataModel from 'navi-data/models/metadata/dimension';
+import DimensionMetadataModel, { DimensionColumn } from 'navi-data/models/metadata/dimension';
 import NaviMetadataService from 'navi-data/services/navi-metadata';
 import { TestContext as Context } from 'ember-test-helpers';
 import ElideOneScenario from 'navi-data/mirage/scenarios/elide-one';

--- a/packages/data/tests/unit/models/navi-dimension-test.ts
+++ b/packages/data/tests/unit/models/navi-dimension-test.ts
@@ -5,8 +5,7 @@ import { TestContext as Context } from 'ember-test-helpers';
 //@ts-ignore
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import NaviMetadataService from 'navi-data/services/navi-metadata';
-import { DimensionColumn } from 'navi-data/adapters/dimensions/interface';
-import DimensionMetadataModel from 'navi-data/models/metadata/dimension';
+import DimensionMetadataModel, { DimensionColumn } from 'navi-data/models/metadata/dimension';
 import ElideOneScenario from 'navi-data/mirage/scenarios/elide-one';
 import { Server } from 'miragejs';
 

--- a/packages/data/tests/unit/models/navi-fact-response-test.ts
+++ b/packages/data/tests/unit/models/navi-fact-response-test.ts
@@ -1,0 +1,134 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import NaviFactResponse from 'navi-data/models/navi-fact-response';
+import { TestContext as Context } from 'ember-test-helpers';
+//@ts-ignore
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import ElideOneScenario from 'navi-data/mirage/scenarios/elide-one';
+import { Server } from 'miragejs';
+import NaviMetadataService from 'navi-data/services/navi-metadata';
+import TimeDimensionMetadataModel from 'navi-data/models/metadata/time-dimension';
+import moment from 'moment';
+import { ResponseV1 } from 'navi-data/serializers/facts/interface';
+
+interface TestContext extends Context {
+  metadataService: NaviMetadataService;
+  server: Server;
+}
+
+module('Unit | Model | navi fact response', function(hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+  hooks.beforeEach(async function(this: TestContext) {
+    ElideOneScenario(this.server);
+    this.metadataService = this.owner.lookup('service:navi-metadata');
+    await this.metadataService.loadMetadata({ dataSourceName: 'elideOne' });
+  });
+
+  test('create', function(this: TestContext, assert) {
+    const rows = [{ 'table1.eventTimeDay': '2014-04-02 00:00:00.000' }];
+    const meta = {};
+
+    const response = NaviFactResponse.create({ rows, meta });
+    assert.equal(rows, response.rows, '`NaviFactResponse` can be hydrated with `rows`');
+    assert.equal(meta, response.meta, '`NaviFactResponse` can be hydrated with `meta`');
+  });
+
+  test('getMaxTimeDimension', function(this: TestContext, assert) {
+    const rows = [
+      { 'table1.eventTimeDay': '2014-04-02 00:00:00.000' },
+      { 'table1.eventTimeDay': '2014-04-03 00:00:00.000' },
+      { 'table1.eventTimeDay': '2014-04-04 00:00:00.000' }
+    ];
+    const response = NaviFactResponse.create({ rows });
+    const columnMetadata = this.metadataService.getById(
+      'timeDimension',
+      'table1.eventTimeDay',
+      'elideOne'
+    ) as TimeDimensionMetadataModel;
+    const max = response.getMaxTimeDimension({ columnMetadata });
+    assert.ok(
+      moment(rows[2]['table1.eventTimeDay']).isSame(max),
+      '`getMaxTimeDimension` returns the max dateTime for a column in moment form'
+    );
+  });
+
+  test('getMinTimeDimension', function(this: TestContext, assert) {
+    const rows = [
+      { 'table1.eventTimeDay': '2014-04-02 00:00:00.000' },
+      { 'table1.eventTimeDay': '2014-04-03 00:00:00.000' },
+      { 'table1.eventTimeDay': '2014-04-04 00:00:00.000' }
+    ];
+    const response = NaviFactResponse.create({ rows });
+    const columnMetadata = this.metadataService.getById(
+      'timeDimension',
+      'table1.eventTimeDay',
+      'elideOne'
+    ) as TimeDimensionMetadataModel;
+    const min = response.getMinTimeDimension({ columnMetadata });
+    assert.ok(
+      moment(rows[0]['table1.eventTimeDay']).isSame(min),
+      '`getMinTimeDimension` returns the min dateTime for a column in moment form'
+    );
+  });
+
+  test('getMaxTimeDimension/getMaxTimeDimension - empty column', function(this: TestContext, assert) {
+    const rows: ResponseV1['rows'] = [];
+    const response = NaviFactResponse.create({ rows });
+    const columnMetadata = this.metadataService.getById(
+      'timeDimension',
+      'table1.eventTimeDay',
+      'elideOne'
+    ) as TimeDimensionMetadataModel;
+    const max = response.getMaxTimeDimension({ columnMetadata });
+    assert.equal(null, max, '`getMaxTimeDimension` returns null for empty responses');
+
+    const min = response.getMinTimeDimension({ columnMetadata });
+    assert.equal(null, min, '`getMinTimeDimension` returns null for empty responses');
+  });
+
+  test('getMaxTimeDimension/getMaxTimeDimension - missing value', function(this: TestContext, assert) {
+    const rows = [
+      { 'table1.eventTimeDay': '2014-04-02 00:00:00.000' },
+      { 'table1.eventTimeDay': '2014-04-03 00:00:00.000' },
+      { 'table1.eventTimeDay': '2014-04-04 00:00:00.000' }
+    ];
+    const response = NaviFactResponse.create({ rows });
+    const columnMetadata = this.metadataService.getById(
+      'timeDimension',
+      'table1.eventTimeMonth',
+      'elideOne'
+    ) as TimeDimensionMetadataModel;
+    const max = response.getMaxTimeDimension({ columnMetadata });
+    assert.equal(null, max, '`getMaxTimeDimension` returns null for missing values');
+
+    const min = response.getMinTimeDimension({ columnMetadata });
+    assert.equal(null, min, '`getMinTimeDimension` returns null for missing values');
+  });
+
+  test('getMaxTimeDimension/getMaxTimeDimension - value gaps', function(this: TestContext, assert) {
+    const rows = [
+      { 'table1.eventTimeDay': null },
+      { 'table1.eventTimeDay': '2014-04-03 00:00:00.000' },
+      { 'table1.eventTimeDay': '2014-04-04 00:00:00.000' }
+    ];
+    const response = NaviFactResponse.create({ rows });
+    const columnMetadata = this.metadataService.getById(
+      'timeDimension',
+      'table1.eventTimeDay',
+      'elideOne'
+    ) as TimeDimensionMetadataModel;
+
+    const max = response.getMaxTimeDimension({ columnMetadata });
+    assert.ok(
+      moment(rows[2]['table1.eventTimeDay']).isSame(max),
+      '`getMaxTimeDimension` returns max dateTime when date values have gaps'
+    );
+
+    const min = response.getMinTimeDimension({ columnMetadata });
+    assert.ok(
+      moment(rows[1]['table1.eventTimeDay']).isSame(min),
+      '`getMinTimeDimension` returns mix dateTime when date values have gaps'
+    );
+  });
+});

--- a/packages/data/tests/unit/models/navi-fact-response-test.ts
+++ b/packages/data/tests/unit/models/navi-fact-response-test.ts
@@ -139,7 +139,7 @@ module('Unit | Model | navi fact response', function(hooks) {
     );
   });
 
-  test('getMaxTimeDimension/getMaxTimeDimension - invalid values', function(this: TestContext, assert) {
+  test('getMaxTimeDimension/getMinTimeDimension - invalid values', function(this: TestContext, assert) {
     const columnMetadata = this.metadataService.getById(
       'timeDimension',
       'table1.eventTimeDay',

--- a/packages/data/tests/unit/models/navi-fact-response-test.ts
+++ b/packages/data/tests/unit/models/navi-fact-response-test.ts
@@ -107,28 +107,35 @@ module('Unit | Model | navi fact response', function(hooks) {
   });
 
   test('getMaxTimeDimension/getMaxTimeDimension - value gaps', function(this: TestContext, assert) {
-    const rows = [
-      { 'table1.eventTimeDay': null },
-      { 'table1.eventTimeDay': '2014-04-03 00:00:00.000' },
-      { 'table1.eventTimeDay': '2014-04-04 00:00:00.000' }
-    ];
-    const response = NaviFactResponse.create({ rows });
     const columnMetadata = this.metadataService.getById(
       'timeDimension',
       'table1.eventTimeDay',
       'elideOne'
     ) as TimeDimensionMetadataModel;
 
-    const max = response.getMaxTimeDimension({ columnMetadata });
+    const maxRows = [
+      { 'table1.eventTimeDay': '2014-04-03 00:00:00.000' },
+      { 'table1.eventTimeDay': null },
+      { 'table1.eventTimeDay': '2014-04-04 00:00:00.000' }
+    ];
+    const maxResponse = NaviFactResponse.create({ rows: maxRows });
+    const max = maxResponse.getMaxTimeDimension({ columnMetadata });
     assert.ok(
-      moment(rows[2]['table1.eventTimeDay']).isSame(max),
+      moment(maxRows[2]['table1.eventTimeDay']).isSame(max),
       '`getMaxTimeDimension` returns max dateTime when date values have gaps'
     );
 
-    const min = response.getMinTimeDimension({ columnMetadata });
+    const minRows = [
+      { 'table1.eventTimeDay': null },
+      { 'table1.eventTimeDay': '2014-04-04 00:00:00.000' },
+      { 'table1.eventTimeDay': '2014-04-03 00:00:00.000' }
+    ];
+    const minResponse = NaviFactResponse.create({ rows: minRows });
+
+    const min = minResponse.getMinTimeDimension({ columnMetadata });
     assert.ok(
-      moment(rows[1]['table1.eventTimeDay']).isSame(min),
-      '`getMinTimeDimension` returns mix dateTime when date values have gaps'
+      moment(minRows[2]['table1.eventTimeDay']).isSame(min),
+      '`getMinTimeDimension` returns min dateTime when date values have gaps'
     );
   });
 });

--- a/packages/data/tests/unit/models/navi-fact-response-test.ts
+++ b/packages/data/tests/unit/models/navi-fact-response-test.ts
@@ -72,7 +72,7 @@ module('Unit | Model | navi fact response', function(hooks) {
     );
   });
 
-  test('getMaxTimeDimension/getMaxTimeDimension - empty column', function(this: TestContext, assert) {
+  test('getMaxTimeDimension/getMinTimeDimension - empty column', function(this: TestContext, assert) {
     const rows: ResponseV1['rows'] = [];
     const response = NaviFactResponse.create({ rows });
     const columnMetadata = this.metadataService.getById(
@@ -87,7 +87,7 @@ module('Unit | Model | navi fact response', function(hooks) {
     assert.equal(null, min, '`getMinTimeDimension` returns null for empty responses');
   });
 
-  test('getMaxTimeDimension/getMaxTimeDimension - missing value', function(this: TestContext, assert) {
+  test('getMaxTimeDimension/getMinTimeDimension - missing value', function(this: TestContext, assert) {
     const rows = [
       { 'table1.eventTimeDay': '2014-04-02 00:00:00.000' },
       { 'table1.eventTimeDay': '2014-04-03 00:00:00.000' },
@@ -106,7 +106,7 @@ module('Unit | Model | navi fact response', function(hooks) {
     assert.equal(null, min, '`getMinTimeDimension` returns null for missing values');
   });
 
-  test('getMaxTimeDimension/getMaxTimeDimension - value gaps', function(this: TestContext, assert) {
+  test('getMaxTimeDimension/getMinTimeDimension - value gaps', function(this: TestContext, assert) {
     const columnMetadata = this.metadataService.getById(
       'timeDimension',
       'table1.eventTimeDay',

--- a/packages/data/tests/unit/models/navi-fact-response-test.ts
+++ b/packages/data/tests/unit/models/navi-fact-response-test.ts
@@ -81,10 +81,10 @@ module('Unit | Model | navi fact response', function(hooks) {
       'elideOne'
     ) as TimeDimensionMetadataModel;
     const max = response.getMaxTimeDimension({ columnMetadata });
-    assert.equal(null, max, '`getMaxTimeDimension` returns null for empty responses');
+    assert.strictEqual(null, max, '`getMaxTimeDimension` returns null for empty responses');
 
     const min = response.getMinTimeDimension({ columnMetadata });
-    assert.equal(null, min, '`getMinTimeDimension` returns null for empty responses');
+    assert.strictEqual(null, min, '`getMinTimeDimension` returns null for empty responses');
   });
 
   test('getMaxTimeDimension/getMinTimeDimension - missing value', function(this: TestContext, assert) {
@@ -100,10 +100,10 @@ module('Unit | Model | navi fact response', function(hooks) {
       'elideOne'
     ) as TimeDimensionMetadataModel;
     const max = response.getMaxTimeDimension({ columnMetadata });
-    assert.equal(null, max, '`getMaxTimeDimension` returns null for missing values');
+    assert.strictEqual(null, max, '`getMaxTimeDimension` returns null for missing values');
 
     const min = response.getMinTimeDimension({ columnMetadata });
-    assert.equal(null, min, '`getMinTimeDimension` returns null for missing values');
+    assert.strictEqual(null, min, '`getMinTimeDimension` returns null for missing values');
   });
 
   test('getMaxTimeDimension/getMinTimeDimension - value gaps', function(this: TestContext, assert) {
@@ -137,5 +137,25 @@ module('Unit | Model | navi fact response', function(hooks) {
       moment(minRows[2]['table1.eventTimeDay']).isSame(min),
       '`getMinTimeDimension` returns min dateTime when date values have gaps'
     );
+  });
+
+  test('getMaxTimeDimension/getMaxTimeDimension - invalid values', function(this: TestContext, assert) {
+    const columnMetadata = this.metadataService.getById(
+      'timeDimension',
+      'table1.eventTimeDay',
+      'elideOne'
+    ) as TimeDimensionMetadataModel;
+
+    const rows = [
+      { 'table1.eventTimeDay': '2014-04-03 00:00:00.000' },
+      { 'table1.eventTimeDay': 'not-a-date' },
+      { 'table1.eventTimeDay': '2014-04-04 00:00:00.000' }
+    ];
+    const response = NaviFactResponse.create({ rows });
+    const max = response.getMaxTimeDimension({ columnMetadata });
+    assert.strictEqual(null, max, '`getMaxTimeDimension` returns null when encountering an invalid date');
+
+    const min = response.getMinTimeDimension({ columnMetadata });
+    assert.strictEqual(null, min, '`getMinTimeDimension` returns null when encountering an invalid date');
   });
 });

--- a/packages/data/tests/unit/models/navi-facts.js
+++ b/packages/data/tests/unit/models/navi-facts.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import NaviFactsModel from 'navi-data/models/navi-facts';
 
-module('Unit | Navi Facts Model', function(hooks) {
+module('Unit | Model | navi facts', function(hooks) {
   let Response, Payload;
 
   hooks.beforeEach(function() {

--- a/packages/data/tests/unit/serializers/dimensions/bard-test.ts
+++ b/packages/data/tests/unit/serializers/dimensions/bard-test.ts
@@ -6,8 +6,7 @@ import NaviMetadataService from 'navi-data/services/navi-metadata';
 //@ts-ignore
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { FiliDimensionResponse } from 'navi-data/adapters/dimensions/bard';
-import { DimensionColumn } from 'navi-data/adapters/dimensions/interface';
-import DimensionMetadataModel from 'navi-data/models/metadata/dimension';
+import DimensionMetadataModel, { DimensionColumn } from 'navi-data/models/metadata/dimension';
 import ContainerDimValues from 'navi-data/mirage/bard-lite/dimensions/container';
 import { cloneDeep } from 'lodash-es';
 

--- a/packages/data/tests/unit/serializers/dimensions/elide-test.ts
+++ b/packages/data/tests/unit/serializers/dimensions/elide-test.ts
@@ -1,8 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { QueryStatus, AsyncQueryResponse, QueryResultType } from 'navi-data/adapters/facts/interface';
-import { DimensionColumn } from 'navi-data/adapters/dimensions/interface';
-import DimensionMetadataModel from 'navi-data/models/metadata/dimension';
+import DimensionMetadataModel, { DimensionColumn } from 'navi-data/models/metadata/dimension';
 import NaviMetadataService from 'navi-data/services/navi-metadata';
 import NaviDimensionModel from 'navi-data/models/navi-dimension';
 import { TestContext as Context } from 'ember-test-helpers';

--- a/packages/data/tests/unit/serializers/facts/bard-test.ts
+++ b/packages/data/tests/unit/serializers/facts/bard-test.ts
@@ -4,6 +4,7 @@ import { TestContext } from 'ember-test-helpers';
 import BardFactSerializer from 'navi-data/serializers/facts/bard';
 import { RequestV2 } from 'navi-data/adapters/facts/interface';
 import NaviFactResponse from 'navi-data/models/navi-fact-response';
+import { ResponseV1 } from 'navi-data/serializers/facts/interface';
 
 let Serializer: BardFactSerializer;
 
@@ -14,32 +15,30 @@ module('Unit | Serializer | facts/bard', function(hooks) {
     Serializer = this.owner.lookup('serializer:facts/bard');
   });
 
-  test('normalize - undefined', function(assert) {
-    //@ts-expect-error
-    assert.deepEqual(Serializer.normalize(), undefined, '`undefined` is returned for an undefined response');
-  });
-
-  test('normalize - invalid', function(assert) {
-    //@ts-expect-error
-    const { rows, meta } = Serializer.normalize({ foo: 'bar' });
-    assert.deepEqual(
-      { rows, meta },
-      { rows: [], meta: {} },
-      'Returns `undefined` with invalid payload and undefined request'
-    );
-  });
-
   test('normalize - empty rows', function(assert) {
-    //@ts-expect-error
-    const { rows, meta } = Serializer.normalize({ rows: [], meta: { next: 'nextLink' } });
-    assert.deepEqual(
-      { rows, meta },
-      {
-        rows: [],
-        meta: { next: 'nextLink' }
-      },
-      'Returns empty rows but preserves meta when there is no request'
-    );
+    const request: RequestV2 = {
+      table: 'tableName',
+      columns: [{ type: 'metric', field: 'metricName', parameters: { param: 'value' } }],
+      filters: [],
+      sorts: [],
+      dataSource: 'bardOne',
+      limit: null,
+      requestVersion: '2.0'
+    };
+
+    const response: ResponseV1 = {
+      rows: [],
+      meta: {
+        pagination: {
+          currentPage: 1,
+          rowsPerPage: 0,
+          perPage: 10,
+          numberOfResults: 0
+        }
+      }
+    };
+    const { rows, meta } = Serializer.normalize(response, request) as NaviFactResponse;
+    assert.deepEqual({ rows, meta }, response, 'Returns empty rows but preserves meta when there is no request');
   });
 
   test('normalize by request', function(assert) {

--- a/packages/data/tests/unit/serializers/facts/elide-test.ts
+++ b/packages/data/tests/unit/serializers/facts/elide-test.ts
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import NaviFactSerializer from 'navi-data/serializers/facts/interface';
 import { AsyncQueryResponse, QueryStatus, QueryResultType, RequestV2 } from 'navi-data/adapters/facts/interface';
+import NaviFactResponse from 'navi-data/models/navi-fact-response';
 
 const Payload: AsyncQueryResponse = {
   asyncQuery: {
@@ -47,9 +48,9 @@ module('Unit | Serializer | facts/elide', function(hooks) {
   });
 
   test('it normalizes an elide fact response', function(assert) {
-    const normalized = Serializer.normalize(Payload, Request);
+    const { rows, meta } = Serializer.normalize(Payload, Request) as NaviFactResponse;
     assert.deepEqual(
-      normalized,
+      { rows, meta },
       {
         meta: {},
         rows: [

--- a/packages/data/tests/unit/services/navi-facts-test.ts
+++ b/packages/data/tests/unit/services/navi-facts-test.ts
@@ -6,6 +6,7 @@ import { RequestV2 } from 'navi-data/adapters/facts/interface';
 import NaviFactsService from 'navi-data/services/navi-facts';
 import { TestContext } from 'ember-test-helpers';
 import { ResponseV1 } from 'navi-data/serializers/facts/interface';
+import NaviFactResponse from 'navi-data/models/navi-fact-response';
 
 let Service: NaviFactsService, Server: PretenderServer;
 
@@ -113,8 +114,6 @@ module('Unit | Service | Navi Facts', function(hooks) {
   });
 
   test('getURL', function(assert) {
-    assert.expect(2);
-
     assert.deepEqual(
       Service.getURL(TestRequest),
       `${HOST}/v1/data/table1/grain1/d1/d2/?` +
@@ -134,49 +133,45 @@ module('Unit | Service | Navi Facts', function(hooks) {
     );
   });
 
-  test('fetch', function(assert) {
-    assert.expect(3);
-
-    return Service.fetch(TestRequest).then(function(model) {
-      assert.deepEqual(
-        model.response,
-        {
-          rows: [
-            {
-              'd1(field=id)': undefined,
-              'd2(field=id)': undefined,
-              m1: undefined,
-              m2: undefined,
-              'table1.dateTime(grain=grain1)': undefined
-            }
-          ],
-          meta: {
-            //@ts-expect-error
-            test: true
+  test('fetch', async function(assert) {
+    const model = await Service.fetch(TestRequest);
+    const { rows, meta } = model.response as NaviFactResponse;
+    assert.deepEqual(
+      { rows, meta },
+      {
+        rows: [
+          {
+            'd1(field=id)': undefined,
+            'd2(field=id)': undefined,
+            m1: undefined,
+            m2: undefined,
+            'table1.dateTime(grain=grain1)': undefined
           }
-        },
-        'Fetch returns a navi response model object for TestRequest'
-      );
+        ],
+        meta: {
+          test: true
+        }
+      },
+      'Fetch returns a navi response model object for TestRequest'
+    );
 
-      assert.deepEqual(model.request, TestRequest, 'Fetch returns a navi response model object with the TestRequest');
+    assert.deepEqual(model.request, TestRequest, 'Fetch returns a navi response model object with the TestRequest');
 
-      assert.deepEqual(
-        model._factService,
-        Service,
-        'Fetch returns a navi response model object with the service instance'
-      );
-    });
+    assert.deepEqual(
+      model._factService,
+      Service,
+      'Fetch returns a navi response model object with the service instance'
+    );
   });
 
   test('fetch with pagination', async function(assert) {
-    assert.expect(1);
     const model = await Service.fetch(TestRequest, { page: 2, perPage: 10 });
+    const { rows, meta } = model.response as NaviFactResponse;
     assert.deepEqual(
-      model.response,
+      { rows, meta },
       {
         rows: [],
         meta: {
-          //@ts-expect-error
           paginated: {
             page: '2',
             perPage: '10'
@@ -213,10 +208,8 @@ module('Unit | Service | Navi Facts', function(hooks) {
     });
   });
 
-  skip('request builder', function(assert) {
+  skip('request builder', function(/*assert*/) {
     // TODO: Remove request builder?
-    assert.expect(2);
-
     /*
     let requestBuilder = Service.request({
       metrics: [

--- a/packages/reports/addon/components/filter-values/dimension-select.ts
+++ b/packages/reports/addon/components/filter-values/dimension-select.ts
@@ -11,11 +11,10 @@ import NaviMetadataService from 'navi-data/services/navi-metadata';
 import { tracked } from '@glimmer/tracking';
 import RequestFragment from 'navi-core/models/bard-request-v2/request';
 import FilterFragment from 'navi-core/models/bard-request-v2/fragments/filter';
-import DimensionMetadataModel from 'navi-data/addon/models/metadata/dimension';
+import DimensionMetadataModel, { DimensionColumn } from 'navi-data/addon/models/metadata/dimension';
 //@ts-ignore
 import { task, timeout } from 'ember-concurrency';
 import NaviDimensionModel from 'navi-data/models/navi-dimension';
-import { DimensionColumn } from 'navi-data/adapters/dimensions/interface';
 
 const SEARCH_DEBOUNCE_TIME = 200;
 


### PR DESCRIPTION
## Description

Add `navi-fact-response` model with min/max time dimension methods for handling non-static date filters

## Proposed Changes

- Refactor column instance types
- Add `navi-fact-response` model 
- Adds min/max time dimension methods
- Adds `getCanonicalName` to base column metadata model
- Renames navi fact model test file name
- Use NaviFactResponse in NaviFacts model

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
