### PR TITLE
Fix Elide `contains` Filter

### DIFF
--- a/packages/core/addon/models/bard-request-v2/fragments/filter.ts
+++ b/packages/core/addon/models/bard-request-v2/fragments/filter.ts
@@ -5,7 +5,7 @@
 import attr from 'ember-data/attr';
 import { validator, buildValidations } from 'ember-cp-validations';
 import BaseFragment from './base';
-import { Filter, FilterOperator } from 'navi-data/adapters/facts/interface';
+import { Filter } from 'navi-data/adapters/facts/interface';
 
 const Validations = buildValidations({
   operator: validator('presence', {
@@ -26,8 +26,8 @@ const Validations = buildValidations({
  */
 export default class FilterFragment extends BaseFragment.extend(Validations) implements Filter {
   @attr('string', { defaultValue: 'in' })
-  operator!: FilterOperator;
+  operator!: Filter['operator'];
 
   @attr({ defaultValue: () => [] })
-  values!: (string | number)[];
+  values!: Filter['values'];
 }

--- a/packages/core/addon/models/bard-request-v2/request.ts
+++ b/packages/core/addon/models/bard-request-v2/request.ts
@@ -35,7 +35,7 @@ type BaseLiteral = {
   type: ColumnType;
   source: string;
   field: string;
-  parameters: Parameters | undefined;
+  parameters: Parameters;
 };
 
 const Validations = buildValidations({
@@ -324,7 +324,7 @@ export default class RequestFragment extends Fragment.extend(Validations) implem
     parameters,
     operator,
     values
-  }: BaseLiteral & { operator: string; values: (string | number)[] }) {
+  }: BaseLiteral & { operator: FilterFragment['operator']; values: FilterFragment['values'] }) {
     this.filters.pushObject(this.fragmentFactory.createFilter(type, source, field, parameters, operator, values));
   }
 

--- a/packages/core/addon/services/fragment-factory.ts
+++ b/packages/core/addon/services/fragment-factory.ts
@@ -60,9 +60,9 @@ export default class FragmentFactory extends Service {
    */
   createFilterFromMeta(
     columnMetadata: ColumnMetadata,
-    parameters: Dict<string> = {},
-    operator: string,
-    values: Array<string | number>
+    parameters: FilterFragment['parameters'],
+    operator: FilterFragment['operator'],
+    values: FilterFragment['values']
   ): FilterFragment {
     const { id: field, metadataType: type, source } = columnMetadata;
     return this.createFilter(type, source, field, parameters, operator, values);
@@ -78,12 +78,12 @@ export default class FragmentFactory extends Service {
    * @param values - array of values to filter by
    */
   createFilter(
-    type: ColumnType,
-    dataSource: string,
-    field: string,
-    parameters: Dict<string> = {},
-    operator: string,
-    values: Array<string | number>
+    type: FilterFragment['type'],
+    dataSource: FilterFragment['source'],
+    field: FilterFragment['field'],
+    parameters: FilterFragment['parameters'],
+    operator: FilterFragment['operator'],
+    values: FilterFragment['values']
   ): FilterFragment {
     return this.store.createFragment('bard-request-v2/fragments/filter', {
       field,

--- a/packages/core/addon/utils/request.ts
+++ b/packages/core/addon/utils/request.ts
@@ -215,7 +215,7 @@ export function normalizeV1toV2(request: RequestV1<string>, dataSource: string):
       field: removeNamespace(dimension, dataSource),
       parameters: { field: field || 'id' },
       operator: operator as FilterOperator,
-      values
+      values: ['null', 'notnull'].includes(operator) ? [true] : values
     })
   );
 

--- a/packages/core/tests/unit/utils/request-test.ts
+++ b/packages/core/tests/unit/utils/request-test.ts
@@ -24,6 +24,18 @@ module('Unit | Utils | Request', function(hooks) {
           field: 'desc',
           operator: 'contains',
           values: ['win']
+        },
+        {
+          dimension: 'platform',
+          field: 'id',
+          operator: 'notnull',
+          values: []
+        },
+        {
+          dimension: 'gender',
+          field: 'id',
+          operator: 'null',
+          values: []
         }
       ],
       metrics: [
@@ -214,6 +226,18 @@ module('Unit | Utils | Request', function(hooks) {
           field: 'desc',
           operator: 'contains',
           values: ['win']
+        },
+        {
+          dimension: 'platform',
+          field: 'id',
+          operator: 'notnull',
+          values: []
+        },
+        {
+          dimension: 'gender',
+          field: 'id',
+          operator: 'null',
+          values: []
         }
       ],
       'filters are normalized correctly'
@@ -314,6 +338,24 @@ module('Unit | Utils | Request', function(hooks) {
           },
           type: 'dimension',
           values: ['win']
+        },
+        {
+          field: 'platform',
+          operator: 'notnull',
+          parameters: {
+            field: 'id'
+          },
+          type: 'dimension',
+          values: [true]
+        },
+        {
+          field: 'gender',
+          operator: 'null',
+          parameters: {
+            field: 'id'
+          },
+          type: 'dimension',
+          values: [true]
         },
         {
           field: 'revenue',

--- a/packages/data/addon/adapters/facts/elide.ts
+++ b/packages/data/addon/adapters/facts/elide.ts
@@ -24,7 +24,7 @@ import { v1 } from 'ember-uuid';
 import moment, { Moment } from 'moment';
 import { Grain } from 'navi-data/utils/date';
 
-const escape = (value: string | number) => `${value}`.replace(/'/g, "\\\\'");
+const escape = (value: string) => value.replace(/'/g, "\\\\'");
 
 /**
  * Formats elide request field
@@ -82,8 +82,14 @@ export default class ElideFactsAdapter extends EmberObject implements NaviFactAd
   private buildFilterStr(filters: Filter[]): string {
     const filterStrings = filters.map(filter => {
       const { field, parameters, operator, values, type } = filter;
+
+      //skip filters without values
+      if (0 === values.length) {
+        return null;
+      }
+
       const fieldStr = getElideField(field, parameters);
-      let filterVals = values.map(v => escape(v));
+      let filterVals = values.map(v => escape(`${v}`));
 
       if (type === 'timeDimension') {
         const grain = filter.parameters.grain as Grain;
@@ -102,7 +108,7 @@ export default class ElideFactsAdapter extends EmberObject implements NaviFactAd
       return builderFn(fieldStr, filterVals);
     });
 
-    return filterStrings.join(';');
+    return filterStrings.filter(f => f).join(';');
   }
 
   /**

--- a/packages/data/addon/adapters/facts/interface.ts
+++ b/packages/data/addon/adapters/facts/interface.ts
@@ -55,7 +55,7 @@ export type Filter = {
   parameters: Parameters;
   type: ColumnType;
   operator: FilterOperator;
-  values: (string | number)[];
+  values: (string | number | boolean)[];
 };
 
 export type Sort = {

--- a/packages/data/tests/unit/adapters/facts/elide-test.ts
+++ b/packages/data/tests/unit/adapters/facts/elide-test.ts
@@ -24,7 +24,7 @@ const TestRequest: RequestV2 = {
   filters: [
     { field: 'table1.d3', operator: 'in', values: ['v1', 'v2'], type: 'dimension', parameters: {} },
     { field: 'table1.d4', operator: 'in', values: ['v3', 'v4'], type: 'dimension', parameters: {} },
-    { field: 'table1.d5', operator: 'null', values: [], type: 'dimension', parameters: {} },
+    { field: 'table1.d5', operator: 'null', values: [true], type: 'dimension', parameters: {} },
     {
       field: 'table1.time',
       operator: 'gte',
@@ -238,7 +238,7 @@ module('Unit | Adapter | facts/elide', function(hooks) {
             parameters: { grain: 'day' },
             type: 'timeDimension',
             operator: 'null',
-            values: []
+            values: [true]
           }
         ],
         requestVersion: '2.0',
@@ -609,6 +609,46 @@ module('Unit | Adapter | facts/elide', function(hooks) {
       adapter['buildFilterStr'](escapedFilter),
       "dim1=in=('*\\\\'*')",
       '`buildFilterStr` builds correct filter string for a `contains` filter and escaped value'
+    );
+  });
+
+  test('buildFilterStr - filter out empty values', async function(assert) {
+    const adapter: ElideFactsAdapter = this.owner.lookup('adapter:facts/elide');
+    const noValues: Filter[] = [
+      {
+        field: 'table1.dim1',
+        parameters: {},
+        type: 'dimension',
+        operator: 'contains',
+        values: []
+      }
+    ];
+    assert.equal(
+      adapter['buildFilterStr'](noValues),
+      '',
+      '`buildFilterStr` returns an empty string if no filters have values'
+    );
+
+    const someValues: Filter[] = [
+      {
+        field: 'table1.dim2',
+        parameters: {},
+        type: 'dimension',
+        operator: 'eq',
+        values: [1]
+      },
+      {
+        field: 'table1.dim1',
+        parameters: {},
+        type: 'dimension',
+        operator: 'contains',
+        values: []
+      }
+    ];
+    assert.equal(
+      adapter['buildFilterStr'](someValues),
+      "dim2==('1')",
+      '`buildFilterStr` filters out filters with empty values'
     );
   });
 });

--- a/packages/data/tests/unit/services/navi-facts-elide-test.js
+++ b/packages/data/tests/unit/services/navi-facts-elide-test.js
@@ -35,7 +35,7 @@ const TestRequest = {
     { field: 'table1.metric1', operator: 'gt', values: ['0'], parameters: {}, type: 'metric' },
     {
       field: 'table1.eventTimeDay',
-      operator: 'ge',
+      operator: 'gte',
       values: ['2015-01-29'],
       parameters: {},
       type: 'timeDimension'
@@ -49,7 +49,7 @@ const TestRequest = {
     },
     {
       field: 'table1.orderTimeDay',
-      operator: 'ge',
+      operator: 'gte',
       values: ['2014-01-05'],
       parameters: {},
       type: 'timeDimension'
@@ -258,7 +258,7 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
     const filters = [
       {
         field: 'table1.eventTimeDay',
-        operator: 'ge',
+        operator: 'gte',
         values: ['2015-01-29'],
         parameters: {},
         type: 'timeDimension'
@@ -272,7 +272,7 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
       },
       {
         field: 'table1.eventTimeDay',
-        operator: 'ge',
+        operator: 'gte',
         values: ['2015-02-05'],
         parameters: {},
         type: 'timeDimension'
@@ -351,7 +351,7 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
         filters: [
           {
             field: 'table1.eventTimeMonth',
-            operator: 'ge',
+            operator: 'gte',
             values: ['2015-01-01'],
             parameters: {},
             type: 'timeDimension'
@@ -427,7 +427,7 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
           filters: [
             {
               field: 'table1.eventTimeDay',
-              operator: 'ge',
+              operator: 'gte',
               values: [
                 moment()
                   .subtract(2, 'days')
@@ -484,7 +484,7 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
         filters: [
           {
             field: 'table1.eventTimeDay',
-            operator: 'ge',
+            operator: 'gte',
             values: ['2015-01-01'],
             parameters: {},
             type: 'timeDimension'
@@ -636,7 +636,7 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
           filters: [
             {
               field: 'table1.eventTimeDay',
-              operator: 'ge',
+              operator: 'gte',
               values: ['2015-01-01'],
               parameters: {},
               type: 'timeDimension'
@@ -694,7 +694,7 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
           filters: [
             {
               field: 'table1.eventTimeDay',
-              operator: 'ge',
+              operator: 'gte',
               values: ['2015-01-01'],
               parameters: {},
               type: 'timeDimension'

--- a/packages/reports/addon/components/filter-values/multi-value-input.ts
+++ b/packages/reports/addon/components/filter-values/multi-value-input.ts
@@ -12,9 +12,10 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import Args from './args-interface';
+import { Filter } from 'navi-data/addon/adapters/facts/interface';
 
 export default class MultiValueInput extends Component<Args> {
-  @tracked tags: (string | number)[] = [];
+  @tracked tags: Filter['values'] = [];
 
   constructor(owner: unknown, args: Args) {
     super(owner, args);

--- a/packages/reports/addon/components/filter-values/null-input.ts
+++ b/packages/reports/addon/components/filter-values/null-input.ts
@@ -8,16 +8,6 @@ import Args from './args-interface';
 export default class NullInput extends Component<Args> {
   constructor(owner: unknown, args: Args) {
     super(owner, args);
-    const {
-      onUpdateFilter,
-      filter: { values }
-    } = this.args;
-
-    /*
-     * Since this operator doesn't require values, set an empty array
-     */
-    if (values.length !== 0) {
-      onUpdateFilter({ values: [] });
-    }
+    this.args.onUpdateFilter({ values: [true] });
   }
 }

--- a/packages/reports/addon/consumers/request/filter.ts
+++ b/packages/reports/addon/consumers/request/filter.ts
@@ -22,7 +22,7 @@ import ColumnMetadataModel from 'navi-data/models/metadata/column';
 import FilterFragment from 'navi-core/models/bard-request-v2/fragments/filter';
 import RequestFragment from 'navi-core/models/bard-request-v2/request';
 
-const DEFAULT_METRIC_FILTER = {
+const DEFAULT_METRIC_FILTER: { operator: FilterFragment['operator']; values: FilterFragment['values'] } = {
   operator: 'gt',
   values: [0]
 };
@@ -118,7 +118,7 @@ export default class FilterConsumer extends ActionConsumer {
 
       const findDefaultOperator = (type: string) => {
         type = type?.toLowerCase();
-        const opDictionary: Record<string, string> = {
+        const opDictionary: Record<string, FilterFragment['operator']> = {
           time: 'gte',
           date: 'gte',
           number: 'eq',
@@ -128,7 +128,7 @@ export default class FilterConsumer extends ActionConsumer {
         return opDictionary[type] || opDictionary.default;
       };
 
-      let defaultOperator = findDefaultOperator(dimensionMetadataModel.valueType);
+      const defaultOperator = findDefaultOperator(dimensionMetadataModel.valueType);
 
       request.addFilter({
         type: dimensionMetadataModel.metadataType,

--- a/packages/reports/tests/integration/components/filter-collection-test.ts
+++ b/packages/reports/tests/integration/components/filter-collection-test.ts
@@ -31,8 +31,8 @@ module('Integration | Component | filter collection', function(hooks) {
       store.createFragment('bard-request-v2/request', {
         columns: [],
         filters: [
-          factory.createFilter('dimension', 'bardOne', 'age', {}, 'notnull', []),
-          factory.createFilter('dimension', 'bardOne', 'property', {}, 'null', []),
+          factory.createFilter('dimension', 'bardOne', 'age', {}, 'notnull', [true]),
+          factory.createFilter('dimension', 'bardOne', 'property', {}, 'null', [true]),
           factory.createFilter('timeDimension', 'bardOne', 'network.dateTime', { grain: 'day' }, 'bet', []),
           factory.createFilter('metric', 'bardOne', 'pageViews', {}, 'gt', ['1000']),
           factory.createFilter('metric', 'bardOne', 'pageViews', {}, 'bet', ['1000', '2000'])

--- a/packages/reports/tests/integration/components/filter-values/null-input-test.ts
+++ b/packages/reports/tests/integration/components/filter-values/null-input-test.ts
@@ -20,7 +20,7 @@ module('Integration | Component | filter values/null input', function(hooks) {
     const fragmentFactory = this.owner.lookup('service:fragment-factory') as FragmentFactory;
     this.filter = fragmentFactory.createFilter('metric', 'bardOne', 'adClicks', {}, 'bet', [1000, 2000]);
     this.onUpdateFilter = (changeSet: Partial<FilterFragment>) => {
-      assert.deepEqual(changeSet.values, [], '`onUpdateFilter` is called when filter `values` is not empty');
+      assert.deepEqual(changeSet.values, [true], '`onUpdateFilter` set `values` to true');
     };
 
     await render(hbs`
@@ -28,22 +28,5 @@ module('Integration | Component | filter values/null input', function(hooks) {
         @filter={{this.filter}}
         @onUpdateFilter={{this.onUpdateFilter}}
       />`);
-  });
-
-  test('onUpdateFilter - empty values', async function(this: TestContext, assert) {
-    assert.expect(1);
-
-    this.fragmentFactory = this.owner.lookup('service:fragment-factory') as FragmentFactory;
-    this.filter = this.fragmentFactory.createFilter('metric', 'bardOne', 'adClicks', {}, 'null', []);
-    this.onUpdateFilter = (_changeSet: Partial<FilterFragment>) => {
-      assert.notOk(true, '`onUpdateFilter` should not be called when filter `values` is empty');
-    };
-
-    await render(hbs`
-      <FilterValues::NullInput
-        @filter={{this.filter}}
-        @onUpdateFilter={{this.onUpdateFilter}}
-      />`);
-    assert.ok('`FilterValues::NullInput instantiates without error');
   });
 });


### PR DESCRIPTION

## Description

Fix Elide `contains` Filter

**Needs** #1133 

## Proposed Changes

- Fix Elide `contains` filter building
- Ignore filters without filter values
- `null` & `notnull` operators now have a value of `true`

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
