### PR TITLE
Update: Use the timeDimension grain if available

### DIFF
--- a/packages/core/addon/chart-builders/base.ts
+++ b/packages/core/addon/chart-builders/base.ts
@@ -27,16 +27,17 @@ export type TooltipData = {
   seriesIndex: number;
   value: number;
 };
+
+type C3Data = { series: C3Row[]; names: Record<string, string> };
+
+//@ts-expect-error
+export const EmptyC3Data: C3Data = { series: [{ x: { rawValue: null, displayValue: '' } } as C3Row], names: {} };
 export interface BaseChartBuilder {
   byXSeries?: DataGroup<ResponseRow>;
 
   getXValue(row: ResponseRow, config: SeriesConfig, request: RequestFragment): string | number;
 
-  buildData(
-    response: NaviFactResponse,
-    _config: SeriesConfig,
-    request: RequestFragment
-  ): { series: C3Row[]; names: Record<string, string> };
+  buildData(response: NaviFactResponse, _config: SeriesConfig, request: RequestFragment): C3Data;
 
   buildTooltip(
     _config: SeriesConfig,

--- a/packages/core/addon/chart-builders/metric.ts
+++ b/packages/core/addon/chart-builders/metric.ts
@@ -20,7 +20,7 @@ import DataGroup from 'navi-core/utils/classes/data-group';
 import { API_DATE_FORMAT_STRING } from 'navi-data/utils/date';
 import EmberObject, { computed } from '@ember/object';
 import RequestFragment from 'navi-core/models/bard-request-v2/request';
-import { BaseChartBuilder, C3Row } from './base';
+import { BaseChartBuilder, C3Row, EmptyC3Data } from './base';
 import { tracked } from '@glimmer/tracking';
 import { MetricSeries } from 'navi-core/models/chart-visualization';
 import NaviFactResponse, { ResponseRow } from 'navi-data/models/navi-fact-response';
@@ -32,6 +32,7 @@ export default class MetricChartBuilder extends EmberObject implements BaseChart
    * @inheritdoc
    */
   getXValue(row: ResponseRow, _config: MetricSeries['config'], request: RequestFragment): string {
+    assert('request should have a timeGrainColumn', request.timeGrainColumn);
     const colName = request.timeGrainColumn.canonicalName;
     const date = row[colName];
     assert(`a date for ${colName} should be found, but got: ${date}`, typeof date === 'string');
@@ -47,6 +48,10 @@ export default class MetricChartBuilder extends EmberObject implements BaseChart
     request: RequestFragment
   ): { series: C3Row[]; names: Record<string, string> } {
     assert('response should be a NaviFactResponse instance', response instanceof NaviFactResponse);
+    if (!(request.timeGrainColumn && response.getIntervalForTimeDimension(request.timeGrainColumn))) {
+      return EmptyC3Data;
+    }
+
     const timeGrainColumn = request.timeGrainColumn.canonicalName;
     const interval = response.getIntervalForTimeDimension(request.timeGrainColumn);
     const { timeGrain } = request;

--- a/packages/core/addon/components/navi-visualizations/line-chart.ts
+++ b/packages/core/addon/components/navi-visualizations/line-chart.ts
@@ -127,12 +127,11 @@ export default class LineChart extends ChartBuildersBase<Args> {
     if ('metricCid' in seriesConfig.config) {
       const { metricCid } = seriesConfig.config;
       const metric = this.request.columns.find(({ cid }) => cid === metricCid);
-      assert(`a metric with cid ${seriesConfig.config.metricCid} should be found`, metric);
       return {
         axis: {
           y: {
             label: {
-              text: metric.displayName
+              text: metric?.displayName
             }
           }
         }

--- a/packages/core/addon/models/bard-request-v2/request.ts
+++ b/packages/core/addon/models/bard-request-v2/request.ts
@@ -188,8 +188,9 @@ export default class RequestFragment extends Fragment.extend(Validations) implem
    * @property {ColumnFragment} timeGrainColumn - The column containing the dateTime timeDimension
    */
   @computed('columns.[]')
-  get timeGrainColumn(): ColumnFragment<'timeDimension'> {
-    return this.columns.filter(column => column.type === 'timeDimension')[0] as ColumnFragment<'timeDimension'>;
+  get timeGrainColumn(): ColumnFragment<'timeDimension'> | undefined {
+    const timeCols = this.columns.filter(({ type }) => type === 'timeDimension') as ColumnFragment<'timeDimension'>[];
+    return timeCols[0];
   }
 
   @computed('columns.[]')

--- a/packages/core/addon/navi-visualization-manifests/base.ts
+++ b/packages/core/addon/navi-visualization-manifests/base.ts
@@ -10,6 +10,10 @@ import { assert } from '@ember/debug';
 import EmberObject from '@ember/object';
 import RequestFragment from 'navi-core/models/bard-request-v2/request';
 
+function isPresent<T>(t: T | undefined | null | void): t is T {
+  return t !== undefined && t !== null;
+}
+
 export default class NaviVisualizationBaseManifest extends EmberObject {
   name!: string;
   niceName!: string;
@@ -39,19 +43,9 @@ export default class NaviVisualizationBaseManifest extends EmberObject {
   /**
    * checks if the request has single time bucket
    */
-  hasInterval(request: RequestFragment): boolean {
-    const { timeGrain, interval } = request;
-
-    return !!(timeGrain && interval);
-  }
-
-  /**
-   * checks if the request has single time bucket
-   */
   hasExplicitSingleTimeBucket(request: RequestFragment): boolean {
     const { timeGrain, interval } = request;
-    assert('request should have a timeGrain', timeGrain);
-    if (this.hasInterval(request)) {
+    if (isPresent(timeGrain) && isPresent(interval)) {
       return interval?.diffForTimePeriod(timeGrain) === 1;
     }
 

--- a/packages/core/addon/navi-visualization-manifests/base.ts
+++ b/packages/core/addon/navi-visualization-manifests/base.ts
@@ -53,6 +53,14 @@ export default class NaviVisualizationBaseManifest extends EmberObject {
   }
 
   /**
+   * checks if the request groups by a time dimension
+   */
+  hasTimeGroupBy(request: RequestFragment): boolean {
+    const { timeGrainColumn } = request;
+    return isPresent(timeGrainColumn);
+  }
+
+  /**
    * checks if the request has no group by
    */
   hasNoGroupBy(request: RequestFragment): boolean {
@@ -70,7 +78,7 @@ export default class NaviVisualizationBaseManifest extends EmberObject {
    * checks if the request has multiple time buckets
    */
   hasPotentialMultipleTimeBuckets(request: RequestFragment): boolean {
-    return !this.hasExplicitSingleTimeBucket(request);
+    return this.hasTimeGroupBy(request) && !this.hasExplicitSingleTimeBucket(request);
   }
 
   /**

--- a/packages/core/addon/navi-visualization-manifests/goal-gauge.ts
+++ b/packages/core/addon/navi-visualization-manifests/goal-gauge.ts
@@ -16,6 +16,10 @@ export default class GoalGaugeManifest extends NaviVisualizationBaseManifest {
   icon = 'tachometer';
 
   typeIsValid(request: RequestFragment) {
-    return this.hasNoGroupBy(request) && this.hasExplicitSingleTimeBucket(request) && this.hasSingleMetric(request);
+    return (
+      this.hasNoGroupBy(request) &&
+      this.hasSingleMetric(request) &&
+      (this.hasExplicitSingleTimeBucket(request) || !this.hasTimeGroupBy(request))
+    );
   }
 }

--- a/packages/core/addon/navi-visualization-manifests/metric-label.ts
+++ b/packages/core/addon/navi-visualization-manifests/metric-label.ts
@@ -15,6 +15,10 @@ export default class MetricLabelManifest extends NaviVisualizationBaseManifest {
   icon = 'list-alt';
 
   typeIsValid(request: RequestFragment) {
-    return this.hasNoGroupBy(request) && this.hasExplicitSingleTimeBucket(request) && this.hasSingleMetric(request);
+    return (
+      this.hasNoGroupBy(request) &&
+      this.hasSingleMetric(request) &&
+      (this.hasExplicitSingleTimeBucket(request) || !this.hasTimeGroupBy(request))
+    );
   }
 }

--- a/packages/core/addon/navi-visualization-manifests/pie-chart.ts
+++ b/packages/core/addon/navi-visualization-manifests/pie-chart.ts
@@ -16,8 +16,8 @@ export default class PieChartManifest extends NaviVisualizationBaseManifest {
 
   typeIsValid(request: RequestFragment) {
     return (
-      this.hasExplicitSingleTimeBucket(request) &&
       this.hasMetric(request) &&
+      (!this.hasTimeGroupBy(request) || this.hasExplicitSingleTimeBucket(request)) &&
       (this.hasGroupBy(request) || this.hasMultipleMetrics(request))
     );
   }

--- a/packages/data/addon/serializers/metadata/elide.ts
+++ b/packages/data/addon/serializers/metadata/elide.ts
@@ -268,11 +268,14 @@ export default class ElideMetadataSerializer extends NaviMetadataSerializer {
           type: 'ref',
           expression: INTRINSIC_VALUE_EXPRESSION,
           defaultValue,
-          _localValues: grainNodes.map(grain => ({
-            id: grain.grain.toLowerCase(),
-            description: upperFirst(grain.grain.toLowerCase()),
-            name: grain.grain.toLowerCase()
-          }))
+          _localValues: grainNodes.map(grain => {
+            const grainName = grain.grain.toLowerCase();
+            return {
+              id: grainName,
+              description: upperFirst(grainName),
+              name: grainName
+            };
+          })
         }
       ]
     };

--- a/packages/data/addon/serializers/metadata/elide.ts
+++ b/packages/data/addon/serializers/metadata/elide.ts
@@ -269,7 +269,7 @@ export default class ElideMetadataSerializer extends NaviMetadataSerializer {
           expression: INTRINSIC_VALUE_EXPRESSION,
           defaultValue,
           _localValues: grainNodes.map(grain => ({
-            id: grain.id,
+            id: grain.grain.toLowerCase(),
             description: upperFirst(grain.grain.toLowerCase()),
             name: grain.grain.toLowerCase()
           }))

--- a/packages/data/tests/unit/serializers/metadata/elide-test.ts
+++ b/packages/data/tests/unit/serializers/metadata/elide-test.ts
@@ -794,11 +794,14 @@ module('Unit | Serializer | metadata/elide', function(hooks) {
             type: 'ref',
             expression: INTRINSIC_VALUE_EXPRESSION,
             defaultValue: 'day',
-            _localValues: grainNodes.map(grain => ({
-              id: grain.id,
-              description: capitalize(grain.grain.toLowerCase()),
-              name: grain.grain.toLowerCase()
-            }))
+            _localValues: grainNodes.map(grain => {
+              const grainName = grain.grain.toLowerCase();
+              return {
+                id: grainName,
+                description: capitalize(grainName),
+                name: grainName
+              };
+            })
           }
         ]
       },

--- a/packages/reports/addon/components/filter-values/base-date.ts
+++ b/packages/reports/addon/components/filter-values/base-date.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2020, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+
+import Component from '@glimmer/component';
+import { computed } from '@ember/object';
+import Args from './args-interface';
+import { Grain } from 'navi-data/addon/utils/date';
+
+export default class BaseDateSelector extends Component<Args> {
+  @computed('args.filter.{columnMetadata.metadataType,parameters.grain}')
+  get timeGrain(): Grain {
+    const { filter } = this.args;
+    let timeGrain;
+    if (filter.columnMetadata.metadataType === 'timeDimension') {
+      timeGrain = filter.parameters.grain as Grain;
+    }
+    return timeGrain || 'day';
+  }
+}

--- a/packages/reports/addon/components/filter-values/date.hbs
+++ b/packages/reports/addon/components/filter-values/date.hbs
@@ -1,20 +1,20 @@
 {{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 {{#if @isCollapsed}}
   {{#if this.date}}
-    {{moment-format this.date "MMM DD, YYYY"}}
+    {{format-date-for-granularity this.date this.timeGrain}}
   {{else}}
     <FilterValues::InvalidValue/>
   {{/if}}
 {{else}}
   <div class="filter-values--date" ...attributes>
     <DropdownDatePicker
-      @dateTimePeriod="day"
+      @dateTimePeriod={{this.timeGrain}}
       @date={{moment this.date}}
       @onUpdate={{this.setDate}}
     >
       <div class="filter-values--date-dimension-select__trigger">
         {{#if this.date}}
-          {{moment-format this.date "MMM DD, YYYY"}}
+          {{format-date-for-granularity this.date this.timeGrain}}
         {{else}}
           <span class="date__placeholder">Select date</span>
         {{/if}}

--- a/packages/reports/addon/components/filter-values/date.ts
+++ b/packages/reports/addon/components/filter-values/date.ts
@@ -2,13 +2,12 @@
  * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
+import BaseDateSelector from './base-date';
 import { readOnly } from '@ember/object/computed';
-import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import moment from 'moment';
-import Args from './args-interface';
 
-export default class DateComponent extends Component<Args> {
+export default class DateComponent extends BaseDateSelector {
   @readOnly('args.filter.values.0')
   date?: string;
 

--- a/packages/reports/addon/components/filter-values/dimension-date-range.hbs
+++ b/packages/reports/addon/components/filter-values/dimension-date-range.hbs
@@ -2,19 +2,19 @@
 <div class="filter-values--dimension-date-range-input" ...attributes>
   {{#if @isCollapsed}}
     {{#if (and this.startDate this.endDate)}}
-      {{moment-format this.startDate "MMM DD, YYYY"}} and {{moment-format this.endDate "MMM DD, YYYY"}}
+      {{format-date-for-granularity this.startDate this.timeGrain}} and {{format-date-for-granularity this.endDate this.timeGrain}}
     {{else}}
       <FilterValues::InvalidValue/>
     {{/if}}
   {{else}}
     <DropdownDatePicker
-      @dateTimePeriod="day"
+      @dateTimePeriod={{this.timeGrain}}
       @date={{moment this.startDate}}
       @onUpdate={{this.setLowValue}}
       class="filter-values--dimension-date-range-input__trigger filter-values--dimension-date-range-input__low-value"
     >
       {{#if this.startDate}}
-        {{moment-format this.startDate "MMM DD, YYYY"}}
+        {{format-date-for-granularity this.startDate this.timeGrain}}
       {{else}}
         <span class="date__placeholder">{{this.lowPlaceholder}}</span>
       {{/if}}
@@ -23,13 +23,13 @@
     <span class="filter-values--dimension-date-range-input__separator">and</span>
 
     <DropdownDatePicker
-      @dateTimePeriod="day"
+      @dateTimePeriod={{this.timeGrain}}
       @date={{moment this.endDate}}
       @onUpdate={{this.setHighValue}}
       class="filter-values--dimension-date-range-input__trigger filter-values--dimension-date-range-input__high-value"
     >
       {{#if this.endDate}}
-        {{moment-format this.endDate "MMM DD, YYYY"}}
+        {{format-date-for-granularity this.endDate this.timeGrain}}
       {{else}}
         <span class="date__placeholder">{{this.highPlaceholder}}</span>
       {{/if}}

--- a/packages/reports/addon/components/filter-values/dimension-date-range.ts
+++ b/packages/reports/addon/components/filter-values/dimension-date-range.ts
@@ -8,14 +8,12 @@
  *     @onUpdateFilter={{this.update}}
  *   />
  */
-
-import Component from '@glimmer/component';
+import BaseDateSelector from './base-date';
 import { action } from '@ember/object';
 import { readOnly } from '@ember/object/computed';
 import moment from 'moment';
-import Args from './args-interface';
 
-export default class DimensionDateRange extends Component<Args> {
+export default class DimensionDateRange extends BaseDateSelector {
   /**
    * @property {String} startDate - date (YYYY-MM-DD) of beginning of interval
    */

--- a/packages/reports/addon/templates/components/navi-date-picker.hbs
+++ b/packages/reports/addon/templates/components/navi-date-picker.hbs
@@ -6,7 +6,7 @@
   @center={{this.centerDate}}
   @onCenterChange={{this.setCenterDate}} as |powerCalendar|
 >
-  {{#if (or (eq this.dateTimePeriod "hour") (eq this.dateTimePeriod "day") (eq this.dateTimePeriod "week"))}}
+  {{#if (contains this.dateTimePeriod (w "hour day week month"))}}
     <powerCalendar.Nav>
       {{#if (not-eq this.dateTimePeriod "month")}}
         <span class="with-invisible-select">
@@ -36,7 +36,7 @@
         {{/with}}
       </span>
     </powerCalendar.Nav>
-  {{else if (or (eq this.dateTimePeriod "month") (eq this.dateTimePeriod "quarter"))}}
+  {{else if (eq this.dateTimePeriod "quarter")}}
     <PowerCalendarSelectorsNav @calendar={{powerCalendar}} @by="year" />
   {{else if (eq this.dateTimePeriod "year")}}
     <PowerCalendarSelectorsNav @calendar={{powerCalendar}} @by="decade" />


### PR DESCRIPTION
## Description
The current date time filter does not make use of the grain being requested, so if the filtered column is a timeDimension we use that grain and fall back to "day" otherwise

## Proposed Changes
- Also cleans up chart builders/viz to better handle changes in request

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
