### PR TITLE
Fix chart builders time dimension

### DIFF
--- a/packages/core/addon/chart-builders/base.ts
+++ b/packages/core/addon/chart-builders/base.ts
@@ -30,8 +30,12 @@ export type TooltipData = {
 
 type C3Data = { series: C3Row[]; names: Record<string, string> };
 
-//@ts-expect-error
-export const EmptyC3Data: C3Data = { series: [{ x: { rawValue: null, displayValue: '' } } as C3Row], names: {} };
+export const BLANK_X_VALUE = '';
+export const EmptyC3Data: C3Data = {
+  series: [{ x: { rawValue: BLANK_X_VALUE, displayValue: BLANK_X_VALUE } } as C3Row],
+  names: {}
+};
+
 export interface BaseChartBuilder {
   byXSeries?: DataGroup<ResponseRow>;
 

--- a/packages/core/addon/chart-builders/date-time.ts
+++ b/packages/core/addon/chart-builders/date-time.ts
@@ -21,7 +21,7 @@ import DataGroup from 'navi-core/utils/classes/data-group';
 import EmberObject, { computed } from '@ember/object';
 import { assert } from '@ember/debug';
 import RequestFragment from 'navi-core/models/bard-request-v2/request';
-import { BaseChartBuilder, C3Row, EmptyC3Data, TooltipData } from './base';
+import { BaseChartBuilder, BLANK_X_VALUE, C3Row, EmptyC3Data, TooltipData } from './base';
 import { tracked } from '@glimmer/tracking';
 import { DateTimeSeries } from 'navi-core/models/chart-visualization';
 import NaviFactResponse, { ResponseRow } from 'navi-data/models/navi-fact-response';
@@ -246,12 +246,20 @@ export default class TimeChartBuilder extends EmberObject implements BaseChartBu
     return _getGrouper(request, config).getSeries(moment(date));
   }
 
-  getXValue(row: ResponseRow, config: DateTimeSeries['config'], request: RequestFragment): number {
-    assert('request should have a timeGrainColumn', request.timeGrainColumn);
-    const colName = request.timeGrainColumn.canonicalName;
-    const date = row[colName];
-    assert(`a date for ${colName} should be found, but got: ${date}`, typeof date === 'string');
-    return _getGrouper(request, config).getXValue(moment(date));
+  getXValue(
+    row: ResponseRow,
+    config: DateTimeSeries['config'],
+    request: RequestFragment
+  ): number | typeof BLANK_X_VALUE {
+    const { timeGrainColumn } = request;
+    if (timeGrainColumn) {
+      const date = row[timeGrainColumn.canonicalName];
+      if (typeof date !== 'string') {
+        return BLANK_X_VALUE;
+      }
+      return _getGrouper(request, config).getXValue(moment(date));
+    }
+    return BLANK_X_VALUE;
   }
 
   buildData(

--- a/packages/core/addon/chart-builders/dimension.ts
+++ b/packages/core/addon/chart-builders/dimension.ts
@@ -62,7 +62,9 @@ export default class DimensionChartBuilder extends EmberObject implements BaseCh
     if (timeGrainColumn) {
       const colName = timeGrainColumn.canonicalName;
       const date = row[colName];
-      assert(`a date for ${colName} should be found, but got: ${date}`, typeof date === 'string');
+      if (typeof date !== 'string') {
+        return BLANK_X_VALUE;
+      }
       return moment(date).format(API_DATE_FORMAT_STRING);
     }
     return BLANK_X_VALUE;

--- a/packages/core/addon/chart-builders/metric.ts
+++ b/packages/core/addon/chart-builders/metric.ts
@@ -39,7 +39,9 @@ export default class MetricChartBuilder extends EmberObject implements BaseChart
     if (timeGrainColumn) {
       const colName = timeGrainColumn.canonicalName;
       const date = row[colName];
-      assert(`a date for ${colName} should be found, but got: ${date}`, typeof date === 'string');
+      if (typeof date !== 'string') {
+        return BLANK_X_VALUE;
+      }
       return moment(date).format(API_DATE_FORMAT_STRING);
     }
     return BLANK_X_VALUE;

--- a/packages/data/addon/adapters/facts/elide.ts
+++ b/packages/data/addon/adapters/facts/elide.ts
@@ -60,7 +60,7 @@ export default class ElideFactsAdapter extends EmberObject implements NaviFactAd
   };
 
   private formatTimeValue(value: Moment | string, grain: Grain) {
-    return moment(value).format(this.grainFormats[grain]);
+    return moment.utc(value).format(this.grainFormats[grain]);
   }
 
   private filterBuilders: Record<FilterOperator, (field: string, value: string[]) => string> = {

--- a/packages/data/addon/mirage/routes/graphql.js
+++ b/packages/data/addon/mirage/routes/graphql.js
@@ -60,10 +60,10 @@ const FILTER_REGEX = new RegExp(`(.*?)(?:\\((.+?)\\))?(${Object.values(OPERATORS
 
 //create an inclusive interval of dates based on filter values and operator
 const DATE_FILTER_OPS = {
-  [OPERATORS.lt]: ([val], grain) => [null, moment(val).subtract(1, grain)],
-  [OPERATORS.gt]: ([val], grain) => [moment(val).add(1, grain), null],
-  [OPERATORS.le]: ([val]) => [null, moment(val)],
-  [OPERATORS.ge]: ([val]) => [moment(val), null],
+  [OPERATORS.lt]: ([val], grain) => [null, moment.utc(val).subtract(1, grain)],
+  [OPERATORS.gt]: ([val], grain) => [moment.utc(val).add(1, grain), null],
+  [OPERATORS.le]: ([val]) => [null, moment.utc(val)],
+  [OPERATORS.ge]: ([val]) => [moment.utc(val), null],
   [OPERATORS.isIn]: () => [null, null], //TODO: Not sure if the following operators are really supported for dates
   [OPERATORS.isNull]: () => [null, null],
   [OPERATORS.notNull]: () => [null, null],
@@ -144,19 +144,19 @@ function _datesForInterval(interval, grain) {
 
   // Default interval to at most 1 month long if start or end are null
   if (!interval[0]) {
-    end = moment(interval[1]).startOf(grain);
-    start = moment(end).subtract(1, 'month'); //Default start to 1 month before end
+    end = moment.utc(interval[1]).startOf(grain);
+    start = moment.utc(end).subtract(1, 'month'); //Default start to 1 month before end
   } else if (!interval[1]) {
     start = interval[0].startOf(grain);
-    let monthAhead = moment(start).add(1, 'month');
-    let current = moment();
+    let monthAhead = moment.utc(start).add(1, 'month');
+    let current = moment.utc();
     end = monthAhead.isSameOrBefore(current) ? monthAhead.startOf(grain) : current.startOf(grain); //Default end to current or 1 month past start, whichever is closer to start
   } else {
     start = interval[0].startOf(grain);
     end = interval[1].startOf(grain);
   }
   for (let i = start; i.isSameOrBefore(end); i.add(1, grain)) {
-    dates.push(moment(i));
+    dates.push(moment.utc(i));
   }
   return dates;
 }


### PR DESCRIPTION
## Description
The line/bar chart did not handle updates to time dimensions well. We thought this was only a fili issue when changing grains in the column config but it affects elide as well

Steps to Reproduce error before this PR
- http://localhost:8080/ui/reports/new
- add country
- add count
- run
- switch to bar chart
- add release year
- filter release year

## Proposed Changes
- Guard against missing timeGrainColumn data
- Use utc for elide filters and mocks

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
