### PR TITLE
Fix dashboard tests

### DIFF
--- a/packages/core/addon/helpers/is-forbidden.js
+++ b/packages/core/addon/helpers/is-forbidden.js
@@ -1,13 +1,17 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Util for testing if a RSVP Promise was rejected because of an ajax forbidden(403) response
  */
 import { helper as buildHelper } from '@ember/component/helper';
 import { isForbiddenError } from 'ember-ajax/errors';
+import NaviAdapterError from 'navi-data/errors/navi-adapter-error';
 
 export function isForbidden(reason) {
+  if (reason instanceof NaviAdapterError) {
+    return reason.errors.some(error => error.status === '403');
+  }
   return isForbiddenError(reason);
 }
 

--- a/packages/core/addon/mirage/fixtures/dashboard.js
+++ b/packages/core/addon/mirage/fixtures/dashboard.js
@@ -84,10 +84,10 @@ export default [
     deliveryRuleIds: [],
     filters: [
       {
-        dimension: 'userSignupDate',
-        operator: 'lt',
+        dimension: 'commaDim',
+        operator: 'in',
         field: 'id',
-        values: ['2019-05-05']
+        values: ['yes, comma']
       }
     ],
     presentation: {

--- a/packages/core/addon/serializers/table.ts
+++ b/packages/core/addon/serializers/table.ts
@@ -169,9 +169,11 @@ export function normalizeTableV2(
       `The request column ${requestColumn.field} should have a present 'cid' field`,
       requestColumn.cid !== undefined
     );
+    const canAggregateSubtotal = tableColumn.type === 'metric' ? attributes?.canAggregateSubtotal : undefined;
+    const format = tableColumn.format !== undefined ? tableColumn.format : attributes?.format;
     columns[requestColumn.cid] = {
-      canAggregateSubtotal: tableColumn.type === 'metric' ? attributes?.canAggregateSubtotal : undefined,
-      format: tableColumn.format !== undefined ? tableColumn.format : attributes?.format
+      ...(canAggregateSubtotal !== undefined ? { canAggregateSubtotal } : {}),
+      ...(format !== undefined ? { format } : {})
     };
     return columns;
   }, {} as Record<string, TableColumnAttributes>);
@@ -197,8 +199,8 @@ export function normalizeTableV2(
     metadata: {
       columnAttributes,
       showTotals: {
-        subtotal,
-        grandTotal: showTotals?.grandTotal
+        ...(subtotal !== undefined ? { subtotal } : {}),
+        ...(showTotals?.grandTotal !== undefined ? { grandTotal: showTotals?.grandTotal } : {})
       }
     }
   };

--- a/packages/core/tests/unit/serializers/table-test.ts
+++ b/packages/core/tests/unit/serializers/table-test.ts
@@ -5,27 +5,24 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import { normalizeTableV2, TableVisMetadataPayloadV1, TableVisualizationMetadata } from 'navi-core/serializers/table';
 import { RequestV2 } from 'navi-data/adapters/facts/interface';
 
-const defaultAttributes = {
-  canAggregateSubtotal: undefined,
-  format: undefined
-};
+const defaultAttributes = {};
 const expected: TableVisualizationMetadata = {
   metadata: {
     columnAttributes: {
       c0: defaultAttributes,
       c1: defaultAttributes,
       c2: {
-        canAggregateSubtotal: false,
-        format: undefined
+        ...defaultAttributes,
+        canAggregateSubtotal: false
       },
       c3: defaultAttributes,
       c4: defaultAttributes,
       c5: {
-        canAggregateSubtotal: undefined,
+        ...defaultAttributes,
         format: ''
       },
       c6: {
-        canAggregateSubtotal: undefined,
+        ...defaultAttributes,
         format: '0.00'
       },
       c7: defaultAttributes

--- a/packages/dashboards/addon/components/dashboard-dimension-selector.js
+++ b/packages/dashboards/addon/components/dashboard-dimension-selector.js
@@ -90,7 +90,7 @@ export default class DashboardDimensionSelectorComponent extends Component {
 
         if (!results[dimension.category][`${dataSource}.${dimension.id}`]) {
           results[dimension.category][`${dataSource}.${dimension.id}`] = {
-            type: dimension instanceof TimeDimensionMetadataModel ? 'timeDimension' : 'dimension',
+            type: dimension.metadataType,
             field: dimension.id,
             name: dimension.name,
             tables: [table],
@@ -114,8 +114,9 @@ export default class DashboardDimensionSelectorComponent extends Component {
       // TODO: Consider including timeDimensions? This would potentially conflict with visualization manifests so skipping for now
       const { id: tableKey, dimensions } = widget.requests?.firstObject?.tableMetadata || {};
       const dataSource = widget?.requests?.firstObject?.dataSource;
-      if (!dimensionMap[tableKey]) {
-        dimensionMap[`${dataSource}.${tableKey}`] = [...dimensions];
+      const key = `${dataSource}.${tableKey}`;
+      if (!dimensionMap[key]) {
+        dimensionMap[key] = [...dimensions];
       }
       return dimensionMap;
     }, {});

--- a/packages/dashboards/addon/components/dashboard-filters.js
+++ b/packages/dashboards/addon/components/dashboard-filters.js
@@ -39,7 +39,7 @@ export default Component.extend({
     return this.store.createFragment('bard-request-v2/request', {
       table: null,
       columns: [],
-      filters: this.dashboard.filters.map(filter => {
+      filters: (this.dashboard.filters || []).map(filter => {
         const newFilter = this.store.createFragment('bard-request-v2/fragments/filter', {
           field: filter.field,
           parameters: filter.parameters,

--- a/packages/dashboards/addon/templates/components/navi-widget.hbs
+++ b/packages/dashboards/addon/templates/components/navi-widget.hbs
@@ -52,6 +52,7 @@
 
   {{!-- Error --}}
   {{#if @taskInstance.isError}}
+    {{!-- TODO: Use Routes::ReportsReportError --}}
     {{#if (is-forbidden @taskInstance.error)}}
       <UnauthorizedTable @report={{@model}} />
     {{else}}
@@ -64,12 +65,13 @@
   {{!-- Success --}}
   {{#if @taskInstance.isSuccessful}}
     <div class="navi-widget__content visualization-container">
-      {{component
-        (concat this.visualizationPrefix @model.visualization.type)
-        model=this.data
-        options=@model.visualization.metadata
-        containerComponent=item
-      }}
+      {{#let (component (concat this.visualizationPrefix @model.visualization.type)) as |Visualization|}}
+        <Visualization
+          @model={{this.data}}
+          @options={{@model.visualization.metadata}}
+          @containerComponent={{item}}
+        />
+      {{/let}}
     </div>
   {{/if}}
 

--- a/packages/dashboards/tests/acceptance/dashboard-filter-test.js
+++ b/packages/dashboards/tests/acceptance/dashboard-filter-test.js
@@ -1,6 +1,6 @@
 import { click, fillIn, visit, triggerKeyEvent, find, findAll, currentURL } from '@ember/test-helpers';
 import { selectChoose } from 'ember-power-select/test-support';
-import { module, test, skip } from 'qunit';
+import { module, test } from 'qunit';
 import config from 'ember-get-config';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -20,8 +20,7 @@ module('Acceptance | Dashboard Filters', function(hooks) {
     window.confirm = confirm;
   });
 
-  // TODO: Broken because reports is broken
-  skip('dashboard filter flow', async function(assert) {
+  test('dashboard filter flow', async function(assert) {
     await visit('/dashboards/1/view');
 
     let dataRequests = [];
@@ -444,8 +443,7 @@ module('Acceptance | Dashboard Filters', function(hooks) {
     );
   });
 
-  // TODO: Broken because reports is broken
-  skip('breadcrumbs in subroute also have query params', async function(assert) {
+  test('breadcrumbs in subroute also have query params', async function(assert) {
     assert.expect(2);
     await visit(
       '/dashboards/1/view?filters=EQbwOsBmCWA2AuBTATgZwgLgNrmAE2gFtEA7VaAexMwgAdkLaV4BPCAGgkZQEN4LkNYNGrBOwAG49YAV0Tpg2ALriYiWHiHRNwAL7tcBYmUqiMEHgHNEHLk2R8BW0eKmz5mLBAC0AZggqEGoaWjq6SrrAQA'

--- a/packages/dashboards/tests/acceptance/dashboard-filter-test.js
+++ b/packages/dashboards/tests/acceptance/dashboard-filter-test.js
@@ -61,7 +61,6 @@ module('Acceptance | Dashboard Filters', function(hooks) {
     await selectChoose('.dashboard-dimension-selector', 'Platform');
 
     await selectChoose('.filter-collection__row:nth-child(2) .filter-builder-dimension__operator', 'Contains');
-    await selectChoose('.filter-builder-dimension__field', 'desc');
     await fillIn('.filter-collection__row:nth-child(2) .filter-builder-dimension__values input', 'win');
     dataRequests = [];
     await triggerKeyEvent(
@@ -72,7 +71,7 @@ module('Acceptance | Dashboard Filters', function(hooks) {
 
     assert.ok(
       dataRequests.every(
-        request => request.queryParams.filters === 'platform|desc-contains["win"],property|id-in["1","2"]'
+        request => request.queryParams.filters === 'property|id-in["1","2"],platform|id-contains["win"]'
       ),
       'each widget request has both filters present after new one is added'
     );
@@ -82,7 +81,7 @@ module('Acceptance | Dashboard Filters', function(hooks) {
     await click('.filter-collection__remove:nth-child(1)');
 
     assert.ok(
-      dataRequests.every(request => request.queryParams.filters == 'platform|desc-contains["win"]'),
+      dataRequests.every(request => request.queryParams.filters == 'platform|id-contains["win"]'),
       'each widget request has the right filters after one has been removed'
     );
     dataRequests = [];
@@ -101,7 +100,7 @@ module('Acceptance | Dashboard Filters', function(hooks) {
 
     assert.deepEqual(
       dashboardBody.data.attributes.filters,
-      [{ dimension: 'bardOne.platform', field: 'desc', operator: 'contains', values: ['win'] }],
+      [{ dimension: 'bardOne.platform', field: 'id', operator: 'contains', values: ['win'] }],
       'Correct filters are saved with the dashboard'
     );
   });
@@ -132,12 +131,6 @@ module('Acceptance | Dashboard Filters', function(hooks) {
       'each widget request has the filter added using the key field'
     );
     assert.equal(dataRequests.length, 3, 'three data requests were made (one for each widget)');
-
-    await click('.dashboard-filters__expand-button');
-
-    assert
-      .dom('.filter-values--collapsed')
-      .matchesText(/[a-z ]+\(1\)/i, 'filter collapse display should show id and not key');
   });
 
   test('dashboard filter query params - ui changes update the model', async function(assert) {
@@ -150,22 +143,22 @@ module('Acceptance | Dashboard Filters', function(hooks) {
 
     const INITIAL_FILTERS = [
       {
-        dimension: 'Property',
+        dimension: 'Property (id)',
         operator: 'contains',
         rawValues: ['114', '100001']
       },
       {
-        dimension: 'Property',
+        dimension: 'Property (id)',
         operator: 'not equals',
         rawValues: ['1']
       },
       {
-        dimension: 'Property',
+        dimension: 'Property (id)',
         operator: 'not equals',
         rawValues: ['2', '3']
       },
       {
-        dimension: 'EventId',
+        dimension: 'EventId (id)',
         operator: 'equals',
         rawValues: ['1']
       }
@@ -194,7 +187,7 @@ module('Acceptance | Dashboard Filters', function(hooks) {
       dirtyFilters,
       [
         {
-          dimension: 'Property',
+          dimension: 'Property (id)',
           operator: 'equals',
           rawValues: ['2', '3']
         }
@@ -234,8 +227,8 @@ module('Acceptance | Dashboard Filters', function(hooks) {
     assert.deepEqual(
       dataRequests.map(req => req.queryParams.filters),
       [
-        'property|id-notin["2","3"],property|id-notin["1"],property|id-contains["114","100001"]',
-        'property|id-notin["2","3"],property|id-notin["1"],property|id-contains["114","100001"]'
+        'property|id-contains["114","100001"],property|id-notin["1"],property|id-notin["2","3"]',
+        'property|id-contains["114","100001"],property|id-notin["1"],property|id-notin["2","3"]'
       ],
       'The requests are sent with the initial filters'
     );
@@ -245,10 +238,10 @@ module('Acceptance | Dashboard Filters', function(hooks) {
     assert.expect(7);
 
     const dirtyURL =
-      '/dashboards/2/view?filters=EQbwOsBmCWA2AuBTATgZwgLgNrmAE2gFtEA7VaAexMwgAdkLaV4BPCAGgkZQEN4LkNYNGrBOwAG49YAV0Tpg2CACYOEAMwQAuuJiJYeIdEPAAvltPAgAAA';
+      '/dashboards/2/view?filters=EQbwOsBmCWA2AuBTATgZwgLgNrmAewAcUBDePZTCaAOwgBoIA3Y2AV0XWGwgCZ6IAzBAC6DKNESwAJpWAFkhFPACe_OcWTEAtoiRpMuGJJlcqJgL5iVRWVOg7qqaHlrAxqPK2QBjRLIBGGlIA8tR-wObC5sBAA';
     const filters = [
       {
-        dimension: 'Property',
+        dimension: 'Property (id)',
         operator: 'equals',
         rawValues: ['2', '3']
       }
@@ -314,11 +307,14 @@ module('Acceptance | Dashboard Filters', function(hooks) {
       {
         filters: [
           {
-            dimension: 'property',
-            field: 'id',
+            type: 'dimension',
+            field: 'property',
+            parameters: {
+              field: 'id'
+            },
             operator: 'in',
             values: [],
-            dataSource: 'bardOne'
+            source: 'bardOne'
           }
         ]
       },
@@ -350,11 +346,14 @@ module('Acceptance | Dashboard Filters', function(hooks) {
       {
         filters: [
           {
-            dimension: 'property',
-            field: 'id',
+            type: 'dimension',
+            field: 'property',
+            parameters: {
+              field: 'id'
+            },
             operator: 'in',
             values: ['1'],
-            dataSource: 'bardOne'
+            source: 'bardOne'
           }
         ]
       },
@@ -399,11 +398,14 @@ module('Acceptance | Dashboard Filters', function(hooks) {
       {
         filters: [
           {
-            dimension: 'property',
-            field: 'id',
+            type: 'dimension',
+            field: 'property',
+            parameters: {
+              field: 'id'
+            },
             operator: 'in',
             values: [],
-            dataSource: 'bardOne'
+            source: 'bardOne'
           }
         ]
       },
@@ -412,7 +414,7 @@ module('Acceptance | Dashboard Filters', function(hooks) {
     assert.equal(dataRequests.length, 3, 'No new requests run on filter add (model hook should use cached data)');
 
     await visit(
-      '/dashboards/1/view?filters=EQbwOsBmCWA2AuBTATgZwgLgNrmAE2gFtEA7VaAexMwgAdkLaV4BPCAGgkZQEN4LkNYNGrBOwAG49YAV0Tpg2ALriYiWHiHRNwAL7tcBYmUqiMEHgHNEHLk2R8BW0eKmz5mLBAC0AZggqEGoaWjq6SrrAQA'
+      '/dashboards/1/view?filters=EQbwOsBmCWA2AuBTATgZwgLgNrmAewAcUBDePZTCaAOwgBoIA3Y2AV0XWGwF0GppEsACaVgBZIRTwAnvQgFiyYgFtESNJlwxBIrlV0BfPjKKih0VdVTQ8tYH1R5WyAMaJRAI0VCA8tXfARriSSmQUesA0csDMbByYWBAAtADMELwQ2sKixADmAXwKSqrqnBhaAtkR0IbG0qYR5pbWttGOzm6e3n4BBtwGwEAAA'
     );
     assert.equal(
       dataRequests.length,
@@ -426,16 +428,24 @@ module('Acceptance | Dashboard Filters', function(hooks) {
       {
         filters: [
           {
-            dimension: 'property',
-            field: 'id',
+            type: 'dimension',
+            field: 'property',
+            parameters: {
+              field: 'id'
+            },
             operator: 'in',
-            values: []
+            values: [],
+            source: 'bardOne'
           },
           {
-            dimension: 'age',
-            field: 'id',
+            type: 'dimension',
+            field: 'age',
+            parameters: {
+              field: 'id'
+            },
             operator: 'in',
-            values: ['-3']
+            values: ['-3'],
+            source: 'bardOne'
           }
         ]
       },

--- a/packages/dashboards/tests/acceptance/dashboards-test.js
+++ b/packages/dashboards/tests/acceptance/dashboards-test.js
@@ -6,7 +6,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { Response } from 'ember-cli-mirage';
 import { selectChoose } from 'ember-power-select/test-support';
-import { clickItem } from 'navi-reports/test-support/report-builder';
+import { clickItem, clickItemFilter } from 'navi-reports/test-support/report-builder';
 import $ from 'jquery';
 
 let confirm;
@@ -62,13 +62,12 @@ module('Acceptance | Dashboards', function(hooks) {
       if (url.includes('/v1/data')) {
         dataRequestsCount++;
       }
-      return { rows: [] };
     };
 
     visit('/dashboards/1');
 
     //navigate to index route before widgets finish loading
-    await waitFor('.navi-dashboard__breadcrumb-link');
+    await waitFor('.navi-dashboard__breadcrumb-link', { timeout: 40000 });
     assert.dom('.navi-widget__content.loader-container').exists({ count: 3 });
     await click('.navi-dashboard__breadcrumb-link');
     //navigate to `Dashboard 2`
@@ -281,7 +280,7 @@ module('Acceptance | Dashboards', function(hooks) {
 
     assert.ok(
       filters.every(filter =>
-        /^(Property|EventId) (contains|not equals|equals) (.*?\d+.*?)(, .*?\d+.*?)*$/.test(filter)
+        /^(Property|EventId) \(id\) (contains|not equals|equals) (.*?\d+.*?)( .*?\d+.*?)*$/.test(filter)
       ),
       'correct format of filters'
     );
@@ -419,6 +418,10 @@ module('Acceptance | Dashboards', function(hooks) {
     await click('.add-widget-modal .add-to-dashboard');
 
     // Fill out request
+    await clickItemFilter('dimension', 'Date Time');
+    await selectChoose('.filter-builder__select-trigger', 'In The Past');
+    await clickItem('dimension', 'Date Time');
+    await selectChoose('.navi-column-config-item__parameter-trigger', 'Day');
     await clickItem('metric', 'Total Clicks');
 
     // Save without running
@@ -440,7 +443,7 @@ module('Acceptance | Dashboards', function(hooks) {
 
     assert.deepEqual(
       widgetColumns,
-      ['Date', 'Total Clicks'],
+      ['Date Time (day)', 'Total Clicks'],
       'Table columns for the new widget are rendered correctly'
     );
 
@@ -449,6 +452,10 @@ module('Acceptance | Dashboards', function(hooks) {
     await click('.add-widget-modal .add-to-dashboard');
 
     // Fill out request
+    await clickItemFilter('dimension', 'Date Time');
+    await selectChoose('.filter-builder__select-trigger', 'In The Past');
+    await clickItem('dimension', 'Date Time');
+    await selectChoose('.navi-column-config-item__parameter-trigger', 'Day');
     await clickItem('metric', 'Total Page Views');
 
     // Run request
@@ -474,7 +481,7 @@ module('Acceptance | Dashboards', function(hooks) {
 
     assert.deepEqual(
       widgetColumns,
-      ['Date', 'Total Page Views'],
+      ['Date Time (day)', 'Total Page Views'],
       'Table columns for the second new widget are rendered correctly'
     );
 
@@ -529,9 +536,17 @@ module('Acceptance | Dashboards', function(hooks) {
       return new Response(500);
     });
 
-    // Create and save
+    // Create widget
     await visit('/dashboards/1/widgets/new');
+
+    // Build Request
+    await clickItemFilter('dimension', 'Date Time');
+    await selectChoose('.filter-builder__select-trigger', 'In The Past');
+    await clickItem('dimension', 'Date Time');
+    await selectChoose('.navi-column-config-item__parameter-trigger', 'Day');
     await clickItem('metric', 'Total Clicks');
+
+    // Save
     await click('.navi-report-widget__run-btn');
     await click('.navi-report-widget__save-btn');
 
@@ -584,6 +599,7 @@ module('Acceptance | Dashboards', function(hooks) {
     });
 
     await visit('/dashboards/2/view');
+
     assert
       .dom('[data-gs-id="4"] .navi-widget__content')
       .hasClass('visualization-container', 'Widget shows visualization for authorized table');
@@ -660,8 +676,8 @@ module('Acceptance | Dashboards', function(hooks) {
     assert.deepEqual(
       dataRequests.map(thing => thing.queryParams.filters),
       [
-        'property|id-notin["2","3"],property|id-notin["1"],property|id-contains["114","100001"]',
-        'property|id-notin["2","3"],property|id-notin["1"],property|id-contains["114","100001"]'
+        'property|id-contains["114","100001"],property|id-notin["1"],property|id-notin["2","3"]',
+        'property|id-contains["114","100001"],property|id-notin["1"],property|id-notin["2","3"]'
       ],
       'the filters from the request are unmodified from the dashboard'
     );
@@ -690,8 +706,8 @@ module('Acceptance | Dashboards', function(hooks) {
     assert.deepEqual(
       dataRequests.map(thing => thing.queryParams.filters),
       [
-        'property|id-notin["2","3"],property|id-contains["114","100001"]',
-        'property|id-notin["2","3"],property|id-contains["114","100001"]'
+        'property|id-contains["114","100001"],property|id-notin["2","3"]',
+        'property|id-contains["114","100001"],property|id-notin["2","3"]'
       ],
       'the filters reflect the dashboards modified filters'
     );
@@ -711,6 +727,10 @@ module('Acceptance | Dashboards', function(hooks) {
     await click('.add-widget-modal .add-to-dashboard');
 
     // Fill out request
+    await clickItemFilter('dimension', 'Date Time');
+    await selectChoose('.filter-builder__select-trigger', 'In The Past');
+    await clickItem('dimension', 'Date Time');
+    await selectChoose('.navi-column-config-item__parameter-trigger', 'Day');
     await clickItem('metric', 'Total Clicks');
 
     // Save without running
@@ -732,7 +752,7 @@ module('Acceptance | Dashboards', function(hooks) {
 
     assert.deepEqual(
       widgetColumns,
-      ['Date', 'Total Clicks'],
+      ['Date Time (day)', 'Total Clicks'],
       'Table columns for the new widget are rendered correctly'
     );
   });

--- a/packages/dashboards/tests/acceptance/dashboards-test.js
+++ b/packages/dashboards/tests/acceptance/dashboards-test.js
@@ -1,6 +1,6 @@
 import { click, currentURL, fillIn, find, findAll, triggerEvent, visit, blur, waitFor } from '@ember/test-helpers';
 import { run } from '@ember/runloop';
-import { module, test, skip } from 'qunit';
+import { module, test } from 'qunit';
 import config from 'ember-get-config';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -401,8 +401,7 @@ module('Acceptance | Dashboards', function(hooks) {
     });
   });
 
-  // TODO: Broken because reports is broken
-  skip('New widget', async function(assert) {
+  test('New widget', async function(assert) {
     assert.expect(15);
 
     // Check original set of widgets
@@ -512,8 +511,7 @@ module('Acceptance | Dashboards', function(hooks) {
     assert.verifySteps(['navigation confirmation denied']);
   });
 
-  // TODO: Broken because reports is broken
-  skip('Failing to save a new widget', async function(assert) {
+  test('Failing to save a new widget', async function(assert) {
     assert.expect(8);
 
     server.patch('/dashboards/1', (_, request) => {
@@ -699,8 +697,7 @@ module('Acceptance | Dashboards', function(hooks) {
     );
   });
 
-  // TODO: Broken because reports is broken
-  skip('New widget after clone', async function(assert) {
+  test('New widget after clone', async function(assert) {
     assert.expect(4);
 
     await visit('/dashboards/1');

--- a/packages/dashboards/tests/acceptance/explore-widget-test.js
+++ b/packages/dashboards/tests/acceptance/explore-widget-test.js
@@ -1,5 +1,5 @@
 import { find, click, fillIn, currentURL, currentRouteName, findAll, blur, visit, waitFor } from '@ember/test-helpers';
-import { module, skip } from 'qunit';
+import { module, test } from 'qunit';
 import config from 'ember-get-config';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -12,12 +12,11 @@ import { selectChoose } from 'ember-power-select/test-support';
 // Regex to check that a string ends with "{uuid}/view"
 const TempIdRegex = /\/reports\/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\/view$/;
 
-// TODO: Broken because reports is broken
 module('Acceptance | Exploring Widgets', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  skip('Widget title', async function(assert) {
+  test('Widget title', async function(assert) {
     assert.expect(1);
 
     await visit('/dashboards/1/widgets/1');
@@ -25,7 +24,7 @@ module('Acceptance | Exploring Widgets', function(hooks) {
     assert.dom('.navi-report-widget__title').hasText('Mobile DAU Goal', 'Widget title is displayed as the page title');
   });
 
-  skip('Editing widget title', async function(assert) {
+  test('Editing widget title', async function(assert) {
     assert.expect(1);
 
     // Edit title
@@ -43,7 +42,7 @@ module('Acceptance | Exploring Widgets', function(hooks) {
     assert.ok(widgetNames.includes('A new title'), 'New widget title is saved and persisted on dashboard');
   });
 
-  skip('Breadcrumb', async function(assert) {
+  test('Breadcrumb', async function(assert) {
     assert.expect(4);
     let originalFeatureFlag = config.navi.FEATURES.enableDirectory;
 
@@ -68,7 +67,7 @@ module('Acceptance | Exploring Widgets', function(hooks) {
     config.navi.FEATURES.enableDirectory = originalFeatureFlag;
   });
 
-  skip('Viewing a widget', async function(assert) {
+  test('Viewing a widget', async function(assert) {
     assert.expect(2);
 
     await visit('/dashboards/1/widgets/2/view');
@@ -80,7 +79,7 @@ module('Acceptance | Exploring Widgets', function(hooks) {
       .exists('The column config exists on the view route');
   });
 
-  skip('Exploring a widget', async function(assert) {
+  test('Exploring a widget', async function(assert) {
     assert.expect(1);
 
     await visit('/dashboards/1');
@@ -89,7 +88,7 @@ module('Acceptance | Exploring Widgets', function(hooks) {
     assert.ok(currentURL().endsWith('/dashboards/1/widgets/2/view'), 'Explore action links to widget view route');
   });
 
-  skip('Changing and saving a widget', async function(assert) {
+  test('Changing and saving a widget', async function(assert) {
     assert.expect(4);
 
     // Add a metric to widget 2, save, and return to dashboard route
@@ -118,7 +117,7 @@ module('Acceptance | Exploring Widgets', function(hooks) {
     );
   });
 
-  skip('Revert changes', async function(assert) {
+  test('Revert changes', async function(assert) {
     assert.expect(4);
 
     await visit('/dashboards/1/widgets/2/view');
@@ -144,7 +143,7 @@ module('Acceptance | Exploring Widgets', function(hooks) {
       .isNotVisible('After clicking "Revert Changes", button is once again hidden');
   });
 
-  skip('Export action', async function(assert) {
+  test('Export action', async function(assert) {
     let originalFeatureFlag = config.navi.FEATURES.exportFileTypes;
 
     // Turn flag off
@@ -184,7 +183,7 @@ module('Acceptance | Exploring Widgets', function(hooks) {
     config.navi.FEATURES.exportFileTypes = originalFeatureFlag;
   });
 
-  skip('Multi export action', async function(assert) {
+  test('Multi export action', async function(assert) {
     assert.expect(1);
 
     await visit('/dashboards/1/widgets/2/view');
@@ -194,7 +193,7 @@ module('Acceptance | Exploring Widgets', function(hooks) {
       .hasAttribute('href', /export\?reportModel=/, 'Export url contains serialized report');
   });
 
-  skip('Get API action - enabled/disabled', async function(assert) {
+  test('Get API action - enabled/disabled', async function(assert) {
     assert.expect(2);
 
     await visit('/dashboards/1/widgets/2/view');
@@ -218,7 +217,7 @@ module('Acceptance | Exploring Widgets', function(hooks) {
       .hasClass('navi-report-widget__action--is-disabled', 'Get API action is disabled when request is not valid');
   });
 
-  skip('Share action', async function(assert) {
+  test('Share action', async function(assert) {
     assert.expect(2);
 
     /* == Unsaved widget == */
@@ -240,7 +239,7 @@ module('Acceptance | Exploring Widgets', function(hooks) {
       .hasText('Share "Mobile DAU Graph"', 'Clicking share action brings up share modal');
   });
 
-  skip('Delete widget', async function(assert) {
+  test('Delete widget', async function(assert) {
     assert.expect(5);
 
     /* == Not author == */
@@ -273,7 +272,7 @@ module('Acceptance | Exploring Widgets', function(hooks) {
     );
   });
 
-  skip('Clone a widget', async function(assert) {
+  test('Clone a widget', async function(assert) {
     assert.expect(4);
     let originalWidgetTitle;
 
@@ -296,7 +295,7 @@ module('Acceptance | Exploring Widgets', function(hooks) {
       .isVisible('Report body has a visualization on the view route');
   });
 
-  skip('Error data request', async function(assert) {
+  test('Error data request', async function(assert) {
     assert.expect(1);
 
     server.get(`${config.navi.dataSources[0].uri}/v1/data/*path`, () => {
@@ -312,7 +311,7 @@ module('Acceptance | Exploring Widgets', function(hooks) {
       );
   });
 
-  skip('Cancel Widget', async function(assert) {
+  test('Cancel Widget', async function(assert) {
     //Slow down mock
     server.timing = 400;
     server.urlPrefix = `${config.navi.dataSources[0].uri}/v1`;

--- a/packages/dashboards/tests/acceptance/explore-widget-test.js
+++ b/packages/dashboards/tests/acceptance/explore-widget-test.js
@@ -6,7 +6,7 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import { Response } from 'ember-cli-mirage';
 import { clickTrigger } from 'ember-basic-dropdown/test-support/helpers';
 import $ from 'jquery';
-import { clickItem, clickItemFilter } from 'navi-reports/test-support/report-builder';
+import { clickItem } from 'navi-reports/test-support/report-builder';
 import { selectChoose } from 'ember-power-select/test-support';
 
 // Regex to check that a string ends with "{uuid}/view"
@@ -136,7 +136,7 @@ module('Acceptance | Exploring Widgets', function(hooks) {
 
     assert
       .dom('.filter-builder__subject')
-      .hasText('Date Time (Day)', 'After clicking "Revert Changes", the changed time grain is returned');
+      .hasText('Date Time (day)', 'After clicking "Revert Changes", the changed time grain is returned');
 
     assert
       .dom('.navi-report-widget__revert-btn')
@@ -162,12 +162,13 @@ module('Acceptance | Exploring Widgets', function(hooks) {
       .dom($('.navi-report-widget__action-link:contains(Export)')[0])
       .hasAttribute('href', /metrics=adClicks%2CnavClicks/, 'Have correct metric in export url');
 
-    // Remove all metrics to create an invalid request
+    // Remove all columns to create an invalid request
     assert
-      .dom('.navi-column-config-item__remove-icon[aria-label="delete time-dimension Date Time (Day)"]')
-      .exists('The datesTime remove icon exists');
-    await click('.navi-column-config-item__remove-icon[aria-label="delete time-dimension Date Time (Day)"]');
+      .dom('.navi-column-config-item__remove-icon[aria-label="delete time-dimension Date Time (day)"]')
+      .exists('The dateTime remove icon exists');
+    await click('.navi-column-config-item__remove-icon[aria-label="delete time-dimension Date Time (day)"]');
     await click('.navi-column-config-item__remove-icon[aria-label="delete metric Nav Link Clicks"]');
+    await click('.navi-column-config-item__remove-icon[aria-label="delete metric Ad Clicks"]');
 
     assert
       .dom($('.navi-report-widget__action-link:contains(Export)')[0])
@@ -201,16 +202,10 @@ module('Acceptance | Exploring Widgets', function(hooks) {
       .dom('.get-api')
       .doesNotHaveClass('.navi-report-widget__action--is-disabled', 'Get API action is enabled for a valid request');
 
-    // Remove all metrics
-    await clickItem('metric', 'Ad Clicks');
-    await clickItem('metric', 'Nav Link Clicks');
-
-    // Remove all metrics to create an invalid request
-    await clickItem('metric', 'Ad Clicks');
-    await clickItem('metric', 'Nav Link Clicks');
-
-    // Create empty filter to make request invalid
-    await clickItemFilter('dimension', 'Operating System');
+    // Remove all columns to create an invalid request
+    await click('.navi-column-config-item__remove-icon[aria-label="delete time-dimension Date Time (day)"]');
+    await click('.navi-column-config-item__remove-icon[aria-label="delete metric Nav Link Clicks"]');
+    await click('.navi-column-config-item__remove-icon[aria-label="delete metric Ad Clicks"]');
 
     assert
       .dom('.get-api')
@@ -304,9 +299,9 @@ module('Acceptance | Exploring Widgets', function(hooks) {
 
     await visit('/dashboards/2/widgets/4/view');
     assert
-      .dom('.navi-report-error__info-message')
+      .dom('.routes-reports-report-error__error-list')
       .hasText(
-        'Oops! There was an error with your request. Cannot merge mismatched time grains month and day',
+        'Cannot merge mismatched time grains month and day',
         'An error message is displayed for an invalid request'
       );
   });

--- a/packages/dashboards/tests/acceptance/mutli-datasource-dashboards-test.js
+++ b/packages/dashboards/tests/acceptance/mutli-datasource-dashboards-test.js
@@ -3,7 +3,7 @@ import { visit, click, findAll, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest, test } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { selectChoose } from 'ember-power-select/test-support';
-import { clickItem } from 'navi-reports/test-support/report-builder';
+import { clickItem, clickItemFilter } from 'navi-reports/test-support/report-builder';
 
 module('Acceptance | Multi datasource Dashboard', function(hooks) {
   setupApplicationTest(hooks);
@@ -19,16 +19,13 @@ module('Acceptance | Multi datasource Dashboard', function(hooks) {
 
     assert
       .dom('.filter-collection--collapsed')
-      .hasText(
-        'Age equals under 13 (1) 13-17 (2) 18-20 (3) Container not equals Bag (1)',
-        'Collapsed filter has the right text'
-      );
+      .hasText('Age (id) equals 1 2 3 Container (id) not equals 1', 'Collapsed filter has the right text');
 
     await click('.dashboard-filters__toggle');
 
     assert.deepEqual(
       findAll('.filter-builder-dimension__subject').map(el => el.textContent.trim()),
-      ['Age', 'Container'],
+      ['Age (id)', 'Container (id)'],
       'Dimensions are properly labeled in filters'
     );
 
@@ -46,7 +43,7 @@ module('Acceptance | Multi datasource Dashboard', function(hooks) {
           )
         ].map(el => el.textContent.trim())
       ),
-      [['under 13 (1)', '13-17 (2)', '18-20 (3)'], ['Bag (1)']],
+      [['1', '2', '3'], ['1']],
       'Dimension value selector showing the right values'
     );
   });
@@ -67,6 +64,10 @@ module('Acceptance | Multi datasource Dashboard', function(hooks) {
     await click('.add-to-dashboard');
 
     await selectChoose('.navi-table-select__dropdown', 'Inventory');
+    await clickItemFilter('dimension', 'Date Time');
+    await selectChoose('.filter-builder__select-trigger', 'Current');
+    await clickItem('dimension', 'Date Time');
+    await selectChoose('.navi-column-config-item__parameter-trigger', 'Day');
     await clickItem('dimension', 'Container');
     await clickItem('metric', 'Used Amount');
 
@@ -81,10 +82,10 @@ module('Acceptance | Multi datasource Dashboard', function(hooks) {
     await click('.dashboard-filters__toggle');
     await click('.dashboard-filters--expanded__add-filter-button');
     await selectChoose('.dashboard-dimension-selector', 'Container');
-    await selectChoose('.filter-builder-dimension__values', 'Bag');
+    await selectChoose('.filter-builder-dimension__values', '1');
 
     const widgetsWithFilterWarning = () =>
-      [...findAll('.navi-widget__filter-errors-icon')].map(el => el.closest('.navi-widget__title').textContent.trim());
+      findAll('.navi-widget__filter-errors-icon').map(el => el.closest('.navi-widget__title').textContent.trim());
 
     assert.deepEqual(
       widgetsWithFilterWarning(),
@@ -95,7 +96,7 @@ module('Acceptance | Multi datasource Dashboard', function(hooks) {
     //add another filter for other datasource
     await click('.dashboard-filters--expanded__add-filter-button');
     await selectChoose('.dashboard-dimension-selector', 'Age');
-    await selectChoose(findAll('.filter-builder-dimension__values')[1], 'under 13 (1)');
+    await selectChoose(findAll('.filter-builder-dimension__values')[1], '1');
 
     assert.deepEqual(
       widgetsWithFilterWarning(),

--- a/packages/dashboards/tests/acceptance/mutli-datasource-dashboards-test.js
+++ b/packages/dashboards/tests/acceptance/mutli-datasource-dashboards-test.js
@@ -1,6 +1,6 @@
 import { module } from 'qunit';
 import { visit, click, findAll, currentURL } from '@ember/test-helpers';
-import { setupApplicationTest, test, skip } from 'ember-qunit';
+import { setupApplicationTest, test } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { selectChoose } from 'ember-power-select/test-support';
 import { clickItem } from 'navi-reports/test-support/report-builder';
@@ -51,8 +51,7 @@ module('Acceptance | Multi datasource Dashboard', function(hooks) {
     );
   });
 
-  // TODO: Broken because reports is broken
-  skip('Create new multisource dashboard', async function(assert) {
+  test('Create new multisource dashboard', async function(assert) {
     assert.expect(8);
 
     await visit('/dashboards/new');

--- a/packages/dashboards/tests/acceptance/report-action-test.js
+++ b/packages/dashboards/tests/acceptance/report-action-test.js
@@ -1,5 +1,5 @@
 import { click, visit } from '@ember/test-helpers';
-import { module, skip } from 'qunit';
+import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import $ from 'jquery';
@@ -9,8 +9,7 @@ module('Acceptances | Report to dashboard action', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  // TODO: Broken because reports is broken
-  skip('Add to dashboard button - flag true', async function(assert) {
+  test('Add to dashboard button - flag true', async function(assert) {
     assert.expect(1);
 
     await visit('/reports/1/view');
@@ -20,8 +19,7 @@ module('Acceptances | Report to dashboard action', function(hooks) {
     );
   });
 
-  // TODO: Broken because reports is broken
-  skip('Add to dashboard button is hidden when there are unrun request changes', async function(assert) {
+  test('Add to dashboard button is hidden when there are unrun request changes', async function(assert) {
     assert.expect(3);
 
     await visit('/reports/1/view');

--- a/packages/dashboards/tests/acceptance/report-action-test.js
+++ b/packages/dashboards/tests/acceptance/report-action-test.js
@@ -3,7 +3,6 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import $ from 'jquery';
-import { clickItemFilter } from 'navi-reports/test-support/report-builder';
 
 module('Acceptances | Report to dashboard action', function(hooks) {
   setupApplicationTest(hooks);
@@ -29,16 +28,19 @@ module('Acceptances | Report to dashboard action', function(hooks) {
       'Add to Dashboard button is visible by default'
     );
 
-    // Create empty filter to make request invalid
-    await clickItemFilter('dimension', 'Operating System');
+    // Remove all columns to make invalid
+    await click('.navi-column-config-item__remove-icon[aria-label="delete time-dimension Date Time (day)"]');
+    await click('.navi-column-config-item__remove-icon[aria-label="delete dimension Property (id)"]');
+    await click('.navi-column-config-item__remove-icon[aria-label="delete metric Nav Link Clicks"]');
+    await click('.navi-column-config-item__remove-icon[aria-label="delete metric Ad Clicks"]');
 
     assert.notOk(
       !!$('.navi-report__action:contains("Add to Dashboard")').length,
       'Add to Dashboard button is hidden when all metrics is disabled'
     );
 
-    // Remove empty filter and run query
-    await clickItemFilter('dimension', 'Operating System');
+    // Revert changes and run query
+    await click('.navi-report__revert-btn');
     await click('.navi-report__run-btn');
 
     assert.ok(

--- a/packages/dashboards/tests/integration/components/dashboard-dimension-selector-test.js
+++ b/packages/dashboards/tests/integration/components/dashboard-dimension-selector-test.js
@@ -25,10 +25,9 @@ module('Integration | Component | dashboard dimension selector', function(hooks)
               table: 'a',
               tableMetadata: {
                 id: 'a',
-                timeDimensions: [],
                 dimensions: [
-                  { id: 'dim1', name: 'dim1', category: 'cat1' },
-                  { id: 'dim2', name: 'dim2', category: 'cat2' }
+                  { id: 'dim1', name: 'dim1', category: 'cat1', metadataType: 'dimension' },
+                  { id: 'dim2', name: 'dim2', category: 'cat2', metadataType: 'dimension' }
                 ]
               }
             }
@@ -47,10 +46,9 @@ module('Integration | Component | dashboard dimension selector', function(hooks)
               table: 'b',
               tableMetadata: {
                 id: 'b',
-                timeDimensions: [],
                 dimensions: [
-                  { id: 'dim3', name: 'dim3', category: 'cat2' },
-                  { id: 'dim1', name: 'dim1', category: 'cat1' }
+                  { id: 'dim3', name: 'dim3', category: 'cat2', metadataType: 'dimension' },
+                  { id: 'dim1', name: 'dim1', category: 'cat1', metadataType: 'dimension' }
                 ]
               }
             }

--- a/packages/dashboards/tests/unit/routes/dashboards/dashboard/clone-test.js
+++ b/packages/dashboards/tests/unit/routes/dashboards/dashboard/clone-test.js
@@ -55,10 +55,10 @@ module('Unit | Route | dashboards/dashboard/clone', function(hooks) {
     assert.expect(4);
 
     const dashboard = await Route.store.findRecord('dashboard', 1);
-    const widgetIdInDashboard = dashboard.get('presentation.layout').map(layout => layout.widgetId);
+    const widgetIdInDashboard = dashboard.presentation.layout.map(layout => layout.widgetId);
     const model = await Route._cloneDashboard(dashboard);
     const expectedModel = model.toJSON();
-    const widgetIdInExpectedModel = model.get('presentation.layout').map(layout => layout.widgetId);
+    const widgetIdInExpectedModel = model.presentation.layout.map(layout => layout.widgetId);
 
     assert.equal(expectedModel.title, CLONED_MODEL.title, 'Expected Models title is correct');
 

--- a/packages/dashboards/tests/unit/routes/dashboards/dashboard/widgets/new-test.js
+++ b/packages/dashboards/tests/unit/routes/dashboards/dashboard/widgets/new-test.js
@@ -23,9 +23,9 @@ const NEW_MODEL = {
   updatedOn: null,
   visualization: {
     type: 'table',
-    version: 1,
+    version: 2,
     metadata: {
-      columns: []
+      columnAttributes: {}
     }
   },
   dashboard: 'dashboard1'

--- a/packages/dashboards/tests/unit/services/dashboard-data-test.js
+++ b/packages/dashboards/tests/unit/services/dashboard-data-test.js
@@ -191,13 +191,16 @@ module('Unit | Service | dashboard data', function(hooks) {
       response = {
         rows: [
           {
-            adClicks: 30
+            adClicks: 30,
+            'network.dateTime(grain=day)': undefined
           },
           {
-            adClicks: 1000
+            adClicks: 1000,
+            'network.dateTime(grain=day)': undefined
           },
           {
-            adClicks: 200
+            adClicks: 200,
+            'network.dateTime(grain=day)': undefined
           }
         ]
       };
@@ -208,7 +211,7 @@ module('Unit | Service | dashboard data', function(hooks) {
     });
 
     return service._fetch(request).then(fetchResponse => {
-      assert.deepEqual(fetchResponse.get('response.rows'), response.rows, 'fetch gets response from web service');
+      assert.deepEqual(fetchResponse.response.rows, response.rows, 'fetch gets response from web service');
     });
   });
 

--- a/packages/data/addon/serializers/metadata/bard.ts
+++ b/packages/data/addon/serializers/metadata/bard.ts
@@ -210,6 +210,7 @@ export default class BardMetadataSerializer extends NaviMetadataSerializer {
     dataSourceName: string
   ): ColumnFunctionMetadataModel {
     const { fields = [] } = dimension;
+    const defaultValue = fields.find(field => field.tags && field.tags.includes('primaryKey'))?.name || fields[0]?.name;
     const sorted = fields.map(field => field.name).sort();
     const columnFunctionId = `${this.namespace}:dimensionField(fields=${sorted.join(',')})`;
     const payload: ColumnFunctionMetadataPayload = {
@@ -225,7 +226,7 @@ export default class BardMetadataSerializer extends NaviMetadataSerializer {
           source: dataSourceName,
           type: 'ref',
           expression: INTRINSIC_VALUE_EXPRESSION,
-          defaultValue: fields[0]?.name,
+          defaultValue,
           _localValues: fields.map(field => ({
             id: field.name,
             description: undefined, // ignoring dimension field description for

--- a/packages/data/addon/services/navi-facts.ts
+++ b/packages/data/addon/services/navi-facts.ts
@@ -57,7 +57,13 @@ export default class NaviFactsService extends Service {
   getURL(request: RequestV2, options: RequestOptions = {}) {
     const type = config.navi.dataSources[0].type;
     const adapter = this._adapterFor(type);
-    return adapter.urlForFindQuery(request, options);
+    let query;
+    try {
+      query = adapter.urlForFindQuery(request, options);
+    } catch (e) {
+      // nothing to do
+    }
+    return query;
   }
 
   /**

--- a/packages/reports/addon/components/filter-collection.hbs
+++ b/packages/reports/addon/components/filter-collection.hbs
@@ -1,5 +1,5 @@
 {{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
-<div class="filter-collection {{if @isCollapsed "filter-collection--collapsed"}}">
+<div class="filter-collection {{if @isCollapsed "filter-collection--collapsed"}}" ...attributes>
   {{#each this.filters as |filter|}}
     {{#let (component (concat "filter-builders/" filter.type)) as |FilterBuilder|}}
       {{#if @isCollapsed}}

--- a/packages/reports/addon/components/unauthorized-table.js
+++ b/packages/reports/addon/components/unauthorized-table.js
@@ -27,6 +27,6 @@ export default Component.extend({
 
   init() {
     this._super(...arguments);
-    set(this, 'tableName', this.report?.request?.logicalTable?.table?.name);
+    set(this, 'tableName', this.report?.request?.tableMetadata?.name);
   }
 });

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -21,7 +21,7 @@ jobs:
       - test-navi-admin: npx lerna run test --scope navi-admin --stream;
       - test-navi-app: npx lerna run test --scope navi-app --stream;
       - test-navi-core: npx lerna run test --scope navi-core --stream;
-      - test-navi-dashboards: npx lerna run test --scope navi-dashboards --stream || true;
+      - test-navi-dashboards: npx lerna run test --scope navi-dashboards --stream;
       - test-navi-data: npx lerna run test --scope navi-data --stream;
       - test-navi-directory: npx lerna run test --scope navi-directory --stream;
       - test-navi-notifications: npx lerna run test --scope navi-notifications --stream;


### PR DESCRIPTION
## Description
Fixes failing dashboards tests

## Proposed Changes
- fixed a bug with dashboard-data service where we yielded a promise instead of a TaskInstance so cancelling did not bubble correctly
- removed date dimension filter
- catch errors when calling `getURL`
- Fili dimensions use `primaryKey` field as default value for dimension field parameter

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
