### PR TITLE
Update: Data epoch for demo app

### DIFF
--- a/packages/app/config/environment.js
+++ b/packages/app/config/environment.js
@@ -27,6 +27,7 @@ module.exports = function(environment) {
     },
 
     navi: {
+      dataEpoch: '1900-01-01',
       FEATURES: {
         enableDashboardFilters: true,
         multipleExportFileTypes: [],


### PR DESCRIPTION
## Description
Set a temporary data epoch to `1900` so that the demo app allows filtering older dates

## Proposed Changes
- This change will allow the demo app to not be limited in the dates it can filter to. In the future we should remove the requirement for an epoch or have a better default

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
