### PR TITLE
Report visualization shade

### DIFF
--- a/packages/reports/addon-test-support/report-builder.js
+++ b/packages/reports/addon-test-support/report-builder.js
@@ -105,7 +105,7 @@ export async function getItem(type, query, itemText) {
  * @param {Object} instance - the test or application instance
  * @param {String} type - a valid selector for grouped lists
  * @param {String} query - The query to type in the search bar
- * @param {String} itemText - The text content of the element to click
+ * @param {String|undefined} itemText - The text content of the element to click
  */
 export async function clickItem(type, query, itemText) {
   assert('clickItem must be passed an accepted type', isAcceptedType(type));

--- a/packages/reports/addon/components/filter-builders/time-dimension.ts
+++ b/packages/reports/addon/components/filter-builders/time-dimension.ts
@@ -119,7 +119,13 @@ export default class TimeDimensionFilterBuilder extends BaseFilterBuilderCompone
       const nonAllGrain = dateTimePeriod === 'all' ? 'day' : dateTimePeriod;
 
       let intervalValue;
-      if (end.isSame(moment.utc(getFirstDayOfGrain(moment.utc(), nonAllGrain)))) {
+      if (
+        end.isSame(
+          moment()
+            .startOf(nonAllGrain)
+            .utc(true)
+        )
+      ) {
         // end is 'current', get lookback amount
         intervalValue = interval.diffForTimePeriod(intervalTimePeriod);
       } else {

--- a/packages/reports/addon/components/filter-builders/time-dimension.ts
+++ b/packages/reports/addon/components/filter-builders/time-dimension.ts
@@ -9,7 +9,7 @@ import { capitalize } from '@ember/string';
 import moment from 'moment';
 import FilterFragment from 'navi-core/addon/models/bard-request-v2/fragments/filter';
 import { parseDuration } from 'navi-data/utils/classes/duration';
-import { DateTimePeriod, getFirstDayOfGrain, getPeriodForGrain, Grain } from 'navi-data/utils/date';
+import { DateTimePeriod, getPeriodForGrain, Grain } from 'navi-data/utils/date';
 import Interval from 'navi-data/utils/classes/interval';
 import BaseFilterBuilderComponent, { FilterBuilderOperators } from './base';
 

--- a/packages/reports/addon/components/report-view-overlay.hbs
+++ b/packages/reports/addon/components/report-view-overlay.hbs
@@ -1,0 +1,20 @@
+<div 
+  class="report-view-overlay {{if this.shouldDisplay "report-view-overlay--visible"}}" 
+  ...attributes
+  {{did-update this.resetDismissed @isVisible}}
+>
+  {{#if (and hasBlock this.shouldDisplay)}}
+    {{yield (hash 
+      dismiss=this.dismiss
+    )}}
+  {{else if this.shouldDisplay}}
+    <div class="report-view-overlay__content">
+      <NaviButton title="Run query to update results" class="report-view-overlay__button--run" @onClick={{@runReport}}>
+        Run
+      </NaviButton>
+      <NaviButton title="Continue with old results" class="report-view-overlay__button--dismiss" @type="secondary" @onClick={{this.dismiss}}>
+        Dismiss
+      </NaviButton>
+    </div>
+  {{/if}}
+</div>

--- a/packages/reports/addon/components/report-view-overlay.hbs
+++ b/packages/reports/addon/components/report-view-overlay.hbs
@@ -1,3 +1,4 @@
+{{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 <div 
   class="report-view-overlay {{if this.shouldDisplay "report-view-overlay--visible"}}" 
   ...attributes
@@ -9,10 +10,10 @@
     )}}
   {{else if this.shouldDisplay}}
     <div class="report-view-overlay__content">
-      <NaviButton title="Run query to update results" class="report-view-overlay__button--run" @onClick={{@runReport}}>
+      <NaviButton title="Run query to update results" class="report-view-overlay__button report-view-overlay__button--run" @onClick={{@runReport}}>
         Run
       </NaviButton>
-      <NaviButton title="Continue with old results" class="report-view-overlay__button--dismiss" @type="secondary" @onClick={{this.dismiss}}>
+      <NaviButton title="Continue with old results" class="report-view-overlay__button report-view-overlay__button--dismiss" @type="secondary" @onClick={{this.dismiss}}>
         Dismiss
       </NaviButton>
     </div>

--- a/packages/reports/addon/components/report-view-overlay.ts
+++ b/packages/reports/addon/components/report-view-overlay.ts
@@ -1,0 +1,26 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+interface Args {
+  isVisible: boolean;
+  runReport: () => void;
+}
+
+export default class ReportViewOverlay extends Component<Args> {
+  @tracked wasDismissed = false;
+
+  get shouldDisplay() {
+    return this.wasDismissed === false && this.args.isVisible === true;
+  }
+
+  @action
+  dismiss() {
+    this.wasDismissed = true;
+  }
+
+  @action
+  resetDismissed(_isVisible: Args['isVisible']) {
+    this.wasDismissed = false;
+  }
+}

--- a/packages/reports/addon/components/report-view-overlay.ts
+++ b/packages/reports/addon/components/report-view-overlay.ts
@@ -1,3 +1,7 @@
+/**
+ * Copyright 2020, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';

--- a/packages/reports/addon/consumers/request/column.js
+++ b/packages/reports/addon/consumers/request/column.js
@@ -79,7 +79,7 @@ export default ActionConsumer.extend({
     },
 
     /**
-     * @action REMOVE_COLUMN_FRAGMENT
+     * @action UPDATE_COLUMN_FRAGMENT_WITH_PARAMS
      * @param route - route that has a model that contains a request property
      * @param columnFragment - data model fragment of the column
      * @param parameterKey - the name of the parameter to update
@@ -90,7 +90,7 @@ export default ActionConsumer.extend({
     },
 
     /**
-     * @action REMOVE_COLUMN_FRAGMENT
+     * @action RENAME_COLUMN_FRAGMENT
      * @param route - route that has a model that contains a request property
      * @param columnFragment - data model fragment of the column
      * @param alias - the new name for the column
@@ -100,7 +100,7 @@ export default ActionConsumer.extend({
     },
 
     /**
-     * @action REMOVE_COLUMN_FRAGMENT
+     * @action REORDER_COLUMN_FRAGMENT
      * @param route - route that has a model that contains a request property
      * @param columnFragment - data model fragment of the column
      * @param index - the index to move the selected column

--- a/packages/reports/addon/routes/reports/report.js
+++ b/packages/reports/addon/routes/reports/report.js
@@ -173,6 +173,7 @@ export default Route.extend({
      */
     revertChanges(report) {
       report.rollbackAttributes();
+      this.send('setModifiedRequest', report.request.serialize());
     },
 
     /**

--- a/packages/reports/addon/templates/components/report-view.hbs
+++ b/packages/reports/addon/templates/components/report-view.hbs
@@ -1,13 +1,17 @@
 {{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 <div class="report-view__visualization-main">
+  <ReportViewOverlay
+    @runReport={{route-action "runReport" @report}}
+    @isVisible={{and @report.request.hasDirtyAttributes (not this.hasRequestRun)}} 
+  />
   <div class="report-view__visualization-header">
     <div class="report-view__visualization-header-left">
       <h3 class="report-view__title">Visualization</h3>
       <VisualizationToggle
-          class="report-view__visualization-toggle"
-          @report={{@report}}
-          @validVisualizations={{this.validVisualizations}}
-          @onVisualizationTypeUpdate={{this.onVisualizationTypeUpdate}}
+        class="report-view__visualization-toggle"
+        @report={{@report}}
+        @validVisualizations={{this.validVisualizations}}
+        @onVisualizationTypeUpdate={{this.onVisualizationTypeUpdate}}
       />
     </div>
       {{#animated-if (and this.hasRequestRun (not this.isEditingVisualization)) use=this.visFadeTransition duration=200}}

--- a/packages/reports/app/components/report-view-overlay.js
+++ b/packages/reports/app/components/report-view-overlay.js
@@ -1,0 +1,1 @@
+export { default } from 'navi-reports/components/report-view-overlay';

--- a/packages/reports/app/styles/navi-reports/components/index.less
+++ b/packages/reports/app/styles/navi-reports/components/index.less
@@ -23,6 +23,7 @@
 @import 'filter-collection';
 @import 'report-builder';
 @import 'report-view';
+@import 'report-view-overlay';
 @import 'print-report-view';
 @import 'reports-index';
 @import 'editable-label';

--- a/packages/reports/app/styles/navi-reports/components/navi-column-config.less
+++ b/packages/reports/app/styles/navi-reports/components/navi-column-config.less
@@ -49,5 +49,9 @@
   &--disabled {
     background: @denali-gray-300;
     cursor: not-allowed;
+
+    .navi-column-config-base__api-column-name {
+      background: none;
+    }
   }
 }

--- a/packages/reports/app/styles/navi-reports/components/navi-column-config.less
+++ b/packages/reports/app/styles/navi-reports/components/navi-column-config.less
@@ -25,6 +25,7 @@
   font-size: @font-size-mid;
 
   &__title {
+    font-size: @font-size-base;
     padding: 10px;
     margin: 0;
     font-family: @font-family-thin;

--- a/packages/reports/app/styles/navi-reports/components/report-builder.less
+++ b/packages/reports/app/styles/navi-reports/components/report-builder.less
@@ -36,6 +36,7 @@
     }
 
     .ember-power-select-trigger,
+    .grouped-list__item-container--selected,
     .metric-selector__item-container--selected {
       background: none;
     }

--- a/packages/reports/app/styles/navi-reports/components/report-view-overlay.less
+++ b/packages/reports/app/styles/navi-reports/components/report-view-overlay.less
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2020, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+
+.report-view-overlay {
+  position: absolute;
+  display: none;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(255, 255, 255, 0.8);
+  z-index: 2;
+
+  &--visible {
+    display: flex;
+  }
+
+  &__content {
+    align-self: center;
+    margin: 0 auto;
+  }
+}

--- a/packages/reports/app/styles/navi-reports/components/report-view-overlay.less
+++ b/packages/reports/app/styles/navi-reports/components/report-view-overlay.less
@@ -17,6 +17,12 @@
 
   &__content {
     align-self: center;
+    display: flex;
+    flex-direction: row;
     margin: 0 auto;
+  }
+
+  &__button:not(:first-of-type) {
+    margin-left: 10px;
   }
 }

--- a/packages/reports/tests/acceptance/report-test.js
+++ b/packages/reports/tests/acceptance/report-test.js
@@ -14,6 +14,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import moment from 'moment';
 import { clickItem, clickItemFilter, getAllSelected, getItem } from 'navi-reports/test-support/report-builder';
 import reorder from '../helpers/reorder';
+import { setupAnimationTest } from 'ember-animated/test-support';
 
 // Regex to check that a string ends with "{uuid}/view"
 const TempIdRegex = /\/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\/view$/;
@@ -25,6 +26,7 @@ let CompressionService;
 
 module('Acceptance | Navi Report', function(hooks) {
   setupApplicationTest(hooks);
+  setupAnimationTest(hooks);
   setupMirage(hooks);
 
   hooks.beforeEach(function() {

--- a/packages/reports/tests/acceptance/report-view-overlay-test.ts
+++ b/packages/reports/tests/acceptance/report-view-overlay-test.ts
@@ -1,0 +1,95 @@
+import { click, visit } from '@ember/test-helpers';
+//@ts-ignore
+import { setupMirage } from 'ember-cli-mirage/test-support';
+//@ts-ignore
+import { selectChoose } from 'ember-power-select/test-support';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+//@ts-ignore
+import { setupAnimationTest } from 'ember-animated/test-support';
+//@ts-ignore
+import { clickItem } from 'navi-reports/test-support/report-builder';
+
+const overlaySelector = '.report-view-overlay--visible';
+function assertOverlayNotVisible(assert: Assert, message = 'The report view overlay is not visible') {
+  assert.dom(overlaySelector).doesNotExist(message);
+}
+
+function assertOverlayVisible(assert: Assert, message = 'The report view overlay is visible') {
+  assert.dom(overlaySelector).exists(message);
+}
+
+function assertReportNeedsRun(assert: Assert, message = 'The response is not up to date with the request') {
+  assert.dom('.report-view__info-text').containsText('Run request', message);
+}
+
+function assertReportDoesNotNeedRun(assert: Assert, message = 'The response is up to date with the request') {
+  assert.dom('.report-view__info-text').doesNotExist(message);
+}
+
+const clickOverlayRun = () => click(`${overlaySelector} .report-view-overlay__button--run`);
+const clickOverlayDismiss = () => click(`${overlaySelector} .report-view-overlay__button--dismiss`);
+const clickRevertReport = () => click('.navi-report__revert-btn');
+
+module('Acceptance | report-view-overlay', function(hooks) {
+  setupApplicationTest(hooks);
+  setupAnimationTest(hooks);
+  setupMirage(hooks);
+
+  test('load existing report', async function(assert) {
+    assert.expect(1);
+
+    await visit('/reports/1/view');
+    assertOverlayNotVisible(assert);
+  });
+
+  test('revert test', async function(assert) {
+    assert.expect(2);
+
+    await visit('/reports/1/view');
+    await click('[aria-label="delete metric Nav Link Clicks"]');
+    assertOverlayVisible(assert, 'The overlay is visible when a column has been removed');
+    await clickRevertReport();
+    assertOverlayNotVisible(assert);
+  });
+
+  test('duplicate column', async function(assert) {
+    assert.expect(4);
+
+    await visit('/reports/1/view');
+    await clickItem('metric', 'Nav Link Clicks', undefined);
+    assertOverlayNotVisible(assert, 'The overlay is not visible when a duplicate column is added');
+    await click('[aria-label="delete metric Nav Link Clicks"]');
+    assertOverlayNotVisible(assert, 'The overlay is not visible when a duplicate column is removed');
+    await clickItem('metric', 'Revenue', undefined);
+    assertOverlayVisible(assert, 'The overlay is visible when a new column is added');
+    await clickRevertReport();
+    assertOverlayNotVisible(assert);
+  });
+
+  test('new column', async function(assert) {
+    assert.expect(5);
+
+    await visit('/reports/1/view');
+    await clickItem('metric', 'Revenue', undefined);
+    assertOverlayVisible(assert, 'The overlay is visible when a new column is added');
+    await clickOverlayDismiss();
+    assertOverlayNotVisible(assert, 'The overlay is not visible after being dismissed');
+    assertReportNeedsRun(assert, 'Dismissing the overlay does not update the report');
+    await clickItem('dimension', 'Age', undefined);
+    assertOverlayNotVisible(assert, 'The overlay is not visible when new updates are made');
+    assertReportNeedsRun(assert, 'The report still needs to be run');
+  });
+
+  test('change parameter', async function(assert) {
+    assert.expect(3);
+
+    await visit('/reports/1/view');
+    await click('.navi-column-config-item[data-name="property(field=id)"] .navi-column-config-item__trigger');
+    await selectChoose('.navi-column-config-item__parameter-trigger', 'desc');
+    assertOverlayVisible(assert, 'The overlay is visible when a parameter is changed');
+    await clickOverlayRun();
+    assertOverlayNotVisible(assert, 'The overlay is not visible when the request has been run');
+    assertReportDoesNotNeedRun(assert);
+  });
+});

--- a/packages/reports/tests/integration/components/report-view-overlay-test.ts
+++ b/packages/reports/tests/integration/components/report-view-overlay-test.ts
@@ -1,0 +1,78 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { TestContext as Context } from 'ember-test-helpers';
+import ReportViewOverlay from 'navi-reports/components/report-view-overlay';
+
+type ComponentArgs = ReportViewOverlay['args'];
+
+interface TestContext extends Context, ComponentArgs {}
+
+const TEMPLATE = hbs`<ReportViewOverlay 
+  @isVisible={{this.isVisible}}
+  @runReport={{this.runReport}}
+/>`;
+
+module('Integration | Component | report-view-overlay', function(hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(async function(this: TestContext) {
+    this.isVisible = false;
+    this.runReport = () => undefined;
+  });
+
+  test('it renders', async function(this: TestContext, assert) {
+    assert.expect(5);
+
+    this.runReport = () => assert.ok(true, 'Called runReport');
+    await render(TEMPLATE);
+
+    assert
+      .dom('.report-view-overlay__content')
+      .doesNotExist('The content is not rendered when the overlay is not visible');
+
+    this.set('isVisible', true);
+
+    assert.dom('.report-view-overlay__content').exists('The content is rendered when the overlay is visible');
+
+    await click('.report-view-overlay__button--run');
+
+    await click('.report-view-overlay__button--dismiss');
+
+    assert
+      .dom('.report-view-overlay__content')
+      .doesNotExist('The content is not rendered when the overlay is dismissed');
+
+    this.set('isVisible', false);
+    this.set('isVisible', true);
+    assert.dom('.report-view-overlay__content').exists('The dismiss is reset when the @isVisible prop is updated');
+  });
+
+  test('it renders - hasBlock', async function(this: TestContext, assert) {
+    this.isVisible = false;
+    this.runReport = () => undefined;
+    await render(hbs`
+      <ReportViewOverlay id="test-overlay-id" @isVisible={{this.isVisible}} @runReport={{this.runReport}} as |Overlay|>
+        Content
+        <button type="button" id="dismiss-button" {{on "click" Overlay.dismiss}} />
+      </ReportViewOverlay>
+    `);
+
+    assert.dom('#test-overlay-id').exists('The wrapper container exists');
+    assert
+      .dom('#test-overlay-id')
+      .doesNotHaveTextContaining('Content', 'The content is not rendered when the overlay is not visible');
+
+    this.set('isVisible', true);
+    assert.dom('#test-overlay-id').hasText('Content', 'The content is not rendered when the overlay is not visible');
+    assert.dom('#dismiss-button').exists('The dismiss button exists');
+
+    await click('#dismiss-button');
+
+    assert
+      .dom('#test-overlay-id')
+      .doesNotHaveTextContaining('Content', 'The content is not rendered when the overlay is not visible');
+    assert.dom('#dismiss-button').doesNotExist('The dismiss button is hidden');
+  });
+});

--- a/packages/reports/tests/unit/routes/reports/report-test.js
+++ b/packages/reports/tests/unit/routes/reports/report-test.js
@@ -91,25 +91,46 @@ module('Unit | Route | reports/report', function(hooks) {
   });
 
   test('revertChanges action', function(assert) {
-    assert.expect(1);
+    assert.expect(4);
 
+    const serializedRequest = 'serializedRequestValue';
     let mockReport = {
         rollbackAttributes() {
           assert.ok(true, 'Report model is asked to rollback');
+        },
+        request: {
+          serialize() {
+            assert.ok(true, 'Report model is asked to serialize');
+            return serializedRequest;
+          }
         }
       },
       route = this.owner.lookup('route:reports/report');
+
+    route.controllerFor = () => ({
+      set(key, value) {
+        assert.deepEqual(key, 'modifiedRequest', 'The route updates the modified request on the controller');
+        assert.deepEqual(value, serializedRequest, 'The serialized request is passed');
+      }
+    });
 
     route.send('revertChanges', mockReport);
   });
 
   test('deactivate method', function(assert) {
-    assert.expect(1);
+    assert.expect(4);
 
+    const serializedRequest = 'serializedRequestValue';
     const mockReport = {
         hasDirtyAttributes: true,
         rollbackAttributes() {
           assert.ok(true, 'Route model is asked to rollback');
+        },
+        request: {
+          serialize() {
+            assert.ok(true, 'Report model is asked to serialize');
+            return serializedRequest;
+          }
         }
       },
       route = this.owner.factoryFor('route:reports/report').create({
@@ -118,6 +139,13 @@ module('Unit | Route | reports/report', function(hooks) {
         },
         routeName: 'reports.report'
       });
+
+    route.controllerFor = () => ({
+      set(key, value) {
+        assert.deepEqual(key, 'modifiedRequest', 'The route updates the modified request on the controller');
+        assert.deepEqual(value, serializedRequest, 'The serialized request is passed');
+      }
+    });
 
     /* == Transition to different route == */
     route.deactivate();


### PR DESCRIPTION
## Description
With request 2.0 we listen to a lot more changes on the request and dynamically update the visualization which sometimes makes it incorrect

## Proposed Changes
- Fix bug with sort consumer where removing a duplicated column removes the sorts
- Adds a shade over the report view when the request has been modified to make the response out of date

## Screenshots
![visualization overlay](https://user-images.githubusercontent.com/12093492/101808359-dde5b600-3adb-11eb-9710-81c55e9e18a1.png)

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
