### PR TITLE
Fix: Use appropriate filter operator for time dimensions

### DIFF
--- a/packages/reports/addon/consumers/request/filter.ts
+++ b/packages/reports/addon/consumers/request/filter.ts
@@ -117,7 +117,9 @@ export default class FilterConsumer extends ActionConsumer {
       const { request } = route.modelFor(routeName) as ReportModel;
 
       const findDefaultOperator = (type: string) => {
+        type = type.toLowerCase();
         const opDictionary: Record<string, string> = {
+          time: 'gte',
           date: 'gte',
           number: 'eq',
           default: 'in'

--- a/packages/reports/tests/unit/consumers/request/filter-test.js
+++ b/packages/reports/tests/unit/consumers/request/filter-test.js
@@ -58,10 +58,10 @@ module('Unit | Consumer | request filter', function(hooks) {
   });
 
   test('ADD_DIMENSION_FILTER', function(assert) {
-    assert.expect(1);
+    assert.expect(2);
 
     const dimensionMetadataModel = this.metadataService.getById('dimension', 'age', 'bardOne');
-    const modelFor = () => ({
+    let modelFor = () => ({
       request: {
         addFilter(filterOptions) {
           assert.deepEqual(
@@ -83,5 +83,28 @@ module('Unit | Consumer | request filter', function(hooks) {
     });
 
     consumer.send(RequestActions.ADD_DIMENSION_FILTER, { modelFor }, dimensionMetadataModel);
+
+    const timeDimensionMetadataModel = this.metadataService.getById('timeDimension', 'network.dateTime', 'bardOne');
+    modelFor = () => ({
+      request: {
+        addFilter(filterOptions) {
+          assert.deepEqual(
+            filterOptions,
+            {
+              type: 'timeDimension',
+              source: 'bardOne',
+              field: 'network.dateTime',
+              parameters: {
+                grain: 'day'
+              },
+              operator: 'gte',
+              values: []
+            },
+            'Correct default operator is added for the metadata type'
+          );
+        }
+      }
+    });
+    consumer.send(RequestActions.ADD_DIMENSION_FILTER, { modelFor }, timeDimensionMetadataModel);
   });
 });


### PR DESCRIPTION
## Description
We can't currently filter on certain time dimensions on request-v2 because their metadataType is set to `TIME` rather than the expected `date`.

## Proposed Changes

- support a `time` metadataType as well for filter adds

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
