### PR TITLE
Update: Migrate chart builders to use navi-fact-response

### DIFF
--- a/packages/core/addon/chart-builders/base.ts
+++ b/packages/core/addon/chart-builders/base.ts
@@ -7,6 +7,7 @@ import EmberObject from '@ember/object';
 import { ResponseV1 } from 'navi-data/serializers/facts/interface';
 import RequestFragment from 'navi-core/models/bard-request-v2/request';
 import { DateTimeSeries, DimensionSeries, MetricSeries } from 'navi-core/models/chart-visualization';
+import NaviFactResponse from 'navi-data/models/navi-fact-response';
 
 export type SeriesType = MetricSeries['type'] | DimensionSeries['type'] | DateTimeSeries['type'];
 export type SeriesConfig = MetricSeries['config'] | DimensionSeries['config'] | DateTimeSeries['config'];
@@ -23,7 +24,7 @@ export type C3Row = {
 export interface BaseChartBuilder {
   getXValue(row: ResponseRow, config: SeriesConfig, request: RequestFragment): string | number;
 
-  buildData(response: ResponseV1, _config: SeriesConfig, request: RequestFragment): C3Row[];
+  buildData(response: NaviFactResponse, _config: SeriesConfig, request: RequestFragment): C3Row[];
 
   buildTooltip(
     _config: SeriesConfig,

--- a/packages/core/addon/chart-builders/base.ts
+++ b/packages/core/addon/chart-builders/base.ts
@@ -4,15 +4,12 @@
  */
 import Mixin from '@ember/object/mixin';
 import EmberObject from '@ember/object';
-import { ResponseV1 } from 'navi-data/serializers/facts/interface';
 import RequestFragment from 'navi-core/models/bard-request-v2/request';
 import { DateTimeSeries, DimensionSeries, MetricSeries } from 'navi-core/models/chart-visualization';
-import NaviFactResponse from 'navi-data/models/navi-fact-response';
+import NaviFactResponse, { ResponseRow } from 'navi-data/models/navi-fact-response';
 
 export type SeriesType = MetricSeries['type'] | DimensionSeries['type'] | DateTimeSeries['type'];
 export type SeriesConfig = MetricSeries['config'] | DimensionSeries['config'] | DateTimeSeries['config'];
-
-export type ResponseRow = ResponseV1['rows'][number];
 
 export type C3Row = {
   x: {

--- a/packages/core/addon/chart-builders/date-time.ts
+++ b/packages/core/addon/chart-builders/date-time.ts
@@ -23,9 +23,8 @@ import { assert } from '@ember/debug';
 import RequestFragment from 'navi-core/models/bard-request-v2/request';
 import { BaseChartBuilder, C3Row } from './base';
 import { tracked } from '@glimmer/tracking';
-import { ResponseV1 } from 'navi-data/serializers/facts/interface';
 import { DateTimeSeries } from 'navi-core/models/chart-visualization';
-import NaviFactResponse from 'navi-data/models/navi-fact-response';
+import NaviFactResponse, { ResponseRow } from 'navi-data/models/navi-fact-response';
 
 const API_DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss.SSS';
 const YEAR_WITH_53_ISOWEEKS = '2015-01-01';
@@ -212,8 +211,6 @@ function _getGrouper(request: RequestFragment, config: DateTimeSeries['config'])
   assert(`Grouper for ${timeGrain} by ${seriesTimeGrain} should exist`, grouper);
   return grouper;
 }
-
-type ResponseRow = ResponseV1['rows'][number];
 
 export default class TimeChartBuilder extends EmberObject implements BaseChartBuilder {
   @tracked byXSeries?: DataGroup<ResponseRow>;

--- a/packages/core/addon/chart-builders/date-time.ts
+++ b/packages/core/addon/chart-builders/date-time.ts
@@ -25,6 +25,7 @@ import { BaseChartBuilder, C3Row } from './base';
 import { tracked } from '@glimmer/tracking';
 import { ResponseV1 } from 'navi-data/serializers/facts/interface';
 import { DateTimeSeries } from 'navi-core/models/chart-visualization';
+import NaviFactResponse from 'navi-data/models/navi-fact-response';
 
 const API_DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss.SSS';
 const YEAR_WITH_53_ISOWEEKS = '2015-01-01';
@@ -224,16 +225,20 @@ export default class TimeChartBuilder extends EmberObject implements BaseChartBu
    * @returns name of series given row belongs to
    */
   getSeriesName(row: ResponseRow, config: DateTimeSeries['config'], request: RequestFragment): string {
-    const date = row[request.timeGrainColumn.canonicalName] as MomentInput;
+    const name = request.timeGrainColumn.canonicalName;
+    const date = row[request.timeGrainColumn.canonicalName];
+    assert(`a date for ${name} should be found, but got ${date}`, typeof date === 'string');
     return _getGrouper(request, config).getSeries(moment(date));
   }
 
   getXValue(row: ResponseRow, config: DateTimeSeries['config'], request: RequestFragment): number {
-    const date = row[request.timeGrainColumn.canonicalName] as MomentInput;
+    const name = request.timeGrainColumn.canonicalName;
+    const date = row[name];
+    assert(`a date for ${name} should be found, but got ${date}`, typeof date === 'string');
     return _getGrouper(request, config).getXValue(moment(date));
   }
 
-  buildData(response: ResponseV1, config: DateTimeSeries['config'], request: RequestFragment): C3Row[] {
+  buildData(response: NaviFactResponse, config: DateTimeSeries['config'], request: RequestFragment): C3Row[] {
     // Group data by x axis value + series name in order to lookup metric attributes when building tooltip
     this.byXSeries = new DataGroup(response.rows, row => {
       let seriesName = this.getSeriesName(row, config, request),

--- a/packages/core/addon/chart-builders/date-time.ts
+++ b/packages/core/addon/chart-builders/date-time.ts
@@ -222,16 +222,16 @@ export default class TimeChartBuilder extends EmberObject implements BaseChartBu
    * @returns name of series given row belongs to
    */
   getSeriesName(row: ResponseRow, config: DateTimeSeries['config'], request: RequestFragment): string {
-    const name = request.timeGrainColumn.canonicalName;
-    const date = row[request.timeGrainColumn.canonicalName];
-    assert(`a date for ${name} should be found, but got ${date}`, typeof date === 'string');
+    const colName = request.timeGrainColumn.canonicalName;
+    const date = row[colName];
+    assert(`a date for ${colName} should be found, but got: ${date}`, typeof date === 'string');
     return _getGrouper(request, config).getSeries(moment(date));
   }
 
   getXValue(row: ResponseRow, config: DateTimeSeries['config'], request: RequestFragment): number {
-    const name = request.timeGrainColumn.canonicalName;
-    const date = row[name];
-    assert(`a date for ${name} should be found, but got ${date}`, typeof date === 'string');
+    const colName = request.timeGrainColumn.canonicalName;
+    const date = row[colName];
+    assert(`a date for ${colName} should be found, but got: ${date}`, typeof date === 'string');
     return _getGrouper(request, config).getXValue(moment(date));
   }
 

--- a/packages/core/addon/chart-builders/dimension.ts
+++ b/packages/core/addon/chart-builders/dimension.ts
@@ -55,9 +55,9 @@ export default class DimensionChartBuilder extends EmberObject implements BaseCh
    * @inheritdoc
    */
   getXValue(row: ResponseRow, _config: DimensionSeries['config'], request: RequestFragment): string {
-    const name = request.timeGrainColumn.canonicalName;
-    const date = row[name];
-    assert(`a date for ${name} should be found, but got ${date}`, typeof date === 'string');
+    const colName = request.timeGrainColumn.canonicalName;
+    const date = row[colName];
+    assert(`a date for ${colName} should be found, but got: ${date}`, typeof date === 'string');
     return moment(date).format(API_DATE_FORMAT_STRING);
   }
 

--- a/packages/core/addon/chart-builders/dimension.ts
+++ b/packages/core/addon/chart-builders/dimension.ts
@@ -34,9 +34,9 @@ import ChartAxisDateTimeFormats from 'navi-core/utils/chart-axis-date-time-forma
 import { groupDataByDimensions } from 'navi-core/utils/chart-data';
 import { BaseChartBuilder, C3Row, ResponseRow } from './base';
 import RequestFragment from 'navi-core/models/bard-request-v2/request';
-import { ResponseV1 } from 'navi-data/serializers/facts/interface';
 import { tracked } from '@glimmer/tracking';
 import { DimensionSeries } from 'navi-core/models/chart-visualization';
+import NaviFactResponse from 'navi-data/models/navi-fact-response';
 
 export default class DimensionChartBuilder extends EmberObject implements BaseChartBuilder {
   @tracked byXSeries?: DataGroup<ResponseRow>;
@@ -48,24 +48,29 @@ export default class DimensionChartBuilder extends EmberObject implements BaseCh
    * @returns name of series given row belongs to
    */
   getSeriesName(row: ResponseRow, _config: DimensionSeries['config'], request: RequestFragment): string {
-    return request.dimensionColumns.map(dim => row[dim.canonicalName]).join(',');
+    return getRequestDimensions(request)
+      .map(dim => row[dim.canonicalName])
+      .join(',');
   }
 
   /**
    * @inheritdoc
    */
   getXValue(row: ResponseRow, _config: DimensionSeries['config'], request: RequestFragment): string {
-    // expects timeGrainColumn values to be a readable moment input
-    const date = row[request.timeGrainColumn.canonicalName] as MomentInput;
+    const name = request.timeGrainColumn.canonicalName;
+    const date = row[name];
+    assert(`a date for ${name} should be found, but got ${date}`, typeof date === 'string');
     return moment(date).format(API_DATE_FORMAT_STRING);
   }
 
   /**
    * @inheritdoc
    */
-  buildData(response: ResponseV1, config: DimensionSeries['config'], request: RequestFragment): C3Row[] {
+  buildData(response: NaviFactResponse, config: DimensionSeries['config'], request: RequestFragment): C3Row[] {
+    assert('response should be a NaviFactResponse instance', response instanceof NaviFactResponse);
     const timeGrainColumn = request.timeGrainColumn.canonicalName;
-    const { timeGrain, interval } = request;
+    const interval = response.getIntervalForTimeDimension(request.timeGrainColumn);
+    const { timeGrain } = request;
     assert('request should have an interval', interval);
     assert('request should have a timeGrain', timeGrain);
     // Group data by x axis value + series name in order to lookup trends when building tooltip
@@ -84,47 +89,50 @@ export default class DimensionChartBuilder extends EmberObject implements BaseCh
     const byDate = new DataGroup(response.rows, row => buildDateKey(row[timeGrainColumn] as string)); // Group by dates for easier lookup
 
     // For each unique date, build the series
-    return interval.getDatesForInterval(timeGrain).map(date => {
-      const key = buildDateKey(date);
+    return interval
+      .makeEndExclusiveFor(timeGrain)
+      .getDatesForInterval(timeGrain)
+      .map(date => {
+        const key = buildDateKey(date);
 
-      // Pulling the specific data rows for the date
-      let dateRows = byDate.getDataForKey(key) || [];
+        // Pulling the specific data rows for the date
+        let dateRows = byDate.getDataForKey(key) || [];
 
-      // Group the dimension required
-      let byDim = groupDataByDimensions(dateRows, dimensions);
+        // Group the dimension required
+        let byDim = groupDataByDimensions(dateRows, dimensions);
 
-      // the data for date used in the C3 chart
-      let dataForDate: C3Row = {
-        x: { rawValue: key, displayValue: moment(date).format(ChartAxisDateTimeFormats[timeGrain]) }
-      } as C3Row;
+        // the data for date used in the C3 chart
+        let dataForDate: C3Row = {
+          x: { rawValue: key, displayValue: moment(date).format(ChartAxisDateTimeFormats[timeGrain]) }
+        } as C3Row;
 
-      // Adding the series to the keys
-      seriesKey.forEach((s, index) => {
-        //Handling the case when some of the data group does not exist
-        if (byDim.getDataForKey(s) && byDim.getDataForKey(s).length) {
-          // Extending the data for date with the grouped dimension and metric value
-          Object.assign(dataForDate, {
-            [seriesName[index]]: byDim.getDataForKey(s)[0][metric.canonicalName]
-          });
-        } else {
-          // Returning null for the chart to show missing data
-          Object.assign(dataForDate, { [seriesName[index]]: null });
-        }
+        // Adding the series to the keys
+        seriesKey.forEach((s, index) => {
+          //Handling the case when some of the data group does not exist
+          if (byDim.getDataForKey(s) && byDim.getDataForKey(s).length) {
+            // Extending the data for date with the grouped dimension and metric value
+            Object.assign(dataForDate, {
+              [seriesName[index]]: byDim.getDataForKey(s)[0][metric.canonicalName]
+            });
+          } else {
+            // Returning null for the chart to show missing data
+            Object.assign(dataForDate, { [seriesName[index]]: null });
+          }
+        });
+
+        /**
+         * sample of return:
+         * x: {
+         *    rawValue: '2016-05-30 00:00:00.000',
+         *    displayValue: 'May 30'
+         *  },
+         *  'All Other | M': 828357,
+         *  'Under 15 | F' : 26357
+         */
+
+        // Return the data for Date
+        return dataForDate;
       });
-
-      /**
-       * sample of return:
-       * x: {
-       *    rawValue: '2016-05-30 00:00:00.000',
-       *    displayValue: 'May 30'
-       *  },
-       *  'All Other | M': 828357,
-       *  'Under 15 | F' : 26357
-       */
-
-      // Return the data for Date
-      return dataForDate;
-    });
   }
 
   /**
@@ -145,7 +153,7 @@ export default class DimensionChartBuilder extends EmberObject implements BaseCh
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         return this.tooltipData.map((series: any) => {
           // Get the full data for this combination of x + series
-          let dataForSeries = builder.byXSeries?.getDataForKey(this.x + series.id) || [];
+          let dataForSeries = builder.byXSeries?.getDataForKey(`${this.x} ${series.id}`) || [];
 
           return dataForSeries[0];
         });

--- a/packages/core/addon/chart-builders/metric.ts
+++ b/packages/core/addon/chart-builders/metric.ts
@@ -32,9 +32,9 @@ export default class MetricChartBuilder extends EmberObject implements BaseChart
    * @inheritdoc
    */
   getXValue(row: ResponseRow, _config: MetricSeries['config'], request: RequestFragment): string {
-    const name = request.timeGrainColumn.canonicalName;
-    const date = row[name];
-    assert(`a date for ${name} should be found, but got ${date}`, typeof date === 'string');
+    const colName = request.timeGrainColumn.canonicalName;
+    const date = row[colName];
+    assert(`a date for ${colName} should be found, but got: ${date}`, typeof date === 'string');
     return moment(date).format(API_DATE_FORMAT_STRING);
   }
 

--- a/packages/core/addon/chart-builders/metric.ts
+++ b/packages/core/addon/chart-builders/metric.ts
@@ -19,13 +19,11 @@ import ChartAxisDateTimeFormats from 'navi-core/utils/chart-axis-date-time-forma
 import DataGroup from 'navi-core/utils/classes/data-group';
 import { API_DATE_FORMAT_STRING } from 'navi-data/utils/date';
 import EmberObject, { computed } from '@ember/object';
-import { ResponseV1 } from 'navi-data/serializers/facts/interface';
 import RequestFragment from 'navi-core/models/bard-request-v2/request';
-import { BaseChartBuilder, C3Row } from './base';
+import { BaseChartBuilder, C3Row, ResponseRow } from './base';
 import { tracked } from '@glimmer/tracking';
 import { MetricSeries } from 'navi-core/models/chart-visualization';
-
-type ResponseRow = ResponseV1['rows'][number];
+import NaviFactResponse from 'navi-data/models/navi-fact-response';
 
 export default class MetricChartBuilder extends EmberObject implements BaseChartBuilder {
   @tracked byXSeries?: DataGroup<ResponseRow>;
@@ -34,17 +32,20 @@ export default class MetricChartBuilder extends EmberObject implements BaseChart
    * @inheritdoc
    */
   getXValue(row: ResponseRow, _config: MetricSeries['config'], request: RequestFragment): string {
-    // expects timeGrainColumn values to be a readable moment input
-    const date = row[request.timeGrainColumn.canonicalName] as MomentInput;
+    const name = request.timeGrainColumn.canonicalName;
+    const date = row[name];
+    assert(`a date for ${name} should be found, but got ${date}`, typeof date === 'string');
     return moment(date).format(API_DATE_FORMAT_STRING);
   }
 
   /**
    * @inheritdoc
    */
-  buildData(response: ResponseV1, config: MetricSeries['config'], request: RequestFragment): C3Row[] {
+  buildData(response: NaviFactResponse, config: MetricSeries['config'], request: RequestFragment): C3Row[] {
+    assert('response should be a NaviFactResponse instance', response instanceof NaviFactResponse);
     const timeGrainColumn = request.timeGrainColumn.canonicalName;
-    const { timeGrain, interval } = request;
+    const interval = response.getIntervalForTimeDimension(request.timeGrainColumn);
+    const { timeGrain } = request;
     assert('request should have an interval', interval);
     assert('request should have a timeGrain', timeGrain);
     // Group data by x axis value in order to lookup row data when building tooltip
@@ -57,7 +58,7 @@ export default class MetricChartBuilder extends EmberObject implements BaseChart
      * Get all date buckets spanned by the data,
      * and group data by date for easier lookup
      */
-    const dates = interval.getDatesForInterval(timeGrain);
+    const dates = interval.makeEndExclusiveFor(timeGrain).getDatesForInterval(timeGrain);
     const byDate = new DataGroup(response.rows, (row: ResponseRow) =>
       buildDateKey(row[timeGrainColumn] as MomentInput)
     );

--- a/packages/core/addon/chart-builders/metric.ts
+++ b/packages/core/addon/chart-builders/metric.ts
@@ -20,10 +20,10 @@ import DataGroup from 'navi-core/utils/classes/data-group';
 import { API_DATE_FORMAT_STRING } from 'navi-data/utils/date';
 import EmberObject, { computed } from '@ember/object';
 import RequestFragment from 'navi-core/models/bard-request-v2/request';
-import { BaseChartBuilder, C3Row, ResponseRow } from './base';
+import { BaseChartBuilder, C3Row } from './base';
 import { tracked } from '@glimmer/tracking';
 import { MetricSeries } from 'navi-core/models/chart-visualization';
-import NaviFactResponse from 'navi-data/models/navi-fact-response';
+import NaviFactResponse, { ResponseRow } from 'navi-data/models/navi-fact-response';
 
 export default class MetricChartBuilder extends EmberObject implements BaseChartBuilder {
   @tracked byXSeries?: DataGroup<ResponseRow>;

--- a/packages/core/addon/components/navi-visualizations/line-chart.ts
+++ b/packages/core/addon/components/navi-visualizations/line-chart.ts
@@ -16,11 +16,11 @@ import { run } from '@ember/runloop';
 import ChartBuildersBase from './chart-builders-base';
 import { VisualizationModel } from './table';
 import { BaseChartBuilder } from 'navi-core/chart-builders/base';
-import { ResponseV1 } from 'navi-data/serializers/facts/interface';
 import RequestFragment from 'navi-core/models/bard-request-v2/request';
 import { LineChartConfig } from 'navi-core/models/line-chart';
 import { Grain } from 'navi-data/utils/date';
 import { ChartSeries } from 'navi-core/models/chart-visualization';
+import NaviFactResponse from 'navi-data/models/navi-fact-response';
 
 const DEFAULT_OPTIONS = <const>{
   style: {
@@ -153,7 +153,7 @@ export default class LineChart extends ChartBuildersBase<Args> {
   }
 
   @readOnly('args.model.0.request') request!: RequestFragment;
-  @readOnly('args.model.0.response') response!: ResponseV1;
+  @readOnly('args.model.0.response') response!: NaviFactResponse;
 
   /**
    * point radius config options for chart
@@ -173,7 +173,7 @@ export default class LineChart extends ChartBuildersBase<Args> {
   /**
    * chart series data
    */
-  @computed('request.columns.[]', 'response', 'builder', 'seriesConfig.config')
+  @computed('request.columns.{[],@each.displayName}', 'response', 'builder', 'seriesConfig.config')
   get seriesData() {
     const { request, response, builder, seriesConfig } = this;
     return builder.buildData(response, seriesConfig.config, request);

--- a/packages/core/addon/components/navi-visualizations/line-chart.ts
+++ b/packages/core/addon/components/navi-visualizations/line-chart.ts
@@ -173,7 +173,7 @@ export default class LineChart extends ChartBuildersBase<Args> {
   /**
    * chart series data
    */
-  @computed('request.columns.{[],@each.displayName}', 'response', 'builder', 'seriesConfig.config')
+  @computed('request.columns.@each.displayName', 'response', 'builder', 'seriesConfig.config')
   get seriesData() {
     const { request, response, builder, seriesConfig } = this;
     return builder.buildData(response, seriesConfig.config, request);

--- a/packages/core/addon/components/navi-visualizations/table.ts
+++ b/packages/core/addon/components/navi-visualizations/table.ts
@@ -21,6 +21,7 @@ import RequestFragment from 'navi-core/models/bard-request-v2/request';
 import { TableVisualizationMetadata, TableColumnAttributes } from 'navi-core/serializers/table';
 import ColumnFragment from 'navi-core/models/bard-request-v2/fragments/column';
 import { ResponseV1 } from 'navi-data/serializers/facts/interface';
+import { ResponseRow } from 'navi-data/models/navi-fact-response';
 
 const HEADER_TITLE = {
   grandTotal: 'Grand Total',
@@ -35,7 +36,6 @@ const NEXT_SORT_DIRECTION: Record<SortDirection, SortDirection> = {
   asc: 'none'
 };
 
-type ResponseRow = ResponseV1['rows'][number];
 type TotalRow = ResponseRow;
 
 type UpdateAction = string;

--- a/packages/core/addon/models/bard-request-v2/fragments/base.ts
+++ b/packages/core/addon/models/bard-request-v2/fragments/base.ts
@@ -33,7 +33,7 @@ const Validations = buildValidations({
 
 export type ColumnMetadataModels = MetadataModelRegistry[ColumnType];
 
-export default class Base extends Fragment.extend(Validations) {
+export default class Base<T extends ColumnType> extends Fragment.extend(Validations) {
   @service naviFormatter!: NaviFormatterService;
 
   @attr('string')
@@ -47,7 +47,7 @@ export default class Base extends Fragment.extend(Validations) {
   parameters!: Parameters;
 
   @attr('string')
-  type!: ColumnType;
+  type!: T;
 
   @attr('string')
   source!: string; //TODO do we need this?
@@ -59,10 +59,10 @@ export default class Base extends Fragment.extend(Validations) {
    * @type {Meta}
    */
   @computed('field', 'type', 'source')
-  get columnMetadata() {
+  get columnMetadata(): MetadataModelRegistry[T] {
     assert('Source must be set in order to access columnMetadata', isPresent(this.source));
     assert('column type must be set in order to access columnMetadata', isPresent(this.type));
-    return this.naviMetadata.getById(this.type, this.field, this.source) as ColumnMetadataModels;
+    return this.naviMetadata.getById(this.type, this.field, this.source) as MetadataModelRegistry[T];
   }
 
   @computed('field', 'parameters.{}')

--- a/packages/core/addon/models/bard-request-v2/fragments/column.ts
+++ b/packages/core/addon/models/bard-request-v2/fragments/column.ts
@@ -9,11 +9,12 @@ import { nanoid } from 'nanoid';
 import { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
 import NaviFormatterService from 'navi-data/services/navi-formatter';
+import { ColumnType } from 'navi-data/models/metadata/column';
 
 /**
  * @augments {BaseFragment}
  */
-export default class ColumnFragment extends BaseFragment implements Column {
+export default class ColumnFragment<T extends ColumnType = ColumnType> extends BaseFragment<T> implements Column {
   @attr('string', { defaultValue: () => nanoid(10) })
   cid!: string;
 
@@ -23,7 +24,7 @@ export default class ColumnFragment extends BaseFragment implements Column {
   @service naviFormatter!: NaviFormatterService;
 
   @computed('alias', 'parameters', 'columnMetadata')
-  get displayName() {
+  get displayName(): string {
     const { alias, parameters, columnMetadata } = this;
     return this.naviFormatter.formatColumnName(columnMetadata, parameters, alias);
   }

--- a/packages/core/addon/models/bard-request-v2/request.ts
+++ b/packages/core/addon/models/bard-request-v2/request.ts
@@ -27,7 +27,7 @@ import { ColumnMetadataModels } from './fragments/base';
 import { Parameters } from 'navi-data/adapters/facts/interface';
 import FilterFragment from 'navi-core/models/bard-request-v2/fragments/filter';
 import SortFragment from './fragments/sort';
-import { TableMetadata } from 'navi-data/models/metadata/table';
+import TableMetadataModel, { TableMetadata } from 'navi-data/models/metadata/table';
 import { ColumnType } from 'navi-data/models/metadata/column';
 import { Grain } from 'navi-data/utils/date';
 
@@ -107,7 +107,7 @@ export default class RequestFragment extends Fragment.extend(Validations) implem
    * @method clone
    * @returns {Fragment} copy of this fragment
    */
-  clone(this: RequestFragment) {
+  clone(this: RequestFragment): RequestFragment {
     const { store } = this;
     const clonedRequest = this.toJSON() as RequestFragment; //POJO form of RequestFragment;
 
@@ -152,7 +152,7 @@ export default class RequestFragment extends Fragment.extend(Validations) implem
   }
 
   @computed('table', 'dataSource')
-  get tableMetadata() {
+  get tableMetadata(): TableMetadataModel | undefined {
     return this.naviMetadata.getById('table', this.table, this.dataSource);
   }
 
@@ -160,13 +160,15 @@ export default class RequestFragment extends Fragment.extend(Validations) implem
    * @property {ColumnFragment[]} metricColumns - The metric columns
    */
   @computed('columns.[]')
-  get metricColumns(): ColumnFragment[] {
-    return this.columns.filter(column => column.type === 'metric');
+  get metricColumns(): ColumnFragment<'metric'>[] {
+    return this.columns.filter(column => column.type === 'metric') as ColumnFragment<'metric'>[];
   }
 
   @computed('columns.[]')
-  get dimensionColumns(): ColumnFragment[] {
-    return this.columns.filter(column => column.type === 'timeDimension' || column.type === 'dimension');
+  get dimensionColumns(): ColumnFragment<'dimension' | 'timeDimension'>[] {
+    return this.columns.filter(
+      column => column.type === 'timeDimension' || column.type === 'dimension'
+    ) as ColumnFragment<'dimension' | 'timeDimension'>[];
   }
 
   @computed('filters.[]')
@@ -186,8 +188,8 @@ export default class RequestFragment extends Fragment.extend(Validations) implem
    * @property {ColumnFragment} timeGrainColumn - The column containing the dateTime timeDimension
    */
   @computed('columns.[]')
-  get timeGrainColumn() {
-    return this.columns.filter(column => column.type === 'timeDimension')[0];
+  get timeGrainColumn(): ColumnFragment<'timeDimension'> {
+    return this.columns.filter(column => column.type === 'timeDimension')[0] as ColumnFragment<'timeDimension'>;
   }
 
   @computed('columns.[]')

--- a/packages/core/addon/models/chart-visualization.ts
+++ b/packages/core/addon/models/chart-visualization.ts
@@ -56,7 +56,7 @@ export default class ChartVisualization extends Visualization {
 
   private buildDimensionSeriesValues(request: RequestFragment, rows: ResponseV1['rows']): DimensionSeriesValues[] {
     const series: Record<string, DimensionSeriesValues> = {};
-    const dimensions = request.nonTimeGrainDimensions;
+    const dimensions = request.nonTimeDimensions;
     rows.forEach(row => {
       const values: Record<string, string | number | boolean> = {};
       const dimensionLabels: Array<string | number | boolean> = [];
@@ -104,7 +104,7 @@ export default class ChartVisualization extends Visualization {
       : request.metricColumns[0];
 
     const responseRows = topN(
-      maxDataByDimensions(response.rows, request.nonTimeGrainDimensions, metric.canonicalName),
+      maxDataByDimensions(response.rows, request.nonTimeDimensions, metric.canonicalName),
       metric.canonicalName,
       10
     );

--- a/packages/core/addon/utils/chart-data.ts
+++ b/packages/core/addon/utils/chart-data.ts
@@ -34,7 +34,7 @@ export function groupDataByDimensions(
  * @returns the chart type
  */
 export function chartTypeForRequest(request: RequestFragment): ChartType {
-  if (request.nonTimeGrainDimensions.length > 0) {
+  if (request.nonTimeDimensions.length > 0) {
     return DIMENSION_SERIES;
   }
 

--- a/packages/core/addon/utils/data.ts
+++ b/packages/core/addon/utils/data.ts
@@ -7,8 +7,7 @@ import { assert } from '@ember/debug';
 import { maxBy } from 'lodash-es';
 import { ResponseV1 } from 'navi-data/serializers/facts/interface';
 import ColumnFragment from 'navi-core/models/bard-request-v2/fragments/column';
-
-type ResponseRow = ResponseV1['rows'][number];
+import { ResponseRow } from 'navi-data/models/navi-fact-response';
 
 /**
  * Trim rows to a max of n values, sorted by highest value for given metric.

--- a/packages/core/addon/validators/request-dimension-order.js
+++ b/packages/core/addon/validators/request-dimension-order.js
@@ -11,7 +11,7 @@ export default BaseValidator.extend({
   validate(value, options /*, model, attribute*/) {
     let request = get(options, 'request');
     if (request) {
-      let requestDimensions = request.nonTimeGrainDimensions;
+      let requestDimensions = request.nonTimeDimensions;
       return isEqual(value, requestDimensions);
     }
   }

--- a/packages/core/tests/dummy/app/routes/line-chart.ts
+++ b/packages/core/tests/dummy/app/routes/line-chart.ts
@@ -1,5 +1,6 @@
 import { A } from '@ember/array';
 import Route from '@ember/routing/route';
+import NaviFactResponse from 'navi-data/models/navi-fact-response';
 import { Grain } from 'navi-data/utils/date';
 import { canonicalizeMetric } from 'navi-data/utils/metric';
 
@@ -300,13 +301,13 @@ export default class LineChartRoute extends Route {
       anomalousRequest
     } = this;
     return {
-      default: A([{ request: defaultRequest, response: { rows: defaultRows, meta: {} } }]),
-      dimension: A([{ request: dimensionRequest, response: { rows: dimensionRows, meta: {} } }]),
-      hourGrain: A([{ request: hourGrainRequest, response: { rows: hourRows, meta: {} } }]),
-      minuteGrain: A([{ request: minuteGrainRequest, response: { rows: minuteRows, meta: {} } }]),
-      secondGrain: A([{ request: secondGrainRequest, response: { rows: secondRows, meta: {} } }]),
+      default: A([{ request: defaultRequest, response: NaviFactResponse.create({ rows: defaultRows }) }]),
+      dimension: A([{ request: dimensionRequest, response: NaviFactResponse.create({ rows: dimensionRows }) }]),
+      hourGrain: A([{ request: hourGrainRequest, response: NaviFactResponse.create({ rows: hourRows }) }]),
+      minuteGrain: A([{ request: minuteGrainRequest, response: NaviFactResponse.create({ rows: minuteRows }) }]),
+      secondGrain: A([{ request: secondGrainRequest, response: NaviFactResponse.create({ rows: secondRows }) }]),
       anomalous: A([
-        { request: anomalousRequest, response: { rows: anomalousRows, meta: {} } },
+        { request: anomalousRequest, response: NaviFactResponse.create({ rows: anomalousRows }) },
         Promise.resolve(
           A([
             { index: 1, actual: 12, predicted: 172724594.12345, standardDeviation: 123.123456 },

--- a/packages/core/tests/integration/components/navi-visualizations/line-chart-test.ts
+++ b/packages/core/tests/integration/components/navi-visualizations/line-chart-test.ts
@@ -16,6 +16,7 @@ import { TestContext } from 'ember-test-helpers';
 import { buildTestRequest } from '../../../helpers/request';
 import LineChart from 'navi-core/components/navi-visualizations/line-chart';
 import StoreService from '@ember-data/store';
+import NaviFactResponse from 'navi-data/models/navi-fact-response';
 
 const TEMPLATE = hbs`
   <NaviVisualizations::LineChart
@@ -45,7 +46,7 @@ module('Integration | Component | line chart', function(hooks) {
           { start: '2016-05-30 00:00:00.000', end: '2016-06-04 00:00:00.000' },
           'day'
         ),
-        response: {
+        response: NaviFactResponse.create({
           rows: [
             {
               'network.dateTime(grain=day)': '2016-05-30 00:00:00.000',
@@ -77,9 +78,8 @@ module('Integration | Component | line chart', function(hooks) {
               totalPageViews: 3697156058,
               'revenue(currency=USD)': 1623430236.42
             }
-          ],
-          meta: {}
-        }
+          ]
+        })
       }
     ]);
 
@@ -126,7 +126,7 @@ module('Integration | Component | line chart', function(hooks) {
             { start: '2016-05-30 00:00:00.000', end: '2016-06-02 00:00:00.000' },
             'day'
           ),
-          response: {
+          response: NaviFactResponse.create({
             rows: [
               {
                 'network.dateTime(grain=day)': '2016-05-30 00:00:00.000',
@@ -137,7 +137,7 @@ module('Integration | Component | line chart', function(hooks) {
                 uniqueIdentifier: 183380921
               }
             ]
-          }
+          })
         }
       ])
     );
@@ -183,7 +183,7 @@ module('Integration | Component | line chart', function(hooks) {
             { start: '2016-05-30 00:00:00.000', end: '2016-06-02 00:00:00.000' },
             'day'
           ),
-          response: {
+          response: NaviFactResponse.create({
             rows: [
               {
                 'network.dateTime(grain=day)': '2016-05-30 00:00:00.000',
@@ -196,7 +196,7 @@ module('Integration | Component | line chart', function(hooks) {
                 uniqueIdentifier: 183380921
               }
             ]
-          }
+          })
         }
       ])
     );
@@ -342,7 +342,7 @@ module('Integration | Component | line chart', function(hooks) {
           { start: '2017-09-01 00:00:00.000', end: '2017-09-07 00:00:00.000' },
           'day'
         ),
-        response: {
+        response: NaviFactResponse.create({
           rows: [
             {
               'network.dateTime(grain=day)': '2017-09-01 00:00:00.000',
@@ -373,7 +373,7 @@ module('Integration | Component | line chart', function(hooks) {
               uniqueIdentifier: 180559793
             }
           ]
-        }
+        })
       },
       new Promise(resolve => {
         resolve(
@@ -443,10 +443,9 @@ module('Integration | Component | line chart', function(hooks) {
             { start: start.format(API_DATE_FORMAT_STRING), end: end.format(API_DATE_FORMAT_STRING) },
             'month'
           ),
-          response: {
-            rows,
-            meta: {}
-          }
+          response: NaviFactResponse.create({
+            rows
+          })
         }
       ])
     );
@@ -550,7 +549,7 @@ module('Integration | Component | line chart', function(hooks) {
             dataSource: 'bardTwo',
             requestVersion: '2.0'
           }),
-          response: {
+          response: NaviFactResponse.create({
             rows: [
               {
                 'inventory.dateTime(grain=day)': '2016-05-30 00:00:00.000',
@@ -577,9 +576,8 @@ module('Integration | Component | line chart', function(hooks) {
                 ownedQuantity: 172724594,
                 usedAmount: 3697156058
               }
-            ],
-            meta: {}
-          }
+            ]
+          })
         }
       ])
     );

--- a/packages/core/tests/unit/chart-builders/date-test.ts
+++ b/packages/core/tests/unit/chart-builders/date-test.ts
@@ -4,12 +4,23 @@ import Object from '@ember/object';
 import BuilderClass from 'navi-core/chart-builders/date-time';
 import TooltipTemplate from 'navi-core/templates/chart-tooltips/date';
 import { C3Row } from 'navi-core/chart-builders/base';
-import { buildTestRequest } from 'dummy/tests/helpers/request';
+import { buildTestRequest } from '../../helpers/request';
+import NaviFactResponse from 'navi-data/models/navi-fact-response';
+// @ts-ignore
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import NaviMetadataService from 'navi-data/services/navi-metadata';
+import { TestContext } from 'ember-test-helpers';
 
 const DateChartBuilder = BuilderClass.create();
 
 module('Unit | Chart Builders | Date Time', function(hooks) {
   setupTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function(this: TestContext) {
+    const naviMetadata = this.owner.lookup('service:navi-metadata') as NaviMetadataService;
+    await naviMetadata.loadMetadata({ dataSourceName: 'bardOne' });
+  });
 
   test('weeks by year uses isoWeekYear', function(assert) {
     assert.expect(2);
@@ -21,13 +32,12 @@ module('Unit | Chart Builders | Date Time', function(hooks) {
       'week'
     );
     const config = { timeGrain: 'year', metricCid: 'cid_pageViews' };
-    const response = {
+    const response = NaviFactResponse.create({
       rows: [
         { 'network.dateTime(grain=week)': '2016-01-04 00:00:00.000', pageViews: 2 }, // Week 1, 2016
         { 'network.dateTime(grain=week)': '2016-01-01 00:00:00.000', pageViews: 1 } // Week 53, 2015
-      ],
-      meta: {}
-    };
+      ]
+    });
     const data = DateChartBuilder.buildData(response, config, request);
 
     assert.equal(data.length, 53, 'A data entry exists for each possible week in a year');
@@ -53,15 +63,14 @@ module('Unit | Chart Builders | Date Time', function(hooks) {
       'day'
     );
     const config = { timeGrain: 'month', metricCid: 'cid_pageViews' };
-    const response = {
+    const response = NaviFactResponse.create({
       rows: [
         { 'network.dateTime(grain=day)': '2016-01-01 00:00:00.000', pageViews: 1 },
         { 'network.dateTime(grain=day)': '2016-02-01 00:00:00.000', pageViews: 2 },
         { 'network.dateTime(grain=day)': '2015-01-01 00:00:00.000', pageViews: 3 },
         { 'network.dateTime(grain=day)': '2016-03-15 00:00:00.000', pageViews: 4 }
-      ],
-      meta: {}
-    };
+      ]
+    });
     const data = DateChartBuilder.buildData(response, config, request);
 
     assert.equal(data.length, 31, 'A data entry exists for each possible day in a month');
@@ -89,15 +98,14 @@ module('Unit | Chart Builders | Date Time', function(hooks) {
       'day'
     );
     const config = { timeGrain: 'year', metricCid: 'cid_pageViews' };
-    const response = {
+    const response = NaviFactResponse.create({
       rows: [
         { 'network.dateTime(grain=day)': '2016-01-01 00:00:00.000', pageViews: 1 },
         { 'network.dateTime(grain=day)': '2016-02-01 00:00:00.000', pageViews: 2 },
         { 'network.dateTime(grain=day)': '2015-01-01 00:00:00.000', pageViews: 3 },
         { 'network.dateTime(grain=day)': '2016-03-15 00:00:00.000', pageViews: 4 }
-      ],
-      meta: {}
-    };
+      ]
+    });
     const data = DateChartBuilder.buildData(response, config, request);
 
     assert.equal(data.length, 366, 'A data entry exists for each possible day in a year');
@@ -123,15 +131,14 @@ module('Unit | Chart Builders | Date Time', function(hooks) {
       'month'
     );
     const config = { timeGrain: 'year', metricCid: 'cid_pageViews' };
-    const response = {
+    const response = NaviFactResponse.create({
       rows: [
         { 'network.dateTime(grain=month)': '2016-01-01 00:00:00.000', pageViews: 1 },
         { 'network.dateTime(grain=month)': '2016-02-01 00:00:00.000', pageViews: 2 },
         { 'network.dateTime(grain=month)': '2015-01-01 00:00:00.000', pageViews: 3 },
         { 'network.dateTime(grain=month)': '2014-03-15 00:00:00.000', pageViews: 4 }
-      ],
-      meta: {}
-    };
+      ]
+    });
     const data = DateChartBuilder.buildData(response, config, request);
 
     assert.equal(data.length, 12, 'A data entry exists for each possible month in a year');
@@ -158,14 +165,13 @@ module('Unit | Chart Builders | Date Time', function(hooks) {
       'hour'
     );
     const config = { timeGrain: 'day', metricCid: 'cid_pageViews' };
-    const response = {
+    const response = NaviFactResponse.create({
       rows: [
         { 'network.dateTime(grain=hour)': '2016-01-01 01:00:00.000', pageViews: 1 },
         { 'network.dateTime(grain=hour)': '2016-01-02 01:00:00.000', pageViews: 2 },
         { 'network.dateTime(grain=hour)': '2016-01-03 01:00:00.000', pageViews: 3 }
-      ],
-      meta: {}
-    };
+      ]
+    });
     const data = DateChartBuilder.buildData(response, config, request);
 
     assert.equal(data.length, 24, 'A data entry exists for each hour in a day');
@@ -192,14 +198,13 @@ module('Unit | Chart Builders | Date Time', function(hooks) {
       'minute'
     );
     const config = { timeGrain: 'hour', metricCid: 'cid_pageViews' };
-    const response = {
+    const response = NaviFactResponse.create({
       rows: [
         { 'network.dateTime(grain=minute)': '2016-01-01 00:04:00.000', pageViews: 1 },
         { 'network.dateTime(grain=minute)': '2016-01-01 01:04:00.000', pageViews: 2 },
         { 'network.dateTime(grain=minute)': '2016-01-02 02:04:00.000', pageViews: 3 }
-      ],
-      meta: {}
-    };
+      ]
+    });
     const data = DateChartBuilder.buildData(response, config, request);
 
     assert.equal(data.length, 60, 'A data entry exists for each minute in a hour');
@@ -226,14 +231,13 @@ module('Unit | Chart Builders | Date Time', function(hooks) {
       'second'
     );
     const config = { timeGrain: 'minute', metricCid: 'cid_pageViews' };
-    const response = {
+    const response = NaviFactResponse.create({
       rows: [
         { 'network.dateTime(grain=second)': '2016-01-01 00:00:20.000', pageViews: 1 },
         { 'network.dateTime(grain=second)': '2016-01-01 00:01:20.000', pageViews: 2 },
         { 'network.dateTime(grain=second)': '2016-01-01 00:03:20.000', pageViews: 3 }
-      ],
-      meta: {}
-    };
+      ]
+    });
     const data = DateChartBuilder.buildData(response, config, request);
 
     assert.equal(data.length, 61, 'A data entry exists for each second in a minute');
@@ -260,10 +264,9 @@ module('Unit | Chart Builders | Date Time', function(hooks) {
       'day'
     );
     const config = { timeGrain: 'month', metricCid: 'cid_pageViews' };
-    const response = {
-      rows: [{ 'network.dateTime(grain=day)': '2016-01-01 00:00:00.000', pageViews: 0 }],
-      meta: {}
-    };
+    const response = NaviFactResponse.create({
+      rows: [{ 'network.dateTime(grain=day)': '2016-01-01 00:00:00.000', pageViews: 0 }]
+    });
     const data = DateChartBuilder.buildData(response, config, request);
 
     assert.deepEqual(
@@ -289,16 +292,19 @@ module('Unit | Chart Builders | Date Time', function(hooks) {
       timeGrain: 'month',
       metricCid: 'cid_pageViews'
     };
-    const response = {
+    const response = NaviFactResponse.create({
       rows: [
-        { dateTime: '2016-01-01 00:00:20.000', pageViews: 1 },
-        { dateTime: '2016-01-02 00:01:20.000', pageViews: 2 },
-        { dateTime: '2016-01-03 00:03:20.000', pageViews: 3 }
-      ],
-      meta: {}
-    };
+        { 'network.dateTime(grain=day)': '2016-01-01 00:00:20.000', pageViews: 1 },
+        { 'network.dateTime(grain=day)': '2016-01-02 00:01:20.000', pageViews: 2 },
+        { 'network.dateTime(grain=day)': '2016-01-03 00:03:20.000', pageViews: 3 }
+      ]
+    });
     const x = 2;
     const tooltipData = [{ x, name: 'Jan 2016', value: 2 }];
+
+    //Populates the 'byXSeries' property in the builder that buildTooltip uses
+    DateChartBuilder.buildData(response, config, request);
+
     const mixin = DateChartBuilder.buildTooltip(config, request);
     const tooltipClass = Object.extend(mixin, {});
     const tooltip = tooltipClass.create({ config, request, tooltipData, x });
@@ -306,6 +312,6 @@ module('Unit | Chart Builders | Date Time', function(hooks) {
     assert.equal(tooltip.layout, TooltipTemplate, 'Tooltip uses date template');
 
     //@ts-expect-error
-    assert.deepEqual(tooltip.rowData, [response[1]], 'The correct response row is given to the tooltip');
+    assert.deepEqual(tooltip.rowData, [response.rows[1]], 'The correct response row is given to the tooltip');
   });
 });

--- a/packages/core/tests/unit/components/navi-visualizations/line-chart-test.ts
+++ b/packages/core/tests/unit/components/navi-visualizations/line-chart-test.ts
@@ -19,6 +19,8 @@ import StoreService from '@ember-data/store';
 import { buildTestRequest } from '../../../helpers/request';
 import { LineChartConfig } from 'navi-core/models/line-chart';
 
+/*eslint max-len: ["error", { "code": 250 }]*/
+
 let Store: StoreService;
 
 module('Unit | Component | line chart', function(hooks) {
@@ -33,32 +35,13 @@ module('Unit | Component | line chart', function(hooks) {
 
   test('dataConfig', function(assert) {
     const response = NaviFactResponse.create({
+      //prettier-ignore
       rows: [
-        {
-          'network.dateTime(grain=day)': '2016-05-30 00:00:00.000',
-          uniqueIdentifier: 172933788,
-          totalPageViews: 3669828357
-        },
-        {
-          'network.dateTime(grain=day)': '2016-05-31 00:00:00.000',
-          uniqueIdentifier: 183206656,
-          totalPageViews: 4088487125
-        },
-        {
-          'network.dateTime(grain=day)': '2016-06-01 00:00:00.000',
-          uniqueIdentifier: 183380921,
-          totalPageViews: 4024700302
-        },
-        {
-          'network.dateTime(grain=day)': '2016-06-02 00:00:00.000',
-          uniqueIdentifier: 180559793,
-          totalPageViews: 3950276031
-        },
-        {
-          'network.dateTime(grain=day)': '2016-06-03 00:00:00.000',
-          uniqueIdentifier: 172724594,
-          totalPageViews: 3697156058
-        }
+        { 'network.dateTime(grain=day)': '2016-05-30 00:00:00.000', uniqueIdentifier: 172933788, totalPageViews: 3669828357 },
+        { 'network.dateTime(grain=day)': '2016-05-31 00:00:00.000', uniqueIdentifier: 183206656, totalPageViews: 4088487125 },
+        { 'network.dateTime(grain=day)': '2016-06-01 00:00:00.000', uniqueIdentifier: 183380921, totalPageViews: 4024700302 },
+        { 'network.dateTime(grain=day)': '2016-06-02 00:00:00.000', uniqueIdentifier: 180559793, totalPageViews: 3950276031 },
+        { 'network.dateTime(grain=day)': '2016-06-03 00:00:00.000', uniqueIdentifier: 172724594, totalPageViews: 3697156058 }
       ]
     });
     const request = Store.createFragment('bard-request-v2/request', {
@@ -216,7 +199,7 @@ module('Unit | Component | line chart', function(hooks) {
       model: A([
         {
           request: buildTestRequest([{ cid: 'cid_totalPageViews', field: 'totalPageViews' }]),
-          response: { rows: [] }
+          response: NaviFactResponse.create()
         }
       ])
     }) as TestLineChart;
@@ -346,15 +329,15 @@ module('Unit | Component | line chart', function(hooks) {
           { start: 'P1D', end: '2016-05-31 00:00:00.000' },
           'day'
         ),
-        response: {
+        response: NaviFactResponse.create({
           rows: [
             {
-              dateTime: '2016-05-30 00:00:00.000',
+              'network.dateTime(grain=day)': '2016-05-30 00:00:00.000',
               uniqueIdentifier: 172933788,
               totalPageViews: 3669828357
             }
           ]
-        }
+        })
       }
     ]);
     const component = createGlimmerComponent('component:navi-visualizations/line-chart', {
@@ -364,9 +347,7 @@ module('Unit | Component | line chart', function(hooks) {
           y: {
             series: {
               type: 'metric',
-              config: {
-                metrics: [{ metric: 'foo', parameters: {}, canonicalName: 'foo' }]
-              }
+              config: {}
             }
           }
         }
@@ -395,21 +376,20 @@ module('Unit | Component | line chart', function(hooks) {
             { start: 'P2D', end: '2016-06-01 00:00:00.000' },
             'day'
           ),
-          response: {
+          response: NaviFactResponse.create({
             rows: [
               {
-                dateTime: '2016-05-30 00:00:00.000',
+                'network.dateTime(grain=day)': '2016-05-30 00:00:00.000',
                 uniqueIdentifier: 172933788,
                 totalPageViews: 3669828357
               },
               {
-                dateTime: '2016-05-31 00:00:00.000',
+                'network.dateTime(grain=day)': '2016-05-31 00:00:00.000',
                 uniqueIdentifier: 172933788,
                 totalPageViews: 3669828357
               }
-            ],
-            meta: {}
-          }
+            ]
+          })
         }
       ])
     );
@@ -427,36 +407,16 @@ module('Unit | Component | line chart', function(hooks) {
   });
 
   test('tooltips', function(assert) {
-    const response = {
+    const response = NaviFactResponse.create({
+      //prettier-ignore
       rows: [
-        {
-          'network.dateTime(grain=day)': '2016-05-30 00:00:00.000',
-          uniqueIdentifier: 172933788,
-          totalPageViews: 3669828357
-        },
-        {
-          'network.dateTime(grain=day)': '2016-05-31 00:00:00.000',
-          uniqueIdentifier: 183206656,
-          totalPageViews: 4088487125
-        },
-        {
-          'network.dateTime(grain=day)': '2016-06-01 00:00:00.000',
-          uniqueIdentifier: 183380921,
-          totalPageViews: 4024700302
-        },
-        {
-          'network.dateTime(grain=day)': '2016-06-02 00:00:00.000',
-          uniqueIdentifier: 180559793,
-          totalPageViews: 3950276031
-        },
-        {
-          'network.dateTime(grain=day)': '2016-06-03 00:00:00.000',
-          uniqueIdentifier: 172724594,
-          totalPageViews: 3697156058
-        }
-      ],
-      meta: {}
-    };
+        { 'network.dateTime(grain=day)': '2016-05-30 00:00:00.000', uniqueIdentifier: 172933788, totalPageViews: 3669828357 },
+        { 'network.dateTime(grain=day)': '2016-05-31 00:00:00.000', uniqueIdentifier: 183206656, totalPageViews: 4088487125 },
+        { 'network.dateTime(grain=day)': '2016-06-01 00:00:00.000', uniqueIdentifier: 183380921, totalPageViews: 4024700302 },
+        { 'network.dateTime(grain=day)': '2016-06-02 00:00:00.000', uniqueIdentifier: 180559793, totalPageViews: 3950276031 },
+        { 'network.dateTime(grain=day)': '2016-06-03 00:00:00.000', uniqueIdentifier: 172724594, totalPageViews: 3697156058 }
+      ]
+    });
     const request = buildTestRequest(
       [{ field: 'uniqueIdentifier' }, { field: 'totalPageViews' }],
       [],
@@ -509,31 +469,15 @@ module('Unit | Component | line chart', function(hooks) {
     );
 
     //new data
-    let response2 = {
+    let response2 = NaviFactResponse.create({
       rows: [
-        {
-          'network.dateTime(grain=day)': '2016-05-30 00:00:00.000',
-          navClicks: 172933788
-        },
-        {
-          'network.dateTime(grain=day)': '2016-05-31 00:00:00.000',
-          navClicks: 4088487125
-        },
-        {
-          'network.dateTime(grain=day)': '2016-06-01 00:00:00.000',
-          navClicks: 183380921
-        },
-        {
-          'network.dateTime(grain=day)': '2016-06-02 00:00:00.000',
-          navClicks: 3950276031
-        },
-        {
-          'network.dateTime(grain=day)': '2016-06-03 00:00:00.000',
-          navClicks: 172724594
-        }
-      ],
-      meta: {}
-    };
+        { 'network.dateTime(grain=day)': '2016-05-30 00:00:00.000', navClicks: 172933788 },
+        { 'network.dateTime(grain=day)': '2016-05-31 00:00:00.000', navClicks: 4088487125 },
+        { 'network.dateTime(grain=day)': '2016-06-01 00:00:00.000', navClicks: 183380921 },
+        { 'network.dateTime(grain=day)': '2016-06-02 00:00:00.000', navClicks: 3950276031 },
+        { 'network.dateTime(grain=day)': '2016-06-03 00:00:00.000', navClicks: 172724594 }
+      ]
+    });
 
     set(component.args, 'model', A([{ request, response: response2 }]));
 
@@ -568,16 +512,15 @@ module('Unit | Component | line chart', function(hooks) {
     let component = createGlimmerComponent('component:navi-visualizations/line-chart', {
       model: A([
         {
-          response: {
+          response: NaviFactResponse.create({
             rows: [
               {
                 'network.dateTime(grain=day)': '2016-05-30 00:00:00.000',
                 uniqueIdentifier: 172933788,
                 totalPageViews: 3669828357
               }
-            ],
-            meta: {}
-          },
+            ]
+          }),
           request: buildTestRequest(
             [{ field: 'uniqueIdentifier' }, { field: 'totalPageViews' }],
             [],
@@ -620,19 +563,12 @@ module('Unit | Component | line chart', function(hooks) {
 
     const getModelDataFor = (start: string, end: string, timeGrain: string) => {
       return {
-        response: {
+        response: NaviFactResponse.create({
           rows: [
-            {
-              [`network.dateTime(grain=${timeGrain})`]: start,
-              uniqueIdentifier: 172933788
-            },
-            {
-              [`network.dateTime(grain=${timeGrain})`]: end,
-              uniqueIdentifier: 183206656
-            }
-          ],
-          meta: {}
-        },
+            { [`network.dateTime(grain=${timeGrain})`]: start, uniqueIdentifier: 172933788 },
+            { [`network.dateTime(grain=${timeGrain})`]: end, uniqueIdentifier: 183206656 }
+          ]
+        }),
         request: buildTestRequest([], [], { start, end }, timeGrain)
       };
     };

--- a/packages/core/tests/unit/utils/chart-data-test.ts
+++ b/packages/core/tests/unit/utils/chart-data-test.ts
@@ -3,7 +3,6 @@ import { groupDataByDimensions, chartTypeForRequest } from 'navi-core/utils/char
 import { buildTestRequest } from '../../helpers/request';
 import { setupTest } from 'ember-qunit';
 import ColumnFragment from 'navi-core/models/bard-request-v2/fragments/column';
-import RequestFragment from 'navi-core/models/bard-request-v2/request';
 
 module('Unit | Utils | Chart Data', function(hooks) {
   setupTest(hooks);

--- a/packages/data/addon/models/navi-fact-response.ts
+++ b/packages/data/addon/models/navi-fact-response.ts
@@ -13,6 +13,7 @@ function notNull<T>(t: T | null): t is T {
   return t !== null;
 }
 
+export type ResponseRow = ResponseV1['rows'][number];
 export default class NaviFactResponse extends EmberObject implements ResponseV1 {
   readonly rows: ResponseV1['rows'] = [];
   readonly meta: ResponseV1['meta'] = {};

--- a/packages/data/addon/utils/classes/interval.ts
+++ b/packages/data/addon/utils/classes/interval.ts
@@ -158,6 +158,27 @@ export default class Interval {
   }
 
   /**
+   * Converts interval from [inclusive, inclusive] to [inclusive, exclusive] for the given grain
+   * @param timePeriod - period to align to
+   * @returns new interval with inclusive exclusive
+   */
+  makeEndExclusiveFor(timePeriod: Grain): Interval {
+    /*
+     * moment does not know how to deal with all,
+     * and we only concern day here, so use day as base unit
+     */
+    if (timePeriod === 'all') {
+      timePeriod = 'day';
+    }
+
+    let { start, end } = this.asMoments();
+    assert('when making the end of an interval exclusive, the end should exist', end);
+    end.startOf(getIsoDateTimePeriod(timePeriod)).add(1, timePeriod);
+
+    return new Interval(start, end);
+  }
+
+  /**
    * Converts interval into another interval with moments that are aligned to the given time period
    * @param timePeriod - period to align to
    * @returns object with start and end properties

--- a/packages/data/tests/unit/utils/classes/interval-test.ts
+++ b/packages/data/tests/unit/utils/classes/interval-test.ts
@@ -199,6 +199,79 @@ module('Unit | Utils | Interval Class', function() {
     assert.ok(moments.start.isSame(moments.end), 'Start moment is same as end moment');
   });
 
+  test('makeEndExclusiveFor', function(assert) {
+    const start = moment('2017-10-10T00:00:00.000Z').utc();
+    const end = moment('2017-10-12T01:02:03.004Z').utc();
+    const interval = new Interval(start, end);
+
+    assert.equal(
+      interval
+        .makeEndExclusiveFor('second')
+        .asMoments()
+        .end?.toISOString(),
+      '2017-10-12T01:02:04.000Z',
+      'interval is inclusive of the second'
+    );
+    assert.equal(
+      interval
+        .makeEndExclusiveFor('minute')
+        .asMoments()
+        .end?.toISOString(),
+      '2017-10-12T01:03:00.000Z',
+      'interval is inclusive of the minute'
+    );
+
+    assert.equal(
+      interval
+        .makeEndExclusiveFor('hour')
+        .asMoments()
+        .end?.toISOString(),
+      '2017-10-12T02:00:00.000Z',
+      'interval is inclusive of the hour'
+    );
+
+    assert.equal(
+      interval
+        .makeEndExclusiveFor('day')
+        .asMoments()
+        .end?.toISOString(),
+      '2017-10-13T00:00:00.000Z',
+      'interval is inclusive of the day'
+    );
+    assert.equal(
+      interval
+        .makeEndExclusiveFor('week')
+        .asMoments()
+        .end?.toISOString(),
+      '2017-10-16T00:00:00.000Z',
+      'interval is inclusive of the week'
+    );
+    assert.equal(
+      interval
+        .makeEndExclusiveFor('month')
+        .asMoments()
+        .end?.toISOString(),
+      '2017-11-01T00:00:00.000Z',
+      'interval is inclusive of the month'
+    );
+    assert.equal(
+      interval
+        .makeEndExclusiveFor('quarter')
+        .asMoments()
+        .end?.toISOString(),
+      '2018-01-01T00:00:00.000Z',
+      'interval is inclusive of the quarter'
+    );
+    assert.equal(
+      interval
+        .makeEndExclusiveFor('year')
+        .asMoments()
+        .end?.toISOString(),
+      '2018-01-01T00:00:00.000Z',
+      'interval is inclusive of the year'
+    );
+  });
+
   test('asIntervalForTimePeriod', function(assert) {
     assert.expect(2);
 


### PR DESCRIPTION
Resolves #1079

## Description
We no longer expect a time filter that specifies the start and end date, so visualizations can no longer rely on an interval specified in the request

## Proposed Changes
- updates line chart visualization to rely solely on the response for defining an interval, which should add support for `gte`, `lte` time filters

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
