### PR TITLE
Update: SD to use TURBO for gh-pages and set 4 JOBS

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -5,18 +5,17 @@ shared:
   image: maven:3.6.3-jdk-8
   environment:
     NODE_VERSION: 12.16.0
-    JOBS: 6
+    JOBS: 4
 
 jobs:
   main:
     annotations:
-      screwdriver.cd/ram: HIGH
-      screwdriver.cd/cpu: HIGH
+      screwdriver.cd/ram: TURBO
+      screwdriver.cd/cpu: TURBO
     steps:
       - install-node: |
           sd-cmd exec screwdriver/install-nodejs@latest $NODE_VERSION
           export NVM_DIR="$HOME/.nvm" && . "$NVM_DIR/nvm.sh" && nvm use node
-      - test-show-cpu: node -e 'console.log(require("os").cpus().length - 1)'
       - install-chrome: ./build-scripts/setup-chrome.sh
       - install: npm ci
       - test-navi-admin: npx lerna run test --scope navi-admin --stream;
@@ -57,8 +56,8 @@ jobs:
   gh-pages:
     requires: main
     annotations:
-      screwdriver.cd/ram: HIGH
-      screwdriver.cd/cpu: HIGH
+      screwdriver.cd/ram: TURBO
+      screwdriver.cd/cpu: TURBO
     environment:
       BUILD_NAVI_DEMO: true
     steps:

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -13,10 +13,10 @@ jobs:
       screwdriver.cd/ram: HIGH
       screwdriver.cd/cpu: HIGH
     steps:
-      - test-show-cpu: node -e 'console.log(require("os").cpus().length - 1)'
       - install-node: |
           sd-cmd exec screwdriver/install-nodejs@latest $NODE_VERSION
           export NVM_DIR="$HOME/.nvm" && . "$NVM_DIR/nvm.sh" && nvm use node
+      - test-show-cpu: node -e 'console.log(require("os").cpus().length - 1)'
       - install-chrome: ./build-scripts/setup-chrome.sh
       - install: npm ci
       - test-navi-admin: npx lerna run test --scope navi-admin --stream;

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -5,13 +5,15 @@ shared:
   image: maven:3.6.3-jdk-8
   environment:
     NODE_VERSION: 12.16.0
+    JOBS: 6
 
 jobs:
   main:
     annotations:
-      screwdriver.cd/ram: TURBO
-      screwdriver.cd/cpu: TURBO
+      screwdriver.cd/ram: HIGH
+      screwdriver.cd/cpu: HIGH
     steps:
+      - test-show-cpu: node -e 'console.log(require("os").cpus().length - 1)'
       - install-node: |
           sd-cmd exec screwdriver/install-nodejs@latest $NODE_VERSION
           export NVM_DIR="$HOME/.nvm" && . "$NVM_DIR/nvm.sh" && nvm use node
@@ -54,6 +56,9 @@ jobs:
 
   gh-pages:
     requires: main
+    annotations:
+      screwdriver.cd/ram: HIGH
+      screwdriver.cd/cpu: HIGH
     environment:
       BUILD_NAVI_DEMO: true
     steps:


### PR DESCRIPTION
## Description
ember-cli-build tries to manage it's own parallelization but it doesn't work well for CI so manually set JOBS to 6 and use HIGH resources for SD

also added a test node script to run to show cpu count

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
