### PR TITLE
Update: Add fili consumer to keep filter in sync with dateTime column

### DIFF
--- a/packages/core/addon/consumers/action-consumer.ts
+++ b/packages/core/addon/consumers/action-consumer.ts
@@ -2,8 +2,28 @@
  * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
-
 import EmberObject from '@ember/object';
 import Ember from 'ember';
 
-export default class ActionConsumer extends EmberObject.extend(Ember.ActionHandler) {}
+export default class ActionConsumer extends EmberObject.extend(Ember.ActionHandler) {
+  /**
+   * Overrides the sending of an action to filter out unwanted actions
+   * @param actionName the name of the action to perform
+   * @param args the args to pass to the action handler
+   */
+  send(actionName: string, ...args: unknown[]) {
+    if (this.shouldConsumeAction(actionName, ...args)) {
+      super.send(actionName, ...args);
+    }
+    return undefined;
+  }
+
+  /**
+   * Filters out actions based on the name and parameters
+   * @param _actionName the name of the action to perform
+   * @param _args the args to pass to the action handler
+   */
+  shouldConsumeAction(_actionName: string, ..._args: unknown[]) {
+    return true;
+  }
+}

--- a/packages/reports/.eslintrc.js
+++ b/packages/reports/.eslintrc.js
@@ -32,6 +32,7 @@ module.exports = {
     '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
     '@typescript-eslint/camelcase': ['error', { allow: ['_id$'] }],
     '@typescript-eslint/explicit-function-return-type': 'off',
+    '@typescript-eslint/ban-ts-ignore': 'off',
 
     // prettier
     'prettier/prettier': 'error',

--- a/packages/reports/addon/consumers/request/fili.ts
+++ b/packages/reports/addon/consumers/request/fili.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2020, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+import { inject as service } from '@ember/service';
+import ActionConsumer from 'navi-core/consumers/action-consumer';
+import Route from '@ember/routing/route';
+import RequestActionDispatcher, { RequestActions } from 'navi-reports/services/request-action-dispatcher';
+import ColumnFragment from 'navi-core/models/bard-request-v2/fragments/column';
+import ReportModel from 'navi-core/models/report';
+import { getDataSource } from 'navi-data/utils/adapter';
+
+export default class FiliConsumer extends ActionConsumer {
+  @service requestActionDispatcher!: RequestActionDispatcher;
+
+  /**
+   * Filters actions to only those updating fili requests
+   */
+  shouldConsumeAction(_actionName: string, route: Route) {
+    const { routeName } = route;
+    const { request } = route.modelFor(routeName) as ReportModel;
+    const { type } = getDataSource(request.dataSource);
+
+    return type === 'bard';
+  }
+
+  actions = {
+    /**
+     * @action UPDATE_COLUMN_FRAGMENT_WITH_PARAMS
+     * @param route - route that has a model that contains a request property
+     * @param columnFragment - data model fragment of the column
+     * @param parameterKey - the name of the parameter to update
+     * @param parameterValue - the value to update the parameter with
+     */
+    [RequestActions.UPDATE_COLUMN_FRAGMENT_WITH_PARAMS](
+      this: FiliConsumer,
+      route: Route,
+      columnFragment: ColumnFragment,
+      parameterKey: string,
+      parameterValue: string
+    ) {
+      const { routeName } = route;
+      const { request } = route.modelFor(routeName) as ReportModel;
+
+      const { timeGrainColumn, dateTimeFilter } = request;
+      if (timeGrainColumn === columnFragment && parameterKey === 'grain' && dateTimeFilter) {
+        const changeset = { parameters: { ...dateTimeFilter.parameters, [parameterKey]: parameterValue } };
+        this.requestActionDispatcher.dispatch(RequestActions.UPDATE_FILTER, route, dateTimeFilter, changeset);
+      }
+    }
+  };
+}

--- a/packages/reports/addon/services/request-action-dispatcher.ts
+++ b/packages/reports/addon/services/request-action-dispatcher.ts
@@ -39,6 +39,6 @@ export const RequestActions = {
 
 export default class RequestActionDispatcher extends ActionDispatcher {
   get consumers() {
-    return [...super.consumers, 'request/column', 'request/filter', 'request/table', 'request/sort'];
+    return [...super.consumers, 'request/column', 'request/filter', 'request/fili', 'request/table', 'request/sort'];
   }
 }

--- a/packages/reports/app/consumers/request/fili.js
+++ b/packages/reports/app/consumers/request/fili.js
@@ -1,0 +1,1 @@
+export { default } from 'navi-reports/consumers/request/fili';

--- a/packages/reports/tests/acceptance/date-filter-test.js
+++ b/packages/reports/tests/acceptance/date-filter-test.js
@@ -67,7 +67,7 @@ module('Acceptance | date filter', function(hooks) {
       .includesText('05,', 'The high value is still set after the report is saved');
   });
 
-  test('verify the different time grains work as expected', async function(assert) {
+  test('verify the different time grains work as expected - bard', async function(assert) {
     assert.expect(72);
 
     await visit('/reports/1/view');

--- a/packages/reports/tests/unit/consumers/request/fili-test.ts
+++ b/packages/reports/tests/unit/consumers/request/fili-test.ts
@@ -1,0 +1,159 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { TestContext as Context } from 'ember-test-helpers';
+//@ts-ignore
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import Route from '@ember/routing/route';
+import { RequestActions } from 'navi-reports/services/request-action-dispatcher';
+import FiliConsumer from 'navi-reports/consumers/request/fili';
+import StoreService from 'ember-data/store';
+import NaviMetadataService from 'navi-data/services/navi-metadata';
+import config from 'ember-get-config';
+import { NaviDataSource } from 'navi-config';
+
+let consumer: FiliConsumer;
+const dispatchedActions: string[] = [];
+const dispatchedActionArgs: unknown[] = [];
+let originalDataSources: NaviDataSource[];
+
+const MockDispatcher = {
+  dispatch(action: string, _route: Route, ...args: unknown[]) {
+    dispatchedActions.push(action);
+    dispatchedActionArgs.push(...args);
+  }
+};
+
+interface TestContext extends Context {
+  metadataService: NaviMetadataService;
+}
+
+module('Unit | Consumer | request fili', function(hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function(this: TestContext) {
+    dispatchedActions.length = 0;
+    dispatchedActionArgs.length = 0;
+    originalDataSources = config.navi.dataSources;
+
+    consumer = this.owner
+      .factoryFor('consumer:request/fili')
+      .create({ requestActionDispatcher: MockDispatcher }) as FiliConsumer;
+    this.metadataService = this.owner.lookup('service:navi-metadata') as NaviMetadataService;
+    await this.metadataService.loadMetadata({ dataSourceName: 'bardOne' });
+  });
+
+  hooks.afterEach(async function() {
+    config.navi.dataSources = originalDataSources;
+  });
+
+  test('UPDATE_COLUMN_FRAGMENT_WITH_PARAMS', function(assert) {
+    const store = this.owner.lookup('service:store') as StoreService;
+    const request = store.createFragment('bard-request-v2/request', {
+      table: 'network',
+      filters: [
+        {
+          type: 'timeDimension',
+          field: 'network.dateTime',
+          parameters: { grain: 'day' },
+          operator: 'bet',
+          values: ['P1D', 'current'],
+          source: 'bardOne'
+        }
+      ],
+      sorts: [],
+      limit: null,
+      dataSource: 'bardOne',
+      requestVersion: '2.0',
+      columns: [
+        {
+          type: 'timeDimension',
+          field: 'network.dateTime',
+          parameters: { grain: 'day' },
+          source: 'bardOne'
+        },
+        {
+          type: 'metric',
+          field: 'adClicks',
+          parameters: {},
+          source: 'bardOne'
+        },
+        {
+          type: 'dimension',
+          field: 'age',
+          parameters: { field: 'id' },
+          source: 'bardOne'
+        }
+      ]
+    });
+
+    const modelFor = () => ({ request });
+
+    consumer.send(
+      RequestActions.UPDATE_COLUMN_FRAGMENT_WITH_PARAMS,
+      { modelFor },
+      request.nonTimeDimensions[0],
+      'field',
+      'desc'
+    );
+    assert.deepEqual(dispatchedActions, [], 'no actions are called when a dimension is updated');
+
+    consumer.send(
+      RequestActions.UPDATE_COLUMN_FRAGMENT_WITH_PARAMS,
+      { modelFor },
+      request.metricColumns[0],
+      'param',
+      'val'
+    );
+    assert.deepEqual(dispatchedActions, [], 'no actions are called when a metric is updated');
+
+    consumer.send(
+      RequestActions.UPDATE_COLUMN_FRAGMENT_WITH_PARAMS,
+      { modelFor },
+      request.timeGrainColumn,
+      'otherParam',
+      'week'
+    );
+    assert.deepEqual(
+      dispatchedActions,
+      [],
+      'no actions are called when the timeDimension updates a non-grain parameter'
+    );
+
+    consumer.send(
+      RequestActions.UPDATE_COLUMN_FRAGMENT_WITH_PARAMS,
+      { modelFor },
+      request.timeGrainColumn,
+      'grain',
+      'week'
+    );
+    assert.deepEqual(
+      dispatchedActions,
+      [RequestActions.UPDATE_FILTER],
+      'UPDATE_FILTER is dispatched when the timeDimension column and filter exists and the grain param is updated'
+    );
+    assert.deepEqual(
+      dispatchedActionArgs,
+      [request.dateTimeFilter, { parameters: { grain: 'week' } }],
+      'UPDATE_FILTER is dispatched with the updated grain parameter'
+    );
+
+    dispatchedActions.length = 0;
+    dispatchedActionArgs.length = 0;
+
+    config.navi.dataSources = [
+      ...config.navi.dataSources,
+      { name: 'Other Data Source', uri: 'data://stuff', type: 'elide' }
+    ];
+    request.dataSource = 'Other Data Source';
+
+    consumer.send(
+      RequestActions.UPDATE_COLUMN_FRAGMENT_WITH_PARAMS,
+      { modelFor },
+      request.timeGrainColumn,
+      'grain',
+      'week'
+    );
+    assert.deepEqual(dispatchedActions, [], 'no actions are called when the request is for an elide dataSource');
+  });
+});


### PR DESCRIPTION
Resolves #1000 

## Description
With the new report view it's challenging to change the parameters of a filter and would be extra work to change a parameter in both the column and filter

## Proposed Changes
- Adds a fili specific consumer which will forward updates to the dateTime column to the dateTime filter so the grains are always in sync

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
