### PR TITLE
Fix missing metric issues

### DIFF
--- a/packages/core/addon/components/navi-visualizations/goal-gauge.ts
+++ b/packages/core/addon/components/navi-visualizations/goal-gauge.ts
@@ -7,7 +7,6 @@ import { readOnly } from '@ember/object/computed';
 import Component from '@glimmer/component';
 import { computed, action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
-import { assert } from '@ember/debug';
 // @ts-ignore
 import d3 from 'd3';
 import numeral from 'numeral';
@@ -41,21 +40,21 @@ export default class GoalGaugeVisualization extends Component<Args> {
   }
 
   @computed('args.{model.firstObject.request.metricColumns.[],options.metricCid}')
-  get metric(): ColumnFragment {
+  get metric(): ColumnFragment | undefined {
     const { request } = this.args.model?.firstObject || {};
     const { metricCid } = this.args.options;
     const metricColumn = request?.metricColumns.find(({ cid }) => cid === metricCid);
-    assert(`A metric column should exist with cid: ${metricCid}`, metricColumn);
     return metricColumn;
   }
 
   @computed('metric', 'args.model.firstObject.response.rows.[]')
   get actualValue(): number {
     const { model } = this.args;
-    if (model) {
+    const { metric } = this;
+    if (model && metric) {
       const { response } = model?.firstObject || {};
       const firstRow = response?.rows?.[0] || {};
-      const { canonicalName } = this.metric;
+      const { canonicalName } = metric;
       return Number(firstRow[canonicalName]);
     }
     return 0;
@@ -187,7 +186,7 @@ export default class GoalGaugeVisualization extends Component<Args> {
     titleElm
       .insert('tspan')
       .attr('class', 'metric-title')
-      .text(metric.displayName)
+      .text(metric?.displayName || '')
       .attr('dy', 26)
       .attr('x', 0);
 

--- a/packages/core/addon/components/navi-visualizations/metric-label.ts
+++ b/packages/core/addon/components/navi-visualizations/metric-label.ts
@@ -11,7 +11,6 @@
 import Component from '@glimmer/component';
 import numeral from 'numeral';
 import { computed } from '@ember/object';
-import { assert } from '@ember/debug';
 import { VisualizationModel } from './table';
 import ColumnFragment from 'navi-core/models/bard-request-v2/fragments/column';
 import { MetricLabelConfig } from 'navi-core/models/metric-label';
@@ -40,11 +39,10 @@ export default class MetricLabelVisualization extends Component<Args> {
   }
 
   @computed('args.{model.[],options.metricCid}')
-  get metric(): ColumnFragment {
+  get metric(): ColumnFragment | undefined {
     const { request } = this.args.model?.firstObject || {};
     const { metricCid } = this.args.options;
     const metricColumn = request?.metricColumns.find(({ cid }) => cid === metricCid);
-    assert(`A metric column should exist with cid: ${metricCid}`, metricColumn);
     return metricColumn;
   }
 
@@ -54,10 +52,11 @@ export default class MetricLabelVisualization extends Component<Args> {
   @computed('args.{options.format,model.[]}', 'metric')
   get value(): string | undefined {
     const { options, model } = this.args;
-    if (model) {
+    const { metric } = this;
+    if (model && metric) {
       const { response } = model?.firstObject || {};
       const firstRow = response?.rows?.[0] || {};
-      const { canonicalName } = this.metric;
+      const { canonicalName } = metric;
       const value = firstRow[canonicalName] as string;
 
       return options?.format ? numeral(value).format(options.format) : String(value);

--- a/packages/core/addon/models/goal-gauge.ts
+++ b/packages/core/addon/models/goal-gauge.ts
@@ -58,16 +58,17 @@ export default class GoalGaugeModel extends VisualizationBase.extend(Validations
    */
   rebuildConfig(request: RequestFragment, response: ResponseV1): GoalGaugeModel {
     if (request && response) {
-      let metricCid = request.metricColumns[0].cid,
-        canonicalName = request.metricColumns[0].canonicalName,
-        firstRow = response?.rows?.[0] || {},
-        actualValue = Number(firstRow[canonicalName]),
-        above = actualValue * 1.1,
-        below = actualValue * 0.9,
-        baselineValue = actualValue > 0 ? below : above,
-        goalValue = actualValue > 0 ? above : below;
+      const metricCid = request.metricColumns[0]?.cid;
+      const canonicalName = request.metricColumns[0]?.canonicalName;
+      const firstRow = response?.rows?.[0] || {};
+      const actualValue = Number(firstRow[canonicalName] || 0);
+      const above = actualValue * 1.1;
+      const below = actualValue * 0.9;
 
-      //handle the zero value casex
+      let baselineValue = actualValue > 0 ? below : above;
+      let goalValue = actualValue > 0 ? above : below;
+
+      //handle the zero value case
       if (actualValue === 0) {
         baselineValue = 0;
         goalValue = 1;

--- a/packages/core/addon/models/metric-label.ts
+++ b/packages/core/addon/models/metric-label.ts
@@ -31,7 +31,7 @@ export type MetricLabelConfig = {
   version: 2;
   metadata: {
     format?: string;
-    metricCid: string;
+    metricCid?: string;
   };
 };
 
@@ -55,7 +55,7 @@ export default class MetricLabelModel extends VisualizationBase.extend(Validatio
   rebuildConfig(request: RequestFragment, _response: ResponseV1) {
     const format = this.metadata.format || NumberFormats[0].format;
 
-    set(this, 'metadata', { format, metricCid: request.metricColumns[0].cid });
+    set(this, 'metadata', { format, metricCid: request.metricColumns[0]?.cid });
     return this;
   }
 }

--- a/packages/core/tests/integration/components/navi-visualizations/goal-gauge-test.ts
+++ b/packages/core/tests/integration/components/navi-visualizations/goal-gauge-test.ts
@@ -391,4 +391,28 @@ module('Integration | Component | navi-visualization/goal gauge ', function(hook
       .dom('text.c3-chart-arcs-title > tspan')
       .exists({ count: 3 }, 'on rerender render, 3 title tspans are present');
   });
+
+  test('goal-gauge - missing metric', async function(this: TestContext, assert) {
+    const store = this.owner.lookup('service:store') as StoreService;
+    this.request = store.createFragment('bard-request-v2/request', {
+      table: null,
+      columns: [],
+      filters: [],
+      sorts: [],
+      limit: null,
+      dataSource: 'bardOne',
+      requestVersion: '2.0'
+    });
+    this.set('model', arr([{ request: this.request, response: NaviFactResponse.create({ rows: [{ m1: 75 }] }) }]));
+    this.set('options', {
+      baselineValue: 0,
+      goalValue: 1,
+      metricCid: undefined
+    });
+    await render(TEMPLATE);
+    assert.dom('.metric-title').hasNoText('metric title is empty when a metric is missing');
+    assert.dom('.value-title').hasText('0', 'value title is `0` when a metric is missing');
+    assert.dom('.c3-chart-arcs-gauge-min').hasText('0', 'min gauge label is `0` when a metric is missing');
+    assert.dom('.c3-chart-arcs-gauge-max').hasText('1', 'max gauge label is `1` when a metric is missing');
+  });
 });

--- a/packages/core/tests/integration/components/navi-visualizations/metric-label-test.ts
+++ b/packages/core/tests/integration/components/navi-visualizations/metric-label-test.ts
@@ -110,4 +110,17 @@ module('Integration | Component | navi-visualization/metric-label', function(hoo
     await render(TEMPLATE);
     assert.dom('.metric-label-vis__value').hasText('$ 1,000,000', 'metric value is formatted correctly');
   });
+
+  test('metric label - missing metric', async function(this: TestContext, assert) {
+    const request = this.model.firstObject?.request as RequestFragment;
+    request.columns.clear();
+    this.options = {
+      format: '$ 0,0[.]00',
+      metricCid: undefined
+    };
+
+    _setModel({ rupees: 1000000 });
+    await render(TEMPLATE);
+    assert.dom('.metric-label-vis__value').hasNoText('metric value is blank when metric is missing');
+  });
 });

--- a/packages/core/tests/unit/models/goal-gauge-test.ts
+++ b/packages/core/tests/unit/models/goal-gauge-test.ts
@@ -150,4 +150,25 @@ module('Unit | Model | Gauge Visualization Fragment', function(hooks) {
     newConfig = goalGauge.rebuildConfig(request, response).toJSON();
     assert.deepEqual(newConfig, expectedZeroConfig, 'rebuilds config based on request with zero metric');
   });
+
+  test('rebuildConfig - no columns', function(assert) {
+    const store = this.owner.lookup('service:store') as StoreService;
+    const request = buildTestRequest([], []);
+    const goalGauge = store.createRecord('all-the-fragments').goalGauge;
+    const response = { rows: [{ rupees: 1 }], meta: {} };
+    const config = goalGauge.rebuildConfig(request, response).toJSON();
+    assert.deepEqual(
+      config,
+      {
+        metadata: {
+          baselineValue: 0,
+          goalValue: 1,
+          metricCid: undefined
+        },
+        type: 'goal-gauge',
+        version: 2
+      },
+      'config can be generated when no columns are present'
+    );
+  });
 });

--- a/packages/core/tests/unit/models/metric-label-test.ts
+++ b/packages/core/tests/unit/models/metric-label-test.ts
@@ -49,4 +49,23 @@ module('Unit | Model | Metric Label Visualization Fragment', function(hooks) {
       'config regenerated with metric updated'
     );
   });
+
+  test('rebuildConfig - no columns', function(assert) {
+    const metricLabel = Store.createRecord('all-the-fragments').metricLabel;
+    const request = buildTestRequest([]);
+    const config = metricLabel.rebuildConfig(request, { rows: [{ rupees: 999, hp: 0 }], meta: {} }).toJSON();
+
+    assert.deepEqual(
+      config,
+      {
+        metadata: {
+          format: '0,0.00',
+          metricCid: undefined
+        },
+        type: 'metric-label',
+        version: 2
+      },
+      'config can be generated when no columns are present'
+    );
+  });
 });


### PR DESCRIPTION
## Description

Currently, the UI breaks when metric label or goal gauge try to render when a metric is missing. This gracefully handles the error, however more will need to be done to indicate to the user that the query needs to be re-executed.

## Proposed Changes

- Handle missing metric in goal gauge
- Handle missing metric in metric label

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
