### PR TITLE
Update: Make getRequestDimensions a property on the request

### DIFF
--- a/packages/core/addon/chart-builders/dimension.ts
+++ b/packages/core/addon/chart-builders/dimension.ts
@@ -31,7 +31,7 @@ import { API_DATE_FORMAT_STRING } from 'navi-data/utils/date';
 //@ts-ignore
 import tooltipLayout from '../templates/chart-tooltips/dimension';
 import ChartAxisDateTimeFormats from 'navi-core/utils/chart-axis-date-time-formats';
-import { getRequestDimensions, groupDataByDimensions } from 'navi-core/utils/chart-data';
+import { groupDataByDimensions } from 'navi-core/utils/chart-data';
 import { BaseChartBuilder, C3Row, ResponseRow } from './base';
 import RequestFragment from 'navi-core/models/bard-request-v2/request';
 import { ResponseV1 } from 'navi-data/serializers/facts/interface';
@@ -78,7 +78,7 @@ export default class DimensionChartBuilder extends EmberObject implements BaseCh
     const { metricCid } = config;
     const metric = request.columns.find(({ cid }) => cid === metricCid);
     assert(`a metric with cid ${metricCid} should be found`, metric);
-    const dimensions = getRequestDimensions(request);
+    const dimensions = request.nonTimeGrainDimensions;
     const seriesKey = config.dimensions.map(s => dimensions.map(d => s.values[d.cid]).join('|')); // Build the series required
     const seriesName = config.dimensions.map(s => s.name); // Get all the series names
     const byDate = new DataGroup(response.rows, row => buildDateKey(row[timeGrainColumn] as string)); // Group by dates for easier lookup

--- a/packages/core/addon/models/bard-request-v2/request.ts
+++ b/packages/core/addon/models/bard-request-v2/request.ts
@@ -190,6 +190,11 @@ export default class RequestFragment extends Fragment.extend(Validations) implem
     return this.columns.filter(column => column.type === 'timeDimension')[0];
   }
 
+  @computed('timeGrainColumn')
+  get nonTimeGrainDimensions(): ColumnFragment[] {
+    return this.dimensionColumns.filter(c => c !== this.timeGrainColumn);
+  }
+
   /**
    * @property {string} timeGrain - The grain parameter of the column containing the dateTime timeDimension
    */

--- a/packages/core/addon/models/bard-request-v2/request.ts
+++ b/packages/core/addon/models/bard-request-v2/request.ts
@@ -191,8 +191,8 @@ export default class RequestFragment extends Fragment.extend(Validations) implem
   }
 
   @computed('timeGrainColumn')
-  get nonTimeGrainDimensions(): ColumnFragment[] {
-    return this.dimensionColumns.filter(c => c !== this.timeGrainColumn);
+  get nonTimeDimensions(): ColumnFragment[] {
+    return this.columns.filter(c => c.type === 'dimension');
   }
 
   /**

--- a/packages/core/addon/models/bard-request-v2/request.ts
+++ b/packages/core/addon/models/bard-request-v2/request.ts
@@ -190,7 +190,7 @@ export default class RequestFragment extends Fragment.extend(Validations) implem
     return this.columns.filter(column => column.type === 'timeDimension')[0];
   }
 
-  @computed('timeGrainColumn')
+  @computed('columns.[]')
   get nonTimeDimensions(): ColumnFragment[] {
     return this.columns.filter(c => c.type === 'dimension');
   }

--- a/packages/core/addon/models/chart-visualization.ts
+++ b/packages/core/addon/models/chart-visualization.ts
@@ -3,13 +3,7 @@
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import { topN, maxDataByDimensions } from 'navi-core/utils/data';
-import {
-  METRIC_SERIES,
-  DIMENSION_SERIES,
-  DATE_TIME_SERIES,
-  getRequestDimensions,
-  ChartType
-} from 'navi-core/utils/chart-data';
+import { METRIC_SERIES, DIMENSION_SERIES, DATE_TIME_SERIES, ChartType } from 'navi-core/utils/chart-data';
 import Visualization from './visualization';
 import RequestFragment from 'navi-core/models/bard-request-v2/request';
 import { ResponseV1 } from 'navi-data/serializers/facts/interface';
@@ -62,7 +56,7 @@ export default class ChartVisualization extends Visualization {
 
   private buildDimensionSeriesValues(request: RequestFragment, rows: ResponseV1['rows']): DimensionSeriesValues[] {
     const series: Record<string, DimensionSeriesValues> = {};
-    const dimensions = getRequestDimensions(request);
+    const dimensions = request.nonTimeGrainDimensions;
     rows.forEach(row => {
       const values: Record<string, string | number | boolean> = {};
       const dimensionLabels: Array<string | number | boolean> = [];
@@ -110,7 +104,7 @@ export default class ChartVisualization extends Visualization {
       : request.metricColumns[0];
 
     const responseRows = topN(
-      maxDataByDimensions(response.rows, getRequestDimensions(request), metric.canonicalName),
+      maxDataByDimensions(response.rows, request.nonTimeGrainDimensions, metric.canonicalName),
       metric.canonicalName,
       10
     );

--- a/packages/core/addon/utils/chart-data.ts
+++ b/packages/core/addon/utils/chart-data.ts
@@ -28,23 +28,13 @@ export function groupDataByDimensions(
 }
 
 /**
- * Returns a list of dimensions id from the request
- *
- * @param request - request object
- * @returns - list of dimension ids
- */
-export function getRequestDimensions(request: RequestFragment): ColumnFragment[] {
-  return request.dimensionColumns.filter(c => c !== request.timeGrainColumn);
-}
-
-/**
  * Determine chart type based on request
  *
  * @param request - request object
  * @returns the chart type
  */
 export function chartTypeForRequest(request: RequestFragment): ChartType {
-  if (getRequestDimensions(request).length > 0) {
+  if (request.nonTimeGrainDimensions.length > 0) {
     return DIMENSION_SERIES;
   }
 

--- a/packages/core/addon/validators/request-dimension-order.js
+++ b/packages/core/addon/validators/request-dimension-order.js
@@ -6,13 +6,12 @@
 import { get } from '@ember/object';
 import BaseValidator from 'ember-cp-validations/validators/base';
 import { isEqual } from 'lodash-es';
-import { getRequestDimensions } from 'navi-core/utils/chart-data';
 
 export default BaseValidator.extend({
   validate(value, options /*, model, attribute*/) {
     let request = get(options, 'request');
     if (request) {
-      let requestDimensions = getRequestDimensions(request);
+      let requestDimensions = request.nonTimeGrainDimensions;
       return isEqual(value, requestDimensions);
     }
   }

--- a/packages/core/tests/unit/models/bard-request-v2/request-test.js
+++ b/packages/core/tests/unit/models/bard-request-v2/request-test.js
@@ -433,4 +433,12 @@ module('Unit | Model | Fragment | BardRequest  - Request', function(hooks) {
       'The request model attribute was serialized correctly'
     );
   });
+
+  test('nonTimeDimensions', function(assert) {
+    assert.deepEqual(
+      mockModel.request.nonTimeDimensions,
+      mockModel.request.columns.filter(c => c.type === 'dimension'),
+      'nonTimeDimensions retuns expected dimension columns ignoring the timeDimension and metric columns'
+    );
+  });
 });

--- a/packages/core/tests/unit/models/bard-request-v2/request-test.js
+++ b/packages/core/tests/unit/models/bard-request-v2/request-test.js
@@ -435,10 +435,24 @@ module('Unit | Model | Fragment | BardRequest  - Request', function(hooks) {
   });
 
   test('nonTimeDimensions', function(assert) {
+    const { request } = mockModel;
     assert.deepEqual(
-      mockModel.request.nonTimeDimensions,
-      mockModel.request.columns.filter(c => c.type === 'dimension'),
-      'nonTimeDimensions retuns expected dimension columns ignoring the timeDimension and metric columns'
+      request.nonTimeDimensions,
+      request.columns.filter(c => c.type === 'dimension'),
+      'nonTimeDimensions returns expected dimension columns ignoring the timeDimension and metric columns'
+    );
+
+    request.addColumn({
+      type: 'dimension',
+      source: request.dataSource,
+      field: 'foo',
+      parameters: {}
+    });
+
+    assert.deepEqual(
+      request.nonTimeDimensions,
+      request.columns.filter(c => c.type === 'dimension'),
+      'nonTimeDimensions recomputes when the request columns change'
     );
   });
 });

--- a/packages/core/tests/unit/utils/chart-data-test.ts
+++ b/packages/core/tests/unit/utils/chart-data-test.ts
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { groupDataByDimensions, chartTypeForRequest, getRequestDimensions } from 'navi-core/utils/chart-data';
+import { groupDataByDimensions, chartTypeForRequest } from 'navi-core/utils/chart-data';
 import { buildTestRequest } from '../../helpers/request';
 import { setupTest } from 'ember-qunit';
 import ColumnFragment from 'navi-core/models/bard-request-v2/fragments/column';
@@ -67,22 +67,6 @@ module('Unit | Utils | Chart Data', function(hooks) {
       chartTypeForRequest(request),
       'dateTime',
       'chartTypeForRequest returns dateTime series when request has single metric, no dimensions, and interval over a year'
-    );
-  });
-
-  test('getRequestDimensions', function(assert) {
-    assert.expect(1);
-
-    const timeGrainColumn = { field: 'time' };
-    let request = ({
-      timeGrainColumn,
-      dimensionColumns: [{ field: 'age' }, timeGrainColumn, { field: 'gender' }]
-    } as unknown) as RequestFragment;
-
-    assert.deepEqual(
-      getRequestDimensions(request),
-      [{ field: 'age' }, { field: 'gender' }] as ColumnFragment[],
-      'getRequestDimensions retuns expected dimension columns ignoring the selected timeGrainColumn'
     );
   });
 });


### PR DESCRIPTION
Resolves #1074 

<!-- The above line will close the issue upon merge -->

## Description
`getRequestDimensions` doesn't need to be a separate utility function

## Proposed Changes

- Make a property on the request fragment that will replace `getRequestDimensions`

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
