### PR TITLE
Update: Clone takes user to edit route

### DIFF
--- a/packages/reports/addon/routes/reports/report/clone.ts
+++ b/packages/reports/addon/routes/reports/report/clone.ts
@@ -29,7 +29,7 @@ export default class ReportsReportCloneRoute extends Route {
    * @override
    */
   afterModel(report: ReportModel): Transition {
-    return this.replaceWith('reports.report.view', report.tempId);
+    return this.replaceWith('reports.report.edit', report.tempId);
   }
 
   /**

--- a/packages/reports/tests/acceptance/report-test.js
+++ b/packages/reports/tests/acceptance/report-test.js
@@ -90,7 +90,7 @@ module('Acceptance | Navi Report', function (hooks) {
 
     await visit('/reports/1/clone');
 
-    assert.dom('.report-view').exists('The route transistions to report view');
+    assert.ok(currentURL().endsWith('/edit'), 'The route transistions to edit route');
 
     assert.equal(
       find('.report-header__title').innerText.trim(),

--- a/packages/reports/tests/acceptance/report-test.js
+++ b/packages/reports/tests/acceptance/report-test.js
@@ -91,7 +91,7 @@ module('Acceptance | Navi Report', function (hooks) {
 
     await visit('/reports/1/clone');
 
-    assert.ok(TempIdEditRegex.test(currentURL()), 'The route transistions to edit route');
+    assert.ok(TempIdEditRegex.test(currentURL()), 'The route transitions to edit route');
 
     assert.equal(
       find('.report-header__title').innerText.trim(),

--- a/packages/reports/tests/acceptance/report-test.js
+++ b/packages/reports/tests/acceptance/report-test.js
@@ -1027,7 +1027,7 @@ module('Acceptance | Navi Report', function (hooks) {
 
     assert.ok(
       TempIdEditRegex.test(currentURL()),
-      'After cloning, user is brought to view route for a new report with a temp id'
+      'After cloning, user is brought to edit route for a new report with a temp id'
     );
 
     assert.dom('.report-header__title').hasText('Copy of Hyrule News', 'Cloned report is being viewed');

--- a/packages/reports/tests/acceptance/report-test.js
+++ b/packages/reports/tests/acceptance/report-test.js
@@ -27,6 +27,7 @@ import moment from 'moment';
 import { getStatus, getDataSourceStatuses, DATE_FORMAT } from 'navi-core/test-support/data-availability';
 
 // Regex to check that a string ends with "{uuid}/view"
+const TempIdEditRegex = /\/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\/edit$/;
 const TempIdRegex = /\/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\/view$/;
 
 // Regex to check that a string ends with "{integer}/view"
@@ -90,7 +91,7 @@ module('Acceptance | Navi Report', function (hooks) {
 
     await visit('/reports/1/clone');
 
-    assert.ok(currentURL().endsWith('/edit'), 'The route transistions to edit route');
+    assert.ok(TempIdEditRegex.test(currentURL()), 'The route transistions to edit route');
 
     assert.equal(
       find('.report-header__title').innerText.trim(),
@@ -550,8 +551,8 @@ module('Acceptance | Navi Report', function (hooks) {
     await click('.report-actions__clone');
 
     assert.ok(
-      TempIdRegex.test(currentURL()),
-      'After cloning, user is brought to view route for a new report with a temp id'
+      TempIdEditRegex.test(currentURL()),
+      'After cloning, user is brought to edit route for a new report with a temp id'
     );
 
     assert.dom('.report-header__title').hasText('Copy of Hyrule News', 'Cloned report is being viewed');
@@ -1025,7 +1026,7 @@ module('Acceptance | Navi Report', function (hooks) {
     await click('.navi-collection__row0 .navi-report-actions__clone');
 
     assert.ok(
-      TempIdRegex.test(currentURL()),
+      TempIdEditRegex.test(currentURL()),
       'After cloning, user is brought to view route for a new report with a temp id'
     );
 


### PR DESCRIPTION
## Description
Cloning a report should not kick it off immediately so that users can start editing and not wait for it to finish running

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
